### PR TITLE
Added array example to getStaticPaths()

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -166,7 +166,7 @@ const {post} = Astro.props;
 <body><h1>{id}: {post.name}</h1></body>
 ```
 
-Alongside of using `await fetch()` you can also pass manually constructed or generated arrays to a `map` function, and let Astro generate all the pages for you, based on the data you have provided. 
+You can also pass a regular array, which may be helpful when generating or stubbing a known list of routes.
 
 ```astro
 ---

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -166,6 +166,30 @@ const {post} = Astro.props;
 <body><h1>{id}: {post.name}</h1></body>
 ```
 
+Alongside of using `await fetch()` you can also pass manually constructed or generated arrays to a `map` function, and let Astro generate all the pages for you, based on the data you have provided. 
+
+```astro
+---
+export async function getStaticPaths() {
+  const posts = [
+    {id: '1', category: "astro", title: "API Reference"},
+    {id: '2', category: "react", title: "Creating a React Counter!"}
+  ];
+  return posts.map((post) => {
+    return {
+      params: { id: post.id },
+      props: { post} };
+  });
+}
+const {id} = Astro.request.params;
+const {post} = Astro.props;
+---
+<body>
+  <h1>{id}: {post.title}</h1>
+  <h2>Category: {post.category}</h2>
+</body>
+```
+
 Then Astro will statically generate `posts/1` and `posts/2` at build time using the page component in `pages/posts/[id].astro`. The page can reference this data using `Astro.props`:
 
 ### `paginate()`


### PR DESCRIPTION
Added a quick array example to getStaticPaths() for those who want to generate data based on a set of locally available ones, but do not use fetch or other functions to retrieve them. 