### PR TITLE
Improve docs rtl language support and acessibility

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -104,7 +104,7 @@ h5 {
 	--icon-size: 1rem;
 }
 
-.heading-wrapper:not(:first-child) {	
+.heading-wrapper:not(:first-child) {
 	margin-block: 0;
 }
 .heading-wrapper:not(:first-child):is(.level-h2, .level-h3) {
@@ -122,7 +122,7 @@ h5 {
 
 .heading-wrapper > .anchor-link {
 	position: relative;
-	inset-inline-start: .75rem;
+	inset-inline-start: 0.75rem;
 	width: var(--icon-size);
 	height: var(--icon-size);
 	color: var(--theme-text-light);
@@ -142,16 +142,16 @@ h5 {
 	.heading-wrapper > .anchor-link {
 		inset-inline-start: -0.75rem;
 	}
-	
+
 	.heading-wrapper .anchor-icon {
 		position: relative;
 		bottom: var(--icon-baseline, 0);
 	}
-	
+
 	.heading-wrapper.level-h2 .anchor-icon {
 		--icon-baseline: 0.35rem;
 	}
-	
+
 	.heading-wrapper.level-h3 .anchor-icon {
 		--icon-baseline: 0.15rem;
 	}
@@ -263,7 +263,7 @@ pre.astro-code > code {
 }
 
 /*RTL Fix Code dir*/
-[dir="rtl"] code {
+[dir='rtl'] code {
 	unicode-bidi: plaintext;
 }
 
@@ -381,15 +381,16 @@ h2.heading {
 
 .header-link {
 	font-size: 1rem;
-	padding: 1px 0 1px 1rem;
-	border-left: 4px solid var(--theme-divider);
-	transition: border-color 100ms ease-out;
+	padding: 1px 0 1px 0;
+	padding-inline-start: 1rem;
+	border-inline-start: 4px solid var(--theme-divider);
+	transition: border-inline-start-color 100ms ease-out;
 }
 
 .header-link:hover,
 .header-link:focus,
 .header-link:focus-within {
-	border-left-color: var(--theme-accent-secondary);
+	border-inline-start-color: var(--theme-accent-secondary);
 }
 .header-link:hover a,
 .header-link a:focus {

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -18,7 +18,7 @@ const t = useTranslations(Astro);
 		<div class="menu-toggle">
 			<SidebarToggle client:idle />
 		</div>
-		<div class="logo flex">
+		<div dir="ltr" lang="en" class="logo flex">
 			<a href="https://astro.build/">
 				<h1 class="sr-only">Astro</h1>
 				<svg xmlns="http://www.w3.org/2000/svg" width="363" height="102" viewBox="0 0 363 102" fill="none">
@@ -77,7 +77,6 @@ const t = useTranslations(Astro);
 	}
 
 	.logo {
-		direction: ltr;
 		display: flex;
 		overflow: hidden;
 		width: 30px;

--- a/src/components/LeftSidebar/Sponsors.astro
+++ b/src/components/LeftSidebar/Sponsors.astro
@@ -1,4 +1,4 @@
-<div class="sponsors">
+<div dir="ltr" lang="en" class="sponsors">
 	<h2 class="sponsors-title">Sponsored by</h2>
 	<div class="sponsor">
 		<a href="https://www.netlify.com/" aria-label="Go to Netlify website">


### PR DESCRIPTION
Right to left languages have a problem with some components styling, this PR fixes the problems I have encountered:
* "on this page" component border direction
* sponsors component direction 
* adding dir and lang attributes in HTML for sponsors and logo components

![image](https://user-images.githubusercontent.com/61414485/165192711-5924ff3d-9778-4e7c-b8f4-dd17cfa4601b.png)


The expected behaviour would be something like what React.js docs does:

![image](https://user-images.githubusercontent.com/61414485/165189946-4e66c4a0-c00a-4c10-9477-b42fd420b664.png)

Fortunately, [CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) help us fix this!

![image](https://user-images.githubusercontent.com/61414485/165193073-ca1d860e-14fc-4b16-967c-013786956798.png)


As you can see, I added explicit lang and dir attributes to sponsors and logo components, the lang attribute makes clear for screen readers it is in English, and not the person's specific language ([See Language of Parts on W3 website](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html)). Sure, I could have used `direction: ltr` in CSS, but that wouldn't work if somehow CSS didn't load properly.

For those concerned about logical properties support, [here is the compatibility table on Can I Use](https://caniuse.com/css-logical-props). This same CSS file uses both `:is` and `:not` who have similar compatibility percentages, as you can [see here](https://caniuse.com/css-matches-pseudo), so, I'm guessing that compatibility isn't a real issue in this case.

Probably there are more problems like this in docs, please feel free to warn me about them!