### PR TITLE
Feat: Add translation status script and workflow

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,18 @@
+name: Install Tools & Dependencies
+description: Installs pnpm, Node.js & package dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Setup PNPM
+      uses: pnpm/action-setup@v2.2.1
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: pnpm
+
+    - name: Install dependencies
+      run: pnpm install
+      shell: bash

--- a/.github/workflows/translation-status.yml
+++ b/.github/workflows/translation-status.yml
@@ -1,0 +1,38 @@
+name: Update Translation Status
+
+on:
+  # Run on every push to the given branches
+  push:
+    branches: [main]
+  # Allow the workflow to be run manually
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Update Translation Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Tools & Dependencies
+        uses: ./.github/actions/install
+
+      - name: Update Translation Status
+        run: pnpm run github:translation-status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "lint:a11y:remote": "pa11y-ci --sitemap 'https://docs.astro.build/sitemap.xml'",
     "lint:linkcheck": "astro build && node ./scripts/lint-linkcheck.mjs",
     "lint:linkcheck:nobuild": "node ./scripts/lint-linkcheck.mjs",
-    "lint:slugcheck": "node ./scripts/lint-slugcheck.mjs"
+    "lint:slugcheck": "node ./scripts/lint-slugcheck.mjs",
+    "github:translation-status": "node ./scripts/github-translation-status.mjs"
   },
   "devDependencies": {
+    "@actions/core": "^1.7.0",
     "@algolia/client-search": "^4.13.0",
     "@astrojs/preact": "^0.0.2",
     "@astrojs/react": "^0.1.0",
@@ -25,6 +27,7 @@
     "@types/react": "^17.0.43",
     "astro": "^1.0.0-beta.17",
     "bcp-47-normalize": "^2.1.0",
+    "dedent-js": "^1.0.1",
     "fast-glob": "^3.2.11",
     "htmlparser2": "^7.2.0",
     "kleur": "^4.1.4",
@@ -33,7 +36,8 @@
     "prettier": "^2.6.2",
     "prompts": "^2.4.2",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "simple-git": "^3.7.1"
   },
   "dependencies": {
     "@astropub/icons": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
+  '@actions/core': ^1.7.0
   '@algolia/client-search': ^4.13.0
   '@astrojs/preact': ^0.0.2
   '@astrojs/react': ^0.1.0
@@ -11,6 +12,7 @@ specifiers:
   '@types/react': ^17.0.43
   astro: ^1.0.0-beta.17
   bcp-47-normalize: ^2.1.0
+  dedent-js: ^1.0.1
   fast-glob: ^3.2.11
   htmlparser2: ^7.2.0
   jsdoc-api: ^7.1.1
@@ -26,10 +28,11 @@ specifiers:
   remark-gfm: ^3.0.1
   remark-smartypants: ^2.0.0
   sass: ^1.50.0
+  simple-git: ^3.7.1
 
 dependencies:
   '@astropub/icons': 0.2.0_astro@1.0.0-beta.17
-  '@docsearch/react': 3.0.0_73997327e0ab5ab2aaf50785071cd6bd
+  '@docsearch/react': 3.0.0_oomxgj7avnnlfkxva6cqohgwxu
   jsdoc-api: 7.1.1
   rehype-autolink-headings: 6.1.1
   rehype-slug: 5.0.1
@@ -38,14 +41,16 @@ dependencies:
   sass: 1.50.0
 
 devDependencies:
+  '@actions/core': 1.7.0
   '@algolia/client-search': 4.13.0
-  '@astrojs/preact': 0.0.2_@babel+core@7.17.9+preact@10.7.1
-  '@astrojs/react': 0.1.0_f370f735164a03a12cea0cc89593cbee
+  '@astrojs/preact': 0.0.2_4aogvlozmxuufv32kpculfbxce
+  '@astrojs/react': 0.1.0_6nyponiwjib2clhkbtejle6l5y
   '@astrojs/sitemap': 0.1.0
   '@babel/core': 7.17.9
   '@types/react': 17.0.43
   astro: 1.0.0-beta.17_sass@1.50.0
   bcp-47-normalize: 2.1.0
+  dedent-js: 1.0.1
   fast-glob: 3.2.11
   htmlparser2: 7.2.0
   kleur: 4.1.4
@@ -55,8 +60,21 @@ devDependencies:
   prompts: 2.4.2
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
+  simple-git: 3.7.1
 
 packages:
+
+  /@actions/core/1.7.0:
+    resolution: {integrity: sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==}
+    dependencies:
+      '@actions/http-client': 1.0.11
+    dev: true
+
+  /@actions/http-client/1.0.11:
+    resolution: {integrity: sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==}
+    dependencies:
+      tunnel: 0.0.6
+    dev: true
 
   /@algolia/autocomplete-core/1.5.2:
     resolution: {integrity: sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==}
@@ -64,7 +82,7 @@ packages:
       '@algolia/autocomplete-shared': 1.5.2
     dev: false
 
-  /@algolia/autocomplete-preset-algolia/1.5.2_0e7d0fa1316a1da795248855ef6c22d0:
+  /@algolia/autocomplete-preset-algolia/1.5.2_bz6q7ijrnio2pfjerbk663bc2a:
     resolution: {integrity: sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==}
     peerDependencies:
       '@algolia/client-search': ^4.9.1
@@ -262,7 +280,7 @@ packages:
       - supports-color
     dev: true
 
-  /@astrojs/preact/0.0.2_@babel+core@7.17.9+preact@10.7.1:
+  /@astrojs/preact/0.0.2_4aogvlozmxuufv32kpculfbxce:
     resolution: {integrity: sha512-rpmQ+nffweQFQQnuSf6tGT8RDVzYURSve8R/fuuf02P0fTU7ZoqBzfG+BlQsAzkqJU8L9BHsnyRJOUoETrfK8w==}
     engines: {node: ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -280,7 +298,7 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0}
     dev: true
 
-  /@astrojs/react/0.1.0_f370f735164a03a12cea0cc89593cbee:
+  /@astrojs/react/0.1.0_6nyponiwjib2clhkbtejle6l5y:
     resolution: {integrity: sha512-WWowT/TsrV5iiBuUstUdm2fBzDkL8EJt5B71xgEEC8OUcLonSD9+cHohVtbgOrNKHqEpm3Shoxx9GrjhK9tZPg==}
     engines: {node: ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -304,7 +322,7 @@ packages:
     resolution: {integrity: sha512-O6LYL9igYSzxCxDHYWUqEquuuUlMG0UL1SliZ7rF/vx9GwU71TCpsRe4iHZ0bcemM5ju9ihoTzGCmLXzYrNw0g==}
     dependencies:
       svelte: 3.46.6
-      svelte2tsx: 0.5.7_svelte@3.46.6+typescript@4.6.3
+      svelte2tsx: 0.5.7_liohzkyisnst3glff4denqdl5m
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -554,7 +572,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: false
 
-  /@docsearch/react/3.0.0_73997327e0ab5ab2aaf50785071cd6bd:
+  /@docsearch/react/3.0.0_oomxgj7avnnlfkxva6cqohgwxu:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -562,7 +580,7 @@ packages:
       react-dom: '>= 16.8.0 < 18.0.0'
     dependencies:
       '@algolia/autocomplete-core': 1.5.2
-      '@algolia/autocomplete-preset-algolia': 1.5.2_0e7d0fa1316a1da795248855ef6c22d0
+      '@algolia/autocomplete-preset-algolia': 1.5.2_bz6q7ijrnio2pfjerbk663bc2a
       '@docsearch/css': 3.0.0
       '@types/react': 17.0.43
       algoliasearch: 4.12.2
@@ -602,6 +620,18 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
+    dev: true
+
+  /@kwsites/file-exists/1.1.1:
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@kwsites/promise-deferred/1.1.1:
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
     dev: true
 
   /@ljharb/has-package-exports-patterns/0.0.2:
@@ -2253,7 +2283,7 @@ packages:
       js2xmlparser: 4.0.2
       klaw: 4.0.1
       markdown-it: 12.3.2
-      markdown-it-anchor: 8.4.1_d643ca6eb40ae68ab966a77bead78073
+      markdown-it-anchor: 8.4.1_2zb4u3vubltivolgu556vv4aom
       marked: 4.0.12
       mkdirp: 1.0.4
       requizzle: 0.2.3
@@ -2376,7 +2406,7 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /markdown-it-anchor/8.4.1_d643ca6eb40ae68ab966a77bead78073:
+  /markdown-it-anchor/8.4.1_2zb4u3vubltivolgu556vv4aom:
     resolution: {integrity: sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==}
     peerDependencies:
       '@types/markdown-it': '*'
@@ -3486,6 +3516,16 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
+  /simple-git/3.7.1:
+    resolution: {integrity: sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==}
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /sirv/2.0.2:
     resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
     engines: {node: '>= 10'}
@@ -3682,7 +3722,7 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.5.7_svelte@3.46.6+typescript@4.6.3:
+  /svelte2tsx/0.5.7_liohzkyisnst3glff4denqdl5m:
     resolution: {integrity: sha512-rekPWR5at7DNvIlJRSCyKFZ6Go/KyqjDRL/zRWQSNMbvTIocsm/gDtSbLz64ZP5Qz3tUeod7QzDqX13lF60kCg==}
     peerDependencies:
       svelte: ^3.24
@@ -3742,6 +3782,11 @@ packages:
     hasBin: true
     dependencies:
       esbuild: 0.14.38
+    dev: true
+
+  /tunnel/0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
     dev: true
 
   /type-fest/0.13.1:

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -347,10 +347,10 @@ class GitHubTranslationStatus {
 			const outdated = arrContent.filter(content => content.translations[lang].isOutdated);
 			lines.push('<details>');
 			lines.push(
-				`<summary><b>` +
+				`<summary><strong>` +
 				`${lang}: ` +
 				`${missing.length} missing, ${outdated.length} needs updating` +
-				`</b></summary>`
+				`</strong></summary>`
 			);
 			lines.push(``);
 			if (missing.length > 0) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -1,0 +1,474 @@
+import fs from 'fs';
+import glob from 'fast-glob';
+import dedent from 'dedent-js';
+import simpleGit from 'simple-git';
+import issues from './lib/github-issues.mjs';
+import output, { dedentMd } from './lib/output.mjs';
+
+/**
+ * Creates or updates a special summary issue on GitHub that provides an overview of
+ * the current Astro documentation translation status.
+ * 
+ * This code is designed to be run on every push to the `main` branch.
+ */
+class GitHubTranslationStatus {
+	constructor ({
+		pageSourceDir,
+		sourceLanguage,
+		targetLanguages,
+		githubToken,
+		githubRepo,
+		githubRefName,
+		issueTitle,
+	}) {
+		this.pageSourceDir = pageSourceDir;
+		this.sourceLanguage = sourceLanguage;
+		this.targetLanguages = targetLanguages;
+		this.githubToken = githubToken;
+		this.githubRepo = githubRepo;
+		this.githubRefName = githubRefName;
+		this.issueTitle = issueTitle;
+		this.git = simpleGit();
+
+		if (!this.githubToken) {
+			if (output.isCi) {
+				output.error('Missing GITHUB_TOKEN. Please add the following lines to the task:\n' +
+					'    env:\n' +
+					'      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+				);
+				process.exit(1);
+			} else {
+				output.warning('You are not running this script from a GitHub workflow. ' +
+					'Performing a dry run without actually updating the issue.');
+			}
+		}
+	}
+
+	/**
+	 * Performs the following steps:
+	 * 
+	 * - Update the state based on the current contents of the repo:
+	 *   - Detect if any pages existing in our index were changed:
+	 *     - Determine which commits were made to the repo since the previous head SHA
+	 *       (which was stored in the state during the last run of this script)
+	 *       - During this check, ignore commits marked as "minor" or "typo"
+	 *     - If any of these commits affected pages contained in our index,
+	 *       update the state to remember when these pages were changed
+	 * - Update the GitHub issue with the new human-friendly summary and JSON metadata
+	 */
+	async update () {
+		// Before we start, validate that this is not a shallow clone of the repo
+		const isShallowRepo = await this.git.revparse(['--is-shallow-repository']);
+		if (isShallowRepo !== 'false') {
+			output.error(dedent`This script cannot operate on a shallow clone of the git repository.
+				Please add the checkout setting "fetch-depth: 0" to your GitHub workflow:
+				- name: Checkout
+				  uses: actions/checkout@v3
+				  with:
+				    fetch-depth: 0
+			`);
+			process.exit(1);
+		}
+
+		// Try to find our summary issue on GitHub and parse its contents
+		// to get the previously stored state (if any)
+		let { issueNumber, issueBody } = await this.tryGetExistingIssue();
+		let state = this.tryGetStatePayloadFromIssueBody(issueBody);
+
+		// If we couldn't find an issue, couldn't get the previously stored state,
+		// or cannot validate its contents, start with a fresh state
+		if (!state || !state.pages || !state.pages[this.sourceLanguage]) {
+			output.warning('Previous state is missing or invalid, starting fresh');
+			state = {
+				pages: {
+					[this.sourceLanguage]: {},
+				},
+			};
+		}
+
+		// Ensure that state.pages contains a full index of relevant markdown pages
+		state.pages = await this.updatePageIndex(state.pages);
+
+		// Render a human-friendly summary of the new state
+		let intro = dedentMd`
+			If you're interested in helping us translate
+			[docs.astro.build](https://docs.astro.build/) into one of the languages listed below,
+			you've come to the right place! This auto-updating issue always lists all the pages
+			that could use your help right now.
+
+			Please note that we're currently limiting translations to a subset of pages
+			that we consider stable enough. All other pages are still subject to change and
+			should not be translated at this point. We will add more pages to these lists soon.
+
+			Before starting, please read our
+			[i18n guide](https://github.com/withastro/docs/tree/main/src/i18n) to learn about
+			our translation process and how you can get involved.
+		`;
+		let humanFriendlySummary = dedent`
+			${intro}
+
+			### Translation status by content
+			${this.renderTranslationStatusByContent(state)}
+
+			### Translation todos by language
+			${this.renderTranslationTodosByLanguage(state)}
+		`;
+		
+		// Build a new issue body with the new human-friendly summary and JSON metadata
+		let newIssueBody =
+			humanFriendlySummary +
+			this.renderAutomatedIssueFooter({
+				message: `This is an automated issue. Every commit to main updates its contents.`,
+				state,
+			});
+
+		if (!this.githubToken) {
+			output.debug(`*** New state:\n\n${JSON.stringify(state, true, 2)}\n`);
+			output.debug(`*** New human-friendly summary:\n\n${humanFriendlySummary}\n`);
+		} else if (!issueNumber) {
+			// Create a new issue if we didn't find an existing one
+			const newIssue = await issues.create({
+				repo: this.githubRepo,
+				title: this.issueTitle,
+				body: newIssueBody,
+				githubToken: this.githubToken,
+			});
+
+			issueNumber = newIssue.number;
+			output.debug(`Created new issue number: ${issueNumber}`);
+		} else if (newIssueBody !== issueBody) {
+			// Update the existing issue if its body changed
+			await issues.update({
+				repo: this.githubRepo,
+				issueNumber,
+				body: newIssueBody,
+				githubToken: this.githubToken,
+			});
+
+			output.debug(`Updated issue`);
+		}
+	}
+
+	async tryGetExistingIssue () {
+		const foundIssues = await issues.search({
+			repo: this.githubRepo,
+			title: this.issueTitle,
+			githubToken: this.githubToken,
+		});
+		let issueNumber = foundIssues &&
+			foundIssues.length > 0 &&
+			foundIssues[0].number || 0;
+
+		// Get the issue directly to avoid caching issues with the search result
+		// (search may return a slightly outdated version of the issue)
+		const issue = issueNumber > 0 && await issues.get({
+			repo: this.githubRepo,
+			issueNumber,
+			githubToken: this.githubToken,
+		});
+		let issueBody = issue && issue.body || '';
+
+		if (issueNumber > 0) {
+			output.debug(`Found existing issue #${issueNumber} with title "${issue.title}"`);
+		} else {
+			output.warning(`Didn't find an issue matching title "${this.issueTitle}", will need to create a new one`);
+		}
+
+		return {
+			issueNumber,
+			issueBody,
+		};
+	}
+
+	/**
+	 * Attempts to extract and parse JSON metadata from the issue body.
+	 * 
+	 * Returns the parsed JSON on success, or `undefined` otherwise.
+	 */
+	tryGetStatePayloadFromIssueBody (issueBody) {
+		if (!issueBody)
+			return;
+
+		const matches = issueBody.match(/\n```json stateData\s([\S\s]*?)\n```/);
+		if (!matches) {
+			output.warning(`Didn't find state payload in issue body`);
+			output.debug(`Issue body: ${JSON.stringify(issueBody)}`);
+			return;
+		}
+
+		const payload = matches[1].trim();
+		try {
+			const state = JSON.parse(payload);
+			return state;
+		} catch (error) {
+			output.warning(`Failed to parse JSON payload in issue body: ${error.message}`);
+			output.debug(`Issue body: ${JSON.stringify(issueBody)}`);
+			output.debug(`Payload: ${JSON.stringify(payload)}`);
+			return;
+		}
+	}
+
+	async updatePageIndex (oldPages) {
+		// Initialize a new page index with a stable key order
+		const pages = {
+			[this.sourceLanguage]: {},
+		};
+		this.targetLanguages.forEach(lang => pages[lang] = {});
+
+		// Enumerate all markdown pages with supported languages in pageSourceDir,
+		// retrieve their page data and update them
+		const pagePaths = await glob(`**/*.md`, {
+			cwd: this.pageSourceDir,
+		});
+		const updatedPages = await Promise.all(pagePaths.sort().map(async pagePath => {
+			const pathParts = pagePath.split('/');
+			if (pathParts.length < 2)
+				return;
+			const lang = pathParts[0];
+			const subpath = pathParts.splice(1).join('/');
+
+			// Ignore pages with languages not contained in our configuration
+			if (!pages[lang])
+				return;
+
+			// Attempt to get old data for the current page from our index
+			const oldPageData = { ...(oldPages[lang] && oldPages[lang][subpath]) };
+
+			// Create or update page data for the page
+			return {
+				lang,
+				subpath,
+				pageData: await this.updateSinglePageData({
+					pagePath,
+					oldPageData
+				}),
+			};
+		}));
+		
+		// Write the updated pages to the index
+		updatedPages.forEach(page => {
+			if (!page)
+				return;
+			const { lang, subpath, pageData } = page;
+			pages[lang][subpath] = pageData;
+		});
+
+		return pages;
+	}
+
+	/**
+	 * Processes the markdown page located in the pageSourceDir subpath `pagePath`
+	 * and creates a new page data object based on its frontmatter, git history and
+	 * old page data.
+	 */
+	async updateSinglePageData ({ pagePath, oldPageData }) {
+		const fullFilePath = `${this.pageSourceDir}/${pagePath}`;
+		const latest = (a, b) => (a > b ? a : b);
+		const pageData = {};
+
+		// Retrieve git history for the current page
+		const gitHistory = await this.getGitHistory(fullFilePath);
+
+		// Detect and store i18nReady flag from frontmatter
+		const frontMatterBlock = this.tryGetFrontMatterBlock(fullFilePath);
+		const i18nReady = /^\s*i18nReady:\s*true\s*$/m.test(frontMatterBlock);
+		if (i18nReady) {
+			pageData.i18nReady = true;
+			// If the page was i18nReady before, keep the old i18nReadyDate (if any),
+			// or use the last commit date as a fallback
+			pageData.i18nReadyDate = oldPageData.i18nReady &&
+				oldPageData.i18nReadyDate || gitHistory.lastCommitDate;
+		}
+
+		// Use the most recent dates (which allows us to manually set future dates
+		// if we do not want a translated page to become outdated) and the actual commit messages
+		pageData.lastChange = latest(oldPageData.lastChange, gitHistory.lastCommitDate);
+		pageData.lastCommitMsg = gitHistory.lastCommitMessage;
+		pageData.lastMajorChange = latest(oldPageData.lastMajorChange, gitHistory.lastMajorCommitDate);
+		pageData.lastMajorCommitMsg = gitHistory.lastMajorCommitMessage;
+		
+		return pageData;
+	}
+
+	tryGetFrontMatterBlock (filePath) {
+		const contents = fs.readFileSync(filePath, 'utf8');
+		const matches = contents.match(/^\s*---([\S\s]*?)\n---/);
+		if (!matches)
+			return '';
+		return matches[1];
+	}
+
+	async getGitHistory (filePath) {
+		const gitLog = await this.git.log({
+			file: filePath,
+			strictDate: true,
+		});
+
+		const lastCommit = gitLog.latest;
+		
+		// Attempt to find the last "major" commit, ignoring any commits that
+		// usually do not require translations to be updated
+		const lastMajorCommit = gitLog.all.find(logEntry => {
+			return !logEntry.message.match(/(minor|typo|broken link|i18nReady)/i);
+		}) || lastCommit;
+
+		return {
+			lastCommitMessage: lastCommit.message,
+			lastCommitDate: this.toUtcString(lastCommit.date),
+			lastMajorCommitMessage: lastMajorCommit.message,
+			lastMajorCommitDate: this.toUtcString(lastMajorCommit.date),
+		};
+	}
+
+	toUtcString (date) {
+		return new Date(date).toISOString();
+	}
+
+	renderTranslationStatusByContent ({ pages }) {
+		const arrContent = this.getTranslationStatusByContent({ pages });
+		const lines = [];
+
+		lines.push(`| Content | ${this.targetLanguages.join(' | ')} |`);
+		lines.push(`| :--- | ${this.targetLanguages.map(_ => ':---:').join(' | ')} |`);
+
+		arrContent.forEach(content => {
+			const cols = [];
+			cols.push(`[${content.subpath}](${content.githubUrl})`);
+			cols.push(...this.targetLanguages.map(lang => {
+				const translation = content.translations[lang];
+				if (translation.isMissing)
+					return '<span title="Missing">❌</span>';
+				if (translation.isOutdated)
+					return '<span title="Needs updating">🔄</span>';
+				return '<span title="Completed">✔</span>';
+			}));
+			lines.push(`| ${cols.join(' | ')} |`);
+		});
+
+		lines.push(`\n<sup>❌ Missing &nbsp; 🔄 Needs updating &nbsp; ✔ Completed</sup>`);
+
+		return lines.join('\n');
+	}
+
+	renderTranslationTodosByLanguage ({ pages }) {
+		const arrContent = this.getTranslationStatusByContent({ pages });
+		const lines = [];
+
+		this.targetLanguages.forEach(lang => {
+			const missing = arrContent.filter(content => content.translations[lang].isMissing);
+			const outdated = arrContent.filter(content => content.translations[lang].isOutdated);
+			lines.push('<details>');
+			lines.push(
+				`<summary><b>` +
+				`${lang}: ` +
+				`${missing.length} missing, ${outdated.length} needs updating` +
+				`</b></summary>`
+			);
+			lines.push(``);
+			if (missing.length > 0) {
+				lines.push(`##### Missing`);
+				lines.push(...missing.map(content =>
+					`- [${content.subpath}](${content.githubUrl})`
+				));
+				lines.push(``);
+			}
+			if (outdated.length > 0) {
+				lines.push(`##### Needs updating`);
+				lines.push(...outdated.map(content =>
+					`- [${content.subpath}](${content.githubUrl}) ` +
+					`([outdated translation](${content.translations[lang].githubUrl}), ` +
+					`[source change history](${content.translations[lang].sourceHistoryUrl}))`
+				));
+				lines.push(``);
+			}
+			lines.push(`</details>`);
+			lines.push(``);
+		});
+
+		return lines.join('\n');
+	}
+
+	getTranslationStatusByContent ({ pages }) {
+		const sourcePages = pages[this.sourceLanguage];
+		const arrContent = [];
+
+		Object.keys(sourcePages).forEach(subpath => {
+			const sourcePage = sourcePages[subpath];
+			if (!sourcePage.i18nReady)
+				return;
+			
+			const content = {
+				subpath,
+				sourcePage,
+				githubUrl: this.getPageUrl({ lang: this.sourceLanguage, subpath }),
+				translations: {},
+			};
+
+			this.targetLanguages.forEach(lang => {
+				const i18nPage = pages[lang][subpath];
+				content.translations[lang] = {
+					page: i18nPage,
+					isMissing: !i18nPage,
+					isOutdated: i18nPage && sourcePage.lastMajorChange > i18nPage.lastChange,
+					githubUrl: this.getPageUrl({ lang, subpath }),
+					sourceHistoryUrl: this.getPageUrl({
+						lang: 'en',
+						subpath,
+						type: 'commits',
+						query: i18nPage ? `?since=${i18nPage.lastChange}` : '',
+					}),
+				};
+			});
+
+			arrContent.push(content);
+		});
+
+		return arrContent;
+	}
+
+	getPageUrl ({ type = 'blob', refName = 'main', lang, subpath, query = '' }) {
+		const noDotSrcDir = this.pageSourceDir.replace(/^.\//, '');
+		return `/${this.githubRepo}/${type}/${refName}` +
+			`/${noDotSrcDir}/${lang}/${subpath}${query}`;
+	}
+
+	/**
+	 * Renders a footer that informs about the automated nature of this issue
+	 * and includes our state data.
+	 */
+	renderAutomatedIssueFooter ({ message, state }) {
+		return dedent`
+
+			##
+			<h6>
+			<i>${message}</i><br/><br/>
+			<sub><details><summary><i>(Expand to see internal state data)</i></summary>
+
+			&nbsp;
+			${this.renderStatePayloadForIssueBody(state)}
+			</details>
+			</sub>
+			</h6>
+		`;
+	}
+
+	/**
+	 * Converts the given `state` to JSON and wraps it in a fenced code block
+	 * with our expected payload marker.
+	 */
+	renderStatePayloadForIssueBody (state) {
+		return '\n```json stateData\n' + JSON.stringify(state, true, 2) + '\n```';
+	}
+}
+
+const githubTranslationStatus = new GitHubTranslationStatus({
+	pageSourceDir: './src/pages',
+	sourceLanguage: 'en',
+	targetLanguages: ['de', 'es', 'fr', 'pt-BR'],
+	githubToken: process.env.GITHUB_TOKEN,
+	githubRepo: process.env.GITHUB_REPOSITORY,
+	githubRefName: process.env.GITHUB_REF_NAME,
+	issueTitle: '[i18n] Translation Status Overview',
+});
+
+githubTranslationStatus.update();

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -44,18 +44,6 @@ class GitHubTranslationStatus {
 		}
 	}
 
-	/**
-	 * Performs the following steps:
-	 * 
-	 * - Update the state based on the current contents of the repo:
-	 *   - Detect if any pages existing in our index were changed:
-	 *     - Determine which commits were made to the repo since the previous head SHA
-	 *       (which was stored in the state during the last run of this script)
-	 *       - During this check, ignore commits marked as "minor" or "typo"
-	 *     - If any of these commits affected pages contained in our index,
-	 *       update the state to remember when these pages were changed
-	 * - Update the GitHub issue with the new human-friendly summary and JSON metadata
-	 */
 	async update () {
 		// Before we start, validate that this is not a shallow clone of the repo
 		const isShallowRepo = await this.git.revparse(['--is-shallow-repository']);

--- a/scripts/lib/github-issues.mjs
+++ b/scripts/lib/github-issues.mjs
@@ -12,23 +12,20 @@ import output from './output.mjs';
 /**
  * Searches for issues matching the given criteria.
  * 
- * Returns an array of issue objects with at least the following properties:
- * ```js
- * {
- *     number: number,
- *     title: string,
+ * @return {{
+ *     number: number;
+ *     title: string;
  *     user: {
- *         login: string,
- *     },
- *     body: string,
- *     state: 'open' | 'closed',
- *     locked: boolean,
- *     labels: string[],
- *     created_at: date,
- *     updated_at: date,
- *     closed_at: date | null,
- * }
- * ```
+ *         login: string;
+ *     };
+ *     body: string;
+ *     state: 'open' | 'closed';
+ *     locked: boolean;
+ *     labels: string[];
+ *     created_at: date;
+ *     updated_at: date;
+ *     closed_at: date | null;
+ * }} An array of issue objects.
  */
 export async function search ({
 	repo,

--- a/scripts/lib/github-issues.mjs
+++ b/scripts/lib/github-issues.mjs
@@ -1,0 +1,230 @@
+/**
+ * Note: This module is only here to avoid including octokit.js with hundreds of dependencies,
+ * which would slow down the install task of our GitHub workflows.
+ * 
+ * If we want to switch to octokit.js at one point, we should make this code independent from
+ * our scripts by creating separate GitHub actions with their own repos and compilation steps.
+ */
+
+import fetch from 'node-fetch';
+import output from './output.mjs';
+
+/**
+ * Searches for issues matching the given criteria.
+ * 
+ * Returns an array of issue objects with at least the following properties:
+ * ```js
+ * {
+ *     number: number,
+ *     title: string,
+ *     user: {
+ *         login: string,
+ *     },
+ *     body: string,
+ *     state: 'open' | 'closed',
+ *     locked: boolean,
+ *     labels: string[],
+ *     created_at: date,
+ *     updated_at: date,
+ *     closed_at: date | null,
+ * }
+ * ```
+ */
+export async function search ({
+	repo,
+	title,
+	author,
+	open,
+	ascending = true,
+	githubToken = undefined,
+}) {
+	const url = new URL('https://api.github.com/search/issues');
+
+	const queryParts = [
+		'type:issue',
+		repo && `repo:${repo}`,
+		author && `author:${author}`,
+		open !== undefined && `state:${open ? 'open' : 'closed'}`,
+		title && `in:title ${title}`,
+	];
+
+	url.searchParams.set('q', queryParts.filter(part => part).join(' '));
+	url.searchParams.set('sort', 'created');
+	url.searchParams.set('order', ascending ? 'asc' : 'desc');
+	url.searchParams.set('per_page', '100');
+
+	const json = await githubGet({
+		url,
+		githubToken,
+	});
+
+	if (json.total_count !== json.items.length) {
+		output.warning(`Query "${url}" returned a total_count of ${json.total_count}, ` +
+			`but items.length was ${json.items.length}. Pagination is not supported yet.`);
+	}
+
+	return json.items;
+}
+
+/**
+ * Gets an existing issue specified by `repo` and `issueNumber`.
+ */
+export async function get ({
+	repo,
+	issueNumber,
+	githubToken = undefined,
+}) {
+	if (typeof issueNumber !== 'number' || !(issueNumber > 0))
+		throw new Error(`Missing or invalid property "issueNumber": Expected a positive number, but got ${JSON.stringify(issueNumber)}`);
+	
+	requireStringProps({ repo });
+
+	const url = new URL(`https://api.github.com/repos/${repo}/issues/${issueNumber}`);
+
+	const issue = await githubGet({
+		url,
+		githubToken,
+	});
+
+	return issue;
+}
+
+/**
+ * Creates a new issue in `repo` with the given contents.
+ * 
+ * Returns the newly created issue object.
+ */
+export async function create ({
+	repo,
+	title,
+	body,
+	labels,
+	githubToken,
+}) {
+	requireStringProps({
+		repo,
+		title,
+		body,
+	});
+
+	const url = new URL(`https://api.github.com/repos/${repo}/issues`);
+
+	const createdIssue = await githubWrite({
+		method: 'post',
+		url,
+		body: {
+			title,
+			body,
+			labels,
+		},
+		githubToken,
+	});
+
+	return createdIssue;
+}
+
+/**
+ * Updates an existing issue specified by `repo` and `issueNumber`.
+ */
+export async function update ({
+	repo,
+	issueNumber,
+	title,
+	body,
+	labels,
+	githubToken,
+}) {
+	if (typeof issueNumber !== 'number' || !(issueNumber > 0))
+		throw new Error(`Missing or invalid property "issueNumber": Expected a positive number, but got ${JSON.stringify(issueNumber)}`);
+	
+	requireStringProps({ repo });
+	optionalTypeProps('string', {
+		title,
+		body,
+	});
+
+	const url = new URL(`https://api.github.com/repos/${repo}/issues/${issueNumber}`);
+
+	const createdIssue = await githubWrite({
+		method: 'patch',
+		url,
+		body: {
+			title,
+			body,
+			labels,
+		},
+		githubToken,
+	});
+
+	return createdIssue;
+}
+
+// #region Helper functions
+
+async function githubGet ({ url, githubToken = undefined }) {
+	const headers = {
+		Accept: 'application/vnd.github.v3+json',
+	};
+	if (githubToken) {
+		headers.Authorization = `token ${githubToken}`;
+	}
+	const response = await fetch(url, {
+		headers,
+	});
+	const json = await response.json();
+
+	if (!response.ok)
+		throw new Error(`GitHub API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
+
+	return json;
+}
+
+async function githubWrite ({ method, url, body, githubToken }) {
+	const allowedMethods = ['post', 'patch', 'put', 'delete'];
+	if (typeof method !== 'string' || !allowedMethods.includes(method.toLowerCase()))
+		throw new Error(`GitHub API call failed: Expected "method" to be one of ${JSON.stringify(allowedMethods)}, but got ${JSON.stringify(method)}`);
+	
+	if (typeof githubToken !== 'string' || !githubToken.length)
+		throw new Error(`GitHub API call failed: ${method.toUpperCase()} "${url}" requires githubToken, but none was provided`);
+	
+	const response = await fetch(url, {
+		method: method.toLowerCase(),
+		headers: {
+			Accept: 'application/vnd.github.v3+json',
+			Authorization: `token ${githubToken}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(body),
+	});
+	const json = await response.json();
+
+	if (!response.ok)
+		throw new Error(`GitHub API call failed: ${method.toUpperCase()} "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
+
+	return json;
+}
+
+function requireStringProps (props) {
+	Object.keys(props).forEach(key => {
+		const val = props[key];
+		if (typeof val !== 'string' || !val.length)
+			throw new Error(`Missing or invalid property "${key}": Expected a non-empty string, but got ${JSON.stringify(val)}`);
+	});
+}
+
+function optionalTypeProps (expectedTypeOrUndefined, props) {
+	Object.keys(props).forEach(key => {
+		const val = props[key];
+		if (val !== undefined && typeof val !== expectedTypeOrUndefined)
+			throw new Error(`Invalid type of optional property "${key}": Expected ${expectedTypeOrUndefined} or undefined, but got ${typeof val} ${JSON.stringify(val)}`);
+	});
+}
+
+// #endregion
+
+export default {
+	search,
+	get,
+	create,
+	update,
+};

--- a/scripts/lib/output.mjs
+++ b/scripts/lib/output.mjs
@@ -1,0 +1,43 @@
+import kleur from 'kleur';
+import core from '@actions/core';
+import dedent from 'dedent-js';
+
+export const isCi = process.env.CI;
+
+export function debug (message, ...params) {
+	console.log(message, ...params);
+}
+
+export function warning (message, ...params) {
+	if (isCi) {
+		core.warning(message, ...params);
+	}
+	else {
+		console.warn(kleur.yellow().bold(`*** WARNING: ${message}`), ...params);
+	}
+}
+
+export function error (message, ...params) {
+	if (isCi) {
+		core.error(message, ...params);
+	}
+	else {
+		console.error(kleur.red().bold(`*** ERROR: ${message}`), ...params);
+	}
+}
+
+/**
+ * Dedents the given markdown and replaces single newlines with spaces,
+ * while leaving new paragraphs intact.
+ */
+export function dedentMd (...markdown) {
+	return dedent(...markdown).replace(/(\S)\n(?!\n)/g, '$1 ');
+}
+
+export default {
+	debug,
+	warning,
+	error,
+	dedentMd,
+	isCi,
+};


### PR DESCRIPTION
Adds a script that creates or updates a special "Translation Status Overview" summary issue on GitHub that provides an overview of the current Astro documentation translation status.

Also adds a GitHub workflow that runs this script on every push to the `main` branch.

An example of the summary issue maintained by this script can be seen here:
https://github.com/hippotastic/astro-docs/issues/2
