### PR TITLE
Updated to existing pages w old render config instructions

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -5,6 +5,35 @@ description: Learn how to use React, Svelte, etc.
 ---
 Build your Astro website without sacrificing your favorite component framework. Astro supports a variety of popular frameworks including [React](https://reactjs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Vue](https://vuejs.org/), [SolidJS](https://www.solidjs.com/), [AlpineJS](https://alpinejs.dev/) and [Lit](https://lit.dev/). 
 
+## Installing Integrations
+
+Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
+
+To configure Astro to use these frameworks, first, install its integration:
+
+```bash
+npm install --save-dev @astrojs/react
+```
+
+Then import and add the function to your list of integrations in `astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config';
+
+import react from '@astrojs/react';
+import preact from '@astrojs/preact';
+import svelte from '@astrojs/svelte';
+import vue from '@astrojs/vue';
+import solid from '@astrojs/solid-js';
+import lit from '@astrojs/lit';
+
+export default defineConfig({
+	integrations: [react(), preact(),svelte(), vue(), solid() , lit()],
+});
+```
+
+⚙️ View the [Integrations Guide](/en/guides/integration-guide) for more details on installing and configuring Astro integrations.
+
 ## Using Framework Components
 
 Use your JavaScript framework components in your Astro pages, layouts and components just like Astro components! All your components can live together in `/src/components`, or can be organized in any way you like.
@@ -139,23 +168,3 @@ This allows you to build entire "apps" in your preferred JavaScript framework an
 [mdn-mm]: https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
 
 
-## Customize Your Frameworks
-
-By default, Astro ships with support out-of-the-box for React, Preact, Svelte and Vue. You can configure Astro to add new frameworks or remove support for any that you are not using.
-
-You can edit your project's current list of available renderers in your `astro.config.mjs` file:
-
-```js
-export default ({
-renderers: [
-    '@astrojs/renderer-svelte',
-    '@astrojs/renderer-vue',
-    '@astrojs/renderer-react',
-    '@astrojs/renderer-preact',
-    '@astrojs/renderer-lit',
-    '@astrojs/renderer-solid',
-  ],
-});
-```
-
-⚙️ View the [Renderer Reference API](/en/reference/renderer-reference) to learn how to build your own framework renderers.

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -7,12 +7,14 @@ Build your Astro website without sacrificing your favorite component framework. 
 
 ## Installing Integrations
 
+**New in v0.25!** 
+
 Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
 
-To configure Astro to use these frameworks, first, install its integration:
+To configure Astro to use these frameworks, first, install its integration and any associated peer dependencies:
 
 ```bash
-npm install --save-dev @astrojs/react
+npm install --save-dev @astrojs/react react react-dom
 ```
 
 Then import and add the function to your list of integrations in `astro.config.mjs`:

--- a/src/pages/en/guides/manual-setup.md
+++ b/src/pages/en/guides/manual-setup.md
@@ -90,17 +90,13 @@ Astro is configured using `astro.config.mjs`. This file is optional if you do no
 Create `astro.config.mjs` at the root of your project, and copy the code below into it:
 
 ```
-// Full Astro Configuration API Documentation:
-// https://docs.astro.build/reference/configuration-reference
+import { defineConfig } from 'astro/config';
 
-// @ts-check
-export default /** @type {import('astro').AstroUserConfig} */ ({
-// Comment out "renderers: []" to enable Astro's default component support.
-renderers: [],
-});
+// https://astro.build/config
+export default defineConfig({});
 ```
 
-If you want to include framework components such as React, Svelte, etc. in your project, here is where you will [manually add any necessary renderers](/en/core-concepts/framework-components/#customize-your-frameworks).
+If you want to include [UI framework components](/en/core-concepts/framework-components/) such as React, Svelte, etc. or use other tools such as Tailwind or Partytown in your project, here is where you will [manually import and configure integrations](/en/guides/integrations-guide).
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 


### PR DESCRIPTION
Slipping this in as a PR to the integration-docs branch, so that it's all contained together.

Updates some exisiting guides that currently explain how to add/update/edit the list of renderers in `astro.config.mjs`. Now, they contain instructions for/links to adding integrations.