### PR TITLE
fix: update githubEditUrl

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -11,7 +11,7 @@ import { SITE } from '../config.ts';
 const { content = {}, hideRightSidebar = false } = Astro.props;
 const currentPage = Astro.request.url.pathname;
 const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
-const githubEditUrl = `https://github.com/withastro/astro/blob/main/${currentFile}`;
+const githubEditUrl = `https://github.com/withastro/docs/blob/main/${currentFile}`;
 const formatTitle = (content, SITE) =>
 	content.title ? `${content.title} 🚀 ${SITE.title}` : SITE.title;
 ---


### PR DESCRIPTION
**Describe the bug**

The "Edit this page" button is broken. 
e.g. go to 
`https://docs.astro.build/en/getting-started/`
click
"Edit this page"
get redirected to 
`https://github.com/withastro/astro/blob/main/src/pages/en/getting-started.md`

**Expected behavior**

Get redirected to 
`https://github.com/withastro/docs/blob/main/src/pages/en/getting-started.md`

**Pull Request**

This patch changes githubEditUrl to reflect the new docs location.