### PR TITLE
Updating docs to list numbers as valid route params in getStaticPaths()

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -185,7 +185,7 @@ The `getStaticPaths()` function should return an array of objects to determine w
 
 The `params` key of every returned object tells Astro what routes to build. The returned params must map back to the dynamic parameters and rest parameters defined in your component filepath.
 
-`params` are encoded into the URL, so only strings are supported as values. The value for each `params` object must match the parameters used in the page name.
+`params` are encoded into the URL, so only strings and numbers are supported as values. The value for each `params` object must match the parameters used in the page name.
 
 For example, suppose that you have a page at `src/pages/posts/[id].astro`. If you export `getStaticPaths` from this page and return the following for paths:
 
@@ -195,6 +195,7 @@ export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
     { params: { id: '2' } },
+    { params: { id:  3 } }
   ];
 }
 
@@ -203,7 +204,7 @@ const { id } = Astro.params;
 <h1>{id}</h1>
 ```
 
-Then Astro will statically generate `posts/1` and `posts/2` at build time.
+Then Astro will statically generate `posts/1`, `posts/2`, and `posts/3` at build time.
 
 ### Data Passing with `props`
 

--- a/src/pages/es/reference/api-reference.md
+++ b/src/pages/es/reference/api-reference.md
@@ -125,7 +125,7 @@ The `getStaticPaths()` function should return an array of objects to determine w
 
 The `params` key of every returned object tells Astro what routes to build. The returned params must map back to the dynamic parameters and rest parameters defined in your component filepath.
 
-`params` are encoded into the URL, so only strings are supported as values. The value for each `params` object must match the parameters used in the page name.
+`params` are encoded into the URL, so only strings and numbers are supported as values. The value for each `params` object must match the parameters used in the page name.
 
 For example, suppose that you have a page at `src/pages/posts/[id].astro`. If you export `getStaticPaths` from this page and return the following for paths:
 
@@ -134,7 +134,8 @@ For example, suppose that you have a page at `src/pages/posts/[id].astro`. If yo
 export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
-    { params: { id: '2' } }
+    { params: { id: '2' } },
+    { params: { id: 3 } }
   ];
 }
 const {id} = Astro.params;
@@ -142,7 +143,7 @@ const {id} = Astro.params;
 <body><h1>{id}</h1></body>
 ```
 
-Then Astro will statically generate `posts/1` and `posts/2` at build time.
+Then Astro will statically generate `posts/1`, `posts/2`, and `posts/3` at build time.
 
 ### Data Passing with `props`
 


### PR DESCRIPTION
[PR #3087](https://github.com/withastro/astro/pull/3087) updates `getStaticPaths()` to support numeric route parameters, ex: including a year/month/day in a blog post URL