### PR TITLE
Fix anchor links

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -44,11 +44,8 @@ export default defineConfig({
 						{
 							properties: { class: 'anchor-link' },
 							behavior: 'after',
-							group: h('div.heading-wrapper'),
-							content: (heading) => [
-								h(`span.anchor-icon.level-${heading.tagName}`, { ariaHidden: 'true' }, AnchorLinkIcon),
-								h('span.sr-only', `Section titled ${toString(heading)}`),
-							],
+							group: ({ tagName }) => h(`div.heading-wrapper.level-${tagName}`),
+							content: (heading) => [h(`span.anchor-icon`, { ariaHidden: 'true' }, AnchorLinkIcon), h('span.sr-only', `Section titled ${toString(heading)}`)],
 						},
 					],
 				],

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,18 @@ import type { AstroMarkdownOptions } from '@astrojs/markdown-remark';
 import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 import react from '@astrojs/react';
+import { toString } from 'hast-util-to-string';
+import { h } from 'hastscript';
+
+const AnchorLinkIcon = h(
+	'svg',
+	{ width: 16, height: 16, version: 1.1, viewBox: '0 0 16 16', xlmns: 'http://www.w3.org/2000/svg' },
+	h('path', {
+		fillRule: 'evenodd',
+		fill: 'currentcolor',
+		d: 'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z',
+	})
+);
 
 // https://astro.build/config
 export default defineConfig({
@@ -30,12 +42,13 @@ export default defineConfig({
 					[
 						'rehype-autolink-headings',
 						{
-							properties: {
-								class: 'heading-fragment-link',
-								title: 'Permalink to this heading',
-							},
-							behavior: 'append',
-							content: { type: 'text', value: '¶' },
+							properties: { class: 'anchor-link' },
+							behavior: 'after',
+							group: h('div.heading-wrapper'),
+							content: (heading) => [
+								h(`span.anchor-icon.level-${heading.tagName}`, { ariaHidden: 'true' }, AnchorLinkIcon),
+								h('span.sr-only', `Section titled ${toString(heading)}`),
+							],
 						},
 					],
 				],

--- a/public/index.css
+++ b/public/index.css
@@ -100,23 +100,50 @@ h5 {
 	font-size: 1rem;
 }
 
-h1 > .heading-fragment-link,
-h2 > .heading-fragment-link,
-h3 > .heading-fragment-link,
-h4 > .heading-fragment-link,
-h5 > .heading-fragment-link,
-h6 > .heading-fragment-link {
-	visibility: hidden;
-	margin-left: 0.5rem;
+.heading-wrapper {
+	--icon-size: 1rem;
 }
 
-h1:hover > .heading-fragment-link,
-h2:hover > .heading-fragment-link,
-h3:hover > .heading-fragment-link,
-h4:hover > .heading-fragment-link,
-h5:hover > .heading-fragment-link,
-h6:hover > .heading-fragment-link {
-	visibility: visible;
+.heading-wrapper > * {
+	display: inline;
+}
+
+.heading-wrapper > .anchor-link {
+	display: inline-block;
+	position: relative;
+	inset-inline-start: .75rem;
+	width: var(--icon-size);
+	height: var(--icon-size);
+	color: var(--theme-text-light);
+	text-decoration: none;
+}
+
+/* Float anchor links to the left of headings on larger screens. */
+@media (min-width: 50em) {
+	.heading-wrapper {
+		display: flex;
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+		align-items: baseline;
+		margin-inline-start: calc(-1 * var(--icon-size));
+	}
+
+	.heading-wrapper > .anchor-link {
+		inset-inline-start: -0.75rem;
+	}
+	
+	.heading-wrapper .anchor-icon {
+		position: relative;
+		bottom: var(--icon-baseline, 0);
+	}
+	
+	.heading-wrapper .anchor-icon.level-h2 {
+		--icon-baseline: 0.35rem;
+	}
+	
+	.heading-wrapper .anchor-icon.level-h3 {
+		--icon-baseline: 0.15rem;
+	}
 }
 
 p,

--- a/public/index.css
+++ b/public/index.css
@@ -141,13 +141,7 @@ h5 {
 	}
 
 	.heading-wrapper > .anchor-link {
-		opacity: 0;
 		inset-inline-start: -0.75rem;
-	}
-	
-	.heading-wrapper:hover > .anchor-link,
-	.anchor-link:focus {
-		opacity: 1;
 	}
 	
 	.heading-wrapper .anchor-icon {

--- a/public/index.css
+++ b/public/index.css
@@ -141,7 +141,13 @@ h5 {
 	}
 
 	.heading-wrapper > .anchor-link {
+		opacity: 0;
 		inset-inline-start: -0.75rem;
+	}
+	
+	.heading-wrapper:hover > .anchor-link,
+	.anchor-link:focus {
+		opacity: 1;
 	}
 	
 	.heading-wrapper .anchor-icon {

--- a/public/index.css
+++ b/public/index.css
@@ -107,18 +107,17 @@ h5 {
 .heading-wrapper:not(:first-child) {	
 	margin-block: 0;
 }
-
-.heading-wrapper > * {
-	display: inline;
-	margin-bottom: 0;
-}
-
 .heading-wrapper:not(:first-child):is(.level-h2, .level-h3) {
 	margin-top: 3rem;
 }
 
 .heading-wrapper:not(:first-child):is(.level-h4, .level-h5, .level-h6) {
 	margin-top: 2rem;
+}
+
+.heading-wrapper > * {
+	display: inline;
+	margin-bottom: 0;
 }
 
 .heading-wrapper > .anchor-link {

--- a/public/index.css
+++ b/public/index.css
@@ -109,15 +109,15 @@ h5 {
 }
 
 .heading-wrapper > * {
-	display: inline-block;
+	display: inline;
 	margin-bottom: 0;
 }
 
-.heading-wrapper:not(:first-child) :is(h2, h3) {
+.heading-wrapper:not(:first-child):is(.level-h2, .level-h3) {
 	margin-top: 3rem;
 }
 
-.heading-wrapper:not(:first-child) :is(h4, h5, h6) {
+.heading-wrapper:not(:first-child):is(.level-h4, .level-h5, .level-h6) {
 	margin-top: 2rem;
 }
 
@@ -149,11 +149,11 @@ h5 {
 		bottom: var(--icon-baseline, 0);
 	}
 	
-	.heading-wrapper .anchor-icon.level-h2 {
+	.heading-wrapper.level-h2 .anchor-icon {
 		--icon-baseline: 0.35rem;
 	}
 	
-	.heading-wrapper .anchor-icon.level-h3 {
+	.heading-wrapper.level-h3 .anchor-icon {
 		--icon-baseline: 0.15rem;
 	}
 }

--- a/public/index.css
+++ b/public/index.css
@@ -158,6 +158,17 @@ h5 {
 	}
 }
 
+@media (hover: hover) {
+	.heading-wrapper > .anchor-link {
+		opacity: 0;
+	}
+
+	.heading-wrapper:hover > .anchor-link,
+	.anchor-link:focus {
+		opacity: 1;
+	}
+}
+
 p,
 .content ul {
 	line-height: 1.65em;

--- a/public/index.css
+++ b/public/index.css
@@ -104,12 +104,24 @@ h5 {
 	--icon-size: 1rem;
 }
 
+.heading-wrapper:not(:first-child) {	
+	margin-block: 0;
+}
+
 .heading-wrapper > * {
-	display: inline;
+	display: inline-block;
+	margin-bottom: 0;
+}
+
+.heading-wrapper:not(:first-child) :is(h2, h3) {
+	margin-top: 3rem;
+}
+
+.heading-wrapper:not(:first-child) :is(h4, h5, h6) {
+	margin-top: 2rem;
 }
 
 .heading-wrapper > .anchor-link {
-	display: inline-block;
 	position: relative;
 	inset-inline-start: .75rem;
 	width: var(--icon-size);

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -1,6 +1,6 @@
 import type { FunctionalComponent } from 'preact';
 import { h, Fragment } from 'preact';
-import { useState, useEffect, useRef, useMemo } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 
 interface Props {
 	headers: any[];
@@ -13,18 +13,6 @@ interface Props {
 const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) => {
 	const itemOffsets = useRef([]);
 	const [activeId, setActiveId] = useState<string>(undefined);
-	const parsedHeaders = useMemo(
-		() => headers
-			.filter(({ depth }) => depth > 1 && depth < 4)
-			.map((header) => {
-				let result = { ...header };
-				// Stop Pilcrow (¶) character that's added to headings from showing up in sidebar
-				if (header.text.endsWith("¶")) {
-					result.text = header.text.slice(0, -1);
-				}
-				return result;
-			}),
-		[headers]);
 
 	useEffect(() => {
 		const getItemOffsets = () => {
@@ -50,7 +38,8 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) =
 				<li class={`header-link depth-2 ${activeId === 'overview' ? 'active' : ''}`.trim()}>
 					<a href="#overview">{labels.overview}</a>
 				</li>
-				{parsedHeaders
+				{headers
+					.filter(({ depth }) => depth > 1 && depth < 4)
 					.map((header) => (
 						<li class={`header-link depth-${header.depth} ${activeId === header.slug ? 'active' : ''}`.trim()}>
 							<a href={`#${header.slug}`}>{header.text}</a>


### PR DESCRIPTION
Nesting the anchor inside the heading was causing it to be picked up by Google, but also could have a11y consequences if it was read by a screenreader as part of the heading.

This PR moves the anchor link out of the heading element and follows the guidance in this article to also make the links more accessible: https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/

TLDR: This uses a structure like:

```html
<h2 id="id">Exciting New Feature</h2>
<a href="#id">
  <span aria-hidden="true">#</span>
  <span class="sr-only">Section titled Exciting New Feature</span>
</a>
```

1. Moving the link after the heading means the link itself isn’t read out in a screen reader table of contents, won’t be picked up by search engine crawlers, and as a bonus means we don’t need to strip it out when building our own table of contents.

2. The visible link icon (`#` in the sample above, an SVG icon added in this PR) is marked as `aria-hidden` to hide it from screen readers.

3. Some useful text content is included for screen readers only, so that tabbing to the anchor link will tell the user the title of the section they are entering.