### PR TITLE
Improve toc indicator precision and add auto-scroll

### DIFF
--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -19,28 +19,61 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) =
 		if (!toc.current) return;
 
 		const setCurrent: IntersectionObserverCallback = (entries) => {
+			const intersectingEntries = [];
+
 			for (const entry of entries) {
-				if (entry.isIntersecting) {
-					setCurrentID(entry.target.id);
-					break;
-				}
+				if (entry.isIntersecting) intersectingEntries.push(entry);
+			}
+
+			if (intersectingEntries.length === 1) {
+				setCurrentID(intersectingEntries[0].target.id);
+				scrollIntoView();
+			} else if (intersectingEntries.length > 1) {
+				const sortedEntries = intersectingEntries.sort((a, b) => {
+					return getHeadingIndex(a.target.id) - getHeadingIndex(b.target.id);
+				});
+				setCurrentID(sortedEntries[0].target.id);
+				scrollIntoView();
 			}
 		};
 
 		const observerOptions: IntersectionObserverInit = {
 			// Negative top margin accounts for `scroll-margin`.
 			// Negative bottom margin means heading needs to be towards top of viewport to trigger intersection.
-			rootMargin: '-100px 0% -66%',
+			rootMargin: '-100px 0px -40% 0px',
 			threshold: 1,
 		};
 
 		const headingsObserver = new IntersectionObserver(setCurrent, observerOptions);
 
-		// Observe all the headings in the main page content.
-		document.querySelectorAll('article :is(h1,h2,h3)').forEach((h) => headingsObserver.observe(h));
+		// removes the headings from "on this page" on mobile using [id] selector.
+		const headings = document.querySelectorAll('article :is(h1,h2[id],h3)');
 
-		// Stop observing when the component is unmounted.
-		return () => headingsObserver.disconnect();
+		const getHeadingIndex = (id) => Array.from(headings).findIndex((heading) => heading.id === id);
+
+		let scrollPosition = 0;
+		let scrollDirection = 10;
+
+		const setScrollDirection = () => {
+			if (document.body.getBoundingClientRect().top > scrollPosition) scrollDirection = -10;
+			else scrollDirection = 10;
+			scrollPosition = document.body.getBoundingClientRect().top;
+		};
+
+		window.addEventListener('scroll', setScrollDirection);
+
+		const scrollIntoView = () => {
+			const scrollingContext = document.querySelector('.sidebar-nav-inner');
+			if (window.matchMedia('(prefers-reduced-motion)')) scrollingContext.scrollBy(0, scrollDirection);
+		};
+
+		// Observe all the headings in the main page content.
+		headings.forEach((h) => headingsObserver.observe(h));
+
+		// Stop observing/listening when the component is unmounted.
+		return () => {
+			headingsObserver.disconnect(), window.removeEventListener('scroll', setScrollDirection);
+		};
 	}, [toc.current]);
 
 	return (

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -40,8 +40,8 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) =
 		const observerOptions: IntersectionObserverInit = {
 			// Negative top margin accounts for `scroll-margin`.
 			// Negative bottom margin means heading needs to be towards top of viewport to trigger intersection.
-			rootMargin: '-100px 0px -40% 0px',
-			threshold: 1,
+			rootMargin: '-100px 0px -66% 0px',
+			threshold: [0.75, 1],
 		};
 
 		const headingsObserver = new IntersectionObserver(setCurrent, observerOptions);


### PR DESCRIPTION
The table of contents indicator logic received some changes to be more precise and now "on this page" auto-scrolls, this way the indicator is always visible.

- Auto-scroll (look how new toc links appear as you scroll down the page):
![KuKYDum](https://user-images.githubusercontent.com/61414485/166849947-67ecd2cd-fa47-4246-ba06-c132bd6a86b8.gif)

- Precision comparison between the old and new logic (Getting Started):

Old
![wDRNvrb](https://user-images.githubusercontent.com/61414485/166850209-b6a38e56-96b0-4731-9946-62af6f2a8e2c.gif)

New
![RVSMZXZ](https://user-images.githubusercontent.com/61414485/166850266-3ba8bbfe-ffa6-4842-9fbb-eb861131062c.gif) 

*Yes, I do love sidebars.*