### PR TITLE
removed link to "snowpack" configuration in Installation Guide

### DIFF
--- a/src/pages/de/installation.md
+++ b/src/pages/de/installation.md
@@ -147,7 +147,7 @@ npm run dev
 
 Astro wird von nun an deine Anwendung unter `http://localhost:3000` bereitstellen. Wenn du diese URL in deinem Browser öffnest, solltest du Astros "Hello, World" sehen.
 
-Falls du deinen Entwicklungsfortschritt im lokalen Netzwerk teilen oder die Anwendung von einem Telefon aus testen möchtest, füge einfach die folgende [snowpack](https://www.snowpack.dev/reference/configuration#devoptionshostname)-Option in `astro.config.mjs` hinzu:
+Falls du deinen Entwicklungsfortschritt im lokalen Netzwerk teilen oder die Anwendung von einem Telefon aus testen möchtest, füge einfach die folgende Option in `astro.config.mjs` hinzu:
 
 ```js
 devOptions: {

--- a/src/pages/en/installation.md
+++ b/src/pages/en/installation.md
@@ -147,7 +147,7 @@ npm run dev
 
 Astro will now start serving your application on `http://localhost:3000`. By opening this URL in your browser, you should see the Astro’s “Hello, World”.
 
-If you need to share your development progress on the local network or check out the app from a phone, just add the following [snowpack](https://www.snowpack.dev/reference/configuration#devoptionshostname) option to `astro.config.mjs`:
+If you need to share your development progress on the local network or check out the app from a phone, just add the following option to `astro.config.mjs`:
 
 ```js
 devOptions: {

--- a/src/pages/es/installation.md
+++ b/src/pages/es/installation.md
@@ -141,7 +141,7 @@ npm run dev
 
 Ahora Astro estará corriendo tu aplicación en `http://localhost:3000`. Al abrir esta URL en tu navegador, deberías ver el “¡Hola, Mundo!” de Astro.
 
-Si necesitas compartir tu progreso de desarrollo en la red local o revisar la aplicación desde un teléfono, sólo agrega la siguiente opción [snowpack](https://www.snowpack.dev/reference/configuration#devoptionshostname) en `astro.config.mjs`:
+Si necesitas compartir tu progreso de desarrollo en la red local o revisar la aplicación desde un teléfono, sólo agrega la siguiente opción en `astro.config.mjs`:
 
 ```js
 devOptions: {

--- a/src/pages/hu/installation.md
+++ b/src/pages/hu/installation.md
@@ -147,7 +147,7 @@ npm run dev
 
 Az Astro mostantól a `http://localhost:3000` címen futtatja az alkalmazásodat. Ha megnyitod ezt a linket a böngésződben, látnod kell az Astro "Hello, World" mintaprogramját.
 
-Ha meg kell osztanod a helyi hálózaton, hogy hogyan halad a fejlesztés, vagy megnéznéd a mobilodról, csak add hozzá a következő [snowpack](https://www.snowpack.dev/reference/configuration#devoptionshostname) opciót az `astro.config.mjs` fájlhoz:
+Ha meg kell osztanod a helyi hálózaton, hogy hogyan halad a fejlesztés, vagy megnéznéd a mobilodról, csak add hozzá a következő opciót az `astro.config.mjs` fájlhoz:
 
 ```js
 devOptions: {

--- a/src/pages/ja/installation.md
+++ b/src/pages/ja/installation.md
@@ -148,7 +148,7 @@ npm run dev
 
 これで Astro は、`http://localhost:3000`でアプリケーションのサービスを開始します。この URL をブラウザで開くと、Astro の「Hello, World」が表示されるはずです。
 
-開発の進捗状況をローカルネットワーク上で共有したり、スマートフォンからアプリを確認したければ、以下の[snowpack](https://www.snowpack.dev/reference/configuration#devoptionshostname)オプションを`astro.config.mjs`に追加してください。
+開発の進捗状況をローカルネットワーク上で共有したり、スマートフォンからアプリを確認したければ、以下の オプションを`astro.config.mjs`に追加してください。
 
 ```js
 devOptions: {


### PR DESCRIPTION
I hope the change was as easy as removing the linked word "snowpack" in all the other languages too. I will post on the docs-i18n channel to ask others to look over their language, just in case.

Note: not every language had this file, and of the ones that did, not every file included this specific configuration. I believe I caught all the existing ones.