### PR TITLE
Adds an AgnosticUI + Astro starter

### DIFF
--- a/src/pages/en/integrations/integrations.md
+++ b/src/pages/en/integrations/integrations.md
@@ -57,5 +57,6 @@ Here are some production sites, repositories, blog posts and videos from the com
 
 [p13rnd/centauri](https://github.com/p13rnd/centauri) - Astro template: Tailwind, Svelte and authentication with Supabase
 
+[AstroAgnosticUIStarter](https://github.com/AgnosticUI/AstroAgnosticUIStarter) — Experimental starter template for leveraging Astro + AgnosticUI to render React, Vue 3, and Svelte.
 
 > See examples of even more starter repositories and sites built with Astro at [Awesome Astro](https://github.com/one-aalam/awesome-astro#%E2%84%B9%EF%B8%8F-repositoriesstarter-kitscomponents)


### PR DESCRIPTION
AgnosticUI is a UI component library where one stylesheet is used for many frameworks. These UI components that work in React, Vue 3, and Svelte so I think that using alongside Astro is a very compelling polyglot microfrontend sort of use case.

