### PR TITLE
CLI Reference - Quick typo/edits

### DIFF
--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -7,7 +7,7 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or whichever folder is specified in your [configuration](/en/reference/configuration-reference)).
+Runs  Astro's `dev` server. It starts a HTTP server which responds to requests for routes or pages that are specified within `src/pages` directory (unless overridden by your `pages` option set in the project [configuration](/en/reference/configuration-reference)).
 
 **Flags**
 

--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -7,17 +7,17 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or which folder is specified in your [configuration](/en/reference/configuration-reference)).
+Runs the Astro development server. This starts an HTTP server that responds to requests for pages stored in `src/pages` (or whichever folder is specified in your [configuration](/en/reference/configuration-reference)).
 
 **Flags**
 
 #### `--port`
 
-Specifies should port to run on. Defaults to `3000`.
+Specifies which port to run on. Defaults to `3000`.
 
 #### `--host [optional host address]`
 
-Set which network IP addresses the dev server should listen on (i.e. non-localhost IPs).
+Sets which network IP addresses the dev server should listen on (i.e. non-localhost IPs).
 - `--host` - listen on all addresses, including LAN and public addresses
 - `--host [custom-address]` - expose on a network IP address at `[custom-address]`
 
@@ -27,7 +27,7 @@ Builds your site for production.
 
 ### `astro preview`
 
-Start a local static file server to serve your built `dist/` directory. Useful for previewing your static build locally, before deploying it.
+Starts a local static file server to serve your built `dist/` directory. Useful for previewing your static build locally, before deploying it.
 
 This command is meant for local testing only, and is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy).
 
@@ -41,7 +41,7 @@ This command is intended to be used in CI workflows.
 
 ### `--config path`
 
-Specify the path to the config file. Defaults to `astro.config.mjs`. Use this if you use a different name for your configuration file or have your config file in another folder.
+Specifies the path to the config file. Defaults to `astro.config.mjs`. Use this if you use a different name for your configuration file or have your config file in another folder.
 
 ```shell
 astro --config config/astro.config.mjs dev
@@ -49,7 +49,7 @@ astro --config config/astro.config.mjs dev
 
 ### `--project-root path`
 
-Specify the path to the project root. If not specified the current working directory is assumed to be the root.
+Specifies the path to the project root. If not specified the current working directory is assumed to be the root.
 
 The root is used for finding the Astro configuration file.
 
@@ -67,12 +67,12 @@ Enables verbose logging, which is helpful when debugging an issue.
 
 ### `--silent`
 
-Enables silent logging, which is helpful for when you don't want to see Astro logs.
+Enables silent logging, which is helpful when you don't want to see Astro logs.
 
 ### `--version`
 
-Print the Astro version number and exit.
+Prints the Astro version number and exits.
 
 ### `--help`
 
-Print the help message and exit.
+Prints the help message and exits.

--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -7,7 +7,7 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs  Astro's `dev` server. It starts a HTTP server which responds to requests for routes or pages that are specified within `src/pages` directory (unless overridden by your `pages` option set in the project [configuration](/en/reference/configuration-reference)).
+Runs  Astro's `dev` server. It starts an HTTP server which responds to requests for routes or pages that are specified within `src/pages` directory (unless overridden by your `pages` option set in the project [configuration](/en/reference/configuration-reference)).
 
 **Flags**
 


### PR DESCRIPTION
Just minor fixes, and updated to the same verb tense throughout all the commands.