### PR TITLE
fix(api-reference.md): fix typo

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -243,7 +243,8 @@ export async function getStaticPaths() {
   return posts.map((post) => {
     return {
       params: { id: post.id },
-      props: { post };
+      props: { post }
+    };
   });
 }
 const {id} = Astro.params;

--- a/src/pages/es/reference/api-reference.md
+++ b/src/pages/es/reference/api-reference.md
@@ -158,7 +158,8 @@ export async function getStaticPaths() {
   return data.map((post) => {
     return {
       params: { id: post.id },
-      props: { post } };
+      props: { post }
+    };
   });
 }
 const {id} = Astro.params;


### PR DESCRIPTION
Examples have couple issues:
 - [es]: formatting issue
 - [en]: typo or missed bracket, that lead to syntax error