### PR TITLE
Fix: logo's link to astro.build clickable on mobile view

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -84,9 +84,8 @@ const lang = currentPage && getLanguageFromURL(currentPage);
 		color: hsla(var(--color-base-white), 100%, 1);
 		text-decoration: none;
 		gap: 0.5em;
-		z-index: -1;
 	}
-
+ 
 	.logo a {
 		padding: 0.5em 0.25em;
 		margin: -0.5em -0.25em;


### PR DESCRIPTION
I noticed that the smaller screen version of the docs site couldn't click through to astro.build via the logo as it did in larger screen sizes. @delucis helped me narrow down that it was a negative `z-index` value making the link unclickable.

We both tested, and removing the `z-index` property entirely didn't seem to affect other parts of the header for either of us.