### PR TITLE
fix(a11y): Purple links in light mode for accessible contrast

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -184,7 +184,7 @@ small,
 }
 
 a {
-	color: var(--theme-accent);
+	color: var(--theme-accent-secondary);
 	text-underline-offset: 0.08em;
 	align-items: center;
 	gap: 0.5rem;

--- a/public/theme.css
+++ b/public/theme.css
@@ -57,7 +57,7 @@
 :root {
 	color-scheme: light;
 	--theme-accent: hsla(var(--color-orange), 1);
-	--theme-accent-secondary: hsla(302, 60%, 38%, 1);
+	--theme-accent-secondary: hsl(324, 75%, 38%);
 	--theme-dim: hsla(var(--color-gray-70), 1);
 	--theme-dim-light: hsla(var(--color-gray-80), 1);
 	--theme-dim-lighter: hsla(var(--color-gray-90), 1);
@@ -99,6 +99,7 @@ body {
 	--color-orange: var(--color-base-orange), 60%;
 	--theme-accent-opacity: 0.4;
 	--theme-accent: hsla(var(--color-orange), 1);
+	--theme-accent-secondary: hsla(var(--color-orange), 1);
 	--theme-text-accent: hsla(var(--color-orange), 1);
 	--theme-dim: hsla(var(--color-gray-90), 0.3);
 	--theme-dim-light: hsla(var(--color-gray-90), 0.2);


### PR DESCRIPTION
I know we discussed this in #198, but seeing as #224 was closed on the basis that I’m “ON THE CASE, ON THE REG,” here I am! On the case!

The current link colour provides insufficient colour contrast in light mode by *quite a bit*. [Guidelines](https://webaim.org/articles/contrast/) require a minimum contrast of 4.5:1 for text content, but the orange links are only around 2.5:1, even lower for inline code snippets within links.

This PR switches links in the body content to use a purple instead of the current orange, which provides a passing colour ratio:

| Before | After |
|---|---|
| <img width="694" alt="image" src="https://user-images.githubusercontent.com/357379/165913576-ab671b25-7291-4c33-8fac-ac939aff1ca2.png"> | <img width="664" alt="image" src="https://user-images.githubusercontent.com/357379/165913828-766eb817-683e-4bd7-bbb5-a68b189fbddf.png"> |

This change only applies in light mode. In dark mode the orange links work well and don’t need changing.

**Why purple?** The issue with orange is that to get enough contrast you need to reduce lightness quite a bit and it loses its vibrancy. It also introduces two slightly different shades of orange between links & logotype, which kind of ends up looking like a mistake. Purple fits with the rest of the theme and provides more contrast without seeming too muted.

This change likely does make links stand out from the rest of the page slightly less. If that’s a concern we could consider other ways to highlight links like a more pronounced underline instead of relying solely on colour.