### PR TITLE
Add more featured packages to docs "Themes" page

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -8,6 +8,12 @@
       "demo": null
     },
     {
+      "name": "Astro Icon",
+      "description": "A straight-forward Icon component for Astro.",
+      "github": "https://github.com/natemoo-re/astro-icon",
+      "demo": null
+    },
+    {
       "name": "Astro Static Tweet",
       "description": "A lightweight static-HTML tweet embed.",
       "github": "https://www.npmjs.com/package/@rebelchris/astro-static-tweet",
@@ -24,6 +30,12 @@
       "description": "A component for Astro JS that turns a website into an SPA.",
       "github": "https://www.npmjs.com/package/astro-spa",
       "demo": ["https://ohka-bots-site-astro-ksoqn4flk7-li4hm4z1a-tc-001.vercel.app/", "https://astro-spafy-component-demo.netlify.app/"]
-    }
+    },
+    {
+      "name": "Radix Icons for Astro",
+      "description": "Radix Icons are a crisp set of 15×15 icons designed by the Modulz team.",
+      "github": "https://github.com/astro-community/icons",
+      "demo": null
+    },
   ]
 }


### PR DESCRIPTION
I thought it would be nice to feature more awesome packages on the docs page, of course if @natemoo-re and @jonathantneal agree with me putting there packages on there, I don't want to impose 🙂