### PR TITLE
Fix white on light grey text in DocSearch modal

### DIFF
--- a/src/components/Header/Search.css
+++ b/src/components/Header/Search.css
@@ -1,5 +1,6 @@
 /** Style Algolia */
 :root {
+	--docsearch-hit-active-color: var(--theme-text);
 	--docsearch-primary-color: var(--theme-text-accent);
 	--docsearch-logo-color: var(--theme-text);
 }


### PR DESCRIPTION
Just noticed that the hovered item in the search modal with the light theme currently uses an illegible text colour. This PR fixes that.

| before | after |
|--------|-------|
| ![Screen Shot 2022-03-22 at 10 09 11](https://user-images.githubusercontent.com/357379/159445918-01373486-2d39-4d5e-91fd-f06bba9d8791.png) | ![Screen Shot 2022-03-22 at 10 09 26](https://user-images.githubusercontent.com/357379/159445928-b35a90f7-feb9-4fd6-9c74-66a30d00a444.png) |

