### PR TITLE
Editor Setup page w VS Code Extension info

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ export const SIDEBAR = {
 		{ text: 'Start Here', header: true, type: 'learn' },
 		{ text: 'Getting Started', link: 'en/getting-started' },
 		{ text: 'Installation', link: 'en/install' },
-		// ADD: Editor Setup
+		{ text: 'Editor Setup', link: 'en/editor-setup' },
 		{ text: 'Migration Guide', link: 'en/migrate' },
 		// REMOVE "Built with Astro": (Move into astro.build)
 		{ text: 'Built with Astro', link: `en/integrations/integrations` },

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -19,9 +19,9 @@ rely on that same setup of configuration files to give you inline typescript inf
 
 ## VS Code
 
-[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. VS Code is our recommended code editor for Astro projects, including VS Code-powered browser editors like [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
+[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. The VS Code engine also powers popular in-browser code editors like [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
 
-The [Official Astro Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) for VS Code makes web development even easier by unlocking several key features for Astro projects:
+Astro works with any code editor. However, VS Code is our recommended editor for Astro projects. We maintain an official [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that unlocks several key features and developer experience improvements for Astro projects.
 
 - Syntax highlighting for `.astro` files.
 - TypeScript type information for `.astro` files.
@@ -31,7 +31,7 @@ To get started, Install the [Astro VS Code Extension](https://marketplace.visual
 
 ## Other Code Editors
 
-Our amazing community maintains extensions for several other popular editors, including:
+Our amazing community maintains several extensions for other popular editors, including:
 
 - [VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) <span style="margin: 0.25em;"><Badge variant="accent">Official</Badge></span> - The official Astro VS Code Extension, available on the Open VSX registry for open platforms like [VSCodium](https://vscodium.com/)
 - [Nova Extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/)<span style="margin: 0.25em;"><Badge variant="neutral">Community</Badge></span> - Syntax highlighting, IntelliSense, autocompletion for Astro

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -1,14 +1,17 @@
 ---
 layout: ~/layouts/MainLayout.astro
+setup: |
+  import Badge from '~/components/Badge.astro';
 title: Editor Setup
 description: Set up your editor to build with Astro.
 ---
 You can build your Astro site with any code editor, installed locally or in the cloud!
 
-[VS Code](https://code.visualstudio.com) is a popular code editor that can be dowloaded locally, and is also used by online platforms such as [GitHub.dev](https://github.dev), [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
-
+This page explains how to improve the experience of editing `.astro` files in supported editors.
 
 ## VS Code Extension
+
+[VS Code](https://code.visualstudio.com) is a popular code editor that can be dowloaded locally, and is also used by online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io). 
 
 Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
 
@@ -21,7 +24,12 @@ Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https:/
 - Code folding
 - Emmet
 
-After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview), to get started building with Astro:
+### Installation
+
+
+After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview) and running any of our [Astro starter templates](https://github.com/withastro/astro/tree/main/examples), the Astro VS Code extension should be recommended to you automatically by a pop-up (in the bottom right corner).
+
+To add the extension yourself:
 
 1. Navigate to the "Extensions" tab ("Ctrl-Shift-X")
 2. Search for "astro" in the VS Code Marketplace
@@ -29,12 +37,14 @@ After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overvi
 
 ## Other Astro language extensions
 
-You can also get Astro language support for other code editors using:
+You can also get Astro language support using:
 
-[Astro VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) - the complete VS Code Extension, available on the Open VSX registry for open platforms like Gitpod.
+- [Astro VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) <span style="margin: 0.25em;"><Badge variant="accent">Official</Badge></span> - The official Astro VS Code Extension, available on the Open VSX registry for open platforms like [VSCodium](https://vscodium.com/)
 
-[Nova editor extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/) - Syntax highlighting, IntelliSense, autocompletion for 🚀 Astro
+- [Nova editor extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/)<span style="margin: 0.25em;"><Badge variant="neutral">Community</Badge></span> - Syntax highlighting, IntelliSense, autocompletion for Astro
 
 ## In-Browser Editors
 
 [StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) are online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
+
+[GitHub.dev](https://github.dev) allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -6,7 +6,7 @@ title: Editor Setup
 description: Set up your editor to build with Astro.
 ---
 
-Set up your code editor to improve the developer experience of working with Astro.
+Customize your code editor to improve the Astro developer experience and unlock new features.
 
 <!-- 
 TODO: ## TypeScript 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -19,15 +19,15 @@ rely on that same setup of configuration files to give you inline typescript inf
 
 ## VS Code
 
-[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. It is our official code editor of choice for Astro because it powers local development and online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
+[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. VS Code is our recommended code editor for Astro projects, including VS Code-powered browser editors like [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
 
-To get started, install the [Official Astro Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) for VS Code. While this extension is not required for development, it unlocks several key features for Astro:
+The [Official Astro Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) for VS Code makes web development even easier by unlocking several key features for Astro projects:
 
 - Syntax highlighting for `.astro` files.
 - TypeScript type information for `.astro` files.
 - [VS Code Intellisense](https://code.visualstudio.com/docs/editor/intellisense) for code completion, hints and more.
 
-Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) to get started. 
+To get started, Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) today.
 
 ## Other Code Editors
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -11,7 +11,7 @@ This page explains how to improve the experience of editing `.astro` files in su
 
 ## VS Code Extension
 
-[VS Code](https://code.visualstudio.com) is a popular code editor that can be dowloaded locally, and is also used by online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io). 
+[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded locally, and is also used by online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io). 
 
 Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
 
@@ -31,7 +31,7 @@ After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overvi
 
 To add the extension yourself:
 
-1. Navigate to the "Extensions" tab ("Ctrl-Shift-X")
+1. Navigate to the "Extensions" tab
 2. Search for "astro" in the VS Code Marketplace
 3. Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode)
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -27,7 +27,7 @@ Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https:/
 ### Installation
 
 
-After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview) and running any of our [Astro starter templates](https://github.com/withastro/astro/tree/main/examples), the Astro VS Code extension should be recommended to you automatically by a pop-up (in the bottom right corner).
+After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview) and starting any of our [Astro starter example templates](https://github.com/withastro/astro/tree/main/examples), VS Code should prompt you to install the Astro extension automatically. (Look for a pop-up in the bottom right corner!)
 
 To add the extension yourself:
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -35,7 +35,7 @@ To add the extension yourself:
 2. Search for "astro" in the VS Code Marketplace
 3. Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode)
 
-## Other Astro language extensions
+## Other Astro Language Extensions
 
 You can also get Astro language support using:
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -11,7 +11,7 @@ Improve your experience by working with `.astro` files in supported editors with
 
 ## VS Code Extension
 
-[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded and used locally as well as on online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
+[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded and used locally or in full online development platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
 
 Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -7,7 +7,7 @@ description: Set up your editor to build with Astro.
 ---
 You can build and develop your Astro project using any of your favorite code editors, either locally or in the cloud!
 
-This page explains how to improve the experience of editing `.astro` files in supported editors.
+Improve your experience by working with `.astro` files in supported editors with Astro language support.
 
 ## VS Code Extension
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -1,0 +1,42 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Editor Setup
+description: Set up your editor to build with Astro.
+---
+You can build your Astro site with any code editor, installed locally or in the cloud!
+
+[VS Code](https://code.visualstudio.com) is a popular code editor that can be dowloaded locally, and is also used by online platforms such as [GitHub.dev](https://github.dev), [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
+
+
+## VS Code Extension
+
+Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
+
+### Full List of Features
+- [Go to Definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
+- Code hover hints 
+- Code completion
+- Function signatures
+- Syntax highlighting
+- Code folding
+- Emmet
+
+After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview), to get started building with Astro:
+
+1. Navigate to the "Extensions" tab ("Ctrl-Shift-X")
+2. Search for "astro" in the VS Code Marketplace
+3. Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode)
+
+## Other Astro language extensions
+
+You can also get Astro language support for other code editors using:
+
+[Astro VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) - the complete VS Code Extension, available on the Open VSX registry for open platforms like Gitpod.
+
+[Nova editor extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/) - Syntax highlighting, IntelliSense, autocompletion for 🚀 Astro
+
+[ide-astro - Language support for Astro in Atom](https://atom.io/packages/ide-astro) - linting, debugging, IntelliSense, code navigation, code formatting, refactoring, unit tests, snippets, and more!
+
+## In-Browser Editors
+
+[StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) are online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -37,7 +37,7 @@ To add the extension yourself:
 
 ## Other Astro Language Extensions
 
-You can also get Astro language support using:
+You can also get Astro language support outside of VS Code using:
 
 - [Astro VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) <span style="margin: 0.25em;"><Badge variant="accent">Official</Badge></span> - The official Astro VS Code Extension, available on the Open VSX registry for open platforms like [VSCodium](https://vscodium.com/)
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -35,8 +35,6 @@ You can also get Astro language support for other code editors using:
 
 [Nova editor extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/) - Syntax highlighting, IntelliSense, autocompletion for 🚀 Astro
 
-[ide-astro - Language support for Astro in Atom](https://atom.io/packages/ide-astro) - linting, debugging, IntelliSense, code navigation, code formatting, refactoring, unit tests, snippets, and more!
-
 ## In-Browser Editors
 
 [StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) are online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -11,7 +11,7 @@ Improve your experience by working with `.astro` files in supported editors with
 
 ## VS Code Extension
 
-[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded locally, and is also used by online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io). 
+[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded and used locally as well as on online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
 
 Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -5,46 +5,40 @@ setup: |
 title: Editor Setup
 description: Set up your editor to build with Astro.
 ---
-You can build and develop your Astro project using any of your favorite code editors, either locally or in the cloud!
 
-Improve your experience by working with `.astro` files in supported editors with Astro language support.
+Set up your code editor to improve the developer experience of working with Astro.
 
-## VS Code Extension
-
-[VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded and used locally or in full online development platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
-
-Astro has its own [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
-
-### Full List of Features
-- [Go to Definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
-- Code hover hints 
-- Code completion
-- Function signatures
-- Syntax highlighting
-- Code folding
-- Emmet
-
-### Installation
+<!-- 
+TODO: ## TypeScript 
+We talked about having a dedicated TypeScript page for specific instructions on how to set 
+up your tsconfig.json, your env files, what features are expected, etc. etc.
+Once that page exists, it would be good to link to that here, since your editor will probably 
+rely on that same setup of configuration files to give you inline typescript info. 
+-->
 
 
-After [setting up VS Code](https://code.visualstudio.com/Docs/setup/setup-overview) and starting any of our [Astro starter example templates](https://github.com/withastro/astro/tree/main/examples), VS Code should prompt you to install the Astro extension automatically. (Look for a pop-up in the bottom right corner!)
+## VS Code
 
-To add the extension yourself:
+[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. It is our official code editor of choice for Astro because it powers local development and online platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
 
-1. Navigate to the "Extensions" tab
-2. Search for "astro" in the VS Code Marketplace
-3. Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode)
+To get started, install the [Official Astro Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) for VS Code. While this extension is not required for development, it unlocks several key features for Astro:
 
-## Other Astro Language Extensions
+- Syntax highlighting for `.astro` files.
+- TypeScript type information for `.astro` files.
+- [VS Code Intellisense](https://code.visualstudio.com/docs/editor/intellisense) for code completion, hints and more.
 
-You can also get Astro language support outside of VS Code using:
+Install the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) to get started. 
 
-- [Astro VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) <span style="margin: 0.25em;"><Badge variant="accent">Official</Badge></span> - The official Astro VS Code Extension, available on the Open VSX registry for open platforms like [VSCodium](https://vscodium.com/)
+## Other Code Editors
 
-- [Nova editor extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/)<span style="margin: 0.25em;"><Badge variant="neutral">Community</Badge></span> - Syntax highlighting, IntelliSense, autocompletion for Astro
+Our amazing community maintains extensions for several other popular editors, including:
+
+- [VS Code Extension on Open VSX](https://open-vsx.org/extension/astro-build/astro-vscode) <span style="margin: 0.25em;"><Badge variant="accent">Official</Badge></span> - The official Astro VS Code Extension, available on the Open VSX registry for open platforms like [VSCodium](https://vscodium.com/)
+- [Nova Extension](https://extensions.panic.com/extensions/sciencefidelity/sciencefidelity.astro/)<span style="margin: 0.25em;"><Badge variant="neutral">Community</Badge></span> - Syntax highlighting, IntelliSense, autocompletion for Astro
 
 ## In-Browser Editors
 
-[StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) are online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
+In addition to local editors, Astro also runs well on in-browser hosted editors, including:
 
-[GitHub.dev](https://github.dev) allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
+- [StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) are online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
+- [GitHub.dev](https://github.dev) allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -13,7 +13,7 @@ Improve your experience by working with `.astro` files in supported editors with
 
 [VS Code](https://code.visualstudio.com) is a popular code editor that can be downloaded and used locally or in full online development platforms such as [GitHub Codespaces](https://github.com/features/codespaces), and [Gitpod](https://gitpod.io).
 
-Astro has its own [Astro VS Code Extension on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
+Astro has its own [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that you can install in any of these VS Code environments for .`astro` syntax highligting, code completion, and more!
 
 ### Full List of Features
 - [Go to Definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -5,7 +5,7 @@ setup: |
 title: Editor Setup
 description: Set up your editor to build with Astro.
 ---
-You can build your Astro site with any code editor, installed locally or in the cloud!
+You can build and develop your Astro project using any of your favorite code editors, either locally or in the cloud!
 
 This page explains how to improve the experience of editing `.astro` files in supported editors.
 


### PR DESCRIPTION
Initial Editor Setup page draft, to highlight the Astro VS code extension