### PR TITLE
i18nReady: true for first batch of pages

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Components
 description: An intro to the .astro component syntax.
+i18nReady: true
 ---
 
 **Astro components** are the basic building blocks of any Astro project. They are HTML-only templating components with no client-side runtime.

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Pages
 description: An introduction to Astro pages
+i18nReady: true
 ---
 
 **Pages** are a special type of [Astro component](/en/core-concepts/astro-components) that live in the `src/pages/` subdirectory. They are responsible for handling routing, data loading, and overall page layout for every HTML page in your website.

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Framework Components
 description: Learn how to use React, Svelte, etc.
+i18nReady: true
 ---
 Build your Astro website without sacrificing your favorite component framework. 
 

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Layouts
 description: An intro to layouts, a type of Astro component that is shared between pages for common layouts.
+i18nReady: true
 ---
 
 **Layouts** are a special type of [Astro component](/en/core-concepts/astro-components) useful for creating reusable page templates. 

--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Project Structure
 description: Learn how to structure a project with Astro.
+i18nReady: true
 ---
 
 Your new Astro project generated from the `create-astro` CLI wizard already includes some files and folders. Others, you will create yourself and add to Astro's existing file structure.

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Configuring Astro
+i18nReady: true
 ---
 
 Customize how Astro works by adding an `astro.config.mjs` file in your project. This is a common file in Astro projects, and all official example templates and themes ship with one by default.

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Static Assets
 description: Learn how to import different content types with Astro.
+i18nReady: true
 ---
 
 Astro supports most static assets with zero configuration required. You can use the `import` statement anywhere in your project JavaScript (including your Astro front matter script) and Astro will include a built, optimized copy of that static asset in your final build. `@import` is also supported inside of CSS & `<style>` tags.

--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -3,6 +3,7 @@ layout: ~/layouts/MainLayout.astro
 setup: |
   import Badge from '~/components/Badge.astro';
 title: Using Integrations
+i18nReady: true
 ---
 
 **Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from npm. 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Markdown
 description: Using Markdown with Astro
+i18nReady: true
 ---
 
 Markdown content is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for Markdown with some added features like support for JavaScript expressions and Astro components right in your Markdown.

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Server-side Rendering (experimental)
+i18nReady: true
 ---
 
 **Server-side Rendering**, aka SSR, is enabled in Astro behind an experimental flag. When you enable SSR you can:

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -3,6 +3,7 @@ title: Install Astro with the Automatic CLI
 description: How to install Astro with NPM, PNPM, or Yarn via the create-astro CLI tool.
 layout: ~/layouts/MainLayout.astro
 setup: import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+i18nReady: true
 ---
 Ready to install Astro? Follow our automatic or manual set-up guide to get started.
 

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -3,6 +3,7 @@ title: Install Astro manually
 description: How to install Astro manually with NPM, PNPM, or Yarn.
 layout: ~/layouts/MainLayout.astro
 setup: import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+i18nReady: true
 ---
 Ready to install Astro? Follow our automatic or manual set-up guide to get started.
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Migration Guide
 description: How to migrate your project to latest version of Astro.
+i18nReady: true
 ---
 
 This guide will help you migrate from older versions of Astro to the latest, most up-to-date version.


### PR DESCRIPTION
Set first batch of mostly core pages as i18nReady!

These pages should now be automatically listed at https://github.com/withastro/docs/issues/438 for translator reference.

Thanks, @hippotastic !