### PR TITLE
added link: directives reference back to scripts

### DIFF
--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -183,6 +183,8 @@ The `is:inline` directive means that `<style>` and `<script>` tags:
 </script>
 ```
 
+📚 See how [client-side scripts](/en/core-concepts/astro-components/#client-side-scripts) work in Astro components.
+
 ### `define:vars`
 
 `define:vars={...}` can pass server-side variables from your component front matter into the client `<script>` or `<style>`. Any *serializable* front matter variable is supported, including props passed to your component through `Astro.props`.


### PR DESCRIPTION
The directives-reference page linked back to info about CSS styling, but not to our info about scripts in Astro components.