### PR TITLE
Removing references to script hoist in translated docs

### DIFF
--- a/src/pages/de/core-concepts/astro-components.md
+++ b/src/pages/de/core-concepts/astro-components.md
@@ -305,7 +305,7 @@ Wenn du jedoch die Skripte aus der Komponente lösen und an den Anfang der Seite
 Ein **priorisiertes Skript** sieht so aus:
 
 ```astro
-<script hoist>
+<script>
   // Ein Inline-Skript
 </script>
 ```
@@ -313,7 +313,7 @@ Ein **priorisiertes Skript** sieht so aus:
 Oder es kann auf eine externe Skript-Datei verweisen:
 
 ```astro
-<script src={Astro.resolve('./meine-komponente.js')} hoist></script>
+<script is:inline src="/meine-komponente.js"></script>
 ```
 
 Ein priorisiertes Skript kann innerhalb einer Seite oder Komponente stehen, und unabhängig davon wie oft die Komponente verwendet wird, das Skript wird nur einmal hinzugefügt:

--- a/src/pages/es/core-concepts/astro-components.md
+++ b/src/pages/es/core-concepts/astro-components.md
@@ -297,7 +297,7 @@ Sin embargo, si deseas que todos tus scripts se extraigan de los componentes y s
 Un **script izado** se ve así:
 
 ```astro
-<script hoist>
+<script>
   // Una secuencia de comandos en línea
 </script>
 ```
@@ -305,7 +305,7 @@ Un **script izado** se ve así:
 O puede vincularse a un archivo JavaScript externo:
 
 ```astro
-<script src={Astro.resolve('./mi-componente.js')} hoist></script>
+<script is:inline src="./mi-componente.js"></script>
 ```
 
 Un script elevado puede estar dentro de una página o un componente, y no importa cuántas veces se use el componente, el script solo se agregará una vez:


### PR DESCRIPTION
Follow-up to #352, removing examples using `<script hoist>` in translated docs