### PR TITLE
Correction to Vercel-from-Git deploy instructions

### DIFF
--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -362,7 +362,7 @@ $ vercel
 
 1. Push your code to your git repository (GitHub, GitLab, BitBucket).
 2. [Import your project](https://vercel.com/new) into Vercel.
-3. Update `Output Directory` to `./dist`.
+3. Update `Output Directory` to `dist`.
 4. Your application is deployed! (e.g. [astro.vercel.app](https://astro.vercel.app/))
 
 After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/concepts/deployments/environments#preview), and all changes made to the Production Branch (commonly “main”) will result in a [Production Deployment](https://vercel.com/docs/concepts/deployments/environments#production).


### PR DESCRIPTION
Correcting the [Vercel-from-Git instructions](https://docs.astro.build/en/guides/deploy/#git) to use `dist` rather than `./dist` for the `Output Directory` settings. Using `./dist` will result in a deployment that renders a 404 for the home page.