### PR TITLE
Feat: Add Discord Notification on Push

### DIFF
--- a/.github/workflows/discord-congrats.yml
+++ b/.github/workflows/discord-congrats.yml
@@ -1,0 +1,30 @@
+name: Discord Notification on Push
+
+on:
+  push:
+    branches: [main]
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  congrats:
+    name: congratsbot
+    if: ${{ github.repository_owner == 'withastro' }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup
+        env:
+          MESSAGE: ${{ github.event.commits[0].message }}
+        run:  |
+              TRIMMED=$(echo "$MESSAGE" | sed '1!d;q')
+              echo "::set-output name=COMMIT_MSG::${TRIMMED}"
+      - name: Send a Discord notification when a PR is merged
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+          # DISCORD_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "**Merged!** ${{ github.event.commits[0].author.name }}: [`${{ steps.setup.outputs.COMMIT_MSG }}`](<https://github.com/withastro/docs/commit/${{ github.event.commits[0].id }}>)"


### PR DESCRIPTION
Adds the same awesome Discord notification on push/PR merge that we already have for `withastro/astro`, but this time for `withastro/docs`!

Note: This workflow requires a new Discord webhook to be created that posts to the `#docs` channel, and the webhook URL to be added to this repo under Settings -> Secrets -> Actions -> New repository secret with the name `DISCORD_WEBHOOK_CONGRATS`. Afterwards, you can merge this PR and will receive instant congratulations for it! 🎉