### PR TITLE
Fix broken links

### DIFF
--- a/src/pages/en/core-concepts/component-hydration.md
+++ b/src/pages/en/core-concepts/component-hydration.md
@@ -90,7 +90,7 @@ Start importing the component JS at page load and hydrate when the import comple
 
 If more than one renderer is included in the Astro [config](/en/reference/configuration-reference), `client:only` needs a hint to know which renderer to use for the component. For example, `client:only="react"` would make sure that the component is hydrated in the browser with the React renderer. For custom renderers not provided by `@astrojs`, use the full name of the renderer provided in your Astro config, i.e. `<client:only="my-custom-renderer" />`.
 
-📚 See our [directives reference](/en/reference/directives-reference#ui-framework-components) page for more infomation on all of the `client:` directives.
+📚 See our [directives reference](/en/reference/directives-reference#client-directives) page for more infomation on all of the `client:` directives.
 
 ## Can I Hydrate Astro Components?
 

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -82,7 +82,7 @@ the user scrolls down and the component is visible on the page -->
 
 There are serveral hydration directives available for UI framework components: `client:load`, `client:idle`, `client:visible`, `client:media={QUERY}` and `client:only=" "`.
 
-📚 See our [directives reference](/en/reference/directives-reference#ui-framework-components) page for a full description of these hydration directives, and their usage.
+📚 See our [directives reference](/en/reference/directives-reference#client-directives) page for a full description of these hydration directives, and their usage.
 
 ## Mixing Frameworks
 

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -46,7 +46,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 ```
 
 
-📚 Learn more about [slots](/en/guides/slots).
+📚 Learn more about [slots](/en/core-concepts/astro-components#slots).
 
 
 ## Nesting Layouts
@@ -70,7 +70,7 @@ const {content} = Astro.props;
 
 ## Markdown Layouts
 
-Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a layout component that will wrap their Markdown content in a full page HTML document. 
+Page layouts are especially useful for [Markdown files.](/en/guides/markdown-content#markdown-pages) Markdown files can use the special `layout` front matter property to specify a layout component that will wrap their Markdown content in a full page HTML document. 
 
 When a Markdown page uses a layout, it passes the layout a single `content` prop that includes all of the Markdown front matter data and final HTML output.  See the `BlogPostLayout.astro` example above for an example of how you would use this `content` prop in your layout component.
 

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -34,7 +34,7 @@ Astro supports several file formats for its JavaScript configuration file: `astr
 TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project tsconfig options.
 ## Config File Resolving
 
-Astro will automatically try to resolve a config file named `astro.config.mjs` inside [project root](/guide/#index-html-and-project-root). If no config file is found in your project root, Astro's default options will be used.
+Astro will automatically try to resolve a config file named `astro.config.mjs` inside project root. If no config file is found in your project root, Astro's default options will be used.
 
 ```bash
 # Example: Reads your configuration from ./astro.config.mjs

--- a/src/pages/en/guides/debugging.md
+++ b/src/pages/en/guides/debugging.md
@@ -35,7 +35,7 @@ This can be useful for debugging differences between the SSR output and the hydr
 
 ## Astro `<Debug />` Component
 
-To help you debug your Astro components, Astro provides a built-in [`<Debug />`](/en/reference/builtin-components#debug-) component which renders any value directly into your component HTML template. This is useful for quick debugging in the browser without having to flip back-and-forth between your terminal and your browser.
+To help you debug your Astro components, Astro provides a built-in [`<Debug />`](/en/reference/api-reference/#debug-) component which renders any value directly into your component HTML template. This is useful for quick debugging in the browser without having to flip back-and-forth between your terminal and your browser.
 
 ```astro
 ---

--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -399,7 +399,7 @@ Use the following build settings:
 - **Framework preset**: `Astro`
 - **Build command:** `npm run build`
 - **Build output directory:** `dist`
-- **Environment variables (advanced)**: Currently, Cloudflare Pages supports `NODE_VERSION = 12.18.0` in the Pages build environment by default. Astro requires `14.15.0`, `v16.0.0`, or higher. You can add an environment variable with the **Variable name** of `NODE_VERSION` and a **Value** of a [Node version that’s compatible with Astro](https://docs.astro.build/install#prerequisites) or by specifying the node version of your project in a `.nvmrc` or `.node-version` file.
+- **Environment variables (advanced)**: Currently, Cloudflare Pages supports `NODE_VERSION = 12.18.0` in the Pages build environment by default. Astro requires `14.15.0`, `v16.0.0`, or higher. You can add an environment variable with the **Variable name** of `NODE_VERSION` and a **Value** of a [Node version that’s compatible with Astro](/en/install/auto#prerequisites) or by specifying the node version of your project in a `.nvmrc` or `.node-version` file.
 
 Then click the **Save and Deploy** button.
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -42,7 +42,7 @@ layout: ../layouts/BaseLayout.astro
 A typical layout for Markdown pages includes:
 
 1. the content prop to access the Markdown page's frontmatter data.
-2. a default [`<slot />`](/en/guides/slots) to indicate where the page's Markdown content should be rendered.
+2. a default [`<slot />`](/en/core-concepts/astro-components#slots) to indicate where the page's Markdown content should be rendered.
 
 
 ```astro
@@ -209,7 +209,7 @@ back to it later.
 
 Astro has a dedicated component used to let you render Markdown in `.astro` files. 
 
-You can import the [built-in Astro Markdown component](/en/reference/builtin-components#markdown) in your component script and then write any Markdown you want between `<Markdown> </Markdown>` tags.
+You can import the [built-in Astro Markdown component](/en/reference/api-reference#markdown-) in your component script and then write any Markdown you want between `<Markdown> </Markdown>` tags.
 
 ````astro
 ---
@@ -352,7 +352,7 @@ export default {
 
 Astro comes with built-in support for [Shiki](https://shiki.matsu.io/) and [Prism](https://prismjs.com/). This provides instant syntax highlighting for:
 - all code fences (\`\`\`) used in a markdown (`.md`) file and the [built-in `<Markdown />` component](#markdown-component).
-- content within the [built-in `<Code />` component](/en/reference/builtin-components/#code-) (powered by Shiki), or the [`<Prism />` component](/en/reference/builtin-components/#prism-) (powered by Prism).
+- content within the [built-in `<Code />` component](/en/reference/api-reference/#code-) (powered by Shiki), or the [`<Prism />` component](/en/reference/api-reference/#prism-) (powered by Prism).
 
 Shiki is enabled by default, preconfigured with the `github-dark` theme. The compiled output will be limited to inline `style`s without any extraneous CSS classes, stylesheets, or client-side JS.
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -84,7 +84,7 @@ const backgroundColor = "rgb(24 121 78)";
 <h1>Hello</h1>
 ```
 
-📚 See our [directives reference](/en/reference/directives-reference#definevarsvariables) page to learn more about `define:vars`.
+📚 See our [directives reference](/en/reference/directives-reference#definevars) page to learn more about `define:vars`.
 
 ## External Styles
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -159,7 +159,7 @@ Unlike the old renderers, integrations no longer mark the frameworks themselves 
 + npm install @astrojs/react react react-dom
 ```
 
-If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project. See our [note on peer dependencies](/en/guides/integrations-guide#peer-dependencies-warning) in the integrations guide for more information.
+If you see a `"Cannot find package 'react'"` (or similar) warning when you start up Astro, that means that you need to install that package into your project. See our [note on peer dependencies](/en/guides/integrations-guide/#handling-integration-dependencies) in the integrations guide for more information.
 
 If you are using `npm` & Node v16+, then this may be automatically handled for you by `npm`, since the latest version of `npm` (v7+) installs peer dependencies like this for you automatically. In that case, installing a framework like "react" into your project is an optional but still recommended step.
 


### PR DESCRIPTION
Used the new link checker to do an audit for broken links and fixed them. Scoped this to the `/en/` pages given the likely future upheaval that awaits other languages.

I did also remove one link completely because I don’t think anything like what it linked to exists any more.

### Link checker output

#### Before

```
*** Found 69 broken links in total:
  [404] 47 broken page links
  [ # ] 22 broken fragment links
```

#### After

```
*** Found 51 broken links in total:
  [404] 35 broken page links
  [ # ] 16 broken fragment links
```