### PR TITLE
Quick fix to replace first paragraph in Install guide

### DIFF
--- a/src/layouts/InstallLayout.astro
+++ b/src/layouts/InstallLayout.astro
@@ -26,23 +26,20 @@ const lang = getLanguageFromURL(Astro.request.url.pathname);
 ---
 
 <MainLayout content={content}>
+	<Markdown>
+		Ready to install Astro? Follow our automatic or manual set-up guide to get started.
+		
+		#### Prerequisites
 
-    <p>
-    Astro CSS works by scanning all of your HTML files, JavaScript components, and any other templates for class names, generating the corresponding styles and then writing them to a static CSS file.
-    </p>
-
-    <Markdown>
-        #### Prerequisites
-
-        - **Node.js** - `14.15.0`, `v16.0.0`, or higher.
-        - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
-        - **Terminal** - Astro is accessed through its command-line interface (CLI).
-        
-        #### Installation
-    </Markdown>
+		- **Node.js** - `14.15.0`, `v16.0.0`, or higher.
+		- **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
+		- **Terminal** - Astro is accessed through its command-line interface (CLI).
+		
+		#### Installation
+	</Markdown>
     
-    <InstallGuideTabGroup currentPage={currentPage} />
+	<InstallGuideTabGroup currentPage={currentPage} />
 
-    <slot />
+	<slot />
     
 </MainLayout>


### PR DESCRIPTION
Replaces the initial paragraph talking about “Astro CSS” in the installation guide.

#### Before

> Astro CSS works by scanning all of your HTML files, JavaScript components, and any other templates for class names, generating the corresponding styles and then writing them to a static CSS file.

#### After

> Ready to install Astro? Follow our automatic or manual set-up guide to get started.