### PR TITLE
Added explicit warning re: importing CSS files at the top

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -94,7 +94,7 @@ There are two ways to resolve external global stylesheets: an ESM import for fil
 
 ### Import a Stylesheet
 
-You can import stylesheets in your Astro component front matter using ESM import syntax. CSS imports work like any other ESM import, and should be referenced as relative to the component.
+You can import stylesheets in your Astro component front matter using ESM import syntax. CSS imports work like [any other ESM import in an Astro component](/en/core-concepts/astro-components/#the-component-script), which should be referenced as **relative to the component** and must be written at the **top** of your component script, with any other imports.
 
 ```astro
 ---


### PR DESCRIPTION
In response to a support thread, this both makes it explicit that an imported CSS file must follow the same rules as any other ESM import and links back to the page/section explaining the Astro component script.