### PR TITLE
fix: broken examples links

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -12,9 +12,9 @@ This reference page is for anyone writing their own integration. To learn how to
 
 The official Astro integrations can act as reference for you as you go to build your own integrations.
 
-- **Renderers:** [`lit`](https://github.com/withastro/astro/blob/main/packages/integrations/lit/index.js), [`svelte`](https://github.com/withastro/astro/blob/main/packages/integrations/svelte/index.js), [`react`](https://github.com/withastro/astro/blob/main/packages/integrations/react/index.js), [`preact`](https://github.com/withastro/astro/blob/main/packages/integrations/preact/index.js), [`vue`](https://github.com/withastro/astro/blob/main/packages/integrations/vue/index.js), [`solid`](https://github.com/withastro/astro/blob/main/packages/integrations/solid/index.js)
-- **Libraries:** [`tailwind`](https://github.com/withastro/astro/blob/main/packages/integrations/tailwind/index.js), [`partytown`](https://github.com/withastro/astro/blob/main/packages/integrations/partytown/index.js), [`turbolinks`](https://github.com/withastro/astro/blob/main/packages/integrations/turbolinks/index.js)
-- **Features:** [`sitemap`](https://github.com/withastro/astro/blob/main/packages/integrations/sitemap/index.js)
+- **Renderers:** [`lit`](https://github.com/withastro/astro/blob/main/packages/integrations/lit/src/index.ts), [`svelte`](https://github.com/withastro/astro/blob/main/packages/integrations/svelte/src/index.ts), [`react`](https://github.com/withastro/astro/blob/main/packages/integrations/react/src/index.ts), [`preact`](https://github.com/withastro/astro/blob/main/packages/integrations/preact/src/index.ts), [`vue`](https://github.com/withastro/astro/blob/main/packages/integrations/vue/src/index.ts), [`solid`](https://github.com/withastro/astro/blob/main/packages/integrations/solid/src/index.ts)
+- **Libraries:** [`tailwind`](https://github.com/withastro/astro/blob/main/packages/integrations/tailwind/src/index.ts), [`partytown`](https://github.com/withastro/astro/blob/main/packages/integrations/partytown/src/index.ts), [`turbolinks`](https://github.com/withastro/astro/blob/main/packages/integrations/turbolinks/src/index.ts)
+- **Features:** [`sitemap`](https://github.com/withastro/astro/blob/main/packages/integrations/sitemap/src/index.ts)
 
 ## Quick API Reference
 


### PR DESCRIPTION
# Description

This pull requests fixes broken examples links in the docs for the new integration system:

```diff
- lit/index.js
+ lit/src/index.ts
```