### PR TITLE
Remove unused imports from TabBox.astro

### DIFF
--- a/src/components/TabBox.astro
+++ b/src/components/TabBox.astro
@@ -1,5 +1,5 @@
 ---
-import { Markdown, Code, Prism } from 'astro/components';
+import { Code } from 'astro/components';
 ---
 <style>
     .hidden {


### PR DESCRIPTION


Closes #387

Turned out `TabBox.astro` _imports_ the Markdown component, but didn’t actually use it, so this was an easy fix.

