### PR TITLE
Typo Fixes during final walk-throughs

### DIFF
--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -6,7 +6,7 @@ description: An intro to layouts, a type of Astro component that is shared betwe
 
 **Layouts** are a special type of [Astro component](/en/core-concepts/astro-components) useful for creating reusable page templates. 
 
-A layout component is conventionally used to provide an [`.astro` or `.md` page](/en/core-concepts/astro-pages) both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot>` to specify where in the layout page content should be injected.
+A layout component is conventionally used to provide an [`.astro` or `.md` page](/en/core-concepts/astro-pages) both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot />` to specify where in the layout page content should be injected.
 
 Layouts often provide common `<head>` elements and common UI elements for the page such as headers, navigation bars and footers.
 

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -94,7 +94,7 @@ export default defineConfig({
 })
 ```
 
-To references a file or directory relative to the configuration file, use `import.meta.url` (unless you are writing a common.js `astro.config.cjs` file).
+To reference a file or directory relative to the configuration file, use `import.meta.url` (unless you are writing a common.js `astro.config.cjs` file).
 
 ```js
 export default defineConfig({

--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -66,9 +66,9 @@ const response = await fetch("https://graphql-weather-api.herokuapp.com",
 const json = await response.json();
 const weather = json.data
 ---
-  <h1>Fetching Weather at build time</h1>
-  <h2>{weather.getCityByName.name}, {weather.getCityByName.country}</h2>
-  <p>Weather: {weather.getCityByName.weather.summary.description}</p>
+<h1>Fetching Weather at build time</h1>
+<h2>{weather.getCityByName.name}, {weather.getCityByName.country}</h2>
+<p>Weather: {weather.getCityByName.weather.summary.description}</p>
 ```
 > 💡 Remember, all data in Astro components is fetched when a component is rendered. 
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -120,7 +120,7 @@ import txtReference from './words.txt'; // txt === '/src/words.txt'
 
 All other assets not explicitly mentioned above can be imported via ESM `import` and will return a URL reference to the final built asset. This can be useful for referencing non-JS assets by URL, like creating an image element with a `src` attribute pointing to that image.
 
-It can also be useful to place images in the `public/`-folder as explained on the [project-structure page](/en/core-concepts/project-structure/#public).
+It can also be useful to place images in the `public/` folder as explained on the [project-structure page](/en/core-concepts/project-structure/#public).
 
 ## WASM
 
@@ -134,7 +134,7 @@ Astro supports loading WASM files directly into your application using the brows
 
 ## Node Builtins
 
-We encourage Astro users to avoid Node.js builtins (`fs`, `path`, etc) whenever possible. Astro aims to be compatible with multiple JavaScript runtimes in the future. This includes [Deno](https://deno.land/) and [Cloudflare Workers](https://workers.cloudflare.com/) which do not support Node builtin modules such as `fs`.
+We encourage Astro users to avoid Node.js builtins (`fs`, `path`, etc.) whenever possible. Astro aims to be compatible with multiple JavaScript runtimes in the future. This includes [Deno](https://deno.land/) and [Cloudflare Workers](https://workers.cloudflare.com/) which do not support Node builtin modules such as `fs`.
 
 Our aim is to provide Astro alternatives to common Node.js builtins. However, no such alternatives exist today. So, if you _really_ need to use these builtin modules we don't want to stop you. Astro supports Node.js builtins using Node’s newer `node:` prefix. If you want to read a file, for example, you can do so like this:
 


### PR DESCRIPTION
Only for the most minor of typo fixes, to keep them in one place and avoid excessive PR traffic.