### PR TITLE
Make OG image translatable

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -8,12 +8,12 @@ export interface Props {
 	canonicalURL: URL;
 }
 const { content = {}, canonicalURL } = Astro.props;
-const imageSrc = content?.image?.src ?? OPEN_GRAPH.image.src;
+const t = useTranslations(Astro);
+const imageSrc = content?.image?.src ?? t('site.og.imageSrc');
 const canonicalImageSrc = new URL(imageSrc, Astro.site);
-const imageAlt = content?.image?.alt ?? OPEN_GRAPH.image.alt;
+const imageAlt = content?.image?.alt ?? t('site.og.imageAlt');
 const lang = getLanguageFromURL(canonicalURL?.pathname || '/');
 const ogLocale = lang.replace(/-/g, '_');
-const t = useTranslations(Astro);
 ---
 
 <!-- Page Metadata -->

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export const SIDEBAR = {
 		{ text: 'Import Aliases', link: 'en/guides/aliases' },
 		{ text: 'Integrations', link: 'en/guides/integrations-guide' },
 		{ text: 'RSS', link: 'en/guides/rss' },
-    { text: 'Server-side Rendering (SSR)', link: 'en/guides/server-side-rendering' },
+		{ text: 'Server-side Rendering (SSR)', link: 'en/guides/server-side-rendering' },
 		{ text: 'TypeScript', link: 'en/guides/typescript' },
 		{ text: 'UI Frameworks', link: 'en/core-concepts/framework-components' },
 
@@ -204,9 +204,5 @@ export const SIDEBAR = {
 };
 
 export const OPEN_GRAPH = {
-	image: {
-		src: '/default-og-image.png?v=1',
-		alt: 'astro logo on a starry expanse of space,' + ' with a purple saturn-like planet floating in the right foreground',
-	},
 	twitter: 'astrodotbuild',
 };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -7,6 +7,8 @@ const en = {
 	// Site settings
 	'site.title': 'Astro Documentation',
 	'site.description': 'Build faster websites with less client-side Javascript.',
+	'site.og.imageSrc': '/default-og-image.png?v=1',
+	'site.og.imageAlt': 'astro logo on a starry expanse of space, with a purple saturn-like planet floating in the right foreground',
 	// Left Sidebar
 	'leftSidebar.a11yTitle': 'Site Navigation',
 	'leftSidebar.learnTab': 'Learn',


### PR DESCRIPTION
See https://discord.com/channels/830184174198718474/853350631389265940/966255545390624800 for context

Moves the Open Graph image source and alt text into the translations dictionary to support translating alt text. Moving the `src` here too is primarily to keep these two bits of content together so they get updated together, but in theory it would also support localising the OG image if it included text. 