### PR TITLE
Remove unneeded labelling rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,9 +3,6 @@
 '🚨 action':
 - .github/workflows/**
 
-docs:
-- ./**
-
 i18n:
 - any:
   - 'src/pages/*/**'


### PR DESCRIPTION
Since this repo is all about the documentation, every PR is about the docs so this rule isn't needed anymore