### PR TITLE
Adding docs for ?url and ?css imports

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -106,6 +106,35 @@ import '../styles/utils.css';
 ```
 
 CSS `import` via ESM are supported inside of any JavaScript file, including JSX components like React & Preact.  This can be useful for writing granular, per-component styles for your React components.
+
+#### Advanced Use Cases
+
+If you really need to control how styles are imported and included in the page, CSS can be imported directly without being bundled or optimized by Astro.
+
+> ⚠️WARNING⚠️:
+> Be careful when bypassing Astro's built-in CSS bundling! Styles won't be included in the built output - this is best used in combination with `set:html` to inline styles directly into the built HTML page.
+
+```astro
+---
+import styles from '../styles/main.css?raw';
+---
+
+<!-- inline contents of main.css directly in the built HTML -->
+<style set:html={styles}></style>
+```
+
+```astro
+---
+import stylesUrl from '../styles/main.css?url';
+---
+
+<!-- manually add a link and preload hint to the built CSS file -->
+<link rel="preload" href={sytylesUrl} as="style">
+<link rel="stylesheet" href={stylesUrl}>
+```
+
+See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details. Take note of the [`assetsInlineLimit`](https://vitejs.dev/config/#build-assetsinlinelimit) option when using `?url` - a base64 string will be returned when the CSS file is below the inline filesize limit!
+
 ### Load an External Stylesheet
 
 You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or an URL to an external website. Relative `<link>` href values are not supported. 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -107,34 +107,6 @@ import '../styles/utils.css';
 
 CSS `import` via ESM are supported inside of any JavaScript file, including JSX components like React & Preact.  This can be useful for writing granular, per-component styles for your React components.
 
-#### Advanced Use Cases
-
-If you really need to control how styles are imported and included in the page, CSS can be imported directly without being bundled or optimized by Astro.
-
-> ⚠️WARNING⚠️:
-> Be careful when bypassing Astro's built-in CSS bundling! Styles won't be included in the built output - this is best used in combination with `set:html` to inline styles directly into the built HTML page.
-
-```astro
----
-import styles from '../styles/main.css?raw';
----
-
-<!-- inline contents of main.css directly in the built HTML -->
-<style set:html={styles}></style>
-```
-
-```astro
----
-import stylesUrl from '../styles/main.css?url';
----
-
-<!-- manually add a link and preload hint to the built CSS file -->
-<link rel="preload" href={sytylesUrl} as="style">
-<link rel="stylesheet" href={stylesUrl}>
-```
-
-See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details. Take note of the [`assetsInlineLimit`](https://vitejs.dev/config/#build-assetsinlinelimit) option when using `?url` - a base64 string will be returned when the CSS file is below the inline filesize limit!
-
 ### Load an External Stylesheet
 
 You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or an URL to an external website. Relative `<link>` href values are not supported. 
@@ -216,6 +188,46 @@ Vue in Astro supports the same methods as `vue-loader` does:
 
 Svelte in Astro also works exactly as expected: [Svelte Styling Docs][svelte-style].
 
+
+## Advanced
+
+> ⚠️WARNING⚠️:
+> Be careful when bypassing Astro's built-in CSS bundling! Styles won't be automatically included in the built output, and it is on you to make sure that the referenced file is properly included in the final page output.
+
+### `?raw` CSS Imports
+
+For advanced use cases, CSS can be read directly from disk without being bundled or optimized by Astro. This can be useful when you need complete control over some snippet of CSS, and need to bypass Astro's automatic CSS handling.
+
+This is not recommended for most users.
+
+```astro
+---
+// Advanced example! Not recommended for most users.
+import rawStylesCSS from '../styles/main.css?raw';
+---
+<style is:inline set:html={rawStylesCSS}></style>
+```
+
+See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details.
+### `?url` CSS Imports
+
+For advanced use cases, you can import a direct URL reference for a CSS file inside of your project `src/` directory. This can be useful when you need complete control over how a CSS file is loaded on the page. However, this will prevent the optimization of that CSS file with the rest of your page CSS .
+
+This is not recommended for most users. Instead, place your CSS files inside of `public/` to get a consistent URL reference.
+
+> ⚠️WARNING⚠️:
+> Importing a smaller CSS file with `?url` may return the base64 encoded contents of the CSS file as a data URL, but only in your final build. You should either write your code to support encoded data URLs (`data:text/css;base64,...`) or set the [`vite.build.assetsInlineLimit`](https://vitejs.dev/config/#build-assetsinlinelimit) config option to `0`  to disable this feature.
+
+```astro
+---
+// Advanced example! Not recommended for most users.
+import stylesUrl from '../styles/main.css?url';
+---
+<link rel="preload" href={sytylesUrl} as="style">
+<link rel="stylesheet" href={stylesUrl}>
+```
+
+See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details. 
 
 
 [less]: https://lesscss.org/


### PR DESCRIPTION
Adding docs for advanced CSS imports using `?raw` and `?url`, related astro [PR #3020](https://github.com/withastro/astro/pull/3020)

**Unless you're building a component library, this probably isn't the feature you were looking for 😄**