### PR TITLE
Updates tailwind docs for 0.24

### DIFF
--- a/src/pages/de/guides/styling.md
+++ b/src/pages/de/guides/styling.md
@@ -240,11 +240,9 @@ Damit bist du ausgerüstet, um Tailwind einzusetzen! Der von uns empfohlene Ansa
 Füge die Datei deiner Astro-Seite (oder deiner Layout-Komponente) hinzu:
 
 ```astro
-<head>
-  <style global>
-			@import "../styles/global.css";
-	</style>
-</head>
+---
+import '../styles/global.css';
+---
 ```
 
 Alternativ zu einer Datei `src/styles/global.css` kannst du Tailwind-Utilities auch in einzelnen `pages/*.astro`-Komponenten in einem `<style>`-Block hinzufügen. Aber vermeide sorgfältig etwaige Dopplungen! Falls du mehrere von Tailwind verwaltete Stylesheets verwendest, stelle sicher, dass du nicht die selben CSS-Styles mehrfach in verschiedenen CSS-Dateien an die Benutzerinnen und Benutzer schickst.

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -261,11 +261,9 @@ Now you're ready to write Tailwind! Our recommended approach is to create a `src
 Lastly, add it to your Astro page (or layout template):
 
 ```astro
-<head>
-  <style global>
-    @import "../styles/global.css";
-  </style>
-</head>
+---
+import '../styles/global.css';
+---
 ```
 
 As an alternative to `src/styles/global.css`, You may also add Tailwind utilities to individual `pages/*.astro` components in `<style>` tags, but be mindful of duplication! If you end up creating multiple Tailwind-managed stylesheets for your site, make sure you're not sending the same CSS to users over and over again in separate CSS files.


### PR DESCRIPTION
ESM imports are the best approach for tailwind style imports to make sure HMR updates are picked up properly

Note: this only works properly with static build, that will be the default in 0.24+ so its probably best to hold on merging this docs update in until 0.24 is released

[Released PR](https://github.com/withastro/astro/pull/2740) updating the `with-tailwindcss` example project as well