### PR TITLE
Update `buildOptions.pageUrlFormat` to `build.format`

### DIFF
--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -158,7 +158,7 @@ You can also set this if you prefer to be more strict yourself, so that URLs wit
 }
 ```
 **See Also:**
-- buildOptions.pageUrlFormat
+- build.format
 
 
 ## Build Options


### PR DESCRIPTION
Fixes an outdated "see also" reference to the recently renamed config option.