### PR TITLE
Fix broken link on "Framework Components" page

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -34,7 +34,7 @@ export default defineConfig({
 });
 ```
 
-⚙️ View the [Integrations Guide](/en/guides/integration-guide) for more details on installing and configuring Astro integrations.
+⚙️ View the [Integrations Guide](/en/guides/integrations-guide) for more details on installing and configuring Astro integrations.
 
 ## Using Framework Components
 


### PR DESCRIPTION
Fixes a link on the "Framework Components" concepts page which currently 404s:

1. click the link:
    <img width="200" alt="Screen Shot 2022-03-29 at 12 59 48 PM" src="https://user-images.githubusercontent.com/3759507/160666141-1020e192-0b09-4f39-84f1-4afc5e1b9166.png">
1. it 404s:
    <img width="475" alt="Screen Shot 2022-03-29 at 1 00 01 PM" src="https://user-images.githubusercontent.com/3759507/160666149-1ac38ec5-38bd-41bf-acc0-8fe7343762f5.png">

