### PR TITLE
Add PostCSS usage notes to page

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -170,26 +170,14 @@ Use `<style lang="less">` in `.astro` files.
 Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project, create a `postcss.config.js` file in the project root. You can import plugins using `require()`.
 
 ```js
-//./postcss.config.js
-// Import a PostCSS plugin (https://www.postcss.parts/)
-const postcssPresetEnv = require('postcss-preset-env');
+// ./postcss.config.js
 
-module.export={
-  // Plugins as an Array
-  plugins:[
-   postcssPresetEnv({
-     //Plugin options
-   }),
-  autoprefixer({
-    ...options
-  }),
+module.exports = {
+  plugins: [
+    require('postcss-preset-env'),
+    require('autoprefixer'),
   ],
-  // Plugins as an object
-  plugins:{
-    postcssPresetEnv:{...options},
-    autoprefixer:{...options},
-  }
-}
+};
 ```
 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -125,7 +125,7 @@ Because this approach uses the `public/` directory, it skips the normal CSS proc
 
 ## CSS Integrations
 
-Astro comes with support for adding popular CSS libraries, tools and frameworks to your project like PostCSS, Tailwind and more! 
+Astro comes with support for adding popular CSS libraries, tools and frameworks to your project like Tailwind and more! 
 
 📚 See the [Integrations Guide](/en/guides/integrations-guide/) for instructions on installing, importing and configuring these integrations.
 
@@ -138,20 +138,24 @@ Astro supports CSS preprocessors such as [Sass][sass], [Stylus][stylus], and [Le
 
  ```
  npm install -D sass
- ````
- Use  `<style lang="scss">` or `<style lang="sass">` in `.astro` files
+ ```
+
+Use  `<style lang="scss">` or `<style lang="sass">` in `.astro` files
 
 ### Stylus
 
 ```
 npm install -D stylus
 ``` 
+
 Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files
 
 ### Less
+
 ```
 npm install -D less
 ``` 
+
 Use `<style lang="less">` in `.astro` files.
 
 
@@ -161,7 +165,32 @@ Use `<style lang="less">` in `.astro` files.
 - **Vue**: `<style lang="scss">`
 - **Svelte**: `<style lang="scss">`
 
-Additionally, PostCSS is supported as an [integration](/en/guides/integrations-guide/).
+## PostCSS
+
+Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project. Make a `postcss.config.js` in the root of the project directory. Import plugins from [npm](https://www.npmjs.com/search?q=postcss). Using `require()` we apply additional plugins to the configuration file.    
+
+```js
+//./postcss.config.js
+// Import a PostCSS plugin (https://www.postcss.parts/)
+const postcssPresetEnv = require('postcss-preset-env');
+
+module.export={
+  // Plugins as an Array
+  plugins:[
+   postcssPresetEnv({
+     //Plugin options
+   }),
+  autoprefixer({
+    ...options
+  }),
+  ],
+  // Plugins as an object
+  plugins:{
+    postcssPresetEnv:{...options},
+    autoprefixer:{...options},
+  }
+}
+```
 
 
 ---

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -167,7 +167,7 @@ Use `<style lang="less">` in `.astro` files.
 
 ## PostCSS
 
-Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project. Make a `postcss.config.js` in the root of the project directory. Import plugins from [npm](https://www.npmjs.com/search?q=postcss). Using `require()` we apply additional plugins to the configuration file.    
+Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project, create a `postcss.config.js` file in the project root. You can import plugins using `require()`.
 
 ```js
 //./postcss.config.js


### PR DESCRIPTION
A couple of users have asked recently about advice on setting and consuming postcss within their projects.

Since we can use `@container` and `@layer` queries, for backwards support users would need to install `postcss-preset-env` to their projects.

This short addition to the Styling Guide should suffice. 
