### PR TITLE
Prevent create page button breaking across lines

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -388,7 +388,7 @@ class GitHubTranslationStatus {
 		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
 		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
-		return `[**\`Create&nbsp;page&nbsp;+\`**](${createUrl.href})`;
+		return `[**\`Create page +\`**](${createUrl.href})`;
 	}
 
 	getTranslationStatusByContent ({ pages }) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -388,7 +388,7 @@ class GitHubTranslationStatus {
 		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
 		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
-		return `[**\`Create page +\`**](${createUrl.href})`;
+		return `[**\`Create&nbsp;page&nbsp;+\`**](${createUrl.href})`;
 	}
 
 	getTranslationStatusByContent ({ pages }) {


### PR DESCRIPTION
Fixes mobile rendering of the “Create page” buttons in the i18n tracking issue. #446 added these but used normal spaces in the button text causing it to wrap across lines on narrow viewports. This replaces those with non-breaking spaces so the whole button always wraps together.