### PR TITLE
Changed all astro.config references to .mjs

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -18,7 +18,7 @@ setup: |
 The following reference covers all supported configuration options in Astro. To learn more configuring Astro, read our guide on [Configuring Astro](/en/guides/configuring-astro/).
 
 \`\`\`js
-// astro.config.js
+// astro.config.mjs
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -29,7 +29,7 @@ export default {}
 
 ## Supported Config File Types
 
-Astro supports several file formats for its JavaScript configuration file: `astro.config.mjs`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. 
+Astro supports several file formats for its JavaScript configuration file: `astro.config.js`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. 
 
 TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project tsconfig options.
 ## Config File Resolving

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -3,7 +3,7 @@ layout: ~/layouts/MainLayout.astro
 title: Configuring Astro
 ---
 
-Customize how Astro works by adding an `astro.config.js` file in your project. This is a common file in Astro projects, and all official example templates and themes ship with one by default.
+Customize how Astro works by adding an `astro.config.mjs` file in your project. This is a common file in Astro projects, and all official example templates and themes ship with one by default.
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for a full overview of all supported configuration options.
 ## The Astro Config File
@@ -11,7 +11,7 @@ Customize how Astro works by adding an `astro.config.js` file in your project. T
 A valid Astro config file exports its configuration using the `default` export, using the recommended `defineConfig` helper:
 
 ```js
-// astro.config.js
+// astro.config.mjs
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
@@ -29,15 +29,15 @@ export default {}
 
 ## Supported Config File Types
 
-Astro supports several file formats for its JavaScript configuration file: `astro.config.js`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. 
+Astro supports several file formats for its JavaScript configuration file: `astro.config.mjs`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. 
 
 TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project tsconfig options.
 ## Config File Resolving
 
-Astro will automatically try to resolve a config file named `astro.config.js` inside [project root](/guide/#index-html-and-project-root). If no config file is found in your project root, Astro's default options will be used.
+Astro will automatically try to resolve a config file named `astro.config.mjs` inside [project root](/guide/#index-html-and-project-root). If no config file is found in your project root, Astro's default options will be used.
 
 ```bash
-# Example: Reads your configuration from ./astro.config.js
+# Example: Reads your configuration from ./astro.config.mjs
 astro build
 ```
 
@@ -53,7 +53,7 @@ astro build --config my-config-file.js
 Astro recommends using the `defineConfig()` helper in your configuration file. `defineConfig()` provides automatic IntelliSense in your IDE. Editors like VSCode are able to read Astro's TypeScript type definitions and provide automatic jsdoc type hints, even if your configuration file isn't written in TypeScript.
 
 ```js
-// astro.config.js
+// astro.config.mjs
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
@@ -65,7 +65,7 @@ export default defineConfig({
 You can also provide type definitions manually to VSCode, using this JSDoc notation:
 
 ```js
-// astro.config.js
+// astro.config.mjs
  export default /** @type {import('astro').AstroUserConfig} */ ({
   // your configuration options here...
   // https://docs.astro.build/en/reference/configuration-reference/

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -27,7 +27,7 @@ Read our [step-by-step walkthrough](/en/guides/integrations-guide) to learn how 
 
 The new integration system replaces the previous `renderers` system, including the published `@astrojs/renderer-*` packages on npm. Going forward, `@astrojs/renderer-react` becomes `@astrojs/react`, `@astrojs/renderer-vue` becomes `@astrojs/vue`, and so on. 
 
-**To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.js` file, based on your current config. You can also update your packages yourself, using the table below. 
+**To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.mjs` file, based on your current config. You can also update your packages yourself, using the table below. 
 
 For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide) to learn how to replace existing renderers with a new Astro framework integration.
 
@@ -38,7 +38,7 @@ For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-
 + npm install @astrojs/react react react-dom
 ```
 ```diff
-# Then, update your `astro.config.js` file:
+# Then, update your `astro.config.mjs` file:
 # (Read the full walkthrough: https://docs.astro.build/en/guides/integrations-guide)
 + import lit from '@astrojs/lit';
 + import react from '@astrojs/react';

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -11,7 +11,7 @@ setup: |
 The following reference covers all supported configuration options in Astro. To learn more about configuring Astro, read our guide on [Configuring Astro](/en/guides/configuring-astro/).
 
 ```js
-// astro.config.js
+// astro.config.mjs
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
@@ -29,7 +29,7 @@ export default defineConfig({
 **Default:** `"."` (current working directory)
 </p>
 
-You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
+You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.mjs` file, since Astro needs to know your project root before it can locate your config file.
 
 If you provide a relative path (ex: `--project-root: './my-project'`) Astro will resolve it against your current working directory.
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -11,7 +11,7 @@ setup: |
 The following reference covers all supported configuration options in Astro. To learn more about configuring Astro, read our guide on [Configuring Astro](/en/guides/configuring-astro/).
 
 ```js
-// astro.config.mjs
+// astro.config.js
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
@@ -29,7 +29,7 @@ export default defineConfig({
 **Default:** `"."` (current working directory)
 </p>
 
-You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.mjs` file, since Astro needs to know your project root before it can locate your config file.
+You should only provide this option if you run the `astro` CLI commands in a directory other than the project root directory. Usually, this option is provided via the CLI instead of the `astro.config.js` file, since Astro needs to know your project root before it can locate your config file.
 
 If you provide a relative path (ex: `--project-root: './my-project'`) Astro will resolve it against your current working directory.
 


### PR DESCRIPTION
Includes the docgen file, but NOT the configuration-reference file, since it is auto-generated.

NOTE: I think the docgen file will address the top of the page config example in /reference/configuration-reference but this page ALSO contains `astro.config.js` in the section "project root." So, whatever generates that description should be updated.