### PR TITLE
Add max-width to docs

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -25,6 +25,8 @@ const lang = getLanguageFromURL(url.pathname);
 		<style>
 			body {
 				width: 100%;
+				max-width: 1600px;
+				margin: auto;
 				display: grid;
 				grid-template-rows: var(--theme-navbar-height) 1fr;
 				--gutter: 0.5rem;

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -25,8 +25,9 @@ const lang = getLanguageFromURL(url.pathname);
 		<style>
 			body {
 				width: 100%;
-				max-width: 1600px;
-				margin: auto;
+				max-width: 100em;
+				margin-left: auto;
+				margin-right: auto;
 				display: grid;
 				grid-template-rows: var(--theme-navbar-height) 1fr;
 				--gutter: 0.5rem;

--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -15,8 +15,9 @@ const lang = getLanguageFromURL(new URL(Astro.request.url).pathname);
 		<style>
 			body {
 				width: 100%;
-				max-width: 1600px;
-				margin: auto;
+				max-width: 100em;
+				margin-left: auto;
+				margin-right: auto;
 				display: grid;
 				grid-template-rows: var(--theme-navbar-height) 1fr;
 				--gutter: 0.5rem;

--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -15,6 +15,8 @@ const lang = getLanguageFromURL(new URL(Astro.request.url).pathname);
 		<style>
 			body {
 				width: 100%;
+				max-width: 1600px;
+				margin: auto;
 				display: grid;
 				grid-template-rows: var(--theme-navbar-height) 1fr;
 				--gutter: 0.5rem;


### PR DESCRIPTION
On bigger screens, the navbar and sidebar are infinitely spaced, personally making it harder to navigate through the docs. This PR limits the body width to 1600px (we can define a better breakpoint if necessary) and centers the page. 

On a 3000-ish wide screen, without max-width we get the result below:
![zyCTy2q](https://user-images.githubusercontent.com/61414485/162340856-8b238a1a-173e-48ab-a047-f0b02d60ebe0.png)

Now, with max-width and margin-auto:
![qeuUjLL](https://user-images.githubusercontent.com/61414485/162340996-948b1e44-2632-4e69-acdb-c9a3599e3a36.png)

There really isn't a consent on this, Vue.js docs has max-width, React.js docs does not, Bootstrap docs unconstrain the main content and adds a margin to the sidebar so it doesn't go all the way to the right.

Feedback if this should be merged or not is much appreciated!

