### PR TITLE
copied "imports on top" issue into regular docs

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -111,6 +111,17 @@ import SomeComponent from './SomeComponent.astro';
 
 📚 You can also import and use components from other frontend frameworks like React, Svelte, and Vue. Read our guide on [Component Hydration](/en/core-concepts/component-hydration) to learn more.
 
+#### Known Issue:
+
+In Astro v0.21+, a bug has been introduced that requires imports inside components to be at the top of your front matter.
+
+```astro
+---
+import Component from '../components/Component.astro'
+const whereShouldIPutMyImports = "on top!"
+---
+```
+
 ### Dynamic JSX Expressions
 
 Instead of inventing our own custom syntax for dynamic templating, we give you direct access to JavaScript values inside of your HTML, using something that feels just like [JSX](https://reactjs.org/docs/introducing-jsx.html).

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -111,15 +111,16 @@ import SomeComponent from './SomeComponent.astro';
 
 📚 You can also import and use components from other frontend frameworks like React, Svelte, and Vue. Read our guide on [Component Hydration](/en/core-concepts/component-hydration) to learn more.
 
-#### Known Issue:
+#### Known Issues
 
-In Astro v0.21+, a bug has been introduced that requires imports inside components to be at the top of your front matter.
+Starting in Astro v0.21+, your imports must be placed at the very top of your Astro component script. If an import happens later in the script, you may encounter compiler issues. This limitation should be resolved before Astro v1.0 is released.
 
 ```astro
 ---
 import Component from '../components/Component.astro'
 const whereShouldIPutMyImports = "on top!"
 ---
+<h1>Remember to place your imports at the {whereShouldIPutMyImports}</h1>
 ```
 
 ### Dynamic JSX Expressions

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -234,11 +234,11 @@ Ensure you have PostCSS installed. This was optional in previous releases, but i
 
 #### Imports on top
 
-In Astro v0.21+, a bug has been introduced that requires imports inside components to be at the top of your frontmatter.
+In Astro v0.21+, a bug has been introduced that requires imports inside components to be at the top of your front matter.
 
 ```astro
 ---
-import Component from '../components/component.astro'
+import Component from '../components/Component.astro'
 const whereShouldIPutMyImports = "on top!"
 ---
 ```


### PR DESCRIPTION
Just took the issue from the migration doc and added to the astro component section in regular docs, so that someone can (hopefully?) see it even if they're not doing a migration.