### PR TITLE
Linked to integrations page from the Integrations Guide

### DIFF
--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -108,7 +108,7 @@ In the future, a helpful `astro add` command will be able to handle all of this 
 
 Astro integrations are always added through the `integrations` property in your  `astro.config.mjs` file. 
 
-> Find more information about using and configuring any individual integration by visiting our [integrations page](https://astro.build/integrations) and following the link to its repository on GitHub.
+> Want to know more about using or configuring a specific integration? Find it in our [integrations directory](https://astro.build/integrations) and follow the link to its repository on GitHub.
 
 There are three common ways to import an integration into your Astro project:
 1. Installing an npm package integration.

--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -108,6 +108,8 @@ In the future, a helpful `astro add` command will be able to handle all of this 
 
 Astro integrations are always added through the `integrations` property in your  `astro.config.mjs` file. 
 
+> Find more information about using and configuring any individual integration by visiting our [integrations page](https://astro.build/integrations) and following the link to its repository on GitHub.
+
 There are three common ways to import an integration into your Astro project:
 1. Installing an npm package integration.
 2. Import your own integration from a local file inside your project.


### PR DESCRIPTION
This adds a call-out link on the Integrations Guide in the docs, making sure people know that they can find specific integration about each integration itself by going to astro.build/integrations and clicking through to each integration's own GitHub repository.