### PR TITLE
Add a Next Step - "Discuss the docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ The docs site will be automatically updated whenever pull requests are merged.
 - [Read the docs](https://docs.astro.build/)
 - [Fork the docs](https://github.com/withastro/docs/fork)
 - [Raise an issue](https://github.com/withastro/docs/issues/new)
+- [Discuss the docs](https://discord.gg/cZDZU3hJHc)


### PR DESCRIPTION
Adds "Discuss the docs" to the Next Steps section, with a Discord invitation link directly to our #docs channel (no expiry, unlimited users, so should be fine as a permanent link).

I tested this anonymously, and this should allow users, even not logged in, to enter our Discord directly into our #docs channel (as unverified, read-only users until an account is confirmed), which I think could be helpful for making sure that (potential) contributors are aware of the specific channel and are encouraged to collaborate there.