### PR TITLE
updated code samples to match migration guide

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -129,7 +129,9 @@ It’s recommended to only use this in scenarios where a `<link>` tag won’t wo
 ```js
 // postcss.config.cjs
 module.exports = {
-  plugins: [require('autoprefixer')],
+  plugins: {
+    autoprefixer: {},
+  },
 };
 ```
 
@@ -200,10 +202,11 @@ _Note: CSS inside `public/` will **not** be transformed! Place it within `src/` 
 
 ### 🍃 Tailwind
 
-Astro can be configured to use [Tailwind][tailwind] easily! Install the dependencies:
+Astro can be configured to use [Tailwind][tailwind] easily! Install the dependencies, and ensure you have PostCSS installed. (This second step was optional in previous releases, but is required now):
 
 ```
 npm install --save-dev tailwindcss
+npm install --save-dev postcss
 ```
 
 And create 2 files in your project root: `tailwind.config.cjs` and `postcss.config.cjs`:
@@ -222,7 +225,9 @@ module.exports = {
 ```js
 // postcss.config.cjs
 module.exports = {
-  plugins: [require('tailwindcss')],
+  plugins: {
+    tailwindcss: {},
+  },
 };
 ```
 


### PR DESCRIPTION
 There was info in the migration guide that was not yet available directly in the Styling page re: tailwind/autoprefixer/postcss (so it would be easy to miss if you *weren't* actually migrating, but just going straight to docs with a new project).

The styling page should now at least have the same information as the migration guide, with code samples copied over to match.