### PR TITLE
Make docs styling slightly fancier 💅

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -324,17 +324,14 @@ h2.heading {
 }
 
 .header-link:hover,
-.header-link:focus {
-	border-left-color: var(--theme-accent);
+.header-link:focus,
+.header-link:focus-within {
+	border-left-color: var(--theme-text-accent);
 }
 .header-link:hover a,
-.header-link:focus a {
-	color: var(--theme-accent);
+.header-link a:focus {
+	color: var(--theme-text-accent);
 	text-decoration: underline;
-}
-.header-link:focus-within {
-	color: var(--theme-text-light);
-	border-left-color: hsla(var(--color-gray-40), 1);
 }
 .header-link svg {
 	opacity: 0.6;

--- a/public/index.css
+++ b/public/index.css
@@ -236,7 +236,7 @@ table {
 
 /* Zebra striping */
 tbody tr:nth-of-type(odd) {
-	background: var(--theme-bg-hover);
+	background: var(--theme-divider);
 }
 th {
 	font-weight: bold;

--- a/public/index.css
+++ b/public/index.css
@@ -263,7 +263,6 @@ blockquote code:not([class*='language']) {
 @media (min-width: 37.75em) {
 	pre {
 		--padding-inline: 1.25rem;
-		border-radius: 2px;
 		border: var(--glow-border);
 		margin-left: 0;
 		margin-right: 0;

--- a/public/index.css
+++ b/public/index.css
@@ -269,6 +269,10 @@ blockquote code:not([class*='language']) {
 	}
 }
 
+pre:focus {
+	outline: 4px solid var(--theme-text-accent);
+}
+
 blockquote {
 	margin: 2rem 0;
 	padding: 1.25em 1.5rem;

--- a/public/index.css
+++ b/public/index.css
@@ -262,8 +262,12 @@ th {
 }
 
 pre {
+	--glow-border: 1px solid var(--theme-glow-highlight);
+	border-top: var(--glow-border);
+	border-bottom: var(--glow-border);
 	background-color: var(--theme-code-bg);
 	color: var(--theme-code-text);
+	box-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse), inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
 }
 
 blockquote code:not([class*='language']) {
@@ -273,7 +277,8 @@ blockquote code:not([class*='language']) {
 @media (min-width: 37.75em) {
 	pre {
 		--padding-inline: 1.25rem;
-		border-radius: 8px;
+		border-radius: 2px;
+		border: var(--glow-border);
 		margin-left: 0;
 		margin-right: 0;
 	}

--- a/public/index.css
+++ b/public/index.css
@@ -208,7 +208,7 @@ code:not([class*='language']) {
 	padding: var(--padding-block) var(--padding-inline);
 	margin: calc(var(--padding-block) * -1) -0.125em;
 	border-radius: var(--border-radius);
-	box-shadow: 0 2px 1px 0 rgba(0, 0, 0, 0.08);
+	box-shadow: 0 2px 1px 0 var(--theme-glow-diffuse);
 	word-break: break-word;
 }
 

--- a/public/index.css
+++ b/public/index.css
@@ -161,21 +161,7 @@ article > section iframe {
 a > code:not([class*='language']) {
 	position: relative;
 	color: var(--theme-text-accent);
-	background: transparent;
 	text-underline-offset: var(--padding-block);
-}
-
-a > code:not([class*='language'])::before {
-	content: '';
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	display: block;
-	background: var(--theme-accent);
-	opacity: var(--theme-accent-opacity);
-	border-radius: var(--border-radius);
 }
 
 a:hover,

--- a/public/theme.css
+++ b/public/theme.css
@@ -58,14 +58,14 @@
 	color-scheme: light;
 	--theme-accent: hsla(var(--color-orange), 1);
 	/* This is a darker, redder orange than the main accent for sufficient contrast. */
-	--theme-text-accent: hsla(12, 100%, 41%, 1);
+	--theme-text-accent: hsla(10, 100%, 35%, 1);
 	--theme-accent-opacity: 0.1;
 	--theme-divider: hsla(var(--color-gray-90), 1);
 	--theme-text: hsla(var(--color-gray-10), 1);
-	--theme-text-light: hsla(var(--color-gray-40), 1);
 	--theme-shade-subtle: hsla(var(--color-gray-80), 1);
 	--theme-bg-hover: hsla(var(--color-gray-95), 1);
 	--theme-bg-offset: hsla(var(--color-gray-90), 1);
+	--theme-text-light: hsla(var(--color-gray-30), 1);
 	--theme-bg: hsl(273, 37%, 93%);
 	--theme-bg-gradient-top: var(--theme-bg);
 	--theme-bg-gradient-bottom: #fdfeff;

--- a/public/theme.css
+++ b/public/theme.css
@@ -57,8 +57,7 @@
 :root {
 	color-scheme: light;
 	--theme-accent: hsla(var(--color-orange), 1);
-	/* This is a darker, redder orange than the main accent for sufficient contrast. */
-	--theme-text-accent: hsla(10, 100%, 35%, 1);
+	--theme-text-accent: hsla(302, 60%, 38%, 1);
 	--theme-accent-opacity: 0.1;
 	--theme-divider: hsla(var(--color-purple), 0.1);
 	--theme-shade-subtle: hsla(var(--color-purple), 0.3);
@@ -69,15 +68,15 @@
 	--theme-bg-gradient-bottom: #fdfeff;
 	--theme-bg-hover: hsla(var(--color-purple), var(--theme-accent-opacity));
 	--theme-bg-offset: hsla(var(--color-purple), 0.1);
-	--theme-bg-accent: hsla(var(--color-orange), var(--theme-accent-opacity));
+	--theme-bg-accent: hsla(var(--color-purple), var(--theme-accent-opacity));
 	--theme-code-inline-bg: hsla(var(--color-purple), 0.075);
 	--theme-code-inline-text: var(--theme-text);
 	--theme-code-bg: hsla(257, 31%, 22%, 1);
 	--theme-code-text: hsla(var(--color-gray-95), 1);
 	--theme-navbar-bg: var(--theme-bg);
 	--theme-navbar-height: 6rem;
-	--theme-selection-color: hsla(var(--color-orange), 1);
-	--theme-selection-bg: hsla(var(--color-orange), var(--theme-accent-opacity));
+	--theme-selection-color: hsla(var(--color-purple), 1);
+	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
 
 	--theme-bg-gradient: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
 
@@ -95,7 +94,7 @@ body {
 	color-scheme: dark;
 	--theme-accent-opacity: 0.4;
 	--theme-accent: hsla(var(--color-orange), 1);
-	--theme-text-accent: hsla(var(--color-orange), 1);
+	--theme-text-accent: hsla(290, 100%, 75%, 1);
 	--theme-divider: hsla(var(--color-gray-95), 0.1);
 	--theme-shade-subtle: hsla(var(--color-gray-95), 0.4);
 	--theme-text: hsla(var(--color-gray-90), 1);

--- a/public/theme.css
+++ b/public/theme.css
@@ -115,6 +115,7 @@ body {
 	--theme-glow-highlight: hsla(var(--color-base-purple), 50%, 1);
 
 	/* DocSearch [Algolia] */
+	--docsearch-primary-color: var(--theme-accent);
 	--docsearch-modal-background: var(--theme-bg-gradient-top);
 	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
 	--docsearch-footer-background: var(--theme-bg-gradient-bottom);

--- a/public/theme.css
+++ b/public/theme.css
@@ -17,7 +17,7 @@
 
 	--color-base-white: 0, 0%;
 	--color-base-black: 240, 100%;
-	--color-base-gray: 215, 14%;
+	--color-base-gray: 250, 14%;
 	--color-base-blue: 212, 100%;
 	--color-base-blue-dark: 212, 72%;
 	--color-base-green: 158, 79%;
@@ -60,17 +60,17 @@
 	/* This is a darker, redder orange than the main accent for sufficient contrast. */
 	--theme-text-accent: hsla(10, 100%, 35%, 1);
 	--theme-accent-opacity: 0.1;
-	--theme-divider: hsla(var(--color-gray-90), 1);
+	--theme-divider: hsla(var(--color-purple), 0.1);
+	--theme-shade-subtle: hsla(var(--color-purple), 0.3);
 	--theme-text: hsla(var(--color-gray-10), 1);
-	--theme-shade-subtle: hsla(var(--color-gray-80), 1);
-	--theme-bg-hover: hsla(var(--color-gray-95), 1);
-	--theme-bg-offset: hsla(var(--color-gray-90), 1);
 	--theme-text-light: hsla(var(--color-gray-30), 1);
 	--theme-bg: hsl(273, 37%, 93%);
 	--theme-bg-gradient-top: var(--theme-bg);
 	--theme-bg-gradient-bottom: #fdfeff;
+	--theme-bg-hover: hsla(var(--color-purple), var(--theme-accent-opacity));
+	--theme-bg-offset: hsla(var(--color-purple), 0.1);
 	--theme-bg-accent: hsla(var(--color-orange), var(--theme-accent-opacity));
-	--theme-code-inline-bg: hsla(var(--color-gray-95), 1);
+	--theme-code-inline-bg: hsla(var(--color-purple), 0.075);
 	--theme-code-inline-text: var(--theme-text);
 	--theme-code-bg: hsla(257, 31%, 22%, 1);
 	--theme-code-text: hsla(var(--color-gray-95), 1);

--- a/public/theme.css
+++ b/public/theme.css
@@ -114,15 +114,20 @@ body {
 	--theme-glow-highlight: hsla(var(--color-base-purple), 50%, 1);
 
 	/* DocSearch [Algolia] */
-	--docsearch-modal-background: var(--theme-bg);
-	--docsearch-searchbox-focus-background: var(--theme-divider);
-	--docsearch-footer-background: var(--theme-divider);
+	--docsearch-modal-background: var(--theme-bg-gradient-top);
+	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
+	--docsearch-footer-background: var(--theme-bg-gradient-bottom);
 	--docsearch-text-color: var(--theme-text);
-	--docsearch-hit-background: var(--theme-divider);
+	--docsearch-hit-background: var(--theme-bg-offset);
 	--docsearch-hit-shadow: none;
 	--docsearch-hit-color: var(--theme-text);
-	--docsearch-footer-shadow: inset 0 2px 10px #000;
-	--docsearch-modal-shadow: inset 0 0 8px #000;
+	--docsearch-footer-shadow: inset 0 -1px 0 var(--theme-glow-highlight), inset 1px 0px 0 var(--theme-glow-highlight), inset -1px 0px 0 var(--theme-glow-highlight),
+		inset 0 calc(-1 * var(--theme-glow-blur)) var(--theme-glow-blur) calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
+		inset calc(-1 * var(--theme-glow-blur)) 0 var(--theme-glow-blur) calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
+		inset var(--theme-glow-blur) 0 var(--theme-glow-blur) calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse);
+	--docsearch-modal-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse), inset 0 0 0 1px var(--theme-glow-highlight),
+		inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
+	--docsearch-container-background: hsla(var(--color-gray-10), 0.8);
 }
 
 ::selection {

--- a/public/theme.css
+++ b/public/theme.css
@@ -78,6 +78,10 @@
 	--theme-navbar-height: 6rem;
 	--theme-selection-color: hsla(var(--color-orange), 1);
 	--theme-selection-bg: hsla(var(--color-orange), var(--theme-accent-opacity));
+
+	--theme-glow-highlight: hsla(var(--color-base-purple), 100%, 1);
+	--theme-glow-diffuse: hsla(var(--color-base-purple), 65%, 0.5);
+	--theme-glow-blur: 15px;
 }
 
 body {
@@ -106,6 +110,8 @@ body {
 	--theme-navbar-bg: var(--theme-bg);
 	--theme-selection-color: hsla(var(--color-base-white), 100%, 1);
 	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
+
+	--theme-glow-highlight: hsla(var(--color-base-purple), 50%, 1);
 
 	/* DocSearch [Algolia] */
 	--docsearch-modal-background: var(--theme-bg);

--- a/public/theme.css
+++ b/public/theme.css
@@ -83,7 +83,7 @@
 
 	--theme-glow-highlight: hsla(var(--color-base-purple), 100%, 1);
 	--theme-glow-diffuse: hsla(var(--color-base-purple), 65%, 0.5);
-	--theme-glow-blur: 15px;
+	--theme-glow-blur: 10px;
 }
 
 body {

--- a/public/theme.css
+++ b/public/theme.css
@@ -63,8 +63,7 @@
 	--theme-divider: hsla(var(--color-gray-90), 1);
 	--theme-text: hsla(var(--color-gray-10), 1);
 	--theme-text-light: hsla(var(--color-gray-40), 1);
-	/* @@@: not used anywhere */
-	--theme-text-lighter: hsla(var(--color-gray-80), 1);
+	--theme-shade-subtle: hsla(var(--color-gray-80), 1);
 	--theme-bg: #fdfeff;
 	--theme-bg-hover: hsla(var(--color-gray-95), 1);
 	--theme-bg-offset: hsla(var(--color-gray-90), 1);
@@ -93,8 +92,7 @@ body {
 	--theme-text: hsla(var(--color-gray-90), 1);
 	--theme-text-light: hsla(var(--color-gray-80), 1);
 
-	/* @@@: not used anywhere */
-	--theme-text-lighter: hsla(var(--color-gray-40), 1);
+	--theme-shade-subtle: hsla(var(--color-gray-40), 1);
 	--theme-bg: hsla(215, 28%, 17%, 1);
 	--theme-bg-hover: hsla(var(--color-gray-40), 1);
 	--theme-bg-offset: hsla(var(--color-gray-5), 1);

--- a/public/theme.css
+++ b/public/theme.css
@@ -79,13 +79,15 @@
 	--theme-selection-color: hsla(var(--color-orange), 1);
 	--theme-selection-bg: hsla(var(--color-orange), var(--theme-accent-opacity));
 
+	--theme-bg-gradient: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
+
 	--theme-glow-highlight: hsla(var(--color-base-purple), 100%, 1);
 	--theme-glow-diffuse: hsla(var(--color-base-purple), 65%, 0.5);
 	--theme-glow-blur: 15px;
 }
 
 body {
-	background: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
+	background: var(--theme-bg-gradient);
 	color: var(--theme-text);
 }
 

--- a/public/theme.css
+++ b/public/theme.css
@@ -90,17 +90,16 @@ body {
 	--theme-accent-opacity: 0.4;
 	--theme-accent: hsla(var(--color-orange), 1);
 	--theme-text-accent: hsla(var(--color-orange), 1);
-	--theme-divider: #393f4a;
+	--theme-divider: hsla(var(--color-gray-95), 0.1);
+	--theme-shade-subtle: hsla(var(--color-gray-95), 0.4);
 	--theme-text: hsla(var(--color-gray-90), 1);
 	--theme-text-light: hsla(var(--color-gray-80), 1);
-
-	--theme-shade-subtle: hsla(var(--color-gray-40), 1);
-	--theme-bg-hover: hsla(var(--color-gray-40), 1);
 	--theme-bg: hsl(256, 44%, 15%);
 	--theme-bg-gradient-top: var(--theme-bg);
 	--theme-bg-gradient-bottom: hsl(252, 53%, 27%);
+	--theme-bg-hover: hsla(var(--color-purple), var(--theme-accent-opacity));
 	--theme-bg-offset: hsla(var(--color-gray-5), 1);
-	--theme-code-inline-bg: hsla(var(--color-gray-10), 1);
+	--theme-code-inline-bg: hsla(var(--color-gray-5), 1);
 	--theme-code-inline-text: var(--theme-text-light);
 	--theme-code-bg: hsla(var(--color-gray-5), 1);
 	--theme-code-text: hsla(var(--color-base-white), 100%, 1);

--- a/public/theme.css
+++ b/public/theme.css
@@ -64,22 +64,24 @@
 	--theme-text: hsla(var(--color-gray-10), 1);
 	--theme-text-light: hsla(var(--color-gray-40), 1);
 	--theme-shade-subtle: hsla(var(--color-gray-80), 1);
-	--theme-bg: #fdfeff;
 	--theme-bg-hover: hsla(var(--color-gray-95), 1);
 	--theme-bg-offset: hsla(var(--color-gray-90), 1);
+	--theme-bg: hsl(273, 37%, 93%);
+	--theme-bg-gradient-top: var(--theme-bg);
+	--theme-bg-gradient-bottom: #fdfeff;
 	--theme-bg-accent: hsla(var(--color-orange), var(--theme-accent-opacity));
 	--theme-code-inline-bg: hsla(var(--color-gray-95), 1);
 	--theme-code-inline-text: var(--theme-text);
 	--theme-code-bg: hsla(257, 31%, 22%, 1);
 	--theme-code-text: hsla(var(--color-gray-95), 1);
-	--theme-navbar-bg: #fdfeff;
+	--theme-navbar-bg: var(--theme-bg);
 	--theme-navbar-height: 6rem;
 	--theme-selection-color: hsla(var(--color-orange), 1);
 	--theme-selection-bg: hsla(var(--color-orange), var(--theme-accent-opacity));
 }
 
 body {
-	background: var(--theme-bg);
+	background: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
 	color: var(--theme-text);
 }
 
@@ -93,14 +95,16 @@ body {
 	--theme-text-light: hsla(var(--color-gray-80), 1);
 
 	--theme-shade-subtle: hsla(var(--color-gray-40), 1);
-	--theme-bg: hsla(215, 28%, 17%, 1);
 	--theme-bg-hover: hsla(var(--color-gray-40), 1);
+	--theme-bg: hsl(256, 44%, 15%);
+	--theme-bg-gradient-top: var(--theme-bg);
+	--theme-bg-gradient-bottom: hsl(252, 53%, 27%);
 	--theme-bg-offset: hsla(var(--color-gray-5), 1);
 	--theme-code-inline-bg: hsla(var(--color-gray-10), 1);
 	--theme-code-inline-text: var(--theme-text-light);
 	--theme-code-bg: hsla(var(--color-gray-5), 1);
 	--theme-code-text: hsla(var(--color-base-white), 100%, 1);
-	--theme-navbar-bg: hsla(215, 28%, 17%, 1);
+	--theme-navbar-bg: var(--theme-bg);
 	--theme-selection-color: hsla(var(--color-base-white), 100%, 1);
 	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
 

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -3,7 +3,7 @@ const { data, index } = Astro.props;
 const hasScreenshot = !!data.demo;
 const backgroundStyle = hasScreenshot
 	? `url('https://v1.screenshot.11ty.dev/${encodeURIComponent(data.demo)}/medium/9:16/')`
-	: `linear-gradient(60deg, var(--theme-bg-accent), var(--theme-accent))`;
+	: `linear-gradient(60deg, var(--theme-bg-accent), var(--theme-accent)) var(--theme-glow-diffuse)`;
 ---
 
 <article class={`card ${hasScreenshot ? 'has-screenshot' : ''}`} style={`background: ${backgroundStyle}; background-size: cover;`}>
@@ -28,11 +28,23 @@ const backgroundStyle = hasScreenshot
 		align-items: center;
 		padding: 1rem;
 		text-align: center;
+		/* Neon glow effect */
+		border-radius: 2px;
+		border: 1px solid var(--theme-glow-highlight);
+		box-shadow:
+		  0 0 var(--theme-glow-blur) var(--theme-glow-diffuse),
+			inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
 	}
 	.card-header {
+		display: block;
 		flex-grow: 1;
 		font-weight: bold;
 		font-size: 1.8rem;
+		text-decoration: none;
+		transition: transform 180ms ease-out;
+	}
+	.card-header:hover, .card-header:focus {
+		transform: translateY(-2px);
 	}
 	.background-dimmer {
 		position: absolute;
@@ -40,7 +52,7 @@ const backgroundStyle = hasScreenshot
 		left: 0;
 		height: 100%;
 		width: 100%;
-		background: linear-gradient(45deg, #0004, #000b);
+		background: linear-gradient(45deg, #0004, #000b) var(--theme-glow-diffuse);
 		z-index: 2;
 	}
 	.card-body,

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -1,7 +1,8 @@
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
-<meta name="theme-color" content="#ff5e00" />
+<meta name="theme-color" content="hsl(256, 44%, 15%)" media="(prefers-color-scheme: dark)" />
+<meta name="theme-color" content="hsl(273, 37%, 93%)" media="(prefers-color-scheme: light)" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="sitemap" href="/sitemap.xml" />

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -146,12 +146,6 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		}
 	}
 
-	/** Style Algolia */
-	:root {
-		--docsearch-primary-color: var(--theme-accent);
-		--docsearch-logo-color: var(--theme-text);
-	}
-
 	.search-item {
 		display: none;
 		position: relative;

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -131,6 +131,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		header {
 			position: static;
 			padding: 2rem 0rem 0 2rem;
+			background-color: transparent;
 		}
 		.logo {
 			width: auto;

--- a/src/components/Header/LanguageSelect.css
+++ b/src/components/Header/LanguageSelect.css
@@ -10,7 +10,7 @@
 	font-family: inherit;
 	line-height: inherit;
 	background-color: var(--theme-bg);
-	border-color: var(--theme-text-lighter);
+	border-color: var(--theme-shade-subtle);
 	color: var(--theme-text-light);
 	border-style: solid;
 	border-width: 1px;

--- a/src/components/Header/Search.css
+++ b/src/components/Header/Search.css
@@ -1,12 +1,12 @@
 /** Style Algolia */
 :root {
-	--docsearch-primary-color: var(--theme-accent);
+	--docsearch-primary-color: var(--theme-text-accent);
 	--docsearch-logo-color: var(--theme-text);
 }
 
 .DocSearch-Modal .DocSearch-Hit a {
 	box-shadow: none;
-	border: 1px solid var(--theme-accent);
+	border: 1px solid var(--theme-glow-diffuse);
 }
 
 /** Style Search Bar */

--- a/src/components/Header/Search.css
+++ b/src/components/Header/Search.css
@@ -60,7 +60,7 @@
 	font-size: 13px;
 	font-family: var(--font-mono);
 	pointer-events: none;
-	border-color: var(--theme-text-lighter);
+	border-color: var(--theme-shade-subtle);
 	color: var(--theme-text-light);
 	border-style: solid;
 	border-width: 1px;

--- a/src/components/LeftSidebar/SidebarSectionToggle.css
+++ b/src/components/LeftSidebar/SidebarSectionToggle.css
@@ -7,6 +7,7 @@
 	border-radius: 0;
 	cursor: pointer;
 	padding: 0.6rem;
+	color: var(--theme-text-light);
 	border-bottom: 4px solid var(--theme-divider);
 	background-color: transparent;
 }
@@ -14,7 +15,7 @@
 	flex-grow: 0;
 }
 .SidebarSectionToggle button.active {
-	color: var(--theme-text-accent);
+	color: var(--theme-text);
 	border-bottom-color: var(--theme-accent);
 	font-weight: bold;
 }

--- a/src/components/LeftSidebar/SidebarSectionToggle.css
+++ b/src/components/LeftSidebar/SidebarSectionToggle.css
@@ -8,6 +8,7 @@
 	cursor: pointer;
 	padding: 0.6rem;
 	border-bottom: 4px solid var(--theme-divider);
+	background-color: transparent;
 }
 .SidebarSectionToggle button.is-icon {
 	flex-grow: 0;

--- a/src/components/LeftSidebar/SidebarSectionToggle.css
+++ b/src/components/LeftSidebar/SidebarSectionToggle.css
@@ -16,4 +16,5 @@
 .SidebarSectionToggle button.active {
 	color: var(--theme-text-accent);
 	border-bottom-color: var(--theme-accent);
+	font-weight: bold;
 }

--- a/src/components/PageContent/ArticleNavigationButton.astro
+++ b/src/components/PageContent/ArticleNavigationButton.astro
@@ -31,7 +31,7 @@ const { item, rel } = Astro.props;
 		color: var(--theme-shade-subtle);
 	}
 	a:hover {
-		color: var(--theme-text-accent);
+		color: var(--theme-accent);
 		border: 1px solid var(--theme-accent);
 	}
 	.copy {

--- a/src/components/PageContent/ArticleNavigationButton.astro
+++ b/src/components/PageContent/ArticleNavigationButton.astro
@@ -26,9 +26,9 @@ const { item, rel } = Astro.props;
 		border: 1px solid var(--theme-divider);
 		padding: 1rem 1.25rem;
 		display: flex;
-		box-shadow: 0px 1px 2px var(--theme-text-lighter);
+		box-shadow: 0px 1px 2px var(--theme-shade-subtle);
 		text-decoration: none;
-		color: var(--theme-text-lighter);
+		color: var(--theme-shade-subtle);
 	}
 	a:hover {
 		color: var(--theme-text-accent);

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -85,6 +85,7 @@ const lang = getLanguageFromURL(Astro.request.url.pathname);
 					padding-left: 2rem;
 					position: sticky;
 					grid-column: 1;
+					background-color: transparent;
 				}
 			}
 

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -50,7 +50,7 @@ const lang = getLanguageFromURL(Astro.request.url.pathname);
 			}
 			#grid-left {
 				position: fixed;
-				background-color: var(--theme-bg);
+				background: var(--theme-bg-gradient);
 				z-index: 10;
 				display: none;
 			}
@@ -85,7 +85,7 @@ const lang = getLanguageFromURL(Astro.request.url.pathname);
 					padding-left: 2rem;
 					position: sticky;
 					grid-column: 1;
-					background-color: transparent;
+					background: transparent;
 				}
 			}
 


### PR DESCRIPTION
Following on from #198, this PR proposes theming changes to the docs site to bring it slightly closer to the main astro.build site.

Key changes:

- Use a gradient background. The light and dark variants draw on gradients used on the astro.build home page introducing subtle purples in the light theme and leaning into a night sky blue in the dark theme 🌟 

- In the light theme in particular many of the grey shades now have a subtly purple hue to vibe with the background.

- Code blocks now have a neon-y glow that is particularly visible in the dark theme.

- The dark theme Algolia DocSearch modal has been updated to match.

- The link cards on the Themes page have been tweaked to fit with the other changes.

Obviously this is all just me tinkering, so feel free to push back or reject any or all of this if it doesn’t seem appropriate.

---

cc @natemoo-re @sarah11918 @RafidMuhymin 

Closes #212