### PR TITLE
Add “Added in v...” entries to API reference

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -76,10 +76,12 @@ export async function run() {
         result += [
             `### ${comment.name}`,
             ``,
-            `**Type:** \`${typesFormatted}\`${'  '}`,
-            cliFlag ? `**CLI:** \`${cliFlag.text}\`${'  '}` : undefined,
-            comment.defaultvalue ? `**Default:** ${comment.defaultvalue}${'  '}` : undefined,
-            comment.version ? `<Since v="${comment.version}" />${'  '}` : undefined,
+            [
+                `**Type:** \`${typesFormatted}\``,
+                cliFlag ? `**CLI:** \`${cliFlag.text}\`` : undefined,
+                comment.defaultvalue ? `**Default:** ${comment.defaultvalue}` : undefined,
+                comment.version ? `<Since v="${comment.version}" />` : undefined
+            ].filter(l => l !== undefined).join('<br>\n'),
             ``,
             comment.description && comment.description.trim(),
             comment.see ? `**See Also:**\n${comment.see.map(s => `- ${s}`.trim()).join('\n')}` : undefined,

--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -11,6 +11,8 @@ const HEADER = `---
 
 layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
+setup: |
+  import Since from '../../../components/Since.astro';
 ---
 
 To configure Astro, add an \`astro.config.mjs\` file to the root of your project.
@@ -76,7 +78,8 @@ export async function run() {
             ``,
             `**Type:** \`${typesFormatted}\`${'  '}`,
             cliFlag ? `**CLI:** \`${cliFlag.text}\`${'  '}` : undefined,
-            comment.defaultvalue ? `**Default:** ${comment.defaultvalue}${'  '}`.trim() : undefined,
+            comment.defaultvalue ? `**Default:** ${comment.defaultvalue}${'  '}` : undefined,
+            comment.version ? `<Since v="${comment.version}" />${'  '}` : undefined,
             ``,
             comment.description && comment.description.trim(),
             comment.see ? `**See Also:**\n${comment.see.map(s => `- ${s}`.trim()).join('\n')}` : undefined,

--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -81,7 +81,7 @@ export async function run() {
                 cliFlag ? `**CLI:** \`${cliFlag.text}\`` : undefined,
                 comment.defaultvalue ? `**Default:** ${comment.defaultvalue}` : undefined,
                 comment.version ? `<Since v="${comment.version}" />` : undefined
-            ].filter(l => l !== undefined).join('<br>\n'),
+            ].filter(l => l !== undefined).join('  \n'),
             ``,
             comment.description && comment.description.trim(),
             comment.see ? `**See Also:**\n${comment.see.map(s => `- ${s}`.trim()).join('\n')}` : undefined,

--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -76,12 +76,15 @@ export async function run() {
         result += [
             `### ${comment.name}`,
             ``,
+            `<p>`,
+            ``,
             [
                 `**Type:** \`${typesFormatted}\``,
                 cliFlag ? `**CLI:** \`${cliFlag.text}\`` : undefined,
                 comment.defaultvalue ? `**Default:** ${comment.defaultvalue}` : undefined,
                 comment.version ? `<Since v="${comment.version}" />` : undefined
-            ].filter(l => l !== undefined).join('  \n'),
+            ].filter(l => l !== undefined).join('<br>\n'),
+            `</p>`,
             ``,
             comment.description && comment.description.trim(),
             comment.see ? `**See Also:**\n${comment.see.map(s => `- ${s}`.trim()).join('\n')}` : undefined,

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,0 +1,31 @@
+---
+export interface Props {
+  variant?: 'neutral' | 'accent';
+}
+const { variant = 'neutral' } = Astro.props as Props;
+---
+<span class={`badge ${variant}`}><slot/></span>
+
+<style>
+.badge {
+  vertical-align: text-bottom;
+  font-size: .75rem;
+  border: 1px solid;
+  padding: 0.125em 0.5em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.1ch;
+}
+
+.neutral {
+  border-color: var(--theme-divider);
+  color: var(--theme-text);
+  background-color: var(--theme-bg-offset);
+}
+
+.accent {
+  border-color: var(--theme-accent);
+  color: var(--theme-text-accent);
+  background-color: var(--theme-bg-accent);
+}
+</style>

--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -8,7 +8,6 @@ const { variant = 'neutral' } = Astro.props as Props;
 
 <style>
 .badge {
-  vertical-align: text-bottom;
   font-size: .75rem;
   border: 1px solid;
   padding: 0.125em 0.5em;

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -1,6 +1,5 @@
 ---
-import { getLanguageString } from '../i18n/util.ts';
-import { getLanguageFromURL } from '../util.ts';
+import UIString from './UIString.astro';
 import Badge from './Badge.astro';
 
 export interface Props {
@@ -30,11 +29,8 @@ const isFeatureNew = async (sinceVersion: string) => {
 };
 
 const isNew = await isFeatureNew(v);
-const lang = getLanguageFromURL(Astro.request.canonicalURL.pathname)
-const addedIn = getLanguageString('addedIn', lang);
-const newString = getLanguageString('new', lang);
 ---
 <span>
-  <strong>{addedIn}:</strong> v{v}
-  {isNew && <Badge variant="accent">{newString}</Badge>}
+  <strong><UIString key="addedIn" /></strong> v{v}
+  {isNew && <Badge variant="accent"><UIString key="new" /></Badge>}
 </span>

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -1,0 +1,40 @@
+---
+import { getLanguageString } from '../i18n/util.ts';
+import { getLanguageFromURL } from '../util.ts';
+import Badge from './Badge.astro';
+
+export interface Props {
+  v: string;
+}
+
+const { v } = Astro.props as Props;
+
+/**
+ * Split a semantic version string like `0.23.3` into a tuple of `[major, minor, patch]`.
+ */
+const parseSemVer = (semver: string) => semver
+  .split('.')
+  .map(part => parseInt(part.replace(/[^0-9]/g, ''), 10));
+
+/**
+ * Decide a feature is “new” if it was added in the latest minor version.
+ * For example, `@version 0.24.0` will be new as long as `astro@latest` is 0.24.x
+ */
+const isFeatureNew = async (sinceVersion: string) => {
+  const astroInfo =
+    await fetch('https://registry.npmjs.org/astro/latest').then(res => res.json());
+  const latestAstroVersion = astroInfo.version;
+  const [sinceMajor, sinceMinor] = parseSemVer(sinceVersion);
+  const [latestMajor, latestMinor] = parseSemVer(latestAstroVersion);
+  return sinceMajor >= latestMajor && sinceMinor >= latestMinor;
+};
+
+const isNew = await isFeatureNew(v);
+const lang = getLanguageFromURL(Astro.request.canonicalURL.pathname)
+const addedIn = getLanguageString('addedIn', lang);
+const newString = getLanguageString('new', lang);
+---
+<span>
+  <strong>{addedIn}:</strong> v{v}
+  {isNew && <Badge variant="accent">{newString}</Badge>}
+</span>

--- a/src/components/UIString.astro
+++ b/src/components/UIString.astro
@@ -1,0 +1,12 @@
+---
+import { getLanguageString } from '../i18n/util.ts';
+import { getLanguageFromURL } from '../util.ts';
+
+export interface Props {
+  key: Parameters<typeof getLanguageString>[0];
+}
+
+const lang = getLanguageFromURL(Astro.request.canonicalURL.pathname)
+const { key } = Astro.props;
+---
+{getLanguageString(key, lang)}

--- a/src/i18n/data.ts
+++ b/src/i18n/data.ts
@@ -1,6 +1,0 @@
-export const i18nStrings = {
-	en: {
-		addedIn: 'Added in',
-		new: 'New',
-	},
-};

--- a/src/i18n/data.ts
+++ b/src/i18n/data.ts
@@ -1,4 +1,6 @@
 export const i18nStrings = {
 	en: {
+		addedIn: 'Added in',
+		new: 'New',
 	},
 };

--- a/src/i18n/data.ts
+++ b/src/i18n/data.ts
@@ -1,0 +1,4 @@
+export const i18nStrings = {
+	en: {
+	},
+};

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,27 @@
+import type { SIDEBAR } from '../config';
+type LanguagesInUse = keyof typeof SIDEBAR;
+const checkLanguages = <T extends Record<LanguagesInUse, Record<string, string>>>(config: T): T => config;
+
+export const translations = checkLanguages({
+	en: {
+		addedIn: 'Added in',
+		new: 'New',
+	},
+	de: {},
+	nl: {},
+	fi: {},
+	es: {},
+	'zh-CN': {},
+	'zh-TW': {},
+	bg: {},
+	fr: {},
+	bn: {},
+	kr: {},
+	ar: {},
+	da: {},
+	ja: {},
+	ru: {},
+	it: {},
+	pl: {},
+	hu: {},
+});

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -4,7 +4,7 @@ const checkLanguages = <T extends Record<LanguagesInUse, Record<string, string>>
 
 export const translations = checkLanguages({
 	en: {
-		addedIn: 'Added in',
+		addedIn: 'Added in:',
 		new: 'New',
 	},
 	de: {},

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -1,11 +1,9 @@
-import { i18nStrings } from './data';
+import { translations } from './translations';
 
 const fallbackLang = 'en';
 
-type Lang = keyof typeof i18nStrings;
-type Keys = keyof typeof i18nStrings[Lang];
+type Keys = keyof typeof translations[typeof fallbackLang];
 
 export function getLanguageString(key: Keys, lang = 'en'): string | undefined {
-	const langStrings = i18nStrings[lang] || i18nStrings[fallbackLang];
-	return langStrings[key];
+	return translations[lang]?.[key] || translations[fallbackLang][key];
 }

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -1,0 +1,11 @@
+import { i18nStrings } from './data';
+
+const fallbackLang = 'en';
+
+type Lang = keyof typeof i18nStrings;
+type Keys = keyof typeof i18nStrings[Lang];
+
+export function getLanguageString(key: Keys, lang = 'en'): string | undefined {
+	const langStrings = i18nStrings[lang] || i18nStrings[fallbackLang];
+	return langStrings[key];
+}

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -31,8 +31,8 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 
 ### projectRoot
 
-**Type:** `string`<br>
-**CLI:** `--project-root`<br>
+**Type:** `string`  
+**CLI:** `--project-root`  
 **Default:** `"."` (current working directory)
 
 You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
@@ -53,7 +53,7 @@ $ astro build --project-root ./my-project-directory
 
 ### dist
 
-**Type:** `string`<br>
+**Type:** `string`  
 **Default:** `"./dist"`
 
 Set the directory that `astro build` writes your final build to.
@@ -69,7 +69,7 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### public
 
-**Type:** `string`<br>
+**Type:** `string`  
 **Default:** `"./public"`
 
 Set the directory for your static assets. Files in this directory are served at `/` during dev and copied to your build directory during build. These files are always served or copied as-is, without transform or bundling.
@@ -85,7 +85,7 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### renderers
 
-**Type:** `Array.<string>`<br>
+**Type:** `Array.<string>`  
 **Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`
 
 Set the UI framework renderers for your project. Framework renderers are what power Astro's ability to use other frameworks inside of your project, like React, Svelte, and Vue.
@@ -149,7 +149,7 @@ Astro will match the site pathname during development so that your development e
 
 ### sitemap
 
-**Type:** `boolean`<br>
+**Type:** `boolean`  
 **Default:** `true`
 
 Generate a sitemap for your build. Set to false to disable.
@@ -190,7 +190,7 @@ Return `true` to include a page in your sitemap, and `false` to remove it.
 
 ### pageUrlFormat
 
-**Type:** `'file' | 'directory'`<br>
+**Type:** `'file' | 'directory'`  
 **Default:** `'directory'`
 
 Control the output file format of each page.
@@ -209,7 +209,7 @@ Control the output file format of each page.
 
 ### drafts
 
-**Type:** `boolean`<br>
+**Type:** `boolean`  
 **Default:** `false`
 
 Control if markdown draft pages should be included in the build.
@@ -230,8 +230,8 @@ A markdown page is considered a draft if it includes `draft: true` in its front 
 
 ### host
 
-**Type:** `string | boolean`<br>
-**Default:** `false`<br>
+**Type:** `string | boolean`  
+**Default:** `false`  
 <Since v="0.24.0" />
 
 Set which network IP addresses the dev server should listen on (i.e. 	non-localhost IPs).
@@ -242,7 +242,7 @@ Set which network IP addresses the dev server should listen on (i.e. 	non-localh
 
 ### hostname
 
-**Type:** `string`<br>
+**Type:** `string`  
 **Default:** `'localhost'`
 
 > **This option is deprecated.** Consider using `host` instead.
@@ -252,7 +252,7 @@ Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to l
 
 ### port
 
-**Type:** `number`<br>
+**Type:** `number`  
 **Default:** `3000`
 
 Set which port the dev server should listen on.
@@ -262,7 +262,7 @@ If the given port is already in use, Astro will automatically try the next avail
 
 ### trailingSlash
 
-**Type:** `'always' | 'never' | 'ignore'`<br>
+**Type:** `'always' | 'never' | 'ignore'`  
 **Default:** `'always'`
 
 Set the route matching behavior of the dev server. Choose from the following options:

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -31,9 +31,9 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 
 ### projectRoot
 
-**Type:** `string`  
-**CLI:** `--project-root`  
-**Default:** `"."` (current working directory)  
+**Type:** `string`<br>
+**CLI:** `--project-root`<br>
+**Default:** `"."` (current working directory)
 
 You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
 
@@ -53,8 +53,8 @@ $ astro build --project-root ./my-project-directory
 
 ### dist
 
-**Type:** `string`  
-**Default:** `"./dist"`  
+**Type:** `string`<br>
+**Default:** `"./dist"`
 
 Set the directory that `astro build` writes your final build to.
 
@@ -69,8 +69,8 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### public
 
-**Type:** `string`  
-**Default:** `"./public"`  
+**Type:** `string`<br>
+**Default:** `"./public"`
 
 Set the directory for your static assets. Files in this directory are served at `/` during dev and copied to your build directory during build. These files are always served or copied as-is, without transform or bundling.
 
@@ -85,8 +85,8 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### renderers
 
-**Type:** `Array.<string>`  
-**Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`  
+**Type:** `Array.<string>`<br>
+**Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`
 
 Set the UI framework renderers for your project. Framework renderers are what power Astro's ability to use other frameworks inside of your project, like React, Svelte, and Vue.
 
@@ -102,7 +102,7 @@ Setting this configuration will disable Astro's default framework support, so yo
 
 ### markdownOptions
 
-**Type:** `Object`  
+**Type:** `Object`
 
 Configure how markdown files (`.md`) are rendered.
 
@@ -131,7 +131,7 @@ Configure how markdown files (`.md`) are rendered.
 
 ### site
 
-**Type:** `string`  
+**Type:** `string`
 
 Your final, deployed URL. Astro uses this full URL to generate your sitemap and canonical URLs in your final build. It is strongly recommended that you set this configuration to get the most out of Astro.
 
@@ -149,8 +149,8 @@ Astro will match the site pathname during development so that your development e
 
 ### sitemap
 
-**Type:** `boolean`  
-**Default:** `true`  
+**Type:** `boolean`<br>
+**Default:** `true`
 
 Generate a sitemap for your build. Set to false to disable.
 
@@ -168,7 +168,7 @@ Astro will automatically generate a sitemap including all generated pages on you
 
 ### sitemapFilter
 
-**Type:** `(page: string) => boolean`  
+**Type:** `(page: string) => boolean`
 
 By default, all pages are included in your generated sitemap.
 You can filter included pages by URL using `buildOptions.sitemapFilter`.
@@ -190,8 +190,8 @@ Return `true` to include a page in your sitemap, and `false` to remove it.
 
 ### pageUrlFormat
 
-**Type:** `'file' | 'directory'`  
-**Default:** `'directory'`  
+**Type:** `'file' | 'directory'`<br>
+**Default:** `'directory'`
 
 Control the output file format of each page.
   - If 'file', Astro will generate an HTML file (ex: "/foo.html") for each page.
@@ -209,8 +209,8 @@ Control the output file format of each page.
 
 ### drafts
 
-**Type:** `boolean`  
-**Default:** `false`  
+**Type:** `boolean`<br>
+**Default:** `false`
 
 Control if markdown draft pages should be included in the build.
 
@@ -230,9 +230,9 @@ A markdown page is considered a draft if it includes `draft: true` in its front 
 
 ### host
 
-**Type:** `string | boolean`  
-**Default:** `false`  
-<Since v="0.24.0" />  
+**Type:** `string | boolean`<br>
+**Default:** `false`<br>
+<Since v="0.24.0" />
 
 Set which network IP addresses the dev server should listen on (i.e. 	non-localhost IPs).
 - `false` - do not expose on a network IP address
@@ -242,8 +242,8 @@ Set which network IP addresses the dev server should listen on (i.e. 	non-localh
 
 ### hostname
 
-**Type:** `string`  
-**Default:** `'localhost'`  
+**Type:** `string`<br>
+**Default:** `'localhost'`
 
 > **This option is deprecated.** Consider using `host` instead.
 
@@ -252,8 +252,8 @@ Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to l
 
 ### port
 
-**Type:** `number`  
-**Default:** `3000`  
+**Type:** `number`<br>
+**Default:** `3000`
 
 Set which port the dev server should listen on.
 
@@ -262,8 +262,8 @@ If the given port is already in use, Astro will automatically try the next avail
 
 ### trailingSlash
 
-**Type:** `'always' | 'never' | 'ignore'`  
-**Default:** `'always'`  
+**Type:** `'always' | 'never' | 'ignore'`<br>
+**Default:** `'always'`
 
 Set the route matching behavior of the dev server. Choose from the following options:
   - 'always' - Only match URLs that include a trailing slash (ex: "/foo/")
@@ -288,7 +288,7 @@ You can also set this if you prefer to be more strict yourself, so that URLs wit
 
 ### vite
 
-**Type:** `vite.UserConfig`  
+**Type:** `vite.UserConfig`
 
 Pass additional configuration options to Vite. Useful when Astro doesn't support some advanced configuration that you may need.
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -4,6 +4,8 @@
 
 layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
+setup: |
+  import Since from '../../../components/Since.astro';
 ---
 
 To configure Astro, add an `astro.config.mjs` file to the root of your project.
@@ -31,7 +33,7 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 
 **Type:** `string`  
 **CLI:** `--project-root`  
-**Default:** `"."` (current working directory)
+**Default:** `"."` (current working directory)  
 
 You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
 
@@ -52,7 +54,7 @@ $ astro build --project-root ./my-project-directory
 ### dist
 
 **Type:** `string`  
-**Default:** `"./dist"`
+**Default:** `"./dist"`  
 
 Set the directory that `astro build` writes your final build to.
 
@@ -68,7 +70,7 @@ The value can be either an absolute file system path or a path relative to the p
 ### public
 
 **Type:** `string`  
-**Default:** `"./public"`
+**Default:** `"./public"`  
 
 Set the directory for your static assets. Files in this directory are served at `/` during dev and copied to your build directory during build. These files are always served or copied as-is, without transform or bundling.
 
@@ -84,7 +86,7 @@ The value can be either an absolute file system path or a path relative to the p
 ### renderers
 
 **Type:** `Array.<string>`  
-**Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`
+**Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`  
 
 Set the UI framework renderers for your project. Framework renderers are what power Astro's ability to use other frameworks inside of your project, like React, Svelte, and Vue.
 
@@ -148,7 +150,7 @@ Astro will match the site pathname during development so that your development e
 ### sitemap
 
 **Type:** `boolean`  
-**Default:** `true`
+**Default:** `true`  
 
 Generate a sitemap for your build. Set to false to disable.
 
@@ -189,7 +191,7 @@ Return `true` to include a page in your sitemap, and `false` to remove it.
 ### pageUrlFormat
 
 **Type:** `'file' | 'directory'`  
-**Default:** `'directory'`
+**Default:** `'directory'`  
 
 Control the output file format of each page.
   - If 'file', Astro will generate an HTML file (ex: "/foo.html") for each page.
@@ -208,7 +210,7 @@ Control the output file format of each page.
 ### drafts
 
 **Type:** `boolean`  
-**Default:** `false`
+**Default:** `false`  
 
 Control if markdown draft pages should be included in the build.
 
@@ -229,7 +231,8 @@ A markdown page is considered a draft if it includes `draft: true` in its front 
 ### host
 
 **Type:** `string | boolean`  
-**Default:** `false`
+**Default:** `false`  
+<Since v="0.24.0" />  
 
 Set which network IP addresses the dev server should listen on (i.e. 	non-localhost IPs).
 - `false` - do not expose on a network IP address
@@ -240,7 +243,7 @@ Set which network IP addresses the dev server should listen on (i.e. 	non-localh
 ### hostname
 
 **Type:** `string`  
-**Default:** `'localhost'`
+**Default:** `'localhost'`  
 
 > **This option is deprecated.** Consider using `host` instead.
 
@@ -250,7 +253,7 @@ Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to l
 ### port
 
 **Type:** `number`  
-**Default:** `3000`
+**Default:** `3000`  
 
 Set which port the dev server should listen on.
 
@@ -260,7 +263,7 @@ If the given port is already in use, Astro will automatically try the next avail
 ### trailingSlash
 
 **Type:** `'always' | 'never' | 'ignore'`  
-**Default:** `'always'`
+**Default:** `'always'`  
 
 Set the route matching behavior of the dev server. Choose from the following options:
   - 'always' - Only match URLs that include a trailing slash (ex: "/foo/")

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -31,9 +31,12 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
 
 ### projectRoot
 
-**Type:** `string`  
-**CLI:** `--project-root`  
+<p>
+
+**Type:** `string`<br>
+**CLI:** `--project-root`<br>
 **Default:** `"."` (current working directory)
+</p>
 
 You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
 
@@ -53,8 +56,11 @@ $ astro build --project-root ./my-project-directory
 
 ### dist
 
-**Type:** `string`  
+<p>
+
+**Type:** `string`<br>
 **Default:** `"./dist"`
+</p>
 
 Set the directory that `astro build` writes your final build to.
 
@@ -69,8 +75,11 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### public
 
-**Type:** `string`  
+<p>
+
+**Type:** `string`<br>
 **Default:** `"./public"`
+</p>
 
 Set the directory for your static assets. Files in this directory are served at `/` during dev and copied to your build directory during build. These files are always served or copied as-is, without transform or bundling.
 
@@ -85,8 +94,11 @@ The value can be either an absolute file system path or a path relative to the p
 
 ### renderers
 
-**Type:** `Array.<string>`  
+<p>
+
+**Type:** `Array.<string>`<br>
 **Default:** `['@astrojs/renderer-svelte','@astrojs/renderer-vue','@astrojs/renderer-react','@astrojs/renderer-preact']`
+</p>
 
 Set the UI framework renderers for your project. Framework renderers are what power Astro's ability to use other frameworks inside of your project, like React, Svelte, and Vue.
 
@@ -102,7 +114,10 @@ Setting this configuration will disable Astro's default framework support, so yo
 
 ### markdownOptions
 
+<p>
+
 **Type:** `Object`
+</p>
 
 Configure how markdown files (`.md`) are rendered.
 
@@ -131,7 +146,10 @@ Configure how markdown files (`.md`) are rendered.
 
 ### site
 
+<p>
+
 **Type:** `string`
+</p>
 
 Your final, deployed URL. Astro uses this full URL to generate your sitemap and canonical URLs in your final build. It is strongly recommended that you set this configuration to get the most out of Astro.
 
@@ -149,8 +167,11 @@ Astro will match the site pathname during development so that your development e
 
 ### sitemap
 
-**Type:** `boolean`  
+<p>
+
+**Type:** `boolean`<br>
 **Default:** `true`
+</p>
 
 Generate a sitemap for your build. Set to false to disable.
 
@@ -168,7 +189,10 @@ Astro will automatically generate a sitemap including all generated pages on you
 
 ### sitemapFilter
 
+<p>
+
 **Type:** `(page: string) => boolean`
+</p>
 
 By default, all pages are included in your generated sitemap.
 You can filter included pages by URL using `buildOptions.sitemapFilter`.
@@ -190,8 +214,11 @@ Return `true` to include a page in your sitemap, and `false` to remove it.
 
 ### pageUrlFormat
 
-**Type:** `'file' | 'directory'`  
+<p>
+
+**Type:** `'file' | 'directory'`<br>
 **Default:** `'directory'`
+</p>
 
 Control the output file format of each page.
   - If 'file', Astro will generate an HTML file (ex: "/foo.html") for each page.
@@ -209,8 +236,11 @@ Control the output file format of each page.
 
 ### drafts
 
-**Type:** `boolean`  
+<p>
+
+**Type:** `boolean`<br>
 **Default:** `false`
+</p>
 
 Control if markdown draft pages should be included in the build.
 
@@ -230,9 +260,12 @@ A markdown page is considered a draft if it includes `draft: true` in its front 
 
 ### host
 
-**Type:** `string | boolean`  
-**Default:** `false`  
+<p>
+
+**Type:** `string | boolean`<br>
+**Default:** `false`<br>
 <Since v="0.24.0" />
+</p>
 
 Set which network IP addresses the dev server should listen on (i.e. 	non-localhost IPs).
 - `false` - do not expose on a network IP address
@@ -242,8 +275,11 @@ Set which network IP addresses the dev server should listen on (i.e. 	non-localh
 
 ### hostname
 
-**Type:** `string`  
+<p>
+
+**Type:** `string`<br>
 **Default:** `'localhost'`
+</p>
 
 > **This option is deprecated.** Consider using `host` instead.
 
@@ -252,8 +288,11 @@ Set which IP addresses the dev server should listen on. Set this to 0.0.0.0 to l
 
 ### port
 
-**Type:** `number`  
+<p>
+
+**Type:** `number`<br>
 **Default:** `3000`
+</p>
 
 Set which port the dev server should listen on.
 
@@ -262,8 +301,11 @@ If the given port is already in use, Astro will automatically try the next avail
 
 ### trailingSlash
 
-**Type:** `'always' | 'never' | 'ignore'`  
+<p>
+
+**Type:** `'always' | 'never' | 'ignore'`<br>
 **Default:** `'always'`
+</p>
 
 Set the route matching behavior of the dev server. Choose from the following options:
   - 'always' - Only match URLs that include a trailing slash (ex: "/foo/")
@@ -288,7 +330,10 @@ You can also set this if you prefer to be more strict yourself, so that URLs wit
 
 ### vite
 
+<p>
+
 **Type:** `vite.UserConfig`
+</p>
 
 Pass additional configuration options to Vite. Useful when Astro doesn't support some advanced configuration that you may need.
 


### PR DESCRIPTION
The main outcome of this PR is to handle the `@version` tag in auto-generated API reference pages (as per @FredKSchott’s suggestion from #209), but it does also add some more general purpose architecture to help that will need reviewing.

1. Adds a `<Since>` component for rendering a message based on the `@version` tag in the reference JSDoc source.

    [See it in action on the deploy preview →](https://deploy-preview-215--astro-docs-2.netlify.app/en/reference/configuration-reference/#host)

    ##### Usage

    ```astro
    <Since v="0.23.0" />
    ```

    ##### Renders

    **Added in:** v0.23.0

    ##### Notes

    - If the `v` prop indicates a version that matches the latest minor version of `astro`, the component also displays a badge reading “NEW” to highlight new API features. In other words any API added in say 0.24.0 will be labelled “NEW” until 0.25.0 is released. We can discuss if that’s useful and the correct heuristic for “newness”.

    - The docgen script injects this component for the reference pages, but it can also be used manually elsewhere in the docs as needed.

    - @bholmesdev Not sure where you’re at with converting the docgen script to run on build, but this PR does include a small update to the current implementation to automatically inject this new component when it finds a `@version` tag.

3. Adds a simple `<Badge>` component used to render the “NEW” message, and that can be used elsewhere too.

    **Usage:**

    ```astro
    <Badge variant="accent">Hot</Badge>
    ```

4. Adds a very simple i18n API that loads UI strings from an object in `src/i18n/translations.ts`, so we can add translations in that data file and have components render the correct string automatically. This is used for the “Added in” and “New” text strings in the `<Since>` component. Render a internationalised string using the `UIString` component:

    ```astro
    <UIString key="addedIn" />
    ```

    For now I’ve only added strings for the `Since` component (and only in English), but would also suggest moving the “Learn”/“API” menu toggle labels here and the content of the right sidebar’s “More” section & subheadings.