### PR TITLE
Use a component to render `import.meta.env`

### DIFF
--- a/src/components/ImportMetaEnv.astro
+++ b/src/components/ImportMetaEnv.astro
@@ -1,0 +1,8 @@
+---
+export interface Props {
+	path?: string;
+}
+const { path = '' } = Astro.props as Props;
+---
+
+<code><Fragment set:html={'i'} />mport.meta.env{path}</code>

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -2,6 +2,8 @@
 layout: ~/layouts/MainLayout.astro
 title: Using environment variables
 description: Learn how to use environment variables in an Astro project.
+setup: |
+  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro uses Vite for environment variables, and allows you to use any of its methods to get and set environment variables. 
@@ -42,11 +44,14 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 ## Getting environment variables
 
-> In this section we use `[dot]` to mean `.` in `import[dot]meta[dot]env` because of a current bug in our build engine. You should write `.` in your code.
+<p>
 
-Instead of using `process.env`, with Vite you use `import[dot]meta[dot]env`, which uses the `import.meta` feature added in ES2020. 
+Instead of using `process.env`, with Vite you use <ImportMetaEnv />, which uses the `import.meta` feature added in ES2020.
+</p>
+<p>
 
-For example, use `import[dot]meta[dot]env.PUBLIC_POKEAPI` to get the `PUBLIC_POKEAPI` environment variable.
+For example, use <ImportMetaEnv path=".PUBLIC_POKEAPI" /> to get the `PUBLIC_POKEAPI` environment variable.
+</p>
 
 ```js
 // When import.meta.env.SSR === true
@@ -56,17 +61,20 @@ const data = await db(import.meta.env.DB_PASSWORD);
 const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
-_Don't worry about browser support! Vite replaces all `import[dot]meta[dot]env` mentions with static values._
+_Don't worry about browser support! Vite replaces all <ImportMetaEnv /> mentions with static values._
 
 
 > ⚠️WARNING⚠️:
-> Because Vite statically replaces `import[dot]meta[dot]env`, you cannot access it with dynamic keys like `import[dot]meta[dot]env[key]`.
+> Because Vite statically replaces <ImportMetaEnv />, you cannot access it with dynamic keys like <ImportMetaEnv path="[key]" />.
 
 
 
 ## IntelliSense for TypeScript
 
-By default, Vite provides type definition for `import[dot]meta[dot]env` in `vite/client.d.ts`. 
+<p>
+
+By default, Vite provides type definition for <ImportMetaEnv /> in `vite/client.d.ts`. 
+</p>
 
 While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables which are prefixed with `PUBLIC_`.
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -1,6 +1,8 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: API Reference
+setup: |
+  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 ## `Astro` global
@@ -369,18 +371,18 @@ interface RSSArgument {
 
 ## `import.meta`
 
-> In this section we use `[dot]` to mean `.`. This is because of a bug in our build engine that is rewriting `import[dot]meta[dot]env` if we use `.` instead of `[dot]`.
+<p>
 
-All ESM modules include a `import.meta` property. Astro adds `import[dot]meta[dot]env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
+All ESM modules include a `import.meta` property. Astro adds <ImportMetaEnv /> through [Vite](https://vitejs.dev/guide/env-and-mode.html).
+</p>
 
-**`import[dot]meta[dot]env[dot]SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
+**<ImportMetaEnv path=".SSR" />** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 
 ```jsx
 import { h } from 'preact';
 
 export default function () {
-  // Note: rewrite "[dot]" to "." for this to to work in your project.
-  return import[dot]meta[dot]env[dot]SSR ? <div class="spinner"></div> : <FancyComponent />;
+  return import.meta.env.SSR ? <div class="spinner"></div> : <FancyComponent />;
 }
 ```
 ## Built-in Components


### PR DESCRIPTION
This fixes the need to write `import[dot]meta[dot]env` by adding an `<ImportMetaEnv />` component to render the correct string for us.

This works but inline components seem to trip up Markdown parsing slightly so some paragraphs need wrapping in explicit `<p>` tags. (Each opening `<p>` is followed by an empty new line as otherwise the _rest_ of the paragraph won’t be parsed…)

It’s clunky on the authoring side, but it does mean we can provide much more readable docs.

H/T to @Princesseuh for the component idea.

---

Relevant pages in the preview:

- Environment Variables: https://deploy-preview-412--astro-docs-2.netlify.app/en/guides/environment-variables/#getting-environment-variables
- Runtime API: https://deploy-preview-412--astro-docs-2.netlify.app/en/reference/api-reference/#importmeta