### PR TITLE
Updated auto install instructions to match new create-astro wizard

### DIFF
--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -80,7 +80,7 @@ At this time, you can verify that any integrations have been added to your proje
 
 ### Initialize a .git Repository (optional)
 
-At the final step of the wizard, you will now be offered to initialize a git repository in your new directory, if you plan to use the tool [Git](https://git-scm.com/) in your project. This is optional.
+At this final step, you can choose to initialize a git repository in your new directory. This is optional, but useful if you plan to use the tool [Git](https://git-scm.com/) for your project.
 
 ### Next Steps
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -47,6 +47,8 @@ You will then see a short list of starter templates to choose from:
 
 Use the arrow keys (up and down) to navigate to the template you want to install, then press return (enter) to submit.
 
+> Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
+
 ### Install Dependencies (optional)
 The wizard will offer to run an `install` command for you at this time, which is optional.
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -56,7 +56,7 @@ The wizard will offer to run an `install` command for you at this time, which is
 ### Install any Official Astro Integrations (optional)
 You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
 
-To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (up and down) to navigate and the space bar to toggle selected/unselected. You can select multiple items at once, or you can continue without selecting any items.
+To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate and the <kbd>Spacebar</kbd> to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
 
 
 When you are satisfied with your selection, press return (enter) to submit. 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -56,6 +56,7 @@ The wizard will offer to run an `install` command for you at this time, which is
 ### Install any Official Astro Integrations (optional)
 You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
 
+
 To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate and the <kbd>Spacebar</kbd> to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
 
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -35,7 +35,6 @@ yarn create astro
 pnpm create astro@latest
 ```
 
-### Confirm Installation of the Setup Wizard
 
 After confirming (y) to install `create-astro@latest`, you will be prompted to specify a project folder. (e.g. `./my-astro-site`)
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -44,23 +44,23 @@ You will then see a short list of starter templates to choose from:
 - `Blog`, `Documentation`, `Portfolio`: opinionated themes for specific use-cases.
 - `Completely empty`: A template that just includes the bare minimium to get started.
 
-Use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
+Use the arrow keys (up and down) to navigate to the template you want to install, then press return (enter) to submit.
 
-> Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
+> 💡 Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
 
 ### Install Dependencies (optional)
 The wizard will offer to run an `install` command for you at this time, which is optional.
 
-> If you do not do so at this time, you will need to [install dependencies](/en/install/auto#2-install-dependencies) after the wizard has finished, before starting your project.
+> ⚠️ If you do not do so at this time, you will need to [install dependencies](/en/install/auto#2-install-dependencies) after the wizard has finished, before starting your project.
 
 ### Install any Official Astro Integrations (optional)
 You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
 
 
-To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate and the <kbd>Spacebar</kbd> to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
+To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (up and down) to navigate and the space bar to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
 
 
-When you are satisfied with your selection, press <kdb>Enter</kdb> to submit. 
+When you are satisfied with your selection, press return (enter) to submit. 
 
 > These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -69,7 +69,7 @@ When you are satisfied with your selection, press <kdb>Enter</kdb> to submit.
 These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
 
 
-After selecting your integrations to add, you should see the following terminal message followed by **the entire contents of the `astro.config.mjs` file** that Astro will include with your project:
+After selecting your integrations to add, you should see the following terminal message notifying you of the changes that `create-astro` will apply to your project's `astro.config.mjs`:
 
 ```bash
 Astro will make the following changes to your config file:

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -75,7 +75,7 @@ After selecting your integrations to add, you should see the following terminal 
 Astro will make the following changes to your config file:
 ```
 
-At this time, you can verify that any integrations have been added to your project configuation, as well as any required `install` actions have run.
+This message should show that your chosen integrations have been successfully added to your project configuation. (If not, you can always add them manually later.)
 
 
 ### Initialize a .git Repository (optional)

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -44,7 +44,7 @@ You will then see a short list of starter templates to choose from:
 - `Blog`, `Documentation`, `Portfolio`: opinionated themes for specific use-cases.
 - `Completely empty`: A template that just includes the bare minimium to get started.
 
-Use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kdb>) to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
+Use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
 
 > Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -86,7 +86,7 @@ At the final step of the wizard, you will now be offered to initialize a git rep
 
 ### Next Steps
 
-When the `create-astro` install wizard is complete, you should see some recommended instructions ("Next Steps") on your screen to follow that will help you complete setup and start your new project. (e.g. `cd my-astro-site && npm run dev`)
+When the `create-astro` install wizard is complete, you should see some recommended instructions ("Next Steps") on your screen to follow that will help you complete setup and start your new project.
 
 ## 2. Install Dependencies
  

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -36,7 +36,7 @@ pnpm create astro@latest
 ```
 
 
-After confirming (y) to install `create-astro@latest`, you will be prompted to specify a project folder. (e.g. `./my-astro-site`)
+Depending on your package manager, you may be prompted to confirm you want to install `create-astro@latest`. You will then be prompted to specify a project folder. (e.g. `./my-astro-site`)
 
 ### Choose a Starter Template
 You will then see a short list of starter templates to choose from: 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -68,7 +68,6 @@ When you are satisfied with your selection, press return (enter) to submit.
 
 These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
 
-### See Your Astro Config File
 
 After selecting your integrations to add, you should see the following terminal message followed by **the entire contents of the `astro.config.mjs` file** that Astro will include with your project:
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -44,7 +44,7 @@ You will then see a short list of starter templates to choose from:
 - `Blog`, `Documentation`, `Portfolio`: opinionated themes for specific use-cases.
 - `Completely empty`: A template that just includes the bare minimium to get started.
 
-Use the arrow keys (up and down) to navigate to the template you want to install, then press return (enter) to submit.
+Use the arrow keys <kbd>Up</kbd> and <kbd>Down</kdb> to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
 
 > Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -36,7 +36,7 @@ pnpm create astro@latest
 ```
 
 
-Depending on your package manager, you may be prompted to confirm you want to install `create-astro@latest`. You will then be prompted to specify a project folder. (e.g. `./my-astro-site`)
+Depending on your package manager, you may be prompted to confirm you want to install `create-astro@latest`. You will then be asked to specify a project folder (e.g. `./my-astro-site`) which will create a new directory.
 
 ### Choose a Starter Template
 You will then see a short list of starter templates to choose from: 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -88,7 +88,7 @@ When the `create-astro` install wizard is complete, you should see some recommen
 
 ## 2. Install Dependencies
  
-If you did not install your project's dependencies using the wizard, you will now need to do so using a package manager like npm:
+If you did not install your project's dependencies using the wizard, you will now need to do so using your preferred package manager:
 
 ```bash
 # npm

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -20,7 +20,9 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 ## 1. Run the CLI
 
-Run the following command in your terminal to start our handy install wizard, `create-astro`. This will walk you through creating your very first Astro project. No need to create a new directory first! You will create a project folder using the wizard.
+Run the following command in your terminal to start our handy install wizard, `create-astro`. This will walk you through creating your very first Astro project.
+
+No need to create a new directory first! The wizard will create a project folder for you.
 
 ```shell
 # npm

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -62,12 +62,7 @@ To select which Astro integrations, if any, you would like to include in your pr
 
 When you are satisfied with your selection, press <kdb>Enter</kdb> to submit. 
 
->🟢 Selected integrations will display a solid (green) circle. (All integrations are **unselected by default**.) 
->
->⚠️ If every item is unselected, then no integrations will be added at this time. 
-
-
-These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
+> These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
 
 
 After selecting your integrations to add, you should see the following terminal message notifying you of the changes that `create-astro` will apply to your project's `astro.config.mjs`:

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -111,13 +111,13 @@ To start, use your package manager to run your pre-configured start script:
 
 ```bash
 # npm
-npm start
+npm run dev
 
 # yarn
 yarn start
 
 # pnpm
-pnpm run start
+pnpm run dev
 ```
 
 If all goes well, Astro should now be serving your project on [http://localhost:3000](http://localhost:3000)! 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -44,7 +44,7 @@ You will then see a short list of starter templates to choose from:
 - `Blog`, `Documentation`, `Portfolio`: opinionated themes for specific use-cases.
 - `Completely empty`: A template that just includes the bare minimium to get started.
 
-Use the arrow keys <kbd>Up</kbd> and <kbd>Down</kdb> to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
+Use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kdb>) to navigate to the template you want to install, then press <kdb>Enter</kdb> to submit.
 
 > Want to check out the templates in your browser before choosing? Visit [astro.new](https://astro.new/)
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -59,7 +59,7 @@ You will be given the option at this time to add any [additional UI frameworks](
 To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (<kbd>Up</kbd> and <kbd>Down</kbd>) to navigate and the <kbd>Spacebar</kbd> to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
 
 
-When you are satisfied with your selection, press return (enter) to submit. 
+When you are satisfied with your selection, press <kdb>Enter</kdb> to submit. 
 
 >🟢 Selected integrations will display a solid (green) circle. (All integrations are **unselected by default**.) 
 >

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -75,7 +75,7 @@ After selecting your integrations to add, you should see the following terminal 
 Astro will make the following changes to your config file:
 ```
 
-This message should show that your chosen integrations have been successfully added to your project configuation. (If not, you can always add them manually later.)
+This message should show that your chosen integrations have been successfully added to your project configuration. (If not, you can always add them manually later.)
 
 
 ### Initialize a .git Repository (optional)

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -20,7 +20,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 ## 1. Run the CLI
 
-Run the following command in your terminal to start our handy install wizard, `create-astro`. This will walk you through creating your very first Astro project in whichever directory you run it in.
+Run the following command in your terminal to start our handy install wizard, `create-astro`. This will walk you through creating your very first Astro project. No need to create a new directory first! You will create a project folder using the wizard.
 
 ```shell
 # npm
@@ -33,18 +33,60 @@ yarn create astro
 pnpm create astro@latest
 ```
 
-If `create-astro` starts successfully, you will see a short list of starter templates to choose from: 
-- `starter`: A great starter template for anyone wanting to explore Astro.
-- `minimal`: A template that just includes the bare minimium to get started.
-- `blog, portfolio, docs, etc`: opinionated themes for specific use-cases.
+### Confirm Installation of the Setup Wizard
 
-If you choose the `starter` template, you will also be asked to select which [additional frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact), if any, you would like to include in your project. Additional frameworks can also be added later.
+After confirming (y) to install `create-astro@latest`, you will be prompted to specify a project folder. (e.g. `./my-astro-site`)
+
+### Choose a Starter Template
+You will then see a short list of starter templates to choose from: 
+- `Just the basics`: A great starter template for anyone wanting to explore Astro.
+- `Blog`, `Documentation`, `Portfolio`: opinionated themes for specific use-cases.
+- `Completely empty`: A template that just includes the bare minimium to get started.
+
+Use the arrow keys (up and down) to navigate to the template you want to install, then press return (enter) to submit.
+
+### Install Dependencies (optional)
+The wizard will offer to run an `install` command for you at this time, which is optional.
+
+> If you do not do so at this time, you will need to [install dependencies](/en/install/auto#2-install-dependencies) after the wizard has finished, before starting your project.
+
+### Install any Official Astro Integrations (optional)
+You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
+
+To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (up and down) to navigate and the space bar to toggle selected/unselected. You can select multiple items at once, or you can continue without selecting any items.
+
+
+When you are satisfied with your selection, press return (enter) to submit. 
+
+>🟢 Selected integrations will display a solid (green) circle. (All integrations are **unselected by default**.) 
+>
+>⚠️ If every item is unselected, then no integrations will be added at this time. 
+
+
+These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
+
+### See Your Astro Config File
+
+After selecting your integrations to add, you should see the following terminal message followed by **the entire contents of the `astro.config.mjs` file** that Astro will include with your project:
+
+```bash
+Astro will make the following changes to your config file:
+```
+
+At this time, you can verify that any integrations have been added to your project configuation, as well as any required `install` actions have run.
+
+
+### Initialize a .git Repository (optional)
+
+At the final step of the wizard, you will now be offered to initialize a git repository in your new directory, if you plan to use the tool [Git](https://git-scm.com/) in your project. This is optional.
+
+### Next Steps
+
+When the `create-astro` install wizard is complete, you should see some recommended instructions ("Next Steps") on your screen to follow that will help you complete setup and start your new project. (e.g. `cd my-astro-site && npm run dev`)
 
 ## 2. Install Dependencies
-
-When the `create-astro` install wizard is complete, you should see some recommended instructions on your screen to follow that will help you complete setup and start your new project. 
-
-The only required step remaining is to install your project's dependencies using a package manager like npm:
+ 
+If you did not install your project's dependencies using the wizard, you will now need to do so using a package manager like npm:
 
 ```bash
 # npm
@@ -58,7 +100,6 @@ pnpm install
 
 ```
 
-This is also a great chance to run `git init` in your new directory, if you plan to use the tool [Git](https://git-scm.com/) in your project.
 
 ## 3. Start Astro ✨
 


### PR DESCRIPTION
These instructions walk through the new create-astro wizard.

Looking for feedback! 

(I am undecided as to whether I like the steps of the wizard showing up in the right sidebar because of the header level. It wasn't my intention, but now that I see them there, I think I like them?)