### PR TITLE
Remove unnecessary backslash

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -94,7 +94,7 @@ An example blog post `content` object might look like:
       }
       /* ... */
     ],
-    "source": "# Astro 0.18 Release\\nA little over a month ago, the first public beta [...]"
+    "source": "# Astro 0.18 Release\nA little over a month ago, the first public beta [...]"
   },
   "url": ""
 }


### PR DESCRIPTION
I added this in [august 2021](https://github.com/withastro/astro/pull/1148/files#r690872040) because there was [a bug](https://github.com/withastro/astro/issues/1147) that would render `\n` as a literal newline, even inside code blocks. This should no longer be the case, so I'm removing it.

Also, now I get to be in the face pile :)