### PR TITLE
Add note about astro.new templates to Framework guide

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -36,6 +36,8 @@ export default defineConfig({
 
 ⚙️ View the [Integrations Guide](/en/guides/integrations-guide) for more details on installing and configuring Astro integrations.
 
+⚙️ Want to see an example for the framework of your choice? Visit [astro.new](https://astro.new) and select one of the framework templates.
+
 ## Using Framework Components
 
 Use your JavaScript framework components in your Astro pages, layouts and components just like Astro components! All your components can live together in `/src/components`, or can be organized in any way you like.


### PR DESCRIPTION
@hippotastic [noted on Discord](https://discord.com/channels/830184174198718474/830184175176122389/964827331640303636) that there’s no mention of the examples on astro.new on the frameworks page, so he hadn’t found it. This PR adds a note saying you can find examples of each framework in use there.