### PR TITLE
update VuePress to v2 for comparison

### DIFF
--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -215,12 +215,11 @@ VuePress doesn't support partial hydration, and instead makes the user load and 
 
 #### Case Study: Building a Documentation Website
 
-[vuepress.vuejs.org](https://vuepress.vuejs.org/guide/) is the official VuePress documentation website, built with VuePress. The website offers a similar enough design and feature set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
+[v2.vuepress.vuejs.org](https://v2.vuepress.vuejs.org/) is the official VuePress documentation website, built with VuePress. The website offers a similar enough design and feature set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
-- **Vuepress performance score**: 63 out of 100 [(full audit)](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fvuepress.vuejs.org%2Fguide%2F)
-- **Astro performance score**: 99 out of 100 [(full audit)](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fdocs.astro.build%2Fgetting-started)
+- **Vuepress performance score**: 84 out of 100 [(run at web.dev)](https://web.dev/measure)
+- **Astro performance score**: 95 out of 100 [(run at web.dev)](https://web.dev/measure)
 
-One big reason behind this performance difference is Astro’s smaller JavaScript payload: [vuepress.vuejs.org](https://vuepress.vuejs.org/guide/) loads **166kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (53% less JavaScript, overall) _after_ first load.
 
 ## Zola vs. Astro
 

--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -217,8 +217,8 @@ VuePress doesn't support partial hydration, and instead makes the user load and 
 
 [v2.vuepress.vuejs.org](https://v2.vuepress.vuejs.org/) is the official VuePress documentation website, built with VuePress. The website offers a similar enough design and feature set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders for this common use-case.
 
-- **Vuepress performance score**: 84 out of 100 [(run at web.dev)](https://web.dev/measure)
-- **Astro performance score**: 95 out of 100 [(run at web.dev)](https://web.dev/measure)
+- **Vuepress performance score**: 86 out of 100 [full audit](https://lighthouse-dot-webdotdevsite.appspot.com/lh/html?url=https://v2.vuepress.vuejs.org/)
+- **Astro performance score**: 95 out of 100 [full audit](https://lighthouse-dot-webdotdevsite.appspot.com/lh/html?url=https://docs.astro.build/en/getting-started/)
 
 
 ## Zola vs. Astro


### PR DESCRIPTION
Responds to issue https://github.com/withastro/docs/issues/197

Unfortunately, I can't seem to find a way to create shareable audit links anymore. This runs a recent comparison using VuePress2 instead of v1 and updates the performance scores accordingly.

UPDATE: Matt shared links below!