### PR TITLE
Fix broken links

### DIFF
--- a/src/pages/de/core-concepts/astro-components.md
+++ b/src/pages/de/core-concepts/astro-components.md
@@ -74,7 +74,7 @@ Die Verwendung von `<style global>` schaltet die ausschließlich spezifische Anw
 
 Sass (eine Alternative zu CSS) ist ebenfalls verfügbar via `<style lang="scss">`.
 
-📚 Lies unsere vollständige Anleitung zum [Styling von Komponenten](/guides/styling), um mehr zu erfahren.
+📚 Lies unsere vollständige Anleitung zum [Styling von Komponenten](/de/guides/styling), um mehr zu erfahren.
 
 ### Frontmatter-Skript
 

--- a/src/pages/de/core-concepts/component-hydration.md
+++ b/src/pages/de/core-concepts/component-hydration.md
@@ -89,7 +89,7 @@ Falls mehr als ein Renderer in der Astro-[Konfiguration](/reference/configuratio
 
 ## Kann ich Astro-Komponenten anreichern?
 
-[Astro-Komponenten](./astro-components) (`.astro`-Dateien) sind reine HTML-Templating-Komponenten ohne Client-seitige Laufzeit. Wenn du versuchst eine Astro-Komponente über einem `client`-Modifikator anzureichern, wird ein Fehler ausgegeben.
+[Astro-Komponenten](/de/core-concepts/astro-components) (`.astro`-Dateien) sind reine HTML-Templating-Komponenten ohne Client-seitige Laufzeit. Wenn du versuchst eine Astro-Komponente über einem `client`-Modifikator anzureichern, wird ein Fehler ausgegeben.
 
 Um deine Astro-Komponente interaktiv zu machen, musst du sie zu einer Frontend-Bibliothek deiner Wahl konvertieren: React, Svelte, Vue etc. Für den Fall, dass du keine bestimmte Bibliothek bevorzugst, empfehlen wir React oder Preact, da sie am meisten Ähnlichkeit mit Astros Syntax aufweisen.
 

--- a/src/pages/de/core-concepts/project-structure.md
+++ b/src/pages/de/core-concepts/project-structure.md
@@ -28,11 +28,11 @@ Der einfachste Weg dein neues Projekt aufzusetzen, ist mittels `npm init astro`.
 
 Das `src`-Verzeichnis beinhaltet den Großteil des Source-Code zu deinem Projekt. Dazu zählen:
 
-- [Astro-Komponenten](/core-concepts/astro-components)
+- [Astro-Komponenten](/de/core-concepts/astro-components)
 - [Astro-Seiten](/de/core-concepts/astro-pages)
 - [Layouts](/de/core-concepts/layouts)
 - [JavaScript-Komponenten](/de/core-concepts/component-hydration)
-- [Styling (CSS, Sass)](/guides/styling)
+- [Styling (CSS, Sass)](/de/guides/styling)
 - [Markdown](/guides/markdown-content)
 
 Astro hat vollständige Kontrolle darüber, wie diese Dateien verarbeitet, optimiert und in deinem abschließenden Website-Build gepackt werden. Einige Dateien (wie Astro-Komponenten) kommen niemals direkt im Browser an - sie werden stattdessen als HTML gerendert und ausgegeben. Andere Dateien (wie CSS) werden an den Browser gesendet, werden möglicherweise aber gepackt - in Abhängigkeit davon, wie deine Site sie einsetzt.

--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -10,7 +10,7 @@ This guide was written to help answer that question for several popular site bui
 Two key features make Astro different from most alternatives:
 
 - [Partial hydration](/en/core-concepts/partial-hydration)
-- [Use your favorite framework(s)](/en/core-condepts/framework-components)
+- [Use your favorite framework(s)](/en/core-concepts/framework-components)
 
 For more details, you can see our in-depth comparisons on this page.
 

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -32,7 +32,7 @@ Astro Pages must return a full `<html>...</html>` page response, including `<hea
 
 ### Leveraging Page Layouts
 
-To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [layout components](/en/core-components/layouts). You can use as many or as few layout components as you'd like.
+To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [layout components](/en/core-concepts/layouts). You can use as many or as few layout components as you'd like.
 
 ```astro
 ---
@@ -51,7 +51,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 Astro also treats any Markdown (`.md`) files inside of `/src/pages/` as pages in your final website. These are commonly used for text-heavy pages like blog posts and documentation. 
 
-Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layout) that will wrap their Markdown content in a full `<html>...</html>` page document. 
+Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layouts) that will wrap their Markdown content in a full `<html>...</html>` page document. 
 
 ```md
 ---

--- a/src/pages/es/core-concepts/component-hydration.md
+++ b/src/pages/es/core-concepts/component-hydration.md
@@ -88,7 +88,7 @@ Si se incluye más de un renderizador en Astro [config](/es/reference/configurat
 
 ## ¿Puedo hidratar los componentes de Astro?
 
-Los [componentes de Astro](./astro-components)(archivos `.astro`) son componentes con plantillas de solo HTML sin ejecución del lado del cliente. Si intentas hidratar un componente Astro con un modificador `client:`, obtendrás un error.
+Los [componentes de Astro](/es/core-concepts/astro-components)(archivos `.astro`) son componentes con plantillas de solo HTML sin ejecución del lado del cliente. Si intentas hidratar un componente Astro con un modificador `client:`, obtendrás un error.
 
 Para hacer que su componente Astro sea interactivo, necesitará convertirlo al framework de su elección: React, Svelte, Vue, etc. Si no tienes preferencias, recomendamos React o Preact ya que son más similares a la sintaxis de Astro.
 

--- a/src/pages/es/quick-start.md
+++ b/src/pages/es/quick-start.md
@@ -27,7 +27,7 @@ Para los sitios de producción,
 npm run build
 ```
 
-Para saber más sobre la instalación y uso de Astro por primera vez, por favor [lea nuestra guía de instalación.](installation)
+Para saber más sobre la instalación y uso de Astro por primera vez, por favor [lea nuestra guía de instalación.](/es/installation)
 
 Si prefieres aprender con ejemplos, revisa nuestra [librería completa de ejemplos](https://github.com/withastro/astro/tree/main/examples) en GitHub. Puedes revisar cualquiera de estos ejemplos localmente ejecutando `npm init astro -- --template "EXAMPLE_NAME"`.
 
@@ -73,4 +73,4 @@ Te recomendamos que te tomes tu tiempo para familiarizarte con la forma en la qu
 
 📚 Aprende más sobre la sintaxis de los componentes de Astro, en nuestra [guía de componentes de Astro](/es/core-concepts/astro-components).
 
-📚 Aprende más sobre la rutas basada en archivos de Astro, en nuestra [guía de rutas](core-concepts/astro-pages).
+📚 Aprende más sobre la rutas basada en archivos de Astro, en nuestra [guía de rutas](/es/core-concepts/astro-pages).

--- a/src/pages/fi/getting-started.md
+++ b/src/pages/fi/getting-started.md
@@ -9,7 +9,7 @@ Astro on moderni työkalu staattisten sivustojen luomiseen. Voit löytää lisä
 
 Helpoin tapa kokeilla Astroa on suorittaa `npm init astro` uudessa hakemistossa omalla koneellasi. Tämä CLI-komento käy lävitse tarvittavat vaiheet uuden Astro-projektin alkuunsaattamiseksi.
 
-[Asennusoppaastamme](/installation) löydät täyden läpikäynnin Astron saamiseksi käyttökuntoon.
+[Asennusoppaastamme](/fi/installation) löydät täyden läpikäynnin Astron saamiseksi käyttökuntoon.
 
 ### Netin leikkikentät
 

--- a/src/pages/fi/installation.md
+++ b/src/pages/fi/installation.md
@@ -23,7 +23,7 @@ npm init astro
 
 Seuraa CLI-ohjelman ohjeistusta asentaaksesi Astron käyttäen yhtä virallisista aloitustemplaateista.
 
-Tämän jälkeen voit siirtyä [pika-aloitusoppaaseen](/quick-start#start-your-project) saadaksesi 30:n sekunnin yhteenvedon siitä, kuinka käynnistää uusi projekti kehittämistä varten, ja kuinka luoda siitä lopullinen sivusto!
+Tämän jälkeen voit siirtyä [pika-aloitusoppaaseen](/fi/quick-start#start-your-project) saadaksesi 30:n sekunnin yhteenvedon siitä, kuinka käynnistää uusi projekti kehittämistä varten, ja kuinka luoda siitä lopullinen sivusto!
 
 ## Asentaminen itse
 
@@ -86,8 +86,8 @@ Voit nyt lisätä uusia sivuja `src/pages`-hakemistoon Astron käyttäessä enne
 
 ### Seuraavat vaiheet
 
-Näin se hoituu! Olet nyt valmis aloittamaan kehittämisen! Siirry [pika-aloitusoppaaseen](/quick-start#start-your-project) saadaksesi 30:n sekunnin läpikäynnin Astron käynnistämisestä ja projektin luomisesta sivustoksi!
+Näin se hoituu! Olet nyt valmis aloittamaan kehittämisen! Siirry [pika-aloitusoppaaseen](/fi/quick-start#start-your-project) saadaksesi 30:n sekunnin läpikäynnin Astron käynnistämisestä ja projektin luomisesta sivustoksi!
 
 📚 Opi lisää Astron projektien rakenteesta [projektin rakenneoppaassa](/core-concepts/project-structure).  
 📚 Opi lisää Astron komponenttien syntaksista [Astro-komponenttien oppaassa](/core-concepts/astro-components).  
-📚 Opi lisää Astron tiedostoihin pohjautuvasta reitityksestä [reititysoppaassa](core-concepts/astro-pages).
+📚 Opi lisää Astron tiedostoihin pohjautuvasta reitityksestä [reititysoppaassa](/core-concepts/astro-pages).

--- a/src/pages/fr/quick-start.md
+++ b/src/pages/fr/quick-start.md
@@ -25,7 +25,7 @@ npm run dev
 npm run build
 ```
 
-Si vous désirez en savoir plus sur les différentes façons d'installer Astro dans votre projet, [lisez notre guide d'installation](installation).
+Si vous désirez en savoir plus sur les différentes façons d'installer Astro dans votre projet, [lisez notre guide d'installation](/fr/installation).
 
 ## Commencez votre projet
 

--- a/src/pages/ja/getting-started.md
+++ b/src/pages/ja/getting-started.md
@@ -40,7 +40,7 @@ Stackblitz、CodeSandbox、Gitpod、GitHub Codespaces などのオンライン�
 Astro には、さまざまなバックグラウンドを持った人が集まっており、学習スタイルもさまざまです。このセクションでは、より理論的なアプローチや実践的なアプローチなど、さまざまな学習スタイルをご紹介していますので、参考になれば幸いです。
 
 - 実際にやってみて学びたいという方は、まず[サンプルライブラリ](https://github.com/withastro/astro/tree/main/examples)から始めてください。
-- また、コンセプトを段階的に学びたい方は、[基本コンセプトとガイド](/core-concepts/project-structure)をご覧ください。
+- また、コンセプトを段階的に学びたい方は、[基本コンセプトとガイド](/ja/core-concepts/project-structure)をご覧ください。
 
 他の慣れない技術と同様、Astro にも若干の習得が必要です。しかし、練習と忍耐力があれば、すぐに使いこなせるようになること間違いなしでしょう。
 

--- a/src/pages/ja/installation.md
+++ b/src/pages/ja/installation.md
@@ -171,8 +171,8 @@ npm run build
 
 Astro がどのように機能しているかをもっとよく知ることを強くオススメします。そのためには、これらのドキュメントを探索することを検討してみてください。
 
-📚 Astro のプロジェクト構造については、[プロジェクト構造ガイド](/core-concepts/project-structure)をご覧ください。
+📚 Astro のプロジェクト構造については、[プロジェクト構造ガイド](/ja/core-concepts/project-structure)をご覧ください。
 
 📚 Astro のコンポーネント構文については[Astro コンポーネントガイド](/core-concepts/astro-components)を参照してください。
 
-📚 Astro のファイルベースのルーティングについては、[ルーティングガイド](core-concepts/astro-pages)を参照してください。
+📚 Astro のファイルベースのルーティングについては、[ルーティングガイド](/core-concepts/astro-pages)を参照してください。

--- a/src/pages/ja/quick-start.md
+++ b/src/pages/ja/quick-start.md
@@ -67,7 +67,7 @@ Astro のサイトは静的なので、お好みのホストにデプロイで�
 
 次のステップでは、Astro の仕組みをより深く理解することをオススメします。これらのドキュメントを探索することを検討してみてください。
 
-📚 Astro のプロジェクト構造については、[プロジェクト構造ガイド](/core-concepts/project-structure)をご覧ください。
+📚 Astro のプロジェクト構造については、[プロジェクト構造ガイド](/ja/core-concepts/project-structure)をご覧ください。
 
 📚 Astro のコンポーネント構文については、[Astro コンポーネントガイド](/core-concepts/astro-components)を参照してください。
 

--- a/src/pages/nl/quick-start.md
+++ b/src/pages/nl/quick-start.md
@@ -72,4 +72,4 @@ We raden je aan om wat tijd te nemen om bekend te raken met hoe Astro werkt. Je 
 
 📚 Leer meer over Astro’s component syntax: [Astro Components handleiding.](/core-concepts/astro-components)
 
-📚 Lees meer over Astro’s bestand routing [Routing handleiding.](core-concepts/astro-pages)
+📚 Lees meer over Astro’s bestand routing [Routing handleiding.](/core-concepts/astro-pages)

--- a/src/pages/zh-CN/getting-started.md
+++ b/src/pages/zh-CN/getting-started.md
@@ -9,9 +9,9 @@ Astro 是一个现代的静态网站生成工具. 你可以从 [我们的主页]
 
 尝试 Astro 的最简单的方法是在新目录下运行 `npm init astro`。我们的 CLI 工具会帮助你创建启动一个新的 Astro 项目。
 
-想要快速了解学习使用 Astro， [快速入门](quick-start).
+想要快速了解学习使用 Astro， [快速入门](/zh-CN/quick-start).
 
-另外，请阅读我们的 [安装指南](/installation)，了解如何使用 Astro 进行安装的全部步骤。
+另外，请阅读我们的 [安装指南](/zh-CN/installation)，了解如何使用 Astro 进行安装的全部步骤。
 
 ### 在线游乐场
 
@@ -33,7 +33,7 @@ Astro 是一个现代的静态网站生成工具. 你可以从 [我们的主页]
 
 当你开始学习 Astro 时，你会看到许多文件使用`.astro`文件扩展名。这是**Astro 的组件语法**：一种特殊的类似 HTML 的文件格式，Astro 用于模板制作。这样设计是为了让任何有 HTML 或 JSX 经验的人更容易上手。
 
-我们在 [Astro 组件](/corecepts/astro-components) 上的有用指南向你介绍了 Astro 语法，这也是学习的最好方法。
+我们在 [Astro 组件](/core-concepts/astro-components) 上的有用指南向你介绍了 Astro 语法，这也是学习的最好方法。
 
 ### API 参考文档
 

--- a/src/pages/zh-CN/installation.md
+++ b/src/pages/zh-CN/installation.md
@@ -27,7 +27,7 @@ npm init astro
 yarn create astro
 ```
 
-[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro) 工具让你从预设的 [启动模板](/examples) 中选择，或者你也可以直接从 Github 导入自己的 Astro 项目。
+[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro) 工具让你从预设的 [启动模板](/zh-CN/examples) 中选择，或者你也可以直接从 Github 导入自己的 Astro 项目。
 
 ```bash
 # 提醒：把「my-astro-project」改为项目的名称。
@@ -167,4 +167,4 @@ npm run build
 
 📚 深入了解 Astro 的组件语法：[Astro 组件指南](/core-concepts/astro-components)
 
-📚 深入了解 Astro 根据文件路径生成路由：[路由指南](core-concepts/astro-pages)
+📚 深入了解 Astro 根据文件路径生成路由：[路由指南](/core-concepts/astro-pages)

--- a/src/pages/zh-CN/quick-start.md
+++ b/src/pages/zh-CN/quick-start.md
@@ -25,7 +25,7 @@ npm run dev
 npm run build
 ```
 
-如果想要知道还有哪些方法能够使用 Astro 来做开发，请阅读 [安装指南](installation)。
+如果想要知道还有哪些方法能够使用 Astro 来做开发，请阅读 [安装指南](/zh-CN/installation)。
 
 ## 启动项目
 
@@ -70,4 +70,4 @@ Astro 生成的网站是静态的可以发布常见的托管服务商：
 
 📚 深入了解 Astro 的组件语法：[Astro 组件指南](/core-concepts/astro-components)
 
-📚 深入了解 Astro 根据文件路径生成路由：[路由指南](core-concepts/astro-pages)
+📚 深入了解 Astro 根据文件路径生成路由：[路由指南](/core-concepts/astro-pages)

--- a/src/pages/zh-TW/getting-started.md
+++ b/src/pages/zh-TW/getting-started.md
@@ -9,9 +9,9 @@ Astro 是利用現代技術的靜態網站生成工具。可以從[首頁](https
 
 試用 Astro 最簡單的方法，就是在機器的新資料夾裡執行 `npm init astro`。我們製作的 CLI 精靈會協助開啟全新的 Astro 專案。
 
-簡易又迅速 5 步驟就開始使用 Astro 的方法，請看 [快速開始指南](quick-start)。
+簡易又迅速 5 步驟就開始使用 Astro 的方法，請看 [快速開始指南](/zh-TW/quick-start)。
 
-或者，閱讀[安裝指南](/installation)，有安裝 Astro 的完整流程。
+或者，閱讀[安裝指南](/zh-TW/installation)，有安裝 Astro 的完整流程。
 
 ### 示範專案
 

--- a/src/pages/zh-TW/installation.md
+++ b/src/pages/zh-TW/installation.md
@@ -25,7 +25,7 @@ npm init astro
 yarn create astro
 ```
 
-[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro) 精靈提供一些[上手範本](/examples)進行挑選。或者，也可以直接從 Github 匯入自己的 Astro 專案。
+[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro) 精靈提供一些[上手範本](/zh-TW/examples)進行挑選。或者，也可以直接從 Github 匯入自己的 Astro 專案。
 
 ```bash
 # 提醒：把「my-astro-project」改為專案的名稱。
@@ -159,4 +159,4 @@ npm run build
 
 📚 深入了解 Astro 的元件語法：[Astro 元件指南。](/core-concepts/astro-components)
 
-📚 深入了解 Astro 根據檔案產生的路徑：[路徑指南。](core-concepts/astro-pages)
+📚 深入了解 Astro 根據檔案產生的路徑：[路徑指南。](/core-concepts/astro-pages)

--- a/src/pages/zh-TW/quick-start.md
+++ b/src/pages/zh-TW/quick-start.md
@@ -25,7 +25,7 @@ npm run dev
 npm run build
 ```
 
-若想要知道還有哪些方法能夠以 Astro 來做專案，請[閱讀安裝指南](installation)。
+若想要知道還有哪些方法能夠以 Astro 來做專案，請[閱讀安裝指南](/zh-TW/installation)。
 
 ## 開始專案
 
@@ -69,4 +69,4 @@ Astro 網站是靜態的，所以可以發布至慣用的主機：
 
 📚 深入了解 Astro 的元件語法：[Astro 元件指南。](/core-concepts/astro-components)
 
-📚 深入了解 Astro 根據檔案產生的路徑：[路徑指南。](core-concepts/astro-pages)
+📚 深入了解 Astro 根據檔案產生的路徑：[路徑指南。](/core-concepts/astro-pages)


### PR DESCRIPTION
I noticed that some of the links on the webpage are broken or pointing to the English page instead of the already translated one. This commit will fix it.