### PR TITLE
Temp fix: escape markdown in client:media directive example

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -96,7 +96,7 @@ Start importing the component JS as soon as the element enters the viewport.
 
 💡 *Useful for content lower down on the page.*
 
-#### `client:media={QUERY}`
+#### `client:media=[curly-brace]QUERY[curly-brace]`
 
 Start importing the component JS as soon as the browser matches the given media query.
 


### PR DESCRIPTION
Emergency fix replacing braces so that the page at least builds.