### PR TITLE
Added to .astro vs .jsx table: conditional rendering

### DIFF
--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -249,6 +249,7 @@ Astro component syntax is a superset of HTML. It was designed to feel familiar t
 | Spread Attributes            | `{...props}` | `{...props}` |
 | Boolean Attributes           | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}` |
 | Inline Functions             | `{items.map(item => <li>{item}</li>)}`  | `{items.map(item => <li>{item}</li>)}` |
+| Conditional Rendering             | `{condition &&  <p>text<p>}`  | `{condition &&  <p>text<p>}` |
 | IDE Support                  | [VS Code][code-ext] | Phenomenal |
 | Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
 | Fragments                    | Automatic top-level, `<Fragment>` or `<>` inside functions | Wrap with `<Fragment>` or `<>` |


### PR DESCRIPTION
Not 100% necessary and likely a temporary home for this concept, so take it or leave it! But as it has come up in support, this seemed like a quick way to have something to point people to and fits with the row above it for inline functions.

At the very least, it would create a search hit for "conditional rendering" and might help community members.