### PR TITLE
add trailing slash for sidebar links

### DIFF
--- a/src/components/LeftSidebar/SidebarContent.astro
+++ b/src/components/LeftSidebar/SidebarContent.astro
@@ -18,7 +18,7 @@ const { type, defaultActiveTab, sidebarSections, currentPageMatch } = Astro.prop
 				{section.children.map((child) => (
 					<li class="nav-link">
 						<a
-							href={`${Astro.site.pathname}${child.link}`}
+							href={`${Astro.site.pathname}${child.link}/`}
 							aria-current={`${currentPageMatch === child.link ? 'page' : 'false'}`}
 							set:html={child.text}
 						/>


### PR DESCRIPTION
The production build/hosting use a trailing slash but the nav links don't. This cases an extra 301 redirect request for every link.

This fixes the problem by adding the slash to the end of the sidebar links. I checked all the links and nothing is broken with this change.


![image](https://user-images.githubusercontent.com/457226/159190764-68effc03-adec-4e8b-b127-f9b41059e579.png)

![image](https://user-images.githubusercontent.com/457226/159190753-f47a5488-1019-405e-a5ae-bdc35c92ea78.png)
