### PR TITLE
New draft of Markdown Guide

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -3,19 +3,25 @@ layout: ~/layouts/MainLayout.astro
 title: Markdown
 description: Building Pages in Markdown
 ---
-Markdown content is commonly used for text-heavy pages like blog posts and documentation. Astro has built-in support for writing in Markdown.
+Markdown content is commonly used for text-heavy pages like blog posts and documentation. Astro has built-in support for writing in Markdown, and even allows you to also use frontmatter-defined variables and imported components.
 
 ## Markdown Pages
 
-Astro treats any `.md` file inside of the `/src/pages` directory as a page. Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file.
+Astro treats any `.md` file inside of the `/src/pages` directory as a page. Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file. 
+
+📚 Read more about Astro's [file-based routing](/en/core-concepts/routing).
 
 ### Layouts
 
-Markdown pages have a special front matter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other page template elements. 
+Markdown pages have a special frontmatter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements. 
 
 > 🛎️ Markdown pages are children for layout components. The Markdown content is placed into the layout component's `<slot />` element, and is rendered as HTML.
 
-All other front matter properties defined in your `.md` page can be passed to the layout component as properties of the `content` object prop.
+📚 Read more about [slots](/en/guides/slots).
+
+### The `Content` Prop
+
+All other frontmatter properties defined in your `.md` page will be passed to the layout as properties of the `content` object prop.
 
 
 ```markdown
@@ -44,8 +50,8 @@ const { content } = Astro.props;
   </body>
 </html>
 ```
-### The content prop
-For Markdown files, the `content` prop also has an `astro` property which holds special metadata about the page such as the complete Markdown `source` and a `headers` object. 
+
+The `content` prop also contains an `astro` property with additional metadata about the page such as the complete Markdown `source` and a `headers` object.
 
 An example blog post `content` object might look like:
 
@@ -78,11 +84,11 @@ An example blog post `content` object might look like:
 }
 ```
 
-> 💡 `astro` and `url` are the only guaranteed properties provided by Astro in the `content` prop. The rest of the object is defined by your front matter variables.
+> 💡 `astro` and `url` are the only guaranteed properties provided by Astro in the `content` prop. The rest of the object is defined by your frontmatter variables.
 
 ### Variables 
 
-Front matter variables can be used directly in your Markdown as properties of the `frontmatter` object.
+frontmatter variables can be used directly in your Markdown as properties of the `frontmatter` object.
 
 ```markdown
 ---
@@ -98,7 +104,7 @@ age: 42
 
 ### Components
 
-You can import components into your Markdown file with `setup` and use them along with Markdown syntax. The `frontmatter` object is also available to any imported components.
+You can import components into your Markdown file with `setup` and use them alongside your Markdown content. The `frontmatter` object is also available to any imported components.
 
 ```markdown
 ---
@@ -120,9 +126,9 @@ author: Leon
 
 ### Draft Pages
 
-`draft: true` is an optional front matter value that will mark an individual `.md` page or post as "unpublished." By default, this page will be excluded from the site build.
+`draft: true` is an optional frontmatter value that will mark an individual `.md` page or post as "unpublished." By default, this page will be excluded from the site build.
 
-Markdown pages with `draft: false` or without the `draft` property are unaffected and will be built.
+Markdown pages without the `draft` property or those with `draft: false` are unaffected and will be included in the final build.
 
 ```markdown
 src/pages/post/blog-post.md
@@ -137,7 +143,7 @@ This is my in-progress blog post.
 No page will be built for this post.
 
 To build and publish this post:
-- update the front matter to `draft: false` or
+- update the frontmatter to `draft: false` or
 - remove the `draft` property entirely.
 ```
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -52,11 +52,11 @@ const { content } = Astro.props;
 ---
 <html>
   <head>
-  <!-- Add other Head elements here, like styles and meta tags. -->
+    <!-- Add other Head elements here, like styles and meta tags. -->
     <title>{content.title}</title>
   </head>
   <body> 
-  <!-- Add other UI components here, like common headers and footers. -->
+    <!-- Add other UI components here, like common headers and footers. -->
     <h1>{content.title} by {content.author}</h1>
     <!-- 2. Rendered HTML will be passed into the default slot. -->
     <slot />

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -47,7 +47,7 @@ For a layout to work with a Markdown page:
 ```astro
 ---
 // src/layouts/BaseLayout.astro
-// 1. The content prop is defined and gives access to frontmatter data
+// 1. The content prop gives access to frontmatter data
 const { content } = Astro.props;
 ---
 <html>

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -39,26 +39,28 @@ layout: ../layouts/BaseLayout.astro
 ---
 ```
 
-For a layout to work with a Markdown page, it must follow a few rules:
-1. Frontmatter data will be passed as the `content` prop.
-2. Rendered HTML will be passed into the layout's default [`<slot />`](/en/guides/slots).
+For a layout to work with a Markdown page:
+1. The page's frontmatter data must be defined as the `content` prop.
+2. The layout must have a default [`<slot />`](/en/guides/slots) for the Markdown content.
 
 
 ```astro
 ---
 // src/layouts/BaseLayout.astro
+// 1. The content prop is defined and gives access to frontmatter data
 const { content } = Astro.props;
 ---
 <html>
   <head>
-    <!-- 1. Frontmatter data passed as the `content` prop. -->
-    <!-- Add other Head elements here, like styles and meta tags. -->
+  <!-- Add other Head elements here, like styles and meta tags. -->
     <title>{content.title}</title>
   </head>
-  <body>
+  <body> 
+  <!-- Add other UI components here, like common headers and footers. -->
+    <h1>{content.title} by {content.author}</h1>
     <!-- 2. Rendered HTML passed into the default slot. -->
-    <!-- Add other UI components here, like common headers and footers. -->
     <slot />
+    <p>Written on: {content.date}</p>
   </body>
 </html>
 ```

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -112,7 +112,7 @@ author: Leon
 
 <Author name={frontmatter.author}/>
 
-<Biography client:visible >
+<Biography client:visible>
 {frontmatter.author} lives in Toronto, Canada and enjoys photography.
 </Biography>
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -1,51 +1,63 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Markdown
-description: Building Pages in Markdown
+description: Using Markdown with Astro
 ---
-Markdown content is commonly used for text-heavy pages like blog posts and documentation. Astro has built-in support for writing in Markdown, and even allows you to also use frontmatter-defined variables and imported components.
+Markdown content is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for Markdown with some added features like support for JavaScript expressions and Astro components right in your Markdown.
 
 ## Markdown Pages
 
 Astro treats any `.md` file inside of the `/src/pages` directory as a page. Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file. 
 
 📚 Read more about Astro's [file-based routing](/en/core-concepts/routing).
+### Basic Example
 
-### Layouts
+The easiest way to start using Markdown in Astro is to create a `src/pages/index.md` homepage route in your project. Copy the basic template below into your project, and then view the rendered HTML at the homepage route of your project. Usually, this is at [http://localhost:3000](http://localhost:3000/).
 
-Markdown pages have a special frontmatter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements. 
-
-> 🛎️ Markdown pages are children for layout components. The Markdown content is placed into the layout component's `<slot />` element, and is rendered as HTML.
-
-📚 Read more about [slots](/en/guides/slots).
-
-### The `Content` Prop
-
-All other frontmatter properties defined in your `.md` page will be passed to the layout as properties of the `content` object prop.
 
 
 ```markdown
 ---
-layout: ../layouts/BaseLayout.astro
-title: My cool page
-description: My first Astro Markdown page
+# Example: src/pages/index.md
+title: Hello, World
 ---
-# Hello World!
+# Hi there!
 
-This is my markdown page.
+This is your first markdown page. It probably isn't styled much, although
+Markdown does support **bold** and *italics.* 
+
+To learn more about adding a layout to your page, read the next section on **Markdown Layouts.**
 ```
 
-```astro
-// src/layouts/BaseLayout.astro
+### Markdown Layouts
+
+Markdown pages have a special frontmatter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements. 
+
+```markdown
 ---
+layout: ../layouts/BaseLayout.astro
+---
+```
+
+For a layout to work with a Markdown page, it must follow a few rules:
+1. Frontmatter data will be passed as the `content` prop.
+2. Rendered HTML will be passed into the layout's default [`<slot />`](/en/guides/slots).
+
+
+```astro
+---
+// src/layouts/BaseLayout.astro
 const { content } = Astro.props;
 ---
 <html>
   <head>
+    <!-- 1. Frontmatter data passed as the `content` prop. -->
+    <!-- Add other Head elements here, like styles and meta tags. -->
     <title>{content.title}</title>
   </head>
-
   <body>
+    <!-- 2. Rendered HTML passed into the default slot. -->
+    <!-- Add other UI components here, like common headers and footers. -->
     <slot />
   </body>
 </html>
@@ -86,45 +98,7 @@ An example blog post `content` object might look like:
 
 > 💡 `astro` and `url` are the only guaranteed properties provided by Astro in the `content` prop. The rest of the object is defined by your frontmatter variables.
 
-### Variables 
-
-frontmatter variables can be used directly in your Markdown as properties of the `frontmatter` object.
-
-```markdown
----
-layout: ../layouts/BaseLayout.astro
-author: Leon
-age: 42
----
-# About the Author
-
-{frontmatter.author} is {frontmatter.age} and lives in Toronto, Canada.
-
-```
-
-### Components
-
-You can import components into your Markdown file with `setup` and use them alongside your Markdown content. The `frontmatter` object is also available to any imported components.
-
-```markdown
----
-layout: ../layouts/BaseLayout.astro
-setup: | 
-  import Author from '../../components/Author.astro'
-  import Biography from '../components/Biography.jsx'
-author: Leon
----
-# About the Author
-
-<Author name={frontmatter.author}/>
-
-<Biography client:visible>
-{frontmatter.author} lives in Toronto, Canada and enjoys photography.
-</Biography>
-
-```
-
-### Draft Pages
+### Markdown Drafts
 
 `draft: true` is an optional frontmatter value that will mark an individual `.md` page or post as "unpublished." By default, this page will be excluded from the site build.
 
@@ -171,6 +145,52 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 
  💡 You can also pass the `--drafts` flag when running `astro build` to build draft pages! 
 
+## Authoring Markdown
+
+In addition to supporting standard Markdown syntax, Astro also extends Markdown to make your content even more expressive. Below are some Markdown features that only exist in Astro.
+### Using Variables in Markdown
+
+frontmatter variables can be used directly in your Markdown as properties of the `frontmatter` object.
+
+```markdown
+---
+author: Leon
+age: 42
+---
+# About the Author
+
+{frontmatter.author} is {frontmatter.age} and lives in Toronto, Canada.
+```
+
+### Using Components in Markdown
+
+You can import components into your Markdown file with `setup` and use them alongside your Markdown content. The `frontmatter` object is also available to any imported components.
+
+```markdown
+---
+layout: ../layouts/BaseLayout.astro
+setup: | 
+  import Author from '../../components/Author.astro'
+  import Biography from '../components/Biography.jsx'
+author: Leon
+---
+<Author name={frontmatter.author}/>
+<Biography client:visible>
+  {frontmatter.author} lives in Toronto, Canada and enjoys photography.
+</Biography>
+```
+
+<!-- 
+
+## Importing Markdown
+
+https://github.com/withastro/rfcs/pull/147
+
+TODO: This RFC will change how we import markdown, if accepted.
+Therefore, I'd recommend not writing this section now and coming
+back to it later.
+
+-->
 
 ## Markdown Component
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -58,7 +58,7 @@ const { content } = Astro.props;
   <body> 
   <!-- Add other UI components here, like common headers and footers. -->
     <h1>{content.title} by {content.author}</h1>
-    <!-- 2. Rendered HTML passed into the default slot. -->
+    <!-- 2. Rendered HTML will be passed into the default slot. -->
     <slot />
     <p>Written on: {content.date}</p>
   </body>

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -31,7 +31,7 @@ To learn more about adding a layout to your page, read the next section on **Mar
 
 ### Markdown Layouts
 
-Markdown pages have a special frontmatter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements. 
+Markdown pages have a special frontmatter property for `layout` that defines the relative path to an Astro [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements. 
 
 ```markdown
 ---

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -39,9 +39,10 @@ layout: ../layouts/BaseLayout.astro
 ---
 ```
 
-For a layout to work with a Markdown page:
-1. The page's frontmatter data must be defined as the `content` prop.
-2. The layout must have a default [`<slot />`](/en/guides/slots) for the Markdown content.
+A typical layout for Markdown pages includes:
+
+1. the content prop to access the Markdown page's frontmatter data.
+2. a default [`<slot />`](https://github.com/en/guides/slots) to indicate where the page's Markdown content should be rendered.
 
 
 ```astro

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -1,139 +1,37 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Markdown
-description: An intro to Markdown with Astro.
+description: Building Pages in Markdown
 ---
-
-Astro comes with out-of-the-box Markdown support powered by the expansive [remark](https://remark.js.org/) ecosystem.
-
-## Parsers
-
-Astro lets you use any Markdown parser you want. It just needs to be a function that follows the `MarkdownParser` type declared inside [this file](https://github.com/withastro/astro/blob/main/packages/astro/src/@types/astro.ts). You can declare it inside `astro.config.mjs`:
-
-```js
-// astro.config.mjs
-export default {
-  markdownOptions: {
-    render: [
-      'parser-name', // or import('parser-name') or (contents) => {...}
-      {
-        // options
-      },
-    ],
-  },
-};
-```
-
-Astro comes with the `@astrojs/markdown-remark` package - the default parser.
-
-### Remark and Rehype Plugins
-
-In addition to custom components inside the [`<Markdown>` component](/en/guides/markdown-content#astros-markdown-component), the default parser comes with these plugins pre-enabled:
-
-- [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm)
-- [remark-smartypants](https://github.com/silvenon/remark-smartypants)
-- [rehype-slug](https://github.com/rehypejs/rehype-slug)
-
-Also, Astro supports third-party plugins for Markdown. You can provide your plugins in `astro.config.mjs`.
-
-> **Note:** Enabling custom `remarkPlugins` or `rehypePlugins` removes Astro’s built-in support for the plugins previously mentioned. You must explicitly add these plugins to your `astro.config.mjs` file, if desired.
-
-### Add a Markdown plugin in Astro
-
-If you want to add a plugin, you need to install the npm package dependency in your project and then update `remarkPlugins` or `rehypePlugins` inside the `@astrojs/markdown-remark` options depending on what plugin you want to have:
-
-```js
-// astro.config.mjs
-export default {
-  markdownOptions: {
-    render: [
-      '@astrojs/markdown-remark',
-      {
-        remarkPlugins: [
-          // Add a Remark plugin that you want to enable for your project.
-          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
-          // ['remark-autolink-headings', { behavior: 'prepend'}],
-        ],
-        rehypePlugins: [
-          // Add a Rehype plugin that you want to enable for your project.
-          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
-          // 'rehype-slug',
-          // ['rehype-autolink-headings', { behavior: 'prepend'}],
-        ],
-      },
-    ],
-  },
-};
-```
-
-You can provide names of the plugins as well as import them:
-
-```js
-import autolinkHeadings from 'remark-autolink-headings';
-
-// astro.config.mjs
-export default {
-  markdownOptions: {
-    render: [
-      '@astrojs/markdown-remark',
-      {
-        remarkPlugins: [[autolinkHeadings, { behavior: 'prepend' }]],
-      },
-    ],
-  },
-};
-```
-
-### Syntax Highlighting
-
-Astro comes with built-in support for [Prism](https://prismjs.com/) and [Shiki](https://shiki.matsu.io/). By default, Prism is enabled. You can modify this behavior by updating the `@astrojs/markdown-remark` options:
-
-```js
-// astro.config.mjs
-export default {
-  markdownOptions: {
-    render: [
-      '@astrojs/markdown-remark',
-      {
-        // Pick a syntax highlighter. Can be 'prism' (default), 'shiki' or false to disable any highlighting.
-        syntaxHighlight: 'prism',
-        // If you are using shiki, here you can define a global theme and
-        // add custom languages.
-        shikiConfig: {
-          theme: 'github-dark',
-          langs: [],
-          wrap: false,
-        },
-      },
-    ],
-  },
-};
-```
-
-You can read more about custom Shiki [themes](https://github.com/shikijs/shiki/blob/main/docs/themes.md#loading-theme) and [languages](https://github.com/shikijs/shiki/blob/main/docs/languages.md#supporting-your-own-languages-with-shiki).
+Markdown content is commonly used for text-heavy pages like blog posts and documentation. Astro has built-in support for writing in Markdown.
 
 ## Markdown Pages
 
-Astro treats any `.md` files inside of the `/src/pages` directory as pages. These files can contain frontmatter, but are otherwise processed as plain markdown files and do not support components. If you're looking to embed rich components in your markdown, take a look at the [Markdown Component](#astros-markdown-component) section.
+Astro treats any `.md` file inside of the `/src/pages` directory as a page. Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file.
 
 ### Layouts
 
-Markdown pages have a special frontmatter property for `layout`. This defines the relative path to an `.astro` component which should wrap your Markdown content, for example a [Layout](/en/core-concepts/layouts) component. All other frontmatter properties defined in your `.md` page will be exposed to the component as properties of the `content` prop. The rendered Markdown content is placed into the default `<slot />` element.
+Markdown pages have a special front matter property for `layout` that defines the relative path to an `.astro` [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other page template elements. 
+
+> 🛎️ Markdown pages are children for layout components. The Markdown content is placed into the layout component's `<slot />` element, and is rendered as HTML.
+
+All other front matter properties defined in your `.md` page can be passed to the layout component as properties of the `content` object prop.
+
 
 ```markdown
 ---
-# src/pages/index.md
 layout: ../layouts/BaseLayout.astro
 title: My cool page
-draft: false
+description: My first Astro Markdown page
 ---
-
 # Hello World!
+
+This is my markdown page.
 ```
 
 ```astro
----
 // src/layouts/BaseLayout.astro
+---
 const { content } = Astro.props;
 ---
 <html>
@@ -146,8 +44,10 @@ const { content } = Astro.props;
   </body>
 </html>
 ```
+### The content prop
+For Markdown files, the `content` prop also has an `astro` property which holds special metadata about the page such as the complete Markdown `source` and a `headers` object. 
 
-For Markdown files, the `content` prop also has an `astro` property which holds special metadata about the page such as the complete Markdown `source` and a `headers` object. An example of what a blog post `content` object might look like is as follows:
+An example blog post `content` object might look like:
 
 ```json
 {
@@ -178,113 +78,107 @@ For Markdown files, the `content` prop also has an `astro` property which holds 
 }
 ```
 
-> Keep in mind that the only guaranteed properties coming from the `content` prop are `astro` and `url`.
+> 💡 `astro` and `url` are the only guaranteed properties provided by Astro in the `content` prop. The rest of the object is defined by your front matter variables.
 
-### Images and videos
+### Variables 
 
-Using images or videos follows Astro’s normal import rules:
+Front matter variables can be used directly in your Markdown as properties of the `frontmatter` object.
 
-- Place them in the `public/` as explained on the [project-structure page](/en/core-concepts/project-structure/#public)
-  - Example: Image is located at `/public/assets/img/astonaut.png` → Markdown: `![Astronaut](/assets/img/astronaut.png)`
-- Or use `import` as explained on the [imports page](/en/guides/imports#other-assets) (when using Astro’s Markdown Component)
+```markdown
+---
+layout: ../layouts/BaseLayout.astro
+author: Leon
+age: 42
+---
+# About the Author
+
+{frontmatter.author} is {frontmatter.age} and lives in Toronto, Canada.
+
+```
 
 ### Components
 
-You can import components from any framework into your markdown file and use it along the markdown syntax. Front matter variables are available to your components from the `frontmatter` object.
+You can import components into your Markdown file with `setup` and use them along with Markdown syntax. The `frontmatter` object is also available to any imported components.
 
 ```markdown
 ---
 layout: ../layouts/BaseLayout.astro
 setup: | 
   import Author from '../../components/Author.astro'
-  import MyReactComponent from '../components/MyReactComponent.jsx'
+  import Biography from '../components/Biography.jsx'
 author: Leon
 ---
-# Hydrating on Visibility
-
-<MyReactComponent client:visible >
-# Hello world!
-</MyReactComponent>
+# About the Author
 
 <Author name={frontmatter.author}/>
+
+<Biography client:visible >
+{frontmatter.author} lives in Toronto, Canada and enjoys photography.
+</Biography>
+
 ```
 
+### Draft Pages
 
-### Markdown draft pages
+`draft: true` is an optional front matter value that will mark an individual `.md` page or post as "unpublished." By default, this page will be excluded from the site build.
 
-By default, Astro excludes `draft` Markdown pages when building your site. This is a built-in, Astro solution for marking individual pages or posts as "unpublished" and excluding them from the site build. No page will be created on your site for a Markdown page that includes `draft: true` in its front matter.
-
-To enable building of draft pages, you can set `buildOptions.drafts: true` in `astro.config.mjs`, or pass the `--drafts` flag when running `astro build`. Markdown pages which do not have the `draft` property set are not affected. 
-
-An example of a Markdown draft blog post:
+Markdown pages with `draft: false` or without the `draft` property are unaffected and will be built.
 
 ```markdown
+src/pages/post/blog-post.md
 ---
-# src/pages/blog-post.md
+layout: ../../layouts/BaseLayout.astro
 title: My Blog Post
 draft: true
 ---
 
-This is my blog post which is currently incomplete, and will not exist on my built site.
+This is my in-progress blog post.
+
+No page will be built for this post.
+
+To build and publish this post:
+- update the front matter to `draft: false` or
+- remove the `draft` property entirely.
 ```
 
-An example of a Markdown post which is not a draft:
 
-```markdown
----
-# src/pages/blog-post.md
-title: My Blog Post
-draft: false
----
+> ⚠️ Although `draft: true` will prevent a page from being built on your site at that page route, `Astro.fetchContent()` currently returns **all your Markdown files**. 
 
-This is my published blog post.
-```
+To exclude the data (e.g. title, link, description) from a draft post from being included in your post archive, or list of most recent posts, be sure that your `Astro.fetchContent()` function also **filters to exclude any draft posts**.
 
-> This feature only applies to local markdown pages, not the `<Markdown />` component, or remote markdown.
+⚙️ To enable building draft pages: 
+
+Add `drafts: true` to `buildOptions` in `astro.config.mjs` 
+
+```js
+//astro.config.mjs
+
+export default /** @type {import('astro').AstroUserConfig} */ ({
+  < ... >
+  buildOptions: {
+    site: 'https://example.com/',
+    drafts: true,
+  },
+
+});
+``` 
+
+ 💡 You can also pass the `--drafts` flag when running `astro build` to build draft pages! 
 
 
-⚠️ Although `draft: true` will prevent a page from being built on your site, `Astro.fetchContent()` currently returns **all your Markdown files**. So, any function to fetch your Markdown files and render a list of blog posts **will include the data from all existing files**, whether or not they are marked as `draft`. To exclude the post data (e.g. title, link, description) from showing up in your post archive, or list of most recent posts, be sure that your `Astro.fetchContent()` function also filters to exclude any draft posts.
+## Markdown Component
 
+Astro has a dedicated component used to let you render Markdown in `.astro` files. 
 
-## Astro’s Markdown Component
-
-Astro has a dedicated component used to let you render your markdown as HTML components. This is a special component that is only exposed to `.astro` files. To use the `<Markdown>` component, within your frontmatter block use the following import statement:
-
-```astro
----
-import { Markdown } from 'astro/components';
----
-```
-
-You can utilize this within your `.astro` file by doing the following:
-
-```astro
----
-import { Markdown } from 'astro/components';
----
-
-<Layout>
-  <Markdown>
-    # Hello world!
-
-    The contents inside here is all in markdown.
-  </Markdown>
-</Layout>
-```
-
-`<Markdown>` components provide more flexibility and allow you to use plain HTML or custom components. For example:
+You can import the [built-in Astro Markdown component](/en/reference/builtin-components#markdown) in your component script and then write any Markdown you want between `<Markdown> </Markdown>` tags.
 
 ````astro
 ---
-// For now, this import _must_ be named "Markdown" and _must not_ be wrapped with a custom component
-// We're working on easing these restrictions!
 import { Markdown } from 'astro/components';
-import Layout from '../layouts/main.astro';
-import MyFancyCodePreview from '../components/MyFancyCodePreview.tsx';
+import Layout from '../layouts/Layout.astro';
 
 const expressions = 'Lorem ipsum';
 ---
-
 <Layout>
   <Markdown>
     # Hello world!
@@ -305,19 +199,13 @@ const expressions = 'Lorem ipsum';
 
     - Rich component support like any `.astro` file!
     - Recursive Markdown support (Component children are also processed as Markdown)
-
-    <MyFancyCodePreview client:visible>
-      ```js
-      const object = { someOtherValue };
-      ```
-    </MyFancyCodePreview client:visible>
   </Markdown>
 </Layout>
 ````
 
-## Remote Markdown
+### Remote Markdown
 
-If you have Markdown in a remote source, you may pass it directly to the Markdown component through the `content` attribute. For example, the example below fetches the README from Snowpack’s GitHub repository and renders it as HTML.
+If you have Markdown in a remote source, you may pass it directly to the Markdown component through the `content` attribute.
 
 ```astro
 ---
@@ -325,13 +213,14 @@ import { Markdown } from 'astro/components';
 
 const content = await fetch('https://raw.githubusercontent.com/withastro/docs/main/README.md').then(res => res.text());
 ---
-
 <Layout>
   <Markdown content={content} />
 </Layout>
 ```
 
-There might be times when you want to combine both dynamic, and static markdown. If that is the case, you can nest `<Markdown>` components with each other to get the best of both worlds.
+### Nested Markdown
+
+`<Markdown>` components can be nested. 
 
 ```astro
 ---
@@ -344,19 +233,128 @@ const content = await fetch('https://raw.githubusercontent.com/withastro/docs/ma
   <Markdown>
     ## Markdown example
 
-    Here we have some __Markdown__ code. We can also dynamically render content from remote places.
+    Here we have some __Markdown__ code. We can also dynamically render remote content.
 
     <Markdown content={content} />
   </Markdown>
 </Layout>
 ```
 
-## Security FAQs
+⚠️ Use of the `Markdown` component to render remote Markdown can open you up to a [cross-site scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) attack. If you are rendering untrusted content, be sure to _sanitize your content **before** rendering it_.
 
-**Aren't there security concerns to rendering remote markdown directly to HTML?**
 
-Yes! Just like with regular HTML, improper use of the `Markdown` component can open you up to a [cross-site scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) attack. If you are rendering untrusted content, be sure to _sanitize your content **before** rendering it_.
+## Markdown Parsers
 
-**Why not use a prop like React’s `dangerouslySetInnerHTML={{ __html: content }}`?**
+Astro comes with Markdown support powered by [remark](https://remark.js.org/). 
 
-Rendering a string of HTML (or Markdown) is an extremely common use case when rendering a static site and you probably don't need the extra hoops to jump through. Rendering untrusted content is always dangerous! Be sure to _sanitize your content **before** rendering it_.
+The `@astrojs/markdown-remark` package is included by default with the following plugins pre-enabled:
+
+- [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm)
+- [remark-smartypants](https://github.com/silvenon/remark-smartypants)
+- [rehype-slug](https://github.com/rehypejs/rehype-slug)
+
+
+> ⚙️ You can include a custom Markdown parser inside `astro.config.mjs` by providing a function that follows the `MarkdownParser` type declared inside [this file](https://github.com/withastro/astro/blob/main/packages/astro/src/@types/astro.ts).
+
+```js
+// astro.config.mjs
+export default {
+  markdownOptions: {
+    render: [
+      'parser-name', // or import('parser-name') or (contents) => {...}
+      {
+        // options
+      },
+    ],
+  },
+};
+```
+
+### Remark and Rehype Plugins
+
+Astro supports third-party plugins for Markdown. You can provide your plugins in `astro.config.mjs`.
+
+> **Note:** Enabling custom `remarkPlugins` or `rehypePlugins` removes Astro’s built-in support for the plugins previously mentioned. You must explicitly add these plugins to your `astro.config.mjs` file, if desired.
+
+### Add a Markdown plugin in Astro
+
+1. Install the npm package dependency in your project.
+
+2. Update `remarkPlugins` or `rehypePlugins` inside the `@astrojs/markdown-remark` options:
+
+```js
+// astro.config.mjs
+export default {
+  markdownOptions: {
+    render: [
+      '@astrojs/markdown-remark',
+      {
+        remarkPlugins: [
+          // Add a Remark plugin that you want to enable for your project.
+          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
+          // ['remark-autolink-headings', { behavior: 'prepend'}],
+        ],
+        rehypePlugins: [
+          // Add a Rehype plugin that you want to enable for your project.
+          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
+          // 'rehype-slug',
+          // ['rehype-autolink-headings', { behavior: 'prepend'}],
+        ],
+      },
+    ],
+  },
+};
+```
+
+You can provide names of the plugins as well as import them:
+
+```js
+// astro.config.mjs
+import autolinkHeadings from 'remark-autolink-headings';
+
+export default {
+  markdownOptions: {
+    render: [
+      '@astrojs/markdown-remark',
+      {
+        remarkPlugins: [[autolinkHeadings, { behavior: 'prepend' }]],
+      },
+    ],
+  },
+};
+```
+
+### Syntax Highlighting
+
+Astro comes with built-in support for [Prism](https://prismjs.com/) and [Shiki](https://shiki.matsu.io/). 
+
+By default, Prism is enabled but no Prism stylesheet is included. (Choose from the available [Prism Themes](https://github.com/PrismJS/prism-themes) and see the [list of languages supported by Prism](https://prismjs.com/#supported-languages) for options and usage.)
+
+You can configure Astro to instead use Shiki or disable syntax highlighting entirely in the `@astrojs/markdown-remark` options:
+
+```js
+// astro.config.mjs
+export default {
+  markdownOptions: {
+    render: [
+      '@astrojs/markdown-remark',
+      {
+        // Pick a syntax highlighter. 
+        // Can be 'prism' (default), 'shiki' or false to disable any highlighting.
+        syntaxHighlight: 'prism',
+        // If you are using shiki, here you can define a global theme and
+        // add custom languages.
+        shikiConfig: {
+          theme: 'github-dark',
+          langs: [],
+          wrap: false,
+        },
+      },
+    ],
+  },
+};
+```
+
+You can read more about custom Shiki [themes](https://github.com/shikijs/shiki/blob/main/docs/themes.md#loading-theme) and [languages](https://github.com/shikijs/shiki/blob/main/docs/languages.md#supporting-your-own-languages-with-shiki).
+
+(See also the [`<Prism />` Astro component](/en/reference/builtin-components/#prism-) and the [`<Code />` Astro component](/en/reference/builtin-components/#code-) powered by Shiki.)


### PR DESCRIPTION
I've updated this (now includes components in markdown! yay!) and also reorganized to I think be more user-friendly.

Instead of starting with parsers/config, it starts with more immediate user-centric concerns like making a page/blog post (as users will be able to do even without touching any config), then makes its way into configuration options.

This is still a lot of content, and not sure whether we want this eventually trimmed to put some stuff more in reference. But I think this organization at least will be more immediately useful.