### PR TITLE
Lightly upgrade migration guide for 0.23

### DIFF
--- a/src/pages/en/migration/0.21.0.md
+++ b/src/pages/en/migration/0.21.0.md
@@ -1,6 +1,6 @@
 ---
 layout: ~/layouts/MainLayout.astro
-title: Migrating to v0.21
+title: Migrating to v0.21+
 description: How to migrate projects from Astro v0.20.
 ---
 
@@ -25,7 +25,7 @@ To learn more about configuring Vite, please visit their [configuration guide](h
 
 ## Aliasing
 
-In Astro v0.21, import aliases can be added from `tsconfig.json` or `jsconfig.json`.
+In Astro v0.21+, import aliases can be added from `tsconfig.json` or `jsconfig.json`.
 
 ```json
 {
@@ -42,7 +42,7 @@ _These aliases are integrated automatically into [VSCode](https://code.visualstu
 
 ## Variables in Scripts & Styles
 
-In Astro v0.21, _serializable_ server-side variables can be passed into client-side `<style>` or `<script>`.
+In Astro v0.21+, _serializable_ server-side variables can be passed into client-side `<style>` or `<script>`.
 
 ```astro
 ---
@@ -50,21 +50,41 @@ In Astro v0.21, _serializable_ server-side variables can be passed into client-s
 const foregroundColor = "rgb(221 243 228)";
 const backgroundColor = "rgb(24 121 78)";
 ---
-<style define:vars={{foregroundColor, backgroundColor}}>
-  h-tick {
-    background-color: var(--backgroundColor);
-    border-radius: 50%;
-    color: var(--foregroundColor);
-    height: 15px;
-    width: 15px;
-  }
+<style define:vars={{ foregroundColor, backgroundColor }}>
+h-tick {
+  background-color: var(--backgroundColor);
+  border-radius: 50%;
+  color: var(--foregroundColor);
+  height: 15px;
+  width: 15px;
+}
 </style>
 <h-tick>✓</h-tick>
 ```
 
+## Build non-HTML files
+
+In Astro v0.23+, with the `--experimental-static-build` flag enabled, files can be generated from `.js` and `.ts` files during the build.
+
+```js
+// src/pages/company.json.ts
+export async function get() {
+  return {
+    body: JSON.stringify({
+      name: 'Astro Technology Company',
+      url: 'https://astro.build/',
+    }),
+  };
+}
+```
+
+When the file is built, source file's extension is dropped, so that `company.json.ts` becomes `company.json`.
+
+Dynamic routes are also supported using `getStaticPaths()`. See [routing](/en/core-concepts/routing/) for details.
+
 ## Imports on top bug
 
-In Astro v0.21, a bug has been introduced that requires imports inside components to be at the top of your frontmatter.
+In Astro v0.21+, a bug has been introduced that requires imports inside components to be at the top of your frontmatter.
 
 ```astro
 ---
@@ -75,9 +95,39 @@ const whereShouldIPutMyImports = "on top!"
 
 _Note: This is a bug that will be fixed._
 
+## Escaping content
+
+In Astro v0.23+, unescaped HTML content in expressions is now deprecated.
+In future releases, content within expressions will have strings escaped to protect against unintended HTML injection.
+
+```diff
+- <h1>{title}</h1> <!-- <h1>Hello <strong>World</strong></h1> -->
++ <h1>{title}</h1> <!-- <h1>Hello &lt;strong&gt;World&lt;/strong&gt;</h1> -->
+```
+
+To continue injecting unescaped HTML, you can now use `set:html`.
+
+```diff
+- <h1>{title}</h1>
++ <h1 set:html={title} />
+```
+
+To avoid a wrapper element, `set:html` can work alongside `<Fragment>`.
+
+```diff
+- <h1>{title}!</h1>
++ <h1><Fragment set:html={title}>!</h1>
+```
+
+You can also protect against unintended HTML injection with `set:text`.
+
+```astro
+<h1 set:text={title} /> <!-- <h1>Hello &lt;strong&gt;World&lt;/strong&gt;</h1> -->
+```
+
 ## Components in Markdown
 
-In Astro v0.21, Components from any framework can be used within Markdown files.
+In Astro v0.21+, Components from any framework can be used within Markdown files.
 
 ```markdown
 ---
@@ -99,11 +149,11 @@ setup: |
 
 Previously, you could create mini Astro Components inside of the Astro Frontmatter, using JSX syntax instead of Astro’s component syntax. This was always a bit of a hack, but in the new compiler it became impossible to support. We hope to re-introduce this feature in a future release of Astro using a different, non-JSX API.
 
-To migrate to v0.21, please convert all JSX Astro components (that is, any Astro components created inside of another component’s frontmatter) to standalone components.
+To migrate to v0.21+, please convert all JSX Astro components (that is, any Astro components created inside of another component’s frontmatter) to standalone components.
 
 ## Environment Variables
 
-In Astro v0.21, environment variables can be loaded from `.env` files in your project directory.
+In Astro v0.21+, environment variables can be loaded from `.env` files in your project directory.
 
 ```ini
 .env                # loaded in all cases
@@ -125,7 +175,7 @@ In this example, `PUBLIC_ANYBODY` will be available as `import.meta.env.PUBLIC_A
 
 ## File Extensions
 
-In Astro v0.21, files need to be referenced by their actual extension, exactly as it is on disk.
+In Astro v0.21+, files need to be referenced by their actual extension, exactly as it is on disk.
 
 ```tsx
 // Div.tsx
@@ -157,7 +207,7 @@ div {
 
 ## Plugins
 
-In Astro v0.21, Vite plugins may be configured within `astro.config.mjs`.
+In Astro v0.21+, Vite plugins may be configured within `astro.config.mjs`.
 
 ```js
 import { imagetools } from 'vite-imagetools';
@@ -173,7 +223,7 @@ To learn more about Vite plugins, please visit their [plugin guide](https://vite
 
 ## Custom Renderers
 
-In Astro v0.21, plugins should now use `viteConfig()`.
+In Astro v0.21+, plugins should now use `viteConfig()`.
 
 ```diff
 // renderer-svelte/index.js


### PR DESCRIPTION
This updates the migration guide to reflect the state of Astro in both v0.21 and v0.23.

- Adds a section lightly documenting the building of non-HTML files.
- Adds a section lightly documenting the deprecation of HTML in expressions and the use of `set:html` and `set:text`.