### PR TITLE
Improve handling of RTL languages

### DIFF
--- a/src/components/Header/LanguageSelect.tsx
+++ b/src/components/Header/LanguageSelect.tsx
@@ -24,9 +24,9 @@ const LanguageSelect: FunctionalComponent<{ lang: string }> = ({ lang }) => {
 					window.location.pathname = `/${newLang}/${slug}`;
 				}}
 			>
-				{Object.entries(languages).map(([code, name]) => (
+				{Object.entries(languages).map(([code, { label }]) => (
 					<option value={code}>
-						<span>{name}</span>
+						<span>{label}</span>
 					</option>
 				))}
 			</select>

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -136,6 +136,10 @@ To get started adding a language, you’ll need:
 
     This will be used to label this language in the site’s language switcher and potentially elsewhere. The best way to get this is probably to ask the person leading translation work for this language.
 
+3. **Its writing direction**
+
+    Check whether this language is written left-to-right or right-to-left.
+
 ### Scaffold files for a new language
 
 To scaffold the basic files for a new language, use the `add-language` script from your terminal:

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -1,25 +1,82 @@
 /**
- * Map of language codes to a written out language name.
- * Used to populate the language switcher in the navbar.
+ * Map of language codes to a written out name and writing direction for each language.
+ * Used to populate the language switcher in the navbar & to control layout direction.
  */
 export default {
-	en: 'English',
-	de: 'Deutsch',
-	nl: 'Nederlands',
-	'pt-BR': 'Português do Brasil',
-	fi: 'Suomi',
-	es: 'Español',
-	'zh-CN': '简体中文',
-	'zh-TW': '正體中文',
-	bg: 'Български',
-	fr: 'Français',
-	bn: 'বাংলা',
-	kr: '한국어',
-	ar: 'العربية',
-	da: 'Dansk',
-	ja: '日本語',
-	ru: 'Русский',
-	it: 'Italiano',
-	pl: 'Polish',
-	hu: 'Hungarian',
+	en: {
+		label: 'English',
+		dir: 'ltr',
+	},
+	de: {
+		label: 'Deutsch',
+		dir: 'ltr',
+	},
+	nl: {
+		label: 'Nederlands',
+		dir: 'ltr',
+	},
+	'pt-BR': {
+		label: 'Português do Brasil',
+		dir: 'ltr',
+	},
+	fi: {
+		label: 'Suomi',
+		dir: 'ltr',
+	},
+	es: {
+		label: 'Español',
+		dir: 'ltr',
+	},
+	'zh-CN': {
+		label: '简体中文',
+		dir: 'ltr',
+	},
+	'zh-TW': {
+		label: '正體中文',
+		dir: 'ltr',
+	},
+	bg: {
+		label: 'Български',
+		dir: 'ltr',
+	},
+	fr: {
+		label: 'Français',
+		dir: 'ltr',
+	},
+	bn: {
+		label: 'বাংলা',
+		dir: 'ltr',
+	},
+	kr: {
+		label: '한국어',
+		dir: 'ltr',
+	},
+	ar: {
+		label: 'العربية',
+		dir: 'rtl',
+	},
+	da: {
+		label: 'Dansk',
+		dir: 'ltr',
+	},
+	ja: {
+		label: '日本語',
+		dir: 'ltr',
+	},
+	ru: {
+		label: 'Русский',
+		dir: 'ltr',
+	},
+	it: {
+		label: 'Italiano',
+		dir: 'ltr',
+	},
+	pl: {
+		label: 'Polish',
+		dir: 'ltr',
+	},
+	hu: {
+		label: 'Hungarian',
+		dir: 'ltr',
+	},
 };

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -2,6 +2,7 @@ import type { AstroGlobal } from 'astro';
 import { readdir } from 'node:fs/promises';
 import { DocSearchTranslation, UIDict, UIDictionaryKeys, NavDict } from './translation-checkers';
 import { getLanguageFromURL } from '../util';
+import languages from './languages';
 
 /**
  * Convert the map of modules returned by `import.meta.globEager` to an object
@@ -96,4 +97,9 @@ export function useTranslations(Astro: Readonly<AstroGlobal>): (key: UIDictionar
 		if (str === undefined) console.error(`Missing translation for “${key}” in “${lang}”.`);
 		return str;
 	};
+}
+
+/** Get a given language’s writing direction: `'ltr' | 'rtl'`. */
+export function getDir(lang: string) {
+	return languages[lang]?.dir || 'ltr';
 }

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -7,7 +7,7 @@ import PageContent from '../components/PageContent/PageContent.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
 import { getLanguageFromURL } from '../util.ts';
-import { useTranslations } from '../i18n/util.ts';
+import { getDir, useTranslations } from '../i18n/util';
 
 const { content = {}, hideRightSidebar = false } = Astro.props;
 const isFallback = !!Astro.params.fallback;
@@ -18,11 +18,12 @@ const githubEditUrl = `https://github.com/withastro/docs/blob/main/${currentFile
 const t = useTranslations(Astro);
 const formatTitle = (content) => (content.title ? `${content.title} 🚀 ${t('site.title')}` : t('site.title'));
 const lang = getLanguageFromURL(url.pathname);
+const dir = getDir(lang);
 const canonicalURL = new URL(Astro.canonicalURL);
 if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/`, '/en/');
 ---
 
-<html dir={content.dir ?? 'ltr'} {lang} class="initial">
+<html {dir} {lang} class="initial">
 	<head>
 		<HeadCommon />
 		<HeadSEO {content} {canonicalURL} />
@@ -137,7 +138,7 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 			<aside id="grid-left" class="grid-sidebar" title={t('leftSidebar.a11yTitle')}>
 				<LeftSidebar {currentPage} />
 			</aside>
-			<div id="grid-main" lang={isFallback && 'en'}>
+			<div id="grid-main" lang={isFallback && 'en'} dir={isFallback && 'ltr'}>
 				<PageContent {content} {githubEditUrl} {currentPage}>
 					{isFallback && <FallbackNotice />}
 					<slot />

--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -2,10 +2,11 @@
 import HeadCommon from '../components/HeadCommon.astro';
 import Header from '../components/Header/Header.astro';
 import { getLanguageFromURL } from '../util.ts';
-import { useTranslations } from '../i18n/util.ts';
+import { getDir, useTranslations } from '../i18n/util';
 
-const { title, dir = 'ltr' } = Astro.props;
+const { title } = Astro.props;
 const lang = getLanguageFromURL(new URL(Astro.request.url).pathname);
+const dir = getDir(lang);
 const t = useTranslations(Astro);
 ---
 

--- a/src/pages/ar/getting-started.md
+++ b/src/pages/ar/getting-started.md
@@ -1,7 +1,6 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: باشر بالبدأ
-dir: rtl
 ---
 
 Astro هو باني موقع ثابت. تعرف أكثر حول ماهية Astro من خلال [صفحتنا الرئيسية](https://astro.build/) أو نشرة [الإصدارات](https://astro.build/blog/introducing-astro). تُعد هذه الصفحة نُبذة موجزة للتوثيق الخاص بـAstro وأيضًا لكل المصادر التي تتعلق به.


### PR DESCRIPTION
This PR stores each language’s writing direction in `src/i18n/languages.ts` to avoid needing to specify it in Markdown frontmatter (which is what Arabic has done up until now).

This allows us to layout RTL-language pages correctly even when they contain LTR fallback content. After #365 the site navigation was on the right on the Arabic “Getting Started” page as expected, but on the left for fallback pages. Making this a per-language and not a per-page setting makes this consistent.

Just to demonstrate what this fixes, here are two Arabic pages as they render currently:

<table>
<tr>
	<th>Arabic content
	<th>Fallback content
<tr>
	<td>
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/357379/165844152-ee547e00-cb54-42e2-8a4f-57573d191d94.png">
</td>
	<td>
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/357379/165844206-b82e94d5-14f8-4e39-90eb-5d5b86babd1c.png"></td>

</table>

This commit also updates the `add-language` script to collect writing direction.