### PR TITLE
Add script to check translation slugs match English slugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+      branches: [main]
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2.2.1
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^17.0.43",
     "astro": "^1.0.0-beta.17",
     "bcp-47-normalize": "^2.1.0",
+    "fast-glob": "^3.2.11",
     "htmlparser2": "^7.2.0",
     "kleur": "^4.1.4",
     "node-fetch": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "build": "astro build",
     "preview": "astro preview",
     "format": "prettier -w .",
-    "lint": "lint:linkcheck",
+    "lint": "pnpm run lint:slugcheck && pnpm run lint:linkcheck",
     "add-language": "node ./scripts/add-language.mjs",
     "lint:a11y": "start-test 'yarn build && yarn preview' 3000 'yarn lint:a11y:local'",
     "lint:a11y:local": "pa11y-ci --sitemap 'http://localhost:3000/sitemap.xml' --sitemap-find 'https://docs.astro.build' --sitemap-replace 'http://localhost:3000'",
     "lint:a11y:remote": "pa11y-ci --sitemap 'https://docs.astro.build/sitemap.xml'",
     "lint:linkcheck": "astro build && node ./scripts/lint-linkcheck.mjs",
-    "lint:linkcheck:nobuild": "node ./scripts/lint-linkcheck.mjs"
+    "lint:linkcheck:nobuild": "node ./scripts/lint-linkcheck.mjs",
+    "lint:slugcheck": "node ./scripts/lint-slugcheck.mjs"
   },
   "devDependencies": {
     "@algolia/client-search": "^4.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@types/react': ^17.0.43
   astro: ^1.0.0-beta.17
   bcp-47-normalize: ^2.1.0
+  fast-glob: ^3.2.11
   htmlparser2: ^7.2.0
   jsdoc-api: ^7.1.1
   kleur: ^4.1.4
@@ -39,6 +40,7 @@ devDependencies:
   '@types/react': 17.0.43
   astro: 1.0.0-beta.17_sass@1.50.0
   bcp-47-normalize: 2.1.0
+  fast-glob: 3.2.11
   htmlparser2: 7.2.0
   kleur: 4.1.4
   node-fetch: 3.2.3

--- a/scripts/lint-slugcheck.mjs
+++ b/scripts/lint-slugcheck.mjs
@@ -1,0 +1,53 @@
+import glob from 'fast-glob';
+import kleur from 'kleur';
+
+/** Makes sure that all translations’ slugs match the English slugs. */
+class SlugChecker {
+	async run() {
+		const errors = await this.#findMismatchedSlugs();
+		this.#outputResult(errors);
+	}
+
+	/** Load all Markdown pages and check non-English pages have counterparts in `pages/en/`. */
+	async #findMismatchedSlugs() {
+		const enSlugs = new Set();
+		/** @type {Record<string, string[]>} */
+		const errorMap = {};
+		(await glob('./src/pages/**/*.md'))
+			.map((file) => {
+				const [, lang, slug] = file.replace('./src/pages/', '').match(/^([^/]+)\/(.+)$/);
+				if (lang === 'en') enSlugs.add(slug);
+				return [lang, slug];
+			})
+			.forEach(([lang, slug]) => {
+				if (enSlugs.has(slug)) return;
+				if (!errorMap[lang]) errorMap[lang] = [];
+				errorMap[lang].push(slug);
+			});
+		return Object.entries(errorMap);
+	}
+
+	/**
+	 * Print the result of the slug check to the console.
+	 * @param {[lang: string, slugs: string[]][]} errors
+	 */
+	#outputResult(errors) {
+		if (errors.length === 0) {
+			console.log(kleur.green().bold(`\n*** Found no translations with mismatched slugs\n`));
+			return;
+		}
+		const prefix = kleur.gray(`  [${kleur.red().bold(' ✖ ')}] `);
+		let errorCount = 0;
+		for (const [lang, slugs] of errors) {
+			errorCount += slugs.length;
+			const summary = [`\n/${lang}/`, ...slugs.map((slug) => prefix + slug)];
+			console.error(summary.join('\n'));
+		}
+		console.error(kleur.red().bold(`\n*** Found ${errorCount} translations with mismatched slugs`));
+		console.error('    Rename the files listed above to match English slugs\n');
+		process.exit(1);
+	}
+}
+
+const checker = new SlugChecker();
+checker.run();


### PR DESCRIPTION
Follow up PR to #365. @FredKSchott suggested:

> a lint script that warns if a language file (ex: `/de/foobar.md`) doesn't have a matching English file (ex: `/en/foobar.md`). We could run this in CI to make sure all PRs are passing.

This PR adds:

- A script that checks slugs as proposed above
- A GitHub action that will run this linter & the broken link checker for PRs and commits to the main branch

This slug linter will error in CI if it finds a slug that doesn’t have an English counterpart. The broken link checker currently just logs its output and won’t error (we can think about changing that once the 41 broken links it reports currently have been cleaned up).