### PR TITLE
added new features from migration guide into regular docs guides

### DIFF
--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -4,19 +4,40 @@ title: Using environment variables
 description: Learn how to use environment variables in an Astro project.
 ---
 
-Astro uses Vite for environment variables, and allows you to use any of its methods to get and set environment variables. Note that all environment variables must be prefixed with `PUBLIC_` to be accessible by client side code.
+Astro uses Vite for environment variables, and allows you to use any of its methods to get and set environment variables. 
 
 The ability to access private variables on the server side is [still being discussed](https://github.com/withastro/astro/issues/1765).
 
+For security purposes, only variables prefixed with `PUBLIC_` are accessible by client side code.
+
+```ini
+SECRET_PASSWORD=password123
+PUBLIC_ANYBODY=there
+```
+
+In this example, `PUBLIC_ANYBODY` will be available as `import.meta.env.PUBLIC_ANYBODY` in server or client code, while `SECRET_PASSWORD` will not.
+
+> In prior releases, these variables were prefixed with `SNOWPACK_PUBLIC_` and required the `@snowpack/plugin-env` plugin.
+
+
 ## Setting environment variables
 
-Vite includes `dotenv` by default, allowing you to easily set environment variables without any extra configuration in Astro projects. You can also attach a mode (either `production` or `development`) to the filename, like `.env.production` or `.env.development`, which makes the environment variables only take effect in that mode.
+In Astro v0.21+, environment variables can be loaded from `.env` files in your project directory.
+
+You can also attach a mode (either `production` or `development`) to the filename, like `.env.production` or `.env.development`, which makes the environment variables only take effect in that mode.
 
 Just create a `.env` file in the project directory and add some variables to it.
 
 ```bash
 # .env
 PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
+```
+
+```ini
+.env                # loaded in all cases
+.env.local          # loaded in all cases, ignored by git
+.env.[mode]         # only loaded in specified mode
+.env.[mode].local   # only loaded in specified mode, ignored by git
 ```
 
 ## Getting environment variables
@@ -29,6 +50,8 @@ fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 
 > ⚠️WARNING⚠️:
 > Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
+
+
 
 ## IntelliSense for TypeScript
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -190,18 +190,23 @@ Using images or videos follows Astro’s normal import rules:
 
 ### Components
 
-You can import any component into your markdown file and use it along the markdown syntax.
+You can import components from any framework into your markdown file and use it along the markdown syntax. Front matter variables are available to your components from the `frontmatter` object.
 
 ```markdown
 ---
+layout: ../layouts/BaseLayout.astro
 setup: | 
   import Author from '../../components/Author.astro'
-  import Button from '../../components/Button.svelte'
+  import MyReactComponent from '../components/MyReactComponent.jsx'
 author: Leon
 ---
-# Blog post title
+# Hydrating on Visibility
+
+<MyReactComponent client:visible >
+# Hello world!
+</MyReactComponent>
+
 <Author name={frontmatter.author}/>
-<Button>Label</Button>
 ```
 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -122,6 +122,28 @@ It’s recommended to only use this in scenarios where a `<link>` tag won’t wo
 
 📚 Read our full guide on [Astro component syntax][astro-component] to learn more about using the `<style>` tag.
 
+### Variables in Scripts & Styles
+
+In Astro v0.21+, _serializable_ server-side variables can be passed into client-side `<style>` or `<script>`.
+
+```astro
+---
+// tick.astro
+const foregroundColor = "rgb(221 243 228)";
+const backgroundColor = "rgb(24 121 78)";
+---
+<style define:vars={{ foregroundColor, backgroundColor }}>
+h-tick {
+  background-color: var(--backgroundColor);
+  border-radius: 50%;
+  color: var(--foregroundColor);
+  height: 15px;
+  width: 15px;
+}
+</style>
+<h-tick>✓</h-tick>
+```
+
 ## Autoprefixer
 
 [Autoprefixer][autoprefixer] takes care of cross-browser CSS compatibility for you. Use it in astro by installing it (`npm install --save-dev autoprefixer`) and adding a `postcss.config.cjs` file to the root of your project:


### PR DESCRIPTION
Related to removing "new features" from the migration guide https://github.com/withastro/docs/pull/145 .

Where not already documented, the features have been added or incorporated into existing sections in /guides/ (without yet consideration for whether they ultimately belong there, or in /reference/ instead). Edited only if (and as much as) required to fit with existing material for now.



