### PR TITLE
Add start script to manual install instructions

### DIFF
--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -48,6 +48,7 @@ Then, replace any placeholder "scripts" section of your `package.json` with the 
   "scripts": \{
 -    "test": "echo \"Error: no test specified\" && exit 1"
 +    "dev": "astro dev",
++    "start": "astro dev",
 +    "build": "astro build",
 +    "preview": "astro preview"
   },


### PR DESCRIPTION
Our current instructions only include dev/build/preview scripts, but then we send the user back to Step 3 of the automatic install instructions: "run start."

(This also matches the package.json scripts generated by `create-astro` / in our starter templates.)