### PR TITLE
Fix initial manual page experience

### DIFF
--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -51,7 +51,7 @@ For this guide, copy-and-paste the following code snippet (including `---` dashe
 
 ```astro
 ---
-// Welcome to Astro! Everything between these "---" code fences
+// Welcome to Astro! Everything between triple-dashed lines
 // is your "component front matter". It never runs in the browser.
 console.log('This runs in your terminal, not the browser!');
 ---

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -51,7 +51,7 @@ For this guide, copy-and-paste the following code snippet (including `---` dashe
 
 ```astro
 ---
-// Welcome to Astro! Everything between triple-dashed lines
+// Welcome to Astro! Everything between these triple-dash code fences
 // is your "component front matter". It never runs in the browser.
 console.log('This runs in your terminal, not the browser!');
 ---


### PR DESCRIPTION
Because of `---` being present on the default frontmatter comment, I had a confusing initial experience while trying to copy and paste the content for my first page, in VSCode with the Astro plugin installed. I spent like 20 minutes digging around until I could understand what was going on. This PR fixes that initial experience by providing a valid synonym that doesn't include the triple dashes. More info about the issue in here: https://github.com/withastro/language-tools/issues/248