### PR TITLE
Update index.css tbody tr

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -244,12 +244,10 @@ table {
 }
 
 /* Zebra striping */
-tr:nth-of-type(odd) {
+tbody tr:nth-of-type(odd) {
 	background: var(--theme-bg-hover);
 }
 th {
-	background: var(--color-black);
-	color: var(--theme-color);
 	font-weight: bold;
 }
 td,


### PR DESCRIPTION
Before (thead color bleeds into tbody):

<img width="744" alt="image" src="https://user-images.githubusercontent.com/990216/154976549-f032d714-7107-4aee-a112-0ed14ca449e5.png">

After (better separation of the first thead from tbody rows):

<img width="750" alt="image" src="https://user-images.githubusercontent.com/990216/154976289-0a56f4fb-6082-48bd-8d8e-2339018fdbd2.png">

Also removes some unused style declarations. 