### PR TITLE
Improve "On this page" scrollbar

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -8,6 +8,26 @@
 	outline: none;
 }
 
+/* Firefox */
+* {
+	scrollbar-color: var(--theme-dim-light) transparent;
+}
+
+/* Webkit */
+
+::-webkit-scrollbar,
+::-webkit-scrollbar-track {
+	/* same as --theme-bg-gradient but without 'fixed' */
+	background: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
+}
+
+::-webkit-scrollbar-thumb {
+	background-color: var(--theme-dim-light);
+	border: 4px solid transparent;
+	background-clip: content-box;
+	border-radius: 10px;
+}
+
 :root {
 	--user-font-scale: 1rem - 16px;
 	--max-width: calc(100% - 1rem);

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -71,23 +71,4 @@ for (const section of sidebarSections) {
 		max-height: 100vh;
 		padding-bottom: var(--theme-navbar-height);
 	}
-
-	/* Scrollbar Design Technique */
-	/* Firefox: */
-	.nav-groups {
-		scrollbar-color: var(--theme-dim-light) transparent;
-	}
-	/* Webkit: */
-	.nav-groups::-webkit-scrollbar,.nav-groups::-webkit-scrollbar-track {
-		background-color: transparent;
-	}
-	.nav-groups:active::-webkit-scrollbar-thumb,.nav-groups:focus-within::-webkit-scrollbar-thumb,.nav-groups:focus::-webkit-scrollbar-thumb,.nav-groups:hover::-webkit-scrollbar-thumb {
-		background-color: var(--theme-dim-light);
-		border: 4px solid transparent;
-		background-clip: content-box;
-		border-radius: 10px;
-	}
-	.nav-groups::-webkit-scrollbar-thumb:active,.nav-groups::-webkit-scrollbar-thumb:hover {
-		background-color: var(--theme-dim) !important;
-	}
 </style>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -38,23 +38,4 @@ const headers = content.astro?.headers;
 		padding-top: var(--doc-padding);
 		overflow: auto;
 	}
-
-	/* Scrollbar Design Technique */
-	/* Firefox: */
-	.sidebar-nav-inner {
-		scrollbar-color: var(--theme-dim-light) transparent;
-	}
-	/* Webkit: */
-	.sidebar-nav-inner::-webkit-scrollbar,.sidebar-nav-inner::-webkit-scrollbar-track {
-		background-color: transparent;
-	}
-	.sidebar-nav-inner:active::-webkit-scrollbar-thumb,.sidebar-nav-inner:focus-within::-webkit-scrollbar-thumb,.sidebar-nav-inner:focus::-webkit-scrollbar-thumb,.sidebar-nav-inner:hover::-webkit-scrollbar-thumb {
-		background-color: var(--theme-dim-light);
-		border: 4px solid transparent;
-		background-clip: content-box;
-		border-radius: 10px;
-	}
-	.sidebar-nav-inner::-webkit-scrollbar-thumb:active,.sidebar-nav-inner::-webkit-scrollbar-thumb:hover {
-		background-color: var(--theme-dim) !important;
-	}
 </style>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -38,4 +38,23 @@ const headers = content.astro?.headers;
 		padding-top: var(--doc-padding);
 		overflow: auto;
 	}
+
+	/* Scrollbar Design Technique */
+	/* Firefox: */
+	.sidebar-nav-inner {
+		scrollbar-color: var(--theme-dim-light) transparent;
+	}
+	/* Webkit: */
+	.sidebar-nav-inner::-webkit-scrollbar,.sidebar-nav-inner::-webkit-scrollbar-track {
+		background-color: transparent;
+	}
+	.sidebar-nav-inner:active::-webkit-scrollbar-thumb,.sidebar-nav-inner:focus-within::-webkit-scrollbar-thumb,.sidebar-nav-inner:focus::-webkit-scrollbar-thumb,.sidebar-nav-inner:hover::-webkit-scrollbar-thumb {
+		background-color: var(--theme-dim-light);
+		border: 4px solid transparent;
+		background-clip: content-box;
+		border-radius: 10px;
+	}
+	.sidebar-nav-inner::-webkit-scrollbar-thumb:active,.sidebar-nav-inner::-webkit-scrollbar-thumb:hover {
+		background-color: var(--theme-dim) !important;
+	}
 </style>


### PR DESCRIPTION
The docs are currently using the default scrollbar on the [`RightSidebar.astro`](https://github.com/withastro/docs/blob/main/src/components/RightSidebar/RightSidebar.astro) component. The default scrollbar is fine for the page itself, but on the table of contents, it creates an unpleasant look on larger pages. 

This PR adds the same custom scrollbar used on the [`LeftSidebar.astro`](https://github.com/withastro/docs/blob/main/src/components/LeftSidebar/LeftSidebar.astro) component as a starting point. 

I think it is worth discussing if we should maintain this more discrete scrollbar styling or change for one that is always visible.

| Astro docs  (current) | Nuxt.js docs | Astro docs (PR) |
| ------------- | ------------- |  ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/166344414-d28fe724-51bb-4b2c-b9d7-63f70fd83f21.png)  | ![image](https://user-images.githubusercontent.com/61414485/166344430-3b819b52-0c61-4228-8ce4-986ffc43a9ce.png)  | ![image](https://user-images.githubusercontent.com/61414485/166345852-4154faf0-22cd-4bbf-b63d-a42813e1e005.png) |

