### PR TITLE
Update the manual-setup.md instructions

### DIFF
--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -85,7 +85,9 @@ Allow: /
 
 ## 5. Create astro.config.mjs
 
-Astro is configured using astro.config.mjs at the root of the project. This file is optional if you do not need to configure Astro, but you may wish to create it now. If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
+Astro is configured using `astro.config.mjs` at the root of the project. This file is optional if you do not need to configure Astro, but you may wish to create it now. 
+
+If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
 
 ```
 // Full Astro Configuration API Documentation:

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -41,6 +41,7 @@ Then, replace any placeholder "scripts" section of your `package.json` with the 
 ```
 
 You'll use these scripts later in the guide to start Astro and run its different commands.
+
 ## 3. Create your first page
 
 In your text editor, create a new file in your directory at `src/pages/index.astro`. This will be your first Astro page in the project. 
@@ -84,7 +85,7 @@ Allow: /
 
 ## 5. Add a basic astro.config.mjs file into the project root
 
-Astro expects at least a minimal configuration file with the following minimal configuration content:
+Astro is configured using astro.config.mjs at the root of the project. This file is optional if you do not need to configure Astro, but you may wish to create it now. If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
 
 ```
 // Full Astro Configuration API Documentation:
@@ -102,14 +103,15 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 If you have followed the steps above, your project directory should now look like this:
 
 ```
-- src/
-  - pages/
-    - index.astro
-- public/
-  - robots.txt
-- package.json
-- package-lock.json (or: yarn.lock, pnpm-lock.yaml, etc.)
-- node_modules/
+├── node_modules/
+├── src/
+│   └── pages/
+│   │   └── index.astro
+├── public/
+│   ├── robots.txt
+├── astro.config.mjs
+├── package.json
+└── package-lock.json (or: yarn.lock, pnpm-lock.yaml, etc.)
 ```
 
 Congratulations, you're now set up to use Astro!

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -85,9 +85,7 @@ Allow: /
 
 ## 5. Create astro.config.mjs
 
-Astro is configured using `astro.config.mjs` at the root of the project. This file is optional if you do not need to configure Astro, but you may wish to create it now. 
-
-If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
+Astro is configured using `astro.config.mjs`. This file is optional if you do not need to configure Astro, but you may wish to create it now. Create this file at the root of your project, and copy the code below into it:
 
 ```
 // Full Astro Configuration API Documentation:
@@ -95,10 +93,14 @@ If you want to include framework components such as React, Svelte, etc. in your 
 
 // @ts-check
 export default /** @type {import('astro').AstroUserConfig} */ ({
-	// Comment out "renderers: []" to enable Astro's default component support.
-	renderers: [],
+// Comment out "renderers: []" to enable Astro's default component support.
+renderers: [],
 });
 ```
+
+If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
+
+📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/)
 
 ## 6. Next steps
 

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -82,7 +82,22 @@ User-agent: *
 Allow: /
 ```
 
-## 5. Next steps
+## 5. Add a basic astro.config.mjs file into the project root
+
+Astro expects at least a minimal configuration file with the following minimal configuration content:
+
+```
+// Full Astro Configuration API Documentation:
+// https://docs.astro.build/reference/configuration-reference
+
+// @ts-check
+export default /** @type {import('astro').AstroUserConfig} */ ({
+	// Comment out "renderers: []" to enable Astro's default component support.
+	renderers: [],
+});
+```
+
+## 6. Next steps
 
 If you have followed the steps above, your project directory should now look like this:
 

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -83,7 +83,7 @@ User-agent: *
 Allow: /
 ```
 
-## 5. Add a basic astro.config.mjs file into the project root
+## 5. Create astro.config.mjs
 
 Astro is configured using astro.config.mjs at the root of the project. This file is optional if you do not need to configure Astro, but you may wish to create it now. If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
 

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -85,7 +85,9 @@ Allow: /
 
 ## 5. Create astro.config.mjs
 
-Astro is configured using `astro.config.mjs`. This file is optional if you do not need to configure Astro, but you may wish to create it now. Create this file at the root of your project, and copy the code below into it:
+Astro is configured using `astro.config.mjs`. This file is optional if you do not need to configure Astro, but you may wish to create it now. 
+
+Create `astro.config.mjs` at the root of your project, and copy the code below into it:
 
 ```
 // Full Astro Configuration API Documentation:
@@ -100,7 +102,7 @@ renderers: [],
 
 If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
 
-📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/)
+📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 
 ## 6. Next steps
 


### PR DESCRIPTION
Add a simple astro configuration file to the instructions to resolve development errors that show up without including this file.