### PR TITLE
Add quick note about Astro.resolve

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -64,6 +64,8 @@ const data = Astro.fetchContent('../pages/post/*.md'); // returns an array of po
 
 ### `Astro.resolve()`
 
+> ⚠️ This feature is in the process of being **deprecated**. Please review the [migration guide](/en/migrate#deprecated-astroresolve) to upgrade your asset references to a future-proof option.
+
 `Astro.resolve()` helps with creating URLs relative to the current Astro file, allowing you to reference files within your `src/` folder.
 
 Astro _does not_ resolve relative links within HTML, such as images:


### PR DESCRIPTION
Added a small/temporary note in the API reference page with a link to the `Astro.resolve()` anchor tag in the migration guide.