### PR TITLE
WIP: Rename integrations to extensions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ packages:
     resolution: {integrity: sha512-4YM4hM02ILvvsSQljAlwLY7OWymlhbikY7O/gsZqELVGMXixemA6dI3GTr2K6duU4ktPBJ3JexuU/OFyb5jvtQ==}
     hasBin: true
     dependencies:
-      '@astrojs/svelte-language-integration': 0.1.2_typescript@4.6.2
+      '@astrojs/svelte-language-extension': 0.1.2_typescript@4.6.2
       '@vscode/emmet-helper': 2.8.4
       lodash: 4.17.21
       source-map: 0.7.3
@@ -237,7 +237,7 @@ packages:
       - '@babel/core'
     dev: true
 
-  /@astrojs/svelte-language-integration/0.1.2_typescript@4.6.2:
+  /@astrojs/svelte-language-extension/0.1.2_typescript@4.6.2:
     resolution: {integrity: sha512-O6LYL9igYSzxCxDHYWUqEquuuUlMG0UL1SliZ7rF/vx9GwU71TCpsRe4iHZ0bcemM5ju9ihoTzGCmLXzYrNw0g==}
     dependencies:
       svelte: 3.46.4

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export const SIDEBAR = {
 		{ text: 'Editor Setup', link: 'en/editor-setup' },
 		{ text: 'Migration Guide', link: 'en/migrate' },
 		// REMOVE "Built with Astro": (Move into astro.build)
-		{ text: 'Built with Astro', link: `en/integrations/integrations` },
+		{ text: 'Built with Astro', link: `en/extensions/extensions` },
 		{ text: 'Astro vs. X', link: 'en/comparing-astro-vs-other-tools' },
 
 		{ text: 'Core Concepts', header: true, type: 'learn' },
@@ -29,8 +29,8 @@ export const SIDEBAR = {
 		{ text: 'Data Fetching', link: 'en/guides/data-fetching' },
 		{ text: 'Deploy', link: 'en/guides/deploy' },
 		{ text: 'Environment Variables', link: 'en/guides/environment-variables' },
+		{ text: 'Extensions', link: 'en/guides/integrations-guide' },
 		{ text: 'Import Aliases', link: 'en/guides/aliases' },
-		{ text: 'Integrations', link: 'en/guides/integrations-guide' },
 		{ text: 'RSS', link: 'en/guides/rss' },
 		{ text: 'UI Frameworks', link: 'en/core-concepts/framework-components' },
 		
@@ -41,7 +41,7 @@ export const SIDEBAR = {
 		},
 		{ text: 'CLI', link: 'en/reference/cli-reference' },
 		{ text: 'Runtime API', link: 'en/reference/api-reference' },
-		{ text: 'Integrations API', link: 'en/reference/integrations-reference' },
+		{ text: 'Extensions API', link: 'en/reference/integrations-reference' },
 		{ text: 'Routing Rules', link: 'en/core-concepts/routing' },
 		// ADD: Astro Component Syntax
 		// ADD: Markdown Syntax

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -5,19 +5,19 @@ description: Learn how to use React, Svelte, etc.
 ---
 Build your Astro website without sacrificing your favorite component framework. Astro supports a variety of popular frameworks including [React](https://reactjs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Vue](https://vuejs.org/), [SolidJS](https://www.solidjs.com/), [AlpineJS](https://alpinejs.dev/) and [Lit](https://lit.dev/). 
 
-## Installing Integrations
+## Installing Extensions
 
 **New in v0.25!** 
 
-Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
+Astro ships with optional extensions for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro extensions can be installed and configured in your project.
 
-To configure Astro to use these frameworks, first, install its integration and any associated peer dependencies:
+To configure Astro to use these frameworks, first, install its extension and any associated peer dependencies:
 
 ```bash
 npm install --save-dev @astrojs/react react react-dom
 ```
 
-Then import and add the function to your list of integrations in `astro.config.mjs`:
+Then import and add the function to your list of extensions in `astro.config.mjs`:
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -30,11 +30,11 @@ import solid from '@astrojs/solid-js';
 import lit from '@astrojs/lit';
 
 export default defineConfig({
-	integrations: [react(), preact(),svelte(), vue(), solid() , lit()],
+	extensions: [react(), preact(),svelte(), vue(), solid() , lit()],
 });
 ```
 
-⚙️ View the [Integrations Guide](/en/guides/integrations-guide) for more details on installing and configuring Astro integrations.
+⚙️ View the [Extensions Guide](/en/guides/integrations-guide) for more details on installing and configuring Astro extensions.
 
 ## Using Framework Components
 

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -66,7 +66,7 @@ See examples of some of the key concepts and patterns of an Astro site!
 
 ## Integrate with Astro
 
-Explore different integrations that our users have combined with Astro!
+Explore different extensions that our users have combined with Astro!
 
 🧰 Use a CMS with your Astro project.
 
@@ -74,7 +74,7 @@ Explore different integrations that our users have combined with Astro!
 
 🧰 Connect a database to your site.
 
-*... see our [third-party integrations](/en/integrations/integrations)*
+*... see our [third-party extensions](/en/extensions/extensions)*
 
 
 

--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -344,7 +344,7 @@ You can also deploy to a [custom domain](http://surge.sh/help/adding-a-custom-do
 
 ## Vercel
 
-You can deploy Astro to [Vercel](http://vercel.com) through the CLI or the Vercel git integrations.
+You can deploy Astro to [Vercel](http://vercel.com) through the CLI or the Vercel git extensions.
 
 ### CLI
 
@@ -367,7 +367,7 @@ $ vercel
 
 After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/concepts/deployments/environments#preview), and all changes made to the Production Branch (commonly “main”) will result in a [Production Deployment](https://vercel.com/docs/concepts/deployments/environments#production).
 
-Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/git).
+Learn more about Vercel’s [Git Extension](https://vercel.com/docs/concepts/git).
 
 ## Azure Static Web Apps
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -21,7 +21,7 @@ The following file types are supported out-of-the-box by Astro:
 - CSS Modules (`.module.css`)
 - Images & Assets (`.svg`, `.jpg`, `.png`, etc.)
 
-If you don't see the asset type that you're looking for, check out our [Integrations Library](https://astro.build/integrations/). You can extend Astro to add support for different file types, like Svelte and Vue components.
+If you don't see the asset type that you're looking for, check out our [Extensions Library](https://astro.build/extensions/). You can extend Astro to add support for different file types, like Svelte and Vue components.
 
 This guide details how different types of assets are built by Astro, and how to import them successfully.
 
@@ -55,7 +55,7 @@ import { MyComponent } from './MyComponent.jsx';
 
 Astro includes built-in support for JSX (`*.jsx` and `*.tsx`) files in your project. JSX sytax is automatically transpiled to JavaScript.
 
-While Astro understands JSX syntax out-of-the-box, you will need to include a framework integration to properly render frameworks like React, Preact and Solid. Check out our [Using Integrations](/en/guides/integrations-guide) guide to learn more.
+While Astro understands JSX syntax out-of-the-box, you will need to include a framework extension to properly render frameworks like React, Preact and Solid. Check out our [Using Extensions](/en/guides/integrations-guide) guide to learn more.
 
 **Note: Astro does not support JSX in `.js`/`.ts` files.** JSX will only be handled inside of files that end with the `.jsx` and `.tsx` file extensions.
 

--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -2,34 +2,34 @@
 layout: ~/layouts/MainLayout.astro
 setup: |
   import Badge from '~/components/Badge.astro';
-title: Using Integrations
+title: Using Extensions
 ---
 
-**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from npm. 
+**Astro Extensions** add new functionality and behaviors for your project with only a few lines of code. You can write a custom extension yourself, or grab popular ones from npm. 
 
 - Unlock React, Vue, Svelte, Solid, and other popular UI frameworks.
 - Integrate tools like Tailwind, Turbolinks, and Partytown with a few lines of code.
 - Add new features to your project, like automatic sitemap generation.
 - Write custom code that hooks into the build process, dev server, and more.
 
-> Integrations are still new, and the API has not yet been finalized. Only official Astro integrations (those published to `@astrojs/` on npm) are currently supported to protect users from breaking changes.
+> Extensions are still new, and the API has not yet been finalized. Only official Astro extensions (those published to `@astrojs/` on npm) are currently supported to protect users from breaking changes.
 > 
-> **To enable 3rd-party integrations:** Run Astro with the `--experimental-integrations` CLI flag.
+> **To enable 3rd-party extensions:** Run Astro with the `--experimental-extensions` CLI flag.
 
 ## Tutorial: Adding React to Your Project
 
-In this example, we will add the `@astrojs/react` integration to add React support to your Astro project. The process for adding any other framwork (Preact, Vue, Svelte or Solid.js) is almost identical and can be followed using the same steps outlined below.
+In this example, we will add the `@astrojs/react` extension to add React support to your Astro project. The process for adding any other framwork (Preact, Vue, Svelte or Solid.js) is almost identical and can be followed using the same steps outlined below.
 
 <blockquote>
   <Badge variant="accent">Feeling adventurous?</Badge>
   
   Astro recent launched an **experimental** `astro add` command to automate this process! Instead of the steps below, you can run `npx astro add react`. That's it! 
   
-  Skip down to [Automatic Integration Setup](/en/guides/integrations-guide/#automatic-integration-setup) for more details.
+  Skip down to [Automatic Extension Setup](/en/guides/integrations-guide/#automatic-extension-setup) for more details.
 
 </blockquote>
 
-First, you will need to install both the integration and any related packages that you expect to use in your project. For React, that means installing the `@astrojs/react` integration ***and*** the `react` + `react-dom` packages.
+First, you will need to install both the extension and any related packages that you expect to use in your project. For React, that means installing the `@astrojs/react` extension ***and*** the `react` + `react-dom` packages.
 
 ```bash
 npm install --save-dev @astrojs/react
@@ -43,28 +43,28 @@ Once your packages have been installed, add two new lines to your `astro.config.
 + import react from '@astrojs/react';
 
   export default defineConfig({
-+   integrations: [react()],
++   extensions: [react()],
   });
 ``` 
 
-The first line is the import statement that imports the integration into your configuration file. The second line calls the integration function (`react()`) and adds the integration so that Astro knows to use it.
+The first line is the import statement that imports the extension into your configuration file. The second line calls the extension function (`react()`) and adds the extension so that Astro knows to use it.
 
-That's it! Restart Astro, and the new integration should take effect immediately. 
+That's it! Restart Astro, and the new extension should take effect immediately. 
 
 If you see an error on startup, make sure that you:
 
 - ✅ installed the required packages with npm
-- ✅ imported the integration into your `astro.config.mjs` file
-- ✅ called your integration as a function (`[react()]`, not `[react]`)
+- ✅ imported the extension into your `astro.config.mjs` file
+- ✅ called your extension as a function (`[react()]`, not `[react]`)
 - ✅ removed the deprecated `renderers:` configuration
 
-## Automatic Integration Setup
+## Automatic Extension Setup
 
-Astro recent launched an **experimental** `astro add` command to automate the setup of integrations.
+Astro recent launched an **experimental** `astro add` command to automate the setup of extensions.
 
 > We will always ask for confirmation before updating any of your files, but it never hurts to have a version-controlled backup just in case.
 
-Instead of the manual configuration outlined above, just run `astro add [name]` and our automatic integration wizard will update your configuration file and install any necessary dependencies.
+Instead of the manual configuration outlined above, just run `astro add [name]` and our automatic extension wizard will update your configuration file and install any necessary dependencies.
 
 ```shell
 # Using NPM
@@ -75,7 +75,7 @@ yarn astro add react
 pnpx astro add react
 ```
 
-It's even possible to configure multiple integrations at the same time!
+It's even possible to configure multiple extensions at the same time!
 
 ```shell
 # Using NPM
@@ -86,14 +86,14 @@ yarn astro add react tailwind partytown
 pnpx astro add react tailwind partytown
 ```
 
-## Handling Integration Dependencies
+## Handling Extension Dependencies
 
-When installing an Astro integration in your project, keep an eye out for any "missing peer dependencies" warnings that you see during the install step. Not all package managers will peer dependencies for you automatically. If you are an Node v16+ and using npm, you should not need to worry about this section.
+When installing an Astro extension in your project, keep an eye out for any "missing peer dependencies" warnings that you see during the install step. Not all package managers will peer dependencies for you automatically. If you are an Node v16+ and using npm, you should not need to worry about this section.
 
-If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project.  React, for example, is a peer dependency of the `@astrojs/react` integration. That means that you should install the official `react` and `react-dom` packages alongside your integration. The integration will then pull from these packages automatically.
+If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project.  React, for example, is a peer dependency of the `@astrojs/react` extension. That means that you should install the official `react` and `react-dom` packages alongside your extension. The extension will then pull from these packages automatically.
 
 ```diff
-# Example: Install integrations and frameworks together
+# Example: Install extensions and frameworks together
 - npm install @astrojs/react
 + npm install @astrojs/react react react-dom
 ```
@@ -102,25 +102,25 @@ If you miss this step, don't worry, Astro will warn you during startup if any mi
 
 Managing your own peer dependencies may be a bit more work, but it also lets you control exactly what versions of packages you use for things like React, Tailwind, and more. This gives you more control over your project.
 
-In the future, a helpful `astro add` command will be able to handle all of this setup for you, and install the correct peer dependencies for your integrations automatically.
+In the future, a helpful `astro add` command will be able to handle all of this setup for you, and install the correct peer dependencies for your extensions automatically.
 
-## Using Integrations
+## Using Extensions
 
-Astro integrations are always added through the `integrations` property in your  `astro.config.mjs` file. 
+Astro extensions are always added through the `extensions` property in your  `astro.config.mjs` file. 
 
-There are three common ways to import an integration into your Astro project:
-1. Installing an npm package integration.
-2. Import your own integration from a local file inside your project.
-3. Write your integration inline, directly in your config file.
+There are three common ways to import an extension into your Astro project:
+1. Installing an npm package extension.
+2. Import your own extension from a local file inside your project.
+3. Write your extension inline, directly in your config file.
 
 ```js
 // astro.config.mjs
 import {defineConfig} from 'astro/config';
 import installedIntegration from '@astrojs/vue';
-import localIntegration from './my-integration.js';
+import localIntegration from './my-extension.js';
 
 export default defineConfig({
-  integrations: [
+  extensions: [
     // 1. Imported from an installed npm package
     installedIntegration(), 
     // 2. Imported from a local JS file
@@ -131,33 +131,33 @@ export default defineConfig({
 })
 ```
 
-Check out the [Integration API](/en/reference/integrations-reference) reference to learn all of the different ways that you can write an integration.
+Check out the [Extension API](/en/reference/integrations-reference) reference to learn all of the different ways that you can write an extension.
 
 ### Custom Options
 
-Integrations are almost always authored as factory functions that return the actual integration object. This lets you pass arguments and options to the factory function that customize the integration for your project.
+Extensions are almost always authored as factory functions that return the actual extension object. This lets you pass arguments and options to the factory function that customize the extension for your project.
 
 ```js
-integrations: [
-  // Example: Customize your integration with function arguments
+extensions: [
+  // Example: Customize your extension with function arguments
   sitemap({filter: true})
 ]
 ```
 
-### Toggle an Integration
+### Toggle an Extension
 
-Falsy integrations are ignored, so you can toggle integrations on & off without worrying about left-behind `undefined` and boolean values.
+Falsy extensions are ignored, so you can toggle extensions on & off without worrying about left-behind `undefined` and boolean values.
 
 ```js
-integrations: [
+extensions: [
   // Example: Skip building a sitemap on Windows
   process.platform !== 'win32' && sitemap()
 ]
 ```
 
 
-## Building Your Own Integration
+## Building Your Own Extension
 
-Astro's Integration API is inspired by Rollup and Vite, and designed to feel familiar to anyone who has ever written a Rollup or Vite plugin before.
+Astro's Extension API is inspired by Rollup and Vite, and designed to feel familiar to anyone who has ever written a Rollup or Vite plugin before.
 
-Check out the [Integration API](/en/reference/integrations-reference) reference to learn what integrations can do and how to write one yourself.
+Check out the [Extension API](/en/reference/integrations-reference) reference to learn what extensions can do and how to write one yourself.

--- a/src/pages/en/guides/publish-to-npm.md
+++ b/src/pages/en/guides/publish-to-npm.md
@@ -156,7 +156,7 @@ We recommend adding `astro-component` as a special keyword to maximize its disco
 }
 ```
 
-> Keywords are also used by our [integrations library](https://astro.build/integrations)! [See below](#integrations-library) for a full list of keywords we look for in NPM.
+> Keywords are also used by our [extensions library](https://astro.build/extensions)! [See below](#extensions-library) for a full list of keywords we look for in NPM.
 
 ---
 
@@ -240,15 +240,15 @@ Notice that there was no `build` step for Astro packages. Any file type that Ast
 
 If you need some other file type that isn't natively supported by Astro, you are welcome to add a build step to your package. This advanced exercise is left up to you.
 
-## Integrations Library
+## Extensions Library
 
-Share your hard work by adding your integration to our [integrations library](https://astro.build/integrations)!
+Share your hard work by adding your extension to our [extensions library](https://astro.build/extensions)!
 
 ### `package.json` data
 
 The library is automatically updated nightly, pulling in every package published to NPM with the `astro-component` keyword.
 
-The integrations library reads the `name`, `description`, `repository`, and `homepage` data from your `package.json`.
+The extensions library reads the `name`, `description`, `repository`, and `homepage` data from your `package.json`.
 
 Avatars are a great way to highlight your brand in the library! Avatars aren't supported by the NPM registry unfortunately, once your package is published you can [file an issue](https://github.com/withastro/astro.build/issues/new/choose) with the avatar attached.
 
@@ -256,7 +256,7 @@ Avatars are a great way to highlight your brand in the library! Avatars aren't s
 
 ### Collections
 
-In addition to the required `astro-component` keyword, special keywords are also used to automatically organize packages. Including any of the keywords below will add your integration to the collection in our integrations library.
+In addition to the required `astro-component` keyword, special keywords are also used to automatically organize packages. Including any of the keywords below will add your extension to the collection in our extensions library.
 
 | collection  | keywords                                 |
 |------------ | ---------------------------------------- |

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -122,11 +122,11 @@ You can also use the `<link>` element to load a stylesheet on the page. This sho
 Because this approach uses the `public/` directory, it skips the normal CSS processing, bundling and optimizations that are provided by Astro. If you need these transformations, use the [Import a Stylesheet](#import-a-stylesheet) method above.
 
 
-## CSS Integrations
+## CSS Extensions
 
 Astro comes with support for adding popular CSS libraries, tools and frameworks to your project like PostCSS, Tailwind and more! 
 
-📚 See the [Integrations Guide](/en/guides/integrations-guide/) for instructions on installing, importing and configuring these integrations.
+📚 See the [Extensions Guide](/en/guides/integrations-guide/) for instructions on installing, importing and configuring these extensions.
 
 
 ## CSS Preprocessors
@@ -160,7 +160,7 @@ Use `<style lang="less">` in `.astro` files.
 - **Vue**: `<style lang="scss">`
 - **Svelte**: `<style lang="scss">`
 
-Additionally, PostCSS is supported as an [integration](/en/guides/integrations-guide/).
+Additionally, PostCSS is supported as an [extension](/en/guides/integrations-guide/).
 
 
 ---

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -95,7 +95,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({});
 ```
 
-If you want to include [UI framework components](/en/core-concepts/framework-components/) such as React, Svelte, etc. or use other tools such as Tailwind or Partytown in your project, here is where you will [manually import and configure integrations](/en/guides/integrations-guide).
+If you want to include [UI framework components](/en/core-concepts/framework-components/) such as React, Svelte, etc. or use other tools such as Tailwind or Partytown in your project, here is where you will [manually import and configure extensions](/en/guides/integrations-guide).
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 

--- a/src/pages/en/integrations/integrations.md
+++ b/src/pages/en/integrations/integrations.md
@@ -7,7 +7,7 @@ Members of the Astro community have been successfully integrating several third-
 
 Here are some production sites, repositories, blog posts and videos from the community demonstrating how you can connect Astro with a variety of popular CMS, eCommerce, Authentication/Authorization, Search and Comment technologies.
 
-> Looking for a specific integration? Check out our new [integrations library](https://astro.build/integrations), and learn how to [add your integrations](/en/guides/publish-to-npm/#integrations-library) to the library!
+> Looking for a specific extension? Check out our new [extensions library](https://astro.build/extensions), and learn how to [add your extensions](/en/guides/publish-to-npm/#extensions-library) to the library!
 
 ## Production Sites
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -10,29 +10,29 @@ While we try to keep breaking changes to a minimum, we still expect some breakin
 
 ## Migrate to v0.25
 
-### Astro Integrations
+### Astro Extensions
 
-The `renderers` config has been replaced by a new, official integration system! This unlocks some really exciting new features for Astro. You can read our [Using Integrations](/en/guides/integrations-guide) guide for more details on how to use this new system.
+The `renderers` config has been replaced by a new, official extension system! This unlocks some really exciting new features for Astro. You can read our [Using Extensions](/en/guides/integrations-guide) guide for more details on how to use this new system.
 
-Integrations replace our original `renderers` concept, and come with a few breaking changes and new defaults for existing users. These changes are covered below.
+Extensions replace our original `renderers` concept, and come with a few breaking changes and new defaults for existing users. These changes are covered below.
 
 #### Removed: Built-in Framework Support
 
 Previously, React, Preact, Svelte, and Vue were all included with Astro by default. Starting in v0.25.0, Astro no longer comes with any built-in renderers. If you did not have a `renderers` configuration entry already defined for your project, you will now need to install those frameworks yourself.
 
-Read our [step-by-step walkthrough](/en/guides/integrations-guide) to learn how to add a new Astro integration for the framework(s) that you currently use.
+Read our [step-by-step walkthrough](/en/guides/integrations-guide) to learn how to add a new Astro extension for the framework(s) that you currently use.
 #### Deprecated: Renderers 
 
 > *Read this section if you have custom "renderers" already defined in your configuration file.*
 
-The new integration system replaces the previous `renderers` system, including the published `@astrojs/renderer-*` packages on npm. Going forward, `@astrojs/renderer-react` becomes `@astrojs/react`, `@astrojs/renderer-vue` becomes `@astrojs/vue`, and so on. 
+The new extension system replaces the previous `renderers` system, including the published `@astrojs/renderer-*` packages on npm. Going forward, `@astrojs/renderer-react` becomes `@astrojs/react`, `@astrojs/renderer-vue` becomes `@astrojs/vue`, and so on. 
 
 **To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.js` file, based on your current config. You can also update your packages yourself, using the table below. 
 
-For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide) to learn how to replace existing renderers with a new Astro framework integration.
+For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide) to learn how to replace existing renderers with a new Astro framework extension.
 
 ```diff  
-# Install your new integrations and frameworks:
+# Install your new extensions and frameworks:
 # (Read the full walkthrough: https://docs.astro.build/en/guides/integrations-guide)
 + npm install @astrojs/lit lit
 + npm install @astrojs/react react react-dom
@@ -45,12 +45,12 @@ For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-
 
 export default {
 -   renderers: ['@astrojs/renderer-lit', '@astrojs/renderer-react'],
-+   integrations: [lit(), react()],
++   extensions: [lit(), react()],
 }
 ```
 
 
-| Deprecated Renderers on npm | v0.25+ Integrations on npm |
+| Deprecated Renderers on npm | v0.25+ Extensions on npm |
 | --------------------------- | -------------------------- |
 | @astrojs/renderer-react     | @astrojs/react             |
 | @astrojs/renderer-preact    | @astrojs/preact            |
@@ -62,15 +62,15 @@ export default {
 
 > *Read this section if: You are on Node v14 **or** if you use any package manager other than npm.*
 
-Unlike the old renderers, integrations no longer mark the frameworks themselves ("react", "svelte", "vue", etc.) as direct dependencies of the integration. Instead, you should now install your framework packages *in addition to* your integrations. 
+Unlike the old renderers, extensions no longer mark the frameworks themselves ("react", "svelte", "vue", etc.) as direct dependencies of the extension. Instead, you should now install your framework packages *in addition to* your extensions. 
 
 ```diff
-# Example: Install integrations and frameworks together
+# Example: Install extensions and frameworks together
 - npm install @astrojs/react
 + npm install @astrojs/react react react-dom
 ```
 
-If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project. See our [note on peer dependencies](/en/guides/integrations-guide#peer-dependencies-warning) in the integrations guide for more information.
+If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project. See our [note on peer dependencies](/en/guides/integrations-guide#peer-dependencies-warning) in the extensions guide for more information.
 
 If you are using `npm` & Node v16+, then this may be automatically handled for you by `npm`, since the latest version of `npm` (v7+) installs peer dependencies like this for you automatically. In that case, installing a framework like "react" into your project is an optional but still recommend step.
 
@@ -90,7 +90,7 @@ import { Prism } from '@astrojs/prism';
 ---
 ```
 
-Since the `@astrojs/prism` package is still bundled with `astro` core, you won't need to install anything new, nor add Prism as an integration! However, note that we _do_ plan to extract `@astrojs/prism` (and Prism syntax highlighting in general) to a separate, installable package in the future. See [the `<Prism />` component API reference](/en/reference/api-reference#prism-) for more.
+Since the `@astrojs/prism` package is still bundled with `astro` core, you won't need to install anything new, nor add Prism as an extension! However, note that we _do_ plan to extract `@astrojs/prism` (and Prism syntax highlighting in general) to a separate, installable package in the future. See [the `<Prism />` component API reference](/en/reference/api-reference#prism-) for more.
 
 ### CSS Parser Upgrade
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -83,28 +83,28 @@ The value can be either an absolute file system path or a path relative to the p
 ```
 
 
-### integrations
+### extensions
 
 <p>
 
-**Type:** `Array.<AstroIntegration>`<br>
+**Type:** `Array.<AstroEntegration>`<br>
 **Default:** `[]`
 </p>
 
-Add Integrations to your project to extend Astro.
+Add Extensions to your project to extend Astro.
 
-Integrations are your one-stop shop to add new frameworks (like Solid.js), new features (like sitemaps), and new libraries (like Partytown and Turbolinks).
+Extensions are your one-stop shop to add new frameworks (like Solid.js), new features (like sitemaps), and new libraries (like Partytown and Turbolinks).
 
-Setting this configuration will disable Astro's default integration, so it is recommended to provide a renderer for every framework that you use:
+Setting this configuration will disable Astro's default extension, so it is recommended to provide a renderer for every framework that you use:
 
-Note: Integrations are currently under active development, and only first-party integrations are supported. In the future, 3rd-party integrations will be allowed.
+Note: Extensions are currently under active development, and only first-party extensions are supported. In the future, 3rd-party extensions will be allowed.
 
 ```js
 import react from '@astrojs/react';
 import vue from '@astrojs/vue';
 {
   // Example: Use Astro with Vue + React, and no other frameworks.
-  integrations: [react(), vue()]
+  extensions: [react(), vue()]
 }
 ```
 

--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -1,25 +1,25 @@
 ---
 layout: ~/layouts/MainLayout.astro
-title: Astro Integration API
+title: Astro Extension API
 ---
 
-**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. 
+**Astro Extensions** add new functionality and behaviors for your project with only a few lines of code. 
 
-This reference page is for anyone writing their own integration. To learn how to use an integration in your project, check out our [Using Integrations](/en/guides/integrations-guide) guide instead.
+This reference page is for anyone writing their own extension. To learn how to use an extension in your project, check out our [Using Extensions](/en/guides/integrations-guide) guide instead.
 
 
 ## Examples
 
-The official Astro integrations can act as reference for you as you go to build your own integrations.
+The official Astro extensions can act as reference for you as you go to build your own extensions.
 
-- **Renderers:** [`lit`](https://github.com/withastro/astro/blob/main/packages/integrations/lit/src/index.ts), [`svelte`](https://github.com/withastro/astro/blob/main/packages/integrations/svelte/src/index.ts), [`react`](https://github.com/withastro/astro/blob/main/packages/integrations/react/src/index.ts), [`preact`](https://github.com/withastro/astro/blob/main/packages/integrations/preact/src/index.ts), [`vue`](https://github.com/withastro/astro/blob/main/packages/integrations/vue/src/index.ts), [`solid`](https://github.com/withastro/astro/blob/main/packages/integrations/solid/src/index.ts)
-- **Libraries:** [`tailwind`](https://github.com/withastro/astro/blob/main/packages/integrations/tailwind/src/index.ts), [`partytown`](https://github.com/withastro/astro/blob/main/packages/integrations/partytown/src/index.ts), [`turbolinks`](https://github.com/withastro/astro/blob/main/packages/integrations/turbolinks/src/index.ts)
-- **Features:** [`sitemap`](https://github.com/withastro/astro/blob/main/packages/integrations/sitemap/src/index.ts)
+- **Renderers:** [`lit`](https://github.com/withastro/astro/blob/main/packages/extensions/lit/src/index.ts), [`svelte`](https://github.com/withastro/astro/blob/main/packages/extensions/svelte/src/index.ts), [`react`](https://github.com/withastro/astro/blob/main/packages/extensions/react/src/index.ts), [`preact`](https://github.com/withastro/astro/blob/main/packages/extensions/preact/src/index.ts), [`vue`](https://github.com/withastro/astro/blob/main/packages/extensions/vue/src/index.ts), [`solid`](https://github.com/withastro/astro/blob/main/packages/extensions/solid/src/index.ts)
+- **Libraries:** [`tailwind`](https://github.com/withastro/astro/blob/main/packages/extensions/tailwind/src/index.ts), [`partytown`](https://github.com/withastro/astro/blob/main/packages/extensions/partytown/src/index.ts), [`turbolinks`](https://github.com/withastro/astro/blob/main/packages/extensions/turbolinks/src/index.ts)
+- **Features:** [`sitemap`](https://github.com/withastro/astro/blob/main/packages/extensions/sitemap/src/index.ts)
 
 ## Quick API Reference
 
 ```ts
-interface AstroIntegration {
+interface AstroEntegration {
     name: string;
     hooks: {
         'astro:config:setup'?: (options: {
@@ -58,17 +58,17 @@ interface AstroIntegration {
 
 
 
-## Integration Ordering
+## Extension Ordering
 
-All Integration hooks are called in the order that they are provided. Whenever possible, you should design your integration to run in any order. However, sometimes this isn't possible, in which case you may have to document somewhere that your integration needs to come first or last in your user's `integrations` configuration array.
+All Extension hooks are called in the order that they are provided. Whenever possible, you should design your extension to run in any order. However, sometimes this isn't possible, in which case you may have to document somewhere that your extension needs to come first or last in your user's `extensions` configuration array.
 
 
-## Combining Plugins
+## Combining Extensions
 
-An integration can also be written as a collection of multiple, smaller integrations. We call these collections **presets.** Instead of creating a factory function that returns a single integration object, a preset returns an *array* of integration objects. This is useful for building complex features out of multiple integrations.
+An extension can also be written as a collection of multiple, smaller extensions. We call these collections **presets.** Instead of creating a factory function that returns a single extension object, a preset returns an *array* of extension objects. This is useful for building complex features out of multiple extensions.
 
 ```js
-integrations: [
+extensions: [
   // Example: where examplePreset() returns: [integrationOne, integrationTwo, ...etc]
   examplePreset()
 ]

--- a/src/pages/es/guides/deploy.md
+++ b/src/pages/es/guides/deploy.md
@@ -318,7 +318,7 @@ $ vercel
 
 Después de que su proyecto haya sido importado e implementado, todos los envíos subsiguientes a las sucursales generarán [Vista previa de implementaciones] (https://vercel.com/docs/concepts/deployments/environments#preview), y todos los cambios realizados en la rama de producción (comúnmente “principal”) dará como resultado una [Implementación de producción](https://vercel.com/docs/concepts/deployments/environments#production).
 
-Obtenga más información sobre [Git Integration] de Vercel (https://vercel.com/docs/concepts/git).
+Obtenga más información sobre [Git Extension] de Vercel (https://vercel.com/docs/concepts/git).
 
 ## Aplicaciones web estáticas de Azure
 


### PR DESCRIPTION
This is an idea that I've been kicking around and mentioned to some core maintainers, but I wanted to see what the change would look like on our docs site.

The reasoning: "Integrations" is both a mouthful (4 syllables) and a pretty meaningless word. It's not bad, but could it be better? "Extensions" came out of the idea of bring more meaning to the word: You add an extension because you want to "extend" Astro with some new feature, power, etc. Seeing this change on the docs site, and I think it's better.

One downside / reason not to make the change: Obviously it will cost us in thrash, even if we make this change in a backwards-compatible way. One bright-side is that we are about to do a config object refactor, so our users will already be updating their config file one more time before v1.0.0-beta.

Example: https://deploy-preview-284--astro-docs-2.netlify.app/en/guides/integrations-guide/ (URLs not yet updated, but will be if we decide to merge this PR)