### PR TITLE
Fix broken link to manual installation guide

### DIFF
--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -35,7 +35,7 @@ npm init astro
 
 ⚙️ Our [Installation Guide](/en/install/auto) has full, step-by-step instructions for installing Astro with your favourite package manager.
 
-⚙️ See instructions for [manual setup](/en/guides/manual-setup) instead.
+⚙️ See instructions for [manual setup](/en/install/manual/) instead.
 
 
 ## Start building with Astro


### PR DESCRIPTION
Just noticed the link from the getting started page wasn’t updated.