### PR TITLE
Add link language indicator

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -190,6 +190,15 @@ a {
 	gap: 0.5rem;
 }
 
+a::after {
+	display: inline-block;
+	content: attr(hreflang);
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	position: relative;
+	bottom: 0.2rem;
+}
+
 article > section :is(ul, ol) > * + * {
 	margin-top: 0.25rem;
 }


### PR DESCRIPTION
This PR is a solution for #298

Links for pages with different languages, indicated by `hreflang` attribute receive an language indicator based on the value attributed to `hreflang`. 

The only downside I know is that you have to use `<a>` tags instead of Markdown syntax, but since this is only for different language links, maybe this isn't much of a problem.

Any link with `hreflang` gets this indicator, see this example:

![image](https://user-images.githubusercontent.com/61414485/165205406-cabe6dd2-960f-43bf-9564-b9fc128c8cb2.png)

HTML inside Markdown:
`🏗️ Add new <a href="/en/core-concepts/astro-pages" hreflang="en">Astro (.astro) pages</a>`