### PR TITLE
Added a new site built with Astro

### DIFF
--- a/src/pages/en/integrations/integrations.md
+++ b/src/pages/en/integrations/integrations.md
@@ -13,6 +13,8 @@ Here are some production sites, repositories, blog posts and videos from the com
 
 [Replicant Band](https://replicant.band) - Astro / GraphCMS / Snipcart / Tailwind
 
+[Design Buddy](https://design-buddy.netlify.app) - Astro / Tailwind / React / Cloudinary
+
 [Spread Bagelry](https://spreadbagelry.com) - Astro / Vue / Tailwind / Strapi CMS / Cloudinary
 
 [Public Transport Forum New Zealand](https://publictransportforum.nz/articles) - Astro / Netlify CMS


### PR DESCRIPTION
#### What is design buddy
- Design buddy is a platform to get job on ui/ux
- Design build brings remote job to your door step

#### Why added this changes
- Added Design buddy to the amazing list of Builtwith Atro to inspire others 