### PR TITLE
fix: escape `sr-only` labels

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -15,6 +15,11 @@ const AnchorLinkIcon = h(
 		d: 'M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z',
 	})
 );
+const createSROnlyLabel = (text: string) => {
+	const node = h('span.sr-only', `Section titled ${text}`);
+	node.properties['is:raw'] = true;
+	return node;
+};
 
 // https://astro.build/config
 export default defineConfig({
@@ -45,7 +50,7 @@ export default defineConfig({
 							properties: { class: 'anchor-link' },
 							behavior: 'after',
 							group: ({ tagName }) => h(`div.heading-wrapper.level-${tagName}`),
-							content: (heading) => [h(`span.anchor-icon`, { ariaHidden: 'true' }, AnchorLinkIcon), h('span.sr-only', `Section titled ${toString(heading)}`)],
+							content: (heading) => [h(`span.anchor-icon`, { ariaHidden: 'true' }, AnchorLinkIcon), createSROnlyLabel(toString(heading))],
 						},
 					],
 				],

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -96,7 +96,7 @@ Start importing the component JS as soon as the element enters the viewport.
 
 💡 *Useful for content lower down on the page.*
 
-#### `client:media=[curly-brace]QUERY[curly-brace]`
+#### `client:media={QUERY}`
 
 Start importing the component JS as soon as the browser matches the given media query.
 


### PR DESCRIPTION
Found the culprit! The auto-generated `sr-only` labels were not escaping any curly braces. Fixed this by adding the `is:raw` directive to any labels that are created.