### PR TITLE
Sarah's edits to new core concepts and installation guides

### DIFF
--- a/src/pages/en/core-concepts/astro-components-new.md
+++ b/src/pages/en/core-concepts/astro-components-new.md
@@ -6,9 +6,9 @@ description: An intro to the .astro component syntax.
 
 **Astro components** are the basic building blocks of any Astro project. 
 
-Astro components are written using the Astro component syntax, a superset of HTML that adds support for things like components and JavaScript expressions. You can spot an Astro component by it's file extension: `.astro`.
+Astro component syntax is a superset of HTML. The syntax was designed to feel familiar to anyone with experience writing HTML or JSX, and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
-Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, and Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
+Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
 
 The most important thing to know about Astro components is that they **render to HTML during your build.** Even if you run JavaScript code inside of your components, it will all run ahead-of-time, stripped from the final page that you send to your users. The result is a faster site, with zero JavaScript footprint added by default.
 
@@ -41,12 +41,12 @@ import Button from './Button.astro';
 
 ### The Component Script
 
-Astro uses a code fence (`---`) to identify the component script in your Astro Component. If you've every written markdown before, you may already be familiar with a similar concept called *front matter.* Astro idea of a component script was directly inspired by this concept.
+Astro uses a code fence (`---`) to identify the component script in your Astro component. If you've ever written Markdown before, you may already be familiar with a similar concept called *front matter.* Astro's idea of a component script was directly inspired by this concept.
 
 You can use the component script to write any JavaScript code that you need to render your template. This can include:
 
 - Importing other Astro components
-- Importing other components, like React
+- Importing other framework components, like React
 - Importing data, like a JSON file
 - fetching content from an API or database
 - creating variables that you will reference in your template
@@ -54,7 +54,7 @@ You can use the component script to write any JavaScript code that you need to r
 ```astro
 ---
 import SomeAstroComponent from '../components/SomeAstroComponent.astro';
-import SomeReactComponent from '../components/SomeReactComponent.astro';
+import SomeReactComponent from '../components/SomeReactComponent.jsx';
 import someData from '../data/pokemon.json';
 
 // Access passed-in component props, like `<X title="Hello, World" />`
@@ -65,34 +65,47 @@ const data = await fetch('SOME_SECRET_API_URL/users').then(r => r.json());
 <!-- Your template here! -->
 ```
 
-The code fence is designed to guarantee that the JavaScript that you write in it is "fenced in." It won't escape into your frontend application, or into your users hands. You can safely write code here that is expensive or sensitive (like a call to your private database) without worrying about it ever ending on your user's browser.
+The code fence is designed to guarantee that the JavaScript that you write in it is "fenced in." It won't escape into your frontend application, or fall into your users hands. You can safely write code here that is expensive or sensitive (like a call to your private database) without worrying about it ever ending up in your user's browser.
 
-You can even write TypeScript in your component script!
+>💡 *You can even write TypeScript in your component script!*
 
 ### The Component Template
 
-Below the component script, sits the component template. The component template decides the HTML output of your component. If you write HTML here, your component will render that HTML onto the page when its used!
+Below the component script, sits the component template. The component template decides the HTML output of your component. 
 
-The component template syntax that is a super-set of HTML that adds support for JavaScript expressions and special Astro directives. The syntax was designed to feel familiar to anyone with experience writing HTML or JSX.
+If you write plain HTML here, your component will render that HTML in any Astro page it is imported and used.
+
+However, Astro's component template syntax also supports **JavaScript expressions**, **imported components** and **special Astro directives**. Data and values defined (at page build time) in the component script can be used in the component template to produce dynamically-created HTML.
 
 ```astro
 ---
 // Your component script here!
+import ReactPokemonComponent from '../components/ReactPokemonComponent.jsx';
 const myFavoritePokemon = [/* ... */];
 ---
 <!-- HTML comments supported! -->
+
 <h1>Hello, world!</h1>
+
 <!-- Use props and other variables from the component script: -->
 <p>My favorite pokemon is: {Astro.props.title}</p>
+
+<!-- Include other components with a `client:` directive to hydrate: -->
+<ReactPokemonComponent client:visible />
+
 <!-- Mix HTML with JavaScript expressions, similar to JSX: -->
 <ul>
   {myFavoritePokemon.map((data) => <li>{data.name}</li>)}
 <ul>
+
+
 ```
 
 ### CSS Styles
 
-CSS `<style>` tags are also supported inside of the component template. They can be used to style your components, and all style rules are automatically scoped to the component to prevent CSS conflicts in large apps.
+CSS `<style>` tags are also supported inside of the component template. 
+
+They can be used to style your components, and all style rules are automatically scoped to the component itself to prevent CSS conflicts in large apps. 
 
 ```astro
 ---
@@ -102,8 +115,11 @@ CSS `<style>` tags are also supported inside of the component template. They can
   /* scoped to the component, other H1s on the page remain the same */
   h1 { color: red }
 </style>
+
 <h1>Hello, world!</h1>
-```
+``` 
+
+> ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default. See our [Styling Guide](/en/guides/styling) for more information on applying styles.
 
 ### Client-Side Scripts
 
@@ -116,12 +132,13 @@ To send JavaScript to the browser without [using a framework component](/en/core
 <script>
   document.querySelector('h1').style.color = 'red';
 </script>
+
 <h1>Hello, world!</h1>
 ```
 
 
 ## Next Steps
 
-TODO(sarah): For more, check out our full reference on Astro components
+📚 Read about [Astro's built-in components](https://docs.astro.build/en/reference/builtin-components/).
 
-
+📚 Learn about using [JavaScript framework components](https://docs.astro.build/en/core-concepts/component-hydration/) in your Astro project.

--- a/src/pages/en/core-concepts/astro-components-new.md
+++ b/src/pages/en/core-concepts/astro-components-new.md
@@ -119,7 +119,9 @@ They can be used to style your components, and all style rules are automatically
 <h1>Hello, world!</h1>
 ``` 
 
-> ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default. See our [Styling Guide](/en/guides/styling) for more information on applying styles.
+> ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default. 
+
+📚 See our [Styling Guide](/en/guides/styling) for more information on applying styles.
 
 ### Client-Side Scripts
 

--- a/src/pages/en/core-concepts/astro-pages-new.md
+++ b/src/pages/en/core-concepts/astro-pages-new.md
@@ -4,7 +4,7 @@ title: Pages
 description: An introduction to Astro pages
 ---
 
-**Pages** are a special type of [Astro Component](/en/core-concepts/astro-components) that live in the `src/pages/` subdirectory. They are responsible for handling routing, data loading, and overall page layout for every HTML page in your website.
+**Pages** are a special type of [Astro component](/en/core-concepts/astro-components) that live in the `src/pages/` subdirectory. They are responsible for handling routing, data loading, and overall page layout for every HTML page in your website.
 
 ### File-based routing
 
@@ -32,7 +32,7 @@ Astro Pages must return a full `<html>...</html>` page response, including `<hea
 
 ### Leveraging Page Layouts
 
-To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [Layout components](/en/core-components/layouts). You can use as many or as few layout components as you'd like.
+To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [layout components](/en/core-components/layouts). You can use as many or as few layout components as you'd like.
 
 ```astro
 ---
@@ -44,24 +44,24 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 </MySiteLayout>
 ```
 
-📚 Read more about [Layout components](/en/core-concepts/layouts-new) in Astro.
+📚 Read more about [layout components](/en/core-concepts/layouts-new) in Astro.
 
 
 ## Markdown Pages
 
 Astro also treats any Markdown (`.md`) files inside of `/src/pages/` as pages in your final website. These are commonly used for text-heavy pages like blog posts and documentation. 
 
-Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specifying a [Layout component](/en/core-concepts/layout) that will wrap their Markdown content in a full `<html>...</html>` page document. 
+Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layout) that will wrap their Markdown content in a full `<html>...</html>` page document. 
 
 ```md
 ---
 # Example: src/pages/page.md
 layout: '../layouts/MySiteLayout.astro'
-title: 'My markdown page'
+title: 'My Markdown page'
 ---
 # Title
 
-This is my page, written in **markdown.**
+This is my page, written in **Markdown.**
 ```
 
 📚 Read more about [Markdown](/en/guides/markdown-content) in Astro.
@@ -71,11 +71,14 @@ This is my page, written in **markdown.**
 
 > ⚠️ This feature is currently only supported with the `--experimental-static-build` CLI flag. This feature may be refined over the next few weeks/months as SSR support is finalized.
 
-Non-HTML pages, like `.json` or `.xml`, can be built from `.js` and `.ts`. Built filenames and extensions are based on the source file's name, ex: `src/pages/data.json.ts` will be built to match the `/data.json` route in your final build.
+Non-HTML pages, like `.json` or `.xml`, can be built from `.js` and `.ts`. 
 
-📚 Read more about generating non-HTML pages in Astro.
+Built filenames and extensions are based on the source file's name, ex: `src/pages/data.json.ts` will be built to match the `/data.json` route in your final build.
+
+📚 Read more about generating [non-HTML pages](https://docs.astro.build/en/core-concepts/astro-pages/#non-html-pages) in Astro.
 
 ## Custom 404 Error Page
 
-For a custom 404 error page create a `404.astro` file in `/src/pages`. That builds to a `404.html` page. Most [deploy services](/en/guides/deploy) will find and use it.
+For a custom 404 error page, you can create a `404.astro` file in `/src/pages`. 
 
+This will build to a `404.html` page. Most [deploy services](/en/guides/deploy) will find and use it.

--- a/src/pages/en/core-concepts/layouts-new.md
+++ b/src/pages/en/core-concepts/layouts-new.md
@@ -4,9 +4,9 @@ title: Layouts
 description: An intro to layouts, a type of Astro component that is shared between pages for common layouts.
 ---
 
-**Layouts** are a special type of [Astro Component](/en/core-concepts/astro-components) useful for creating reusable page templates. 
+**Layouts** are a special type of [Astro component](/en/core-concepts/astro-components) useful for creating reusable page templates. 
 
-Layouts are a common convention in Astro for any component that contains both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot>` that page content is injected into. 
+A layout component is conventionally used to provide an [`.astro` or `.md` page](/en/core-concepts/astro-pages) both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot>` to specify where in the layout page content should be injected.
 
 Layouts often provide common `<head>` elements and common UI elements for the page such as headers, navigation bars and footers.
 
@@ -46,12 +46,12 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 ```
 
 
-📚 Learn more about how `<slot/>` works in our [Astro Component guide.](/en/core-concepts/astro-components)
+📚 Learn more about how `<slot/>` works in our [Astro component guide.](/en/core-concepts/astro-components/#slots)
 
 
 ## Nesting Layouts
 
-Layout components don't need to contain an entire page worth of HTML. You can break your layouts into smaller components, and then reuse those components to create even more flexible, powerful layouts in your project.
+Layout components do not need to contain an entire page worth of HTML. You can break your layouts into smaller components, and then reuse those components to create even more flexible, powerful layouts in your project.
 
 For example, a common layout for blog posts may display a title, date and author. A `BlogPostLayout.astro` layout component could add this UI to the page and also leverage a larger, site-wide layout to handle the rest of your page.
 
@@ -70,12 +70,13 @@ const {content} = Astro.props;
 
 ## Markdown Layouts
 
-Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specifying a Layout component that will wrap their Markdown content in a full page HTML document. 
+Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a layout component that will wrap their Markdown content in a full page HTML document. 
 
-When a markdown page uses a layout, it passes the layout a single `content` prop that includes all of the markdown front matter data and final HTML output.  See the `BlogPostLayout.astro` example above for an example of how you would use this `content` prop in your layout component.
+When a Markdown page uses a layout, it passes the layout a single `content` prop that includes all of the Markdown front matter data and final HTML output.  See the `BlogPostLayout.astro` example above for an example of how you would use this `content` prop in your layout component.
 
 
 ```markdown
+// src/pages/posts/post-1.md
 ---
 title: Blog Post
 description: My first blog post!
@@ -84,4 +85,4 @@ layout: ../layouts/BlogPostLayout.astro
 This is a post written in Markdown.
 ```
 
-📚 Learn more about Astro’s markdown support in our [Markdown guide](/en/guides/markdown-content).
+📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content).

--- a/src/pages/en/core-concepts/project-structure-new.md
+++ b/src/pages/en/core-concepts/project-structure-new.md
@@ -4,17 +4,20 @@ title: Project Structure
 description: Learn how to structure a project with Astro.
 ---
 
-> TODO(sarah): INTRO - what is this guide for? who is it for?
+Your new Astro project generated from the `create-astro` CLI wizard already includes some files and folders. Others, you will create yourself and add to Astro's existing file structure. 
 
-## Project Structure
+Here's how an Astro project is organized, and the some files you will find in your new project.
 
-Astro leverages an opinionated folder layout for your project. Every Astro project include the following magic directories and files:
+## Directories and Files
+
+Astro leverages an opinionated folder layout for your project. Every Astro project root should include the following directories and files:
 
 - `src/*` - Your project source code (components, pages, styles, etc.)
 - `public/*` - Your non-code, unprocessed assets (fonts, icons, etc.)
 - `package.json` - A project manifest.
+- `astro.config.mjs` - An Astro configuration file. (optional)
 
-### Example
+### Example Project Tree
 
 A common project directory might look like this:
 
@@ -37,7 +40,9 @@ A common project directory might look like this:
 │   ├── robots.txt
 │   ├── favicon.svg
 │   └-─ social-image.png
+├── astro.config.mjs
 └── package.json
+
 ```
 
 ### `src/`
@@ -46,8 +51,8 @@ The src folder is where most of your project source code lives. This includes:
 
 - [Pages](/en/core-concepts/astro-pages)
 - [Layouts](/en/core-concepts/layouts)
-- [Astro Components](/en/core-concepts/astro-components)
-- [Frontend Components (React, etc.)](/en/core-concepts/component-hydration)
+- [Astro components](/en/core-concepts/astro-components)
+- [Frontend components (React, etc.)](/en/core-concepts/component-hydration)
 - [Styles (CSS, Sass)](/en/guides/styling)
 - [Markdown](/en/guides/markdown-content)
 
@@ -57,21 +62,21 @@ Some files (like Astro components) are not even sent to the browser as written, 
 
 ### `src/components`
 
-**Components** are reusable units of code for your HTML pages. These could be [Astro Components](/en/core-concepts/astro-components), or [Frontend Components](/en/core-concepts/component-hydration) like React or Vue.  It is common to group and organize all of your project components together in this folder.
+**Components** are reusable units of code for your HTML pages. These could be [Astro components](/en/core-concepts/astro-components), or [Frontend components](/en/core-concepts/component-hydration) like React or Vue.  It is common to group and organize all of your project components together in this folder.
 
 This is a common convention in Astro projects, but it is not required. Feel free to organize your components however you like!
 
 ### `src/layouts`
 
-[Layouts](/en/core-concepts/layouts) are special kind of component that wrap some content in a larger page layout. Most often, these are used by [Markdown Pages](/en/guides/markdown-content) to define the layout of the page. used to create larger page layouts. 
+[Layouts](/en/core-concepts/layouts) are special kind of component that wrap some content in a larger page layout. These are most often used by [Astro pages](/en/core-concepts/astro-pages) and [Markdown pages](/en/guides/markdown-content) to define the layout of the page.
 
-Just like `src/components`, this is a common convention but not required.
+Just like `src/components`, this directory is a common convention but not required.
 
 ### `src/pages`
 
-[Pages](/en/core-concepts/astro-pages) are special kind of component used to create new pages on your site. A page can be an Astro component, or a markdown file that represents some page of content for your site. 
+[Pages](/en/core-concepts/astro-pages) are special kind of component used to create new pages on your site. A page can be an Astro component, or a Markdown file that represents some page of content for your site. 
 
-`src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!
+> ⚠️  `src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!
 
 ### `src/styles`
 
@@ -83,10 +88,18 @@ The `public/` directory is for files and assets that do not need to be processed
 
 This behavior makes `public/` ideal for common assets like images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`. 
 
-You can place CSS and JavaScript in your `public/` directory, but be aware that those files will not be bundled or optimized in your final build. As a general rule, any CSS or JavaScript that you write yourself should live in your `src/` directory.
+You can place CSS and JavaScript in your `public/` directory, but be aware that those files will not be bundled or optimized in your final build. 
+
+ 💡 *As a general rule, any CSS or JavaScript that you write yourself should live in your `src/` directory.*
 
 ### `package.json`
 
 This is a file used by JavaScript package managers to manage your dependencies. It also defines the scripts that are commonly used to run Astro (ex: `npm start`, `npm run build`).
 
 For help creating a new `package.json` file for your project, check out the [manual setup](/en/guides/manual-setup-new) instructions.
+
+### `astro.config.mjs`
+
+This file is generated in every starter template and includes configuration options for your Astro project. Here you can specify renderers to use, devOptions, buildOptions, and more. 
+
+See the [Configuration Reference](https://docs.astro.build/en/reference/configuration-reference/#article) for details on setting configurations.

--- a/src/pages/en/guides/manual-setup-new.md
+++ b/src/pages/en/guides/manual-setup-new.md
@@ -3,8 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: Manual Setup
 description: How to install and set up Astro manually
 ---
+If you do not wish to use a [starter template](https://github.com/withastro/astro/tree/main/examples), you can install Astro dependencies manually and create a new project with a `package.json` file and an Astro `index` page.
 
-> TODO(sarah): INTRO - what is this guide for? who is it for?
 ## 1. Create your directory
 
 Create an empty directory with the name of your project, and then navigate into it.
@@ -23,13 +23,13 @@ npm init --yes
 
 ## 2. Install Astro
 
-3. Install the Astro project dependencies inside your project.
+First, install the Astro project dependencies inside your project.
 
 ```bash
 npm install astro
 ```
 
-1. Replace any placeholder "scripts" section of your `package.json` with the following:
+Then, replace any placeholder "scripts" section of your `package.json` with the following:
 
 ```diff
   "scripts": \{
@@ -73,7 +73,7 @@ You will also want to create a `public/` directory to store your static assets. 
 
 In your text editor, create a new file in your directory at `public/robots.txt`. `robots.txt` is a simple file that most sites will include to tell search bots like Google how to treat your site.
 
-For this guide, copy-and-paste the following code snippet (including `---` dashes) into your new file:
+For this guide, copy-and-paste the following code snippet into your new file:
 
 ```
 # Example: Allow all bots to scan and index your site. 
@@ -99,4 +99,4 @@ If you have followed the steps above, your project directory should now look lik
 
 Congratulations, you're now set up to use Astro!
 
-If you'd like to continue a guided tour of Astro, read our main [Installation guide](/en/installation-new#3-start-). If you followed this guide completely, you can jump directly to [Step 3: Start](/en/installation-new#3-start-) to continue and learn how to run Astro for the first time.
+If you followed this guide completely, you can jump directly to [Step 3: Start](/en/installation-new#3-start-) to continue and learn how to run Astro for the first time.

--- a/src/pages/en/installation-new.md
+++ b/src/pages/en/installation-new.md
@@ -3,6 +3,9 @@ layout: ~/layouts/MainLayout.astro
 title: Installation
 description: How to install Astro with NPM, PNPM, or Yarn.
 ---
+Use npm, pnpm or yarn to create and set up a new Astro project locally!
+
+
 ## Prerequisites
 
 - **Node.js** - `14.15.0`, `v16.0.0`, or higher.
@@ -11,7 +14,7 @@ description: How to install Astro with NPM, PNPM, or Yarn.
 
 ## 1. Install Astro
 
-Run one of the following commands in your terminal to start our handy install wizard, `create-astro`. `create-astro` will walk you through creating your very first Astro project in whatever directory you run it in.
+Run one of the following commands in your terminal to start our handy install wizard, `create-astro`. This will walk you through creating your very first Astro project in whatever directory you run it in.
 
 ```shell
 # npm
@@ -27,16 +30,28 @@ pnpm create astro
 > ⚔️ Prefer to go it alone? Read our [manual setup](/en/guides/manual-setup-new) instructions instead.
 
 
-If `create-astro` starts successfully, you will see a list of [starter templates](https://github.com/withastro/astro/tree/main/examples) to choose from: 
+If `create-astro` starts successfully, you will see a short list of starter templates to choose from: 
 - `starter`: A great starter template for anyone wanting to explore Astro.
 - `minimal`: A template that just includes the bare minimium to get started.
 - `blog, portfolio, docs, etc`: opinionated themes for specific use-cases.
 
 If you choose the `starter` template, you will also be asked to select which [additional frameworks](/en/core-concepts/component-hydration) (React, Svelte, Vue, Solid, Preact), if any, you would like to include in your project. (Additional frameworks can also be added manually later.)
 
+> 💡 Or, you can install any of our [many starter templates](https://github.com/withastro/astro/tree/main/examples) directly via the command line: 
+>```shell
+># npm
+>npm init astro -- --template framework-svelte
+>
+># yarn
+>yarn create astro -- --template with-nanostores
+>
+># pnpm
+>pnpm create astro -- --template with-tailwindcss
+>```
+
 ## 2. Setup your project
 
-When the `create-astro` install wizard is complete, you should see some instructions on your screen on how to start your new project. The most important step is to install your project's dependencies using a package manager like npm:
+When the `create-astro` install wizard is complete, you should see some instructions on your screen to follow that will start your new project. The most important step is to install your project's dependencies using a package manager like npm:
 
 ```bash
 # npm
@@ -68,7 +83,9 @@ yarn start
 pnpm run start
 ```
 
-If all goes well, Astro should now be serving your project on [http://localhost:3000](http://localhost:3000)! Astro will listen for live file changes in your `src/` directory, so you will not need to restart the server as you make changes during development.
+If all goes well, Astro should now be serving your project on [http://localhost:3000](http://localhost:3000)! 
+
+Astro will listen for live file changes in your `src/` directory, so you will not need to restart the server as you make changes during development.
 
 If you aren't able to open your project in the browser, go back to the terminal where you ran the `start` command to see what went wrong.
 

--- a/src/pages/en/installation-new.md
+++ b/src/pages/en/installation-new.md
@@ -38,16 +38,16 @@ If `create-astro` starts successfully, you will see a short list of starter temp
 If you choose the `starter` template, you will also be asked to select which [additional frameworks](/en/core-concepts/component-hydration) (React, Svelte, Vue, Solid, Preact), if any, you would like to include in your project. (Additional frameworks can also be added manually later.)
 
 > 💡 Or, you can install any of our [many starter templates](https://github.com/withastro/astro/tree/main/examples) directly via the command line: 
->```shell
-># npm
->npm init astro -- --template framework-svelte
->
-># yarn
->yarn create astro -- --template with-nanostores
->
-># pnpm
->pnpm create astro -- --template with-tailwindcss
->```
+```shell
+# npm
+npm init astro -- --template framework-svelte
+
+# yarn
+yarn create astro -- --template with-nanostores
+
+# pnpm
+pnpm create astro -- --template with-tailwindcss
+```
 
 ## 2. Setup your project
 


### PR DESCRIPTION
@FredKSchott - here are my proposed edits to your edits!  For your consideration. :)

Once we are happy with these files:
- CORE CONCEPTS: The following -new pages can be renamed and replace the existing pages, no changes to sidebar (yet):
-- Project Structure
-- Components
-- Pages
-- Layouts
(No changes yet to ...)
-- (Routing: we discussed moving "Routing" out of Core Concepts)
-- (Partial Hydration: to be discussed separately)

- SETUP Section updates:
-- Installation can be replaced with installation-new (renamed to remove -new)
-- manual-setup-new can be added to the sidebar (rename the file to remove -new and make sure Installation links to it properly)
-- Quick Start can be deleted and removed from the sidebar

 