### PR TITLE
Fix typo: CustomFile --> CustomDataFile

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -84,7 +84,7 @@ Other files may have various different interfaces, but `Astro.glob()` accepts a 
 interface CustomDataFile {
   default: Record<string, any>;
 }
-const data = await Astro.glob<CustomDataFile>('../data/**/*.js');
+const data = await Astro.glob<CustomDataFile>('../data/**/*.js'); 
 ---
 ```
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -84,7 +84,7 @@ Other files may have various different interfaces, but `Astro.glob()` accepts a 
 interface CustomDataFile {
   default: Record<string, any>;
 }
-const data = await Astro.glob<CustomFile>('../data/**/*.js');
+const data = await Astro.glob<CustomDataFile>('../data/**/*.js');
 ---
 ```
 


### PR DESCRIPTION
I'm unfamiliar with TypeScript, but it looks like the interface `CustomDataFile` is defined in a code sample, but then referenced as `<CustomFile>` just below. Maybe I'm just misunderstanding this code, though!