### PR TITLE
Add visual indicator to the table of contents

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -389,11 +389,14 @@ h2.heading {
 
 .header-link:hover,
 .header-link:focus,
-.header-link:focus-within {
+.header-link:focus-within,
+.current-header-link {
 	border-inline-start-color: var(--theme-accent-secondary);
 }
+
 .header-link:hover a,
-.header-link a:focus {
+.header-link a:focus,
+.current-header-link {
 	color: var(--theme-text);
 	text-decoration: underline;
 }

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -23,8 +23,44 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) =
 			}));
 		};
 
+		const addObservers = () => {
+			const observerOptions = {
+				root: null,
+				rootMargin: '0px',
+				threshold: [1],
+			};
+
+			const setCurrent = (element) => {
+				const tocItems = document.querySelectorAll('.sidebar-nav #toc li');
+
+				element.map((e) => {
+					const currentHeadingLink = document.querySelector(`.sidebar-nav #toc li a[href="#${e.target.id}"]`);
+
+					if (e.isIntersecting === true && currentHeadingLink !== null) {
+						tocItems.forEach((item) => {
+							item.classList.remove('current-header-link');
+
+							if (item.contains(currentHeadingLink)) {
+								item.classList.add('current-header-link');
+							}
+						});
+					}
+				});
+			};
+
+			const observeHeadings = new IntersectionObserver(setCurrent, observerOptions);
+
+			const headings = document.querySelectorAll('article :is(h1,h2,h3,h4):not(nav.sidebar-nav)');
+
+			headings.forEach((header) => {
+				observeHeadings.observe(header);
+			});
+		};
+
 		getItemOffsets();
 		window.addEventListener('resize', getItemOffsets);
+
+		addObservers();
 
 		return () => {
 			window.removeEventListener('resize', getItemOffsets);
@@ -34,7 +70,7 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) =
 	return (
 		<>
 			<h2 class="heading">{labels.onThisPage}</h2>
-			<ul>
+			<ul id="toc">
 				<li class={`header-link depth-2 ${activeId === 'overview' ? 'active' : ''}`.trim()}>
 					<a href="#overview">{labels.overview}</a>
 				</li>


### PR DESCRIPTION
Adds styling indicating the part of the docs you're currently reading as you scroll the page. This only works for desktop, on mobile you can't see the table of contents as you scroll, so I didn't include it. Solution for #400 

See the gif as an example:
![Ojm0jKO](https://user-images.githubusercontent.com/61414485/166169798-4ad22909-87d6-47c3-b0ff-a448d27b3ede.gif)

The performance difference on Lighthouse (looks like the preview deploy is slower but the other metrics are the same, so I think it doesn't really impact the overall performance, needs further testing):


| Preview  | Official |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/166170523-274092d2-4e93-4351-a832-96301fa565ea.png)  | ![image](https://user-images.githubusercontent.com/61414485/166170539-002dd120-c178-4390-91e3-60aa88340537.png)  |


This is not 100% yet. I think there are some improvements we can make to make the transition between headings smoother, I just don't know how yet.
