### PR TITLE
Document renderers configuration with no built-in defaults

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -141,7 +141,7 @@ This allows you to build entire "apps" in your preferred JavaScript framework an
 
 ## Customize Your Frameworks
 
-By default, Astro ships with support out-of-the-box for React, Preact, Svelte and Vue. You can configure Astro to add new frameworks or remove support for any that you are not using.
+Astro ships with support for React, Preact, Svelte and Vue. You can configure Astro to add new frameworks.
 
 You can edit your project's current list of available renderers in your `astro.config.mjs` file:
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -84,11 +84,11 @@ The value can be either an absolute file system path or a path relative to the p
 ### renderers
 
 **Type:** `Array.<string>`  
-**Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`
+**Default:** `[]`
 
 Set the UI framework renderers for your project. Framework renderers are what power Astro's ability to use other frameworks inside of your project, like React, Svelte, and Vue.
 
-Setting this configuration will disable Astro's default framework support, so you will need to provide a renderer for every framework that you want to use.
+You will need to provide a renderer for every framework that you want to use.
 
 ```js
 {

--- a/src/pages/en/reference/renderer-reference.md
+++ b/src/pages/en/reference/renderer-reference.md
@@ -3,9 +3,9 @@ layout: ~/layouts/MainLayout.astro
 title: UI Renderer Reference
 ---
 
-Astro is designed to support your favorite UI frameworks. [React](https://npm.im/@astrojs/renderer-react), [Svelte](https://npm.im/@astrojs/renderer-svelte), [Vue](https://npm.im/@astrojs/renderer-vue), and [Preact](https://npm.im/@astrojs/renderer-preact) are all built-in to Astro and supported out of the box. No configuration is needed to enable these.
+Astro is designed to support your favorite UI frameworks. [React](https://npm.im/@astrojs/renderer-react), [Svelte](https://npm.im/@astrojs/renderer-svelte), [Vue](https://npm.im/@astrojs/renderer-vue), and [Preact](https://npm.im/@astrojs/renderer-preact) are all offically supported.
 
-Internally, each framework is supported via a framework **renderer.** A renderer is a type of Astro plugin that adds support for a framework. Some are built-in, but you can also provide your own third-party renderers to add Astro support for new frameworks.
+Internally, each framework is supported via a framework **renderer.** A renderer is a type of Astro plugin that adds support for a framework. To use a renderer, install the appropriate renderer package and add it to [Astro's configuration](/en/reference/configuration-reference#renderers). You can even provide your own third-party renderers to add Astro support for new frameworks.
 
 ## What is a renderer?
 


### PR DESCRIPTION
As a follow-up to withastro/astro@10a9c3412b4f6e8607687a74eafdb150d3222047 and in preparation of removing supported renderers as direct dependencies of Astro.

More context: https://github.com/withastro/rfcs/pull/121 & https://github.com/withastro/rfcs/discussions/100