### PR TITLE
Polish to the automated i18n issue

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -358,7 +358,7 @@ class GitHubTranslationStatus {
 			if (missing.length > 0) {
 				lines.push(`##### Missing`);
 				lines.push(...missing.map(content =>
-					`- [${content.subpath}](${content.githubUrl}) ${this.renderCreatePageButton(lang, content.subpath)}`
+					`- [${content.subpath}](${content.githubUrl}) &nbsp; ${this.renderCreatePageButton(lang, content.subpath)}`
 				));
 				lines.push(``);
 			}
@@ -387,7 +387,7 @@ class GitHubTranslationStatus {
 		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
 		createUrl.searchParams.set('filename', filename);
 		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
-		return `[**\`Create page\`**](${createUrl.href})`;
+		return `[**\`Create page +\`**](${createUrl.href})`;
 	}
 
 	getTranslationStatusByContent ({ pages }) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -384,8 +384,9 @@ class GitHubTranslationStatus {
 	 * @param {string} filename Subpath of page to create
 	 */
 	renderCreatePageButton(lang, filename) {
+		// We include `lang` twice because GitHub eats the last path segment when setting filename.
 		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
-		createUrl.searchParams.set('filename', filename);
+		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
 		return `[**\`Create page +\`**](${createUrl.href})`;
 	}

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -354,9 +354,13 @@ class GitHubTranslationStatus {
 			);
 			lines.push(``);
 			if (missing.length > 0) {
+				// Pre-filled link to GitHub’s UI for adding a new file
+				const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
+				createUrl.searchParams.set('filename', content.subpath);
+				createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
 				lines.push(`##### Missing`);
 				lines.push(...missing.map(content =>
-					`- [${content.subpath}](${content.githubUrl})`
+					`- [${content.subpath}](${content.githubUrl}) [**\`Create page\`**](${createUrl.href})`
 				));
 				lines.push(``);
 			}

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -356,13 +356,9 @@ class GitHubTranslationStatus {
 			);
 			lines.push(``);
 			if (missing.length > 0) {
-				// Pre-filled link to GitHub’s UI for adding a new file
-				const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
-				createUrl.searchParams.set('filename', content.subpath);
-				createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
 				lines.push(`##### Missing`);
 				lines.push(...missing.map(content =>
-					`- [${content.subpath}](${content.githubUrl}) [**\`Create page\`**](${createUrl.href})`
+					`- [${content.subpath}](${content.githubUrl}) ${this.renderCreatePageButton(lang, content.subpath)}`
 				));
 				lines.push(``);
 			}
@@ -380,6 +376,18 @@ class GitHubTranslationStatus {
 		});
 
 		return lines.join('\n');
+	}
+
+	/**
+	 * Render a link to a pre-filled GitHub UI for creating a new file
+	 * @param {string} lang Language tag to create page for
+	 * @param {string} filename Subpath of page to create
+	 */
+	renderCreatePageButton(lang, filename) {
+		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
+		createUrl.searchParams.set('filename', filename);
+		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
+		return `[**\`Create page\`**](${createUrl.href})`;
 	}
 
 	getTranslationStatusByContent ({ pages }) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -356,14 +356,14 @@ class GitHubTranslationStatus {
 			);
 			lines.push(``);
 			if (missing.length > 0) {
-				lines.push(`##### Missing`);
+				lines.push(`##### ❌&nbsp; Missing`);
 				lines.push(...missing.map(content =>
 					`- [${content.subpath}](${content.githubUrl}) &nbsp; ${this.renderCreatePageButton(lang, content.subpath)}`
 				));
 				lines.push(``);
 			}
 			if (outdated.length > 0) {
-				lines.push(`##### Needs updating`);
+				lines.push(`##### 🔄&nbsp; Needs updating`);
 				lines.push(...outdated.map(content =>
 					`- [${content.subpath}](${content.githubUrl}) ` +
 					`([outdated translation](${content.translations[lang].githubUrl}), ` +

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -91,7 +91,7 @@ class GitHubTranslationStatus {
 			should not be translated at this point. We will add more pages to these lists soon.
 
 			Before starting, please read our
-			[i18n guide](https://github.com/withastro/docs/tree/main/src/i18n) to learn about
+			[i18n guide](https://github.com/withastro/docs/tree/main/src/i18n/README.md) to learn about
 			our translation process and how you can get involved.
 		`;
 		let humanFriendlySummary = dedent`

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -16,6 +16,7 @@ class GitHubTranslationStatus {
 		pageSourceDir,
 		sourceLanguage,
 		targetLanguages,
+		languageLabels,
 		githubToken,
 		githubRepo,
 		githubRefName,
@@ -24,6 +25,7 @@ class GitHubTranslationStatus {
 		this.pageSourceDir = pageSourceDir;
 		this.sourceLanguage = sourceLanguage;
 		this.targetLanguages = targetLanguages;
+		this.languageLabels = languageLabels;
 		this.githubToken = githubToken;
 		this.githubRepo = githubRepo;
 		this.githubRefName = githubRefName;
@@ -348,7 +350,7 @@ class GitHubTranslationStatus {
 			lines.push('<details>');
 			lines.push(
 				`<summary><strong>` +
-				`${lang}: ` +
+				`${this.languageLabels[lang]} (${lang}): ` +
 				`${missing.length} missing, ${outdated.length} needs updating` +
 				`</strong></summary>`
 			);
@@ -457,6 +459,7 @@ const githubTranslationStatus = new GitHubTranslationStatus({
 	pageSourceDir: './src/pages',
 	sourceLanguage: 'en',
 	targetLanguages: ['de', 'es', 'fr', 'ja', 'pt-BR', 'zh-CN'],
+	languageLabels: { de: 'Deutsch', es: 'Español', fr: 'Français', ja: '日本語', 'pt-BR': 'Português do Brasil', 'zh-CN': '简体中文' },
 	githubToken: process.env.GITHUB_TOKEN,
 	githubRepo: process.env.GITHUB_REPOSITORY,
 	githubRefName: process.env.GITHUB_REF_NAME,


### PR DESCRIPTION
This PR adds a few little details to our new automated i18n tracker.

You can see a live preview of the changes here: https://github.com/delucis/docs/issues/1

- Adds a “Create page” link next to missing content:
   <img width="403" alt="image" src="https://user-images.githubusercontent.com/357379/166895676-eab83460-61eb-4028-8060-60d2dc7fdd0f.png">
   This links to a GitHub UI for creating a new file with the correct name and pre-fills it with the basic Markdown frontmatter

- Displays each language’s full name in the todos list:
   <img width="427" alt="image" src="https://user-images.githubusercontent.com/357379/166895870-174dfab7-28da-473f-b674-ff3f45fb0b7b.png">

- Fixes the i18n guide link in the intro (h/t @hippotastic)

- Adds the emoji to the subheadings in each language’s todo section
   <img width="88" alt="image" src="https://user-images.githubusercontent.com/357379/166896048-332963fc-d496-415c-9ef4-60ba4dd30380.png"> <img width="137" alt="image" src="https://user-images.githubusercontent.com/357379/166896074-c49e7b0e-8ac9-4e5c-a08f-2d94a7f57744.png">
