### PR TITLE
i18n(fr): Updating `getting-started.md` and UI elements translation. 

### DIFF
--- a/src/i18n/fr/docsearch.ts
+++ b/src/i18n/fr/docsearch.ts
@@ -4,7 +4,7 @@ export default DocSearchDictionary({
 	button: 'Rechercher',
 	placeholder: 'Rechercher dans la documentation',
 	shortcutLabel: 'Appuyez sur / pour rechercher',
-	translations: {
+	modal: {
 		searchBox: {
 			resetButtonTitle: 'Effacer la recherche',
 			resetButtonAriaLabel: 'Effacer la recherche',

--- a/src/i18n/fr/docsearch.ts
+++ b/src/i18n/fr/docsearch.ts
@@ -1,0 +1,43 @@
+import { DocSearchDictionary } from '../translation-checkers';
+
+export default DocSearchDictionary({
+	button: 'Rechercher',
+	placeholder: 'Rechercher dans la documentation',
+	shortcutLabel: 'Appuyez sur / pour rechercher',
+	translations: {
+		searchBox: {
+			resetButtonTitle: 'Effacer la recherche',
+			resetButtonAriaLabel: 'Effacer la recherche',
+			cancelButtonText: 'Annuler',
+			cancelButtonAriaLabel: 'Annuler',
+		},
+		startScreen: {
+			recentSearchesTitle: 'Recherches récentes',
+			noRecentSearchesText: 'Aucune recherche récente',
+			saveRecentSearchButtonTitle: 'Sauvegarder cette recherche',
+			removeRecentSearchButtonTitle: "Enlever cette recherche de l'historique",
+			favoriteSearchesTitle: 'Favoris',
+			removeFavoriteSearchButtonTitle: 'Enlever cette recherche des favoris',
+		},
+		errorScreen: {
+			titleText: 'Erreur lors de la récupération des résultats',
+			helpText: "Vous devriez vérifier l'état de votre connection internet.",
+		},
+		footer: {
+			selectText: 'pour sélectionner',
+			selectKeyAriaLabel: 'Appuyez sur la touche',
+			navigateText: 'pour naviguer',
+			navigateUpKeyAriaLabel: 'Flèche du haut',
+			navigateDownKeyAriaLabel: 'Flèche du bas',
+			closeText: 'pour fermer',
+			closeKeyAriaLabel: "Touche d'échappement",
+			searchByText: 'Recherche via',
+		},
+		noResultsScreen: {
+			noResultsText: 'Aucun résultat trouvé pour',
+			suggestedQueryText: 'Essayez de rechercher pour',
+			reportMissingResultsText: 'Vous pensez que vous avez trouvé une erreur ?',
+			reportMissingResultsLinkText: 'Faites-le nous savoir.',
+		},
+	},
+});

--- a/src/i18n/fr/docsearch.ts
+++ b/src/i18n/fr/docsearch.ts
@@ -36,7 +36,7 @@ export default DocSearchDictionary({
 		noResultsScreen: {
 			noResultsText: 'Aucun résultat trouvé pour',
 			suggestedQueryText: 'Essayez de rechercher pour',
-			reportMissingResultsText: 'Vous pensez que vous avez trouvé une erreur ?',
+			reportMissingResultsText: 'Vous pensez avoir trouvé une erreur ?',
 			reportMissingResultsLinkText: 'Faites-le nous savoir.',
 		},
 	},

--- a/src/i18n/fr/nav.ts
+++ b/src/i18n/fr/nav.ts
@@ -26,7 +26,7 @@ export default NavDictionary({
 	// Features
 	features: 'Fonctionnalités',
 	'guides/configuring-astro': 'Configurer Astro',
-	'guides/styling': 'CSS et Stylisation',
+	'guides/styling': 'CSS et Styles',
 	'guides/debugging': 'Déboguer',
 	'guides/data-fetching': 'Récupération de Données',
 	'guides/deploy': 'Déployer',

--- a/src/i18n/fr/nav.ts
+++ b/src/i18n/fr/nav.ts
@@ -1,6 +1,51 @@
 import { NavDictionary } from '../translation-checkers';
 
 export default NavDictionary({
-	startHere: 'Bienvenue',
+	// Start Here
+	startHere: 'Commencez ici',
 	'getting-started': 'Bien démarrer',
+	install: 'Installation',
+	'editor-setup': "Configuration de l'éditeur de code",
+	migrate: 'Guide de Migration',
+	'integrations/integrations': 'Construit avec Astro',
+	'comparing-astro-vs-other-tools': 'Astro vs. X',
+
+	// Core Concepts
+	coreConcepts: 'Concepts Principaux',
+	'core-concepts/partial-hydration': 'Hydratation partielle',
+
+	// Basics
+	basics: 'Les Bases',
+	'core-concepts/project-structure': 'Structure du Projet',
+	'core-concepts/astro-components': 'Composants',
+	'core-concepts/astro-pages': 'Pages',
+	'core-concepts/layouts': 'Layouts',
+	'guides/markdown-content': 'Markdown',
+	'guides/imports': 'Fichiers Statiques',
+
+	// Features
+	features: 'Fonctionnalités',
+	'guides/configuring-astro': 'Configurer Astro',
+	'guides/styling': 'CSS et Stylisation',
+	'guides/debugging': 'Déboguer',
+	'guides/data-fetching': 'Récupération de Données',
+	'guides/deploy': 'Déployer',
+	'guides/environment-variables': "Variables d'Environnement",
+	'guides/aliases': "Alias d'Importation",
+	'guides/integrations-guide': 'Intégrations',
+	'guides/rss': 'Flux RSS',
+	'guides/server-side-rendering': 'Interprétation côté serveur (SSR)',
+	'guides/typescript': 'TypeScript',
+	'core-concepts/framework-components': 'Composants de Frameworks',
+
+	// Reference
+	reference: 'Référence',
+	'reference/configuration-reference': 'Configuration',
+	'reference/cli-reference': 'Lignes de Commandes',
+	'reference/api-reference': 'API d\'Exécution',
+	'reference/integrations-reference': 'API d\'Intégration',
+	'reference/adapter-reference': 'API des adaptateurs (expérimental)',
+	'core-concepts/routing': 'Règles de Routage',
+	'reference/directives-reference': 'Utilisation des Directives',
+	'guides/publish-to-npm': 'Format de Packet NPM',
 });

--- a/src/i18n/fr/ui.ts
+++ b/src/i18n/fr/ui.ts
@@ -32,9 +32,9 @@ export default UIDictionary({
 	'install.autoTab': "Automatiquement via l'ILC",
 	'install.manualTab': 'Configuration manuelle',
 	// `<ContributorList>` fallback text
-	'contributors.seeAll': 'Voir tout les contributeurs',
+	'contributors.seeAll': 'Voir tous les contributeurs',
 	// Fallback content notice shown when a page is not yet translated
-	'fallbackContent.notice': "Cette page n'est pas encore disponible dans votre langue, la version anglaise vous a donc été fournie. Vous pouvez aider en la traduisant !",
+	'fallbackContent.notice': "Cette page est affichée en anglais car elle n'est pas encore disponible dans votre langue. Vous pouvez aider en la traduisant !",
 	'fallbackContent.linkText': 'En savoir plus sur la façon de contribuer',
 	// 404 Page
 	'404.title': 'Page introuvable',

--- a/src/i18n/fr/ui.ts
+++ b/src/i18n/fr/ui.ts
@@ -1,4 +1,43 @@
 import { UIDictionary } from '../translation-checkers';
 
 export default UIDictionary({
+	'a11y.skipLink': 'Aller au contenu principal',
+	'navbar.a11yTitle': 'Navigation principale',
+	// Site settings
+	'site.title': 'Documentation Astro',
+	'site.description': 'Compilez des sites plus rapidement avec moins de JavaScript pour vos utilisateurs.',
+	'site.og.imageSrc': '/default-og-image.png?v=1',
+	'site.og.imageAlt': "Logo d'Astro dans l'espace, avec une planète violette dans le style de saturne flottant à droite de l'image.",
+	// Left Sidebar
+	'leftSidebar.a11yTitle': 'Navigation du site',
+	'leftSidebar.learnTab': 'Apprendre',
+	'leftSidebar.referenceTab': 'Référence',
+	'leftSidebar.noTranslations': 'Aucune traduction trouvée.',
+	'leftSidebar.viewInEnglish': 'Voir en anglais',
+	// Right Sidebar
+	'rightSidebar.a11yTitle': 'Table des matières',
+	'rightSidebar.onThisPage': 'Sur cette page',
+	'rightSidebar.overview': 'Vue générale',
+	'rightSidebar.more': 'Plus',
+	'rightSidebar.editPage': 'Modifier cette page',
+	'rightSidebar.translatePage': 'Traduire cette page',
+	'rightSidebar.joinCommunity': 'Rejoindre notre communauté',
+	// Used in previous/next page links at the bottom of pages
+	'articleNav.nextPage': 'Page suivante',
+	'articleNav.prevPage': 'Page précédente',
+	// Used in `<Since>`: Added in: v0.24.0 [NEW]
+	'since.addedIn': 'Ajouté à la version :',
+	'since.new': 'Nouveau',
+	// Installation Guide
+	'install.autoTab': "Automatiquement via l'ILC",
+	'install.manualTab': 'Configuration manuelle',
+	// `<ContributorList>` fallback text
+	'contributors.seeAll': 'Voir tout les contributeurs',
+	// Fallback content notice shown when a page is not yet translated
+	'fallbackContent.notice': "Cette page n'est pas encore disponible dans votre langue, la version anglaise vous a donc été fournie. Vous pouvez aider en la traduisant !",
+	'fallbackContent.linkText': 'En savoir plus sur la façon de contribuer',
+	// 404 Page
+	'404.title': 'Page introuvable',
+	'404.content': 'Cette page ne fait pas partie de notre système solaire.',
+	'404.linkText': 'Ramenez moi à la maison',
 });

--- a/src/pages/fr/getting-started.md
+++ b/src/pages/fr/getting-started.md
@@ -9,7 +9,7 @@ description: Une intro basique à Astro.
 Générateur de sites statiques  🚀  Amenez votre propre Framework  🚀  Expédiez moins de JavaScript
 
 
-> Vous avez un projet vieux projet dépoussiérer ? Suivez le [guide de migration](/fr/migrate) pour mettre à jour vers la version beta 1.0 !
+> Vous avez un ancien projet à dépoussiérer ? Le [guide de migration](/fr/migrate) vous permettra de le mettre à jour vers la version beta 1.0 !
 
 
 ## Essayez Astro
@@ -87,7 +87,7 @@ Voici quelques exemples de concepts et modèles de sites construits avec Astro !
 
 ## Rejoindre notre communauté
 
-Venez sur [le Discord d'Astro](https://astro.build/chat) pour partager vos créations et obtenir l'aide d'une communauté active et conviviale !
+Rejoignez [le Discord d'Astro](https://astro.build/chat) pour partager vos créations et obtenir l'aide d'une communauté active et conviviale !
 
 💬 Dites bonjour dans notre salon `#introduce-yourself` !
 

--- a/src/pages/fr/getting-started.md
+++ b/src/pages/fr/getting-started.md
@@ -8,6 +8,10 @@ description: Une intro basique à Astro.
 ---
 Générateur de sites statiques  🚀  Amenez votre propre Framework  🚀  Expédiez moins de JavaScript
 
+
+> Vous avez un projet vieux projet dépoussiérer ? Suivez le [guide de migration](/fr/migrate) pour mettre à jour vers la version beta 1.0 !
+
+
 ## Essayez Astro
 
 Nous avons simplifié au maximum votre début dans Astro, que ce soit dans votre navigateur ou sur votre machine !
@@ -30,64 +34,66 @@ Prêt à installer ?
 Créez un nouveau projet prêt localement et en un rien de temps avec notre assistant de création via terminal de commande `create-astro` !
 
 ```bash
-# Éxécutez cette commande dans un nouveau répertoire pour commencer !
+# Faites un nouveau dossier pour votre projet et accédez-y
+mkdir my-astro-project && cd $_
+
+# Créez un nouveau projet avec npm
 npm create astro@latest
+
+# ou avec yarn
+yarn create astro
+
+# ou bien pnpm
+pnpm create astro@latest
 ```
 
-⚙️ Notre [Guide d'installation (en)](/en/install/auto) contient les instructions complètes et détaillées pour installer Astro avec votre gestionnaire de package favori.
+⚙️ Notre [Guide d'installation](/fr/install/auto) contient les instructions complètes et détaillées pour installer Astro avec votre gestionnaire de package favori.
 
-⚙️ Ou alors, jetez un oeil aux instructions pour une [Installation manuelle (en)](/en/install/manual/).
-
+⚙️ Ou alors, jetez un oeil aux instructions pour une [Installation manuelle](/fr/install/manual/).
 
 ## Commencez à construire avec Astro
 
 Allez directement à l'essentiel et ajoutez quelques contenus et fonctionnalités à votre site !
 
-🏗️ Ajoutez de nouvelles [Pages Astro (en)](/en/core-concepts/astro-pages) et/ou [Pages Markdown (en)](/en/guides/markdown-content) à votre site.
+🏗️ Ajoutez de nouvelles [Pages Astro](/fr/core-concepts/astro-pages) et/ou [Pages Markdown](/fr/guides/markdown-content) à votre site.
 
-🏗️ Créez votre premier [Composant Layout (en)](/en/core-concepts/layouts).
+🏗️ Créez votre premier [Composant Layout](/fr/core-concepts/layouts).
 
-🏗️ Ajoutez vos propres [Règles CSS (en)](/en/guides/styling) à votre site.
+🏗️ Ajoutez vos propres [Règles CSS](/fr/guides/styling) à votre site.
 
-*... et encore plus de Guides dans la catégorie **Apprendre***
-
+*... et encore plus dans la catégorie **Fonctionnalités***
 
 ## Apprendre Astro
 
 Voici quelques exemples de concepts et modèles de sites construits avec Astro !
 
-📚 En savoir plus sur la [Structure d'un Projet (en)](/en/core-concepts/project-structure) Astro.
+📚 En savoir plus sur la [Structure d'un Projet](/fr/core-concepts/project-structure) Astro.
 
-📚 Apprendre plus à propos des [Composants Intégrés (en)](/en/reference/api-reference/#built-in-components) dans Astro.
+📚 Apprendre plus à propos des [Directives de Composants](/fr/reference/directives-reference) inclus dans Astro.
 
-📚 Explorez l'[API (en)](/en/reference/api-reference) d'Astro.
+📚 Explorez l'[API](/fr/reference/api-reference) d'Astro.
 
-*... et encore plus d'informations dans la catégorie **API***
+*... et encore plus d'infos dans la catégorie **Référence***
 
-## Intégrer avec Astro
+## Étendre l'écosystème Astro
 
-Explorez les différentes intégrations que nos utilisateurs ont combinées avec Astro !
+🧰 Démarrez votre prochain projet avec un [thème pré-construit](https://astro.build/themes)
 
-🧰 Utilisez un CMS avec votre projet Astro.
+🧰 Personnalisez votre site avec des [plugins et composants](https://astro.build/integrations/) officiels et communautaires.
 
-🧰 Créez un site d'eCommerce.
+🧰 Inspirez-vous en visitant notre [présentation de sites](https://astro.build/showcase).
 
-🧰 Connectez votre site à une base de données.
-
-*... allez voir nos [intégration de librairies tierces (en)](/en/integrations/integrations)*
-
-
+*... allez voir notre [guide d'utilisation des intégrations](/fr/guides/integrations-guide)*
 
 ## Rejoindre notre communauté
 
-Venez sur [notre Discord](https://astro.build/chat) pour partager vos créations et obtenir l'aide d'une communauté active et conviviale !
+Venez sur [le Discord d'Astro](https://astro.build/chat) pour partager vos créations et obtenir l'aide d'une communauté active et conviviale !
 
 💬 Dites bonjour dans notre salon `#introduce-yourself` !
 
 💬 Demandez de l'aide à l'équipe de support dans notre salon `#support` !
 
-💬 Partagez ce sur quoi vous travaillez en ce moment dans notre salon `#showcase` !
-
+💬 Partagez ce sur quoi vous travaillez en ce moment dans notre salon `#showcase`
 
 ## Apprendre Encore Plus
 
@@ -95,7 +101,7 @@ Venez sur [notre Discord](https://astro.build/chat) pour partager vos créations
 
 [Note de Mise à Jour d'Astro](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)
 
-[Guide de Migration d'Astro (en)](/en/migrate) (vers la mise à jour v0.21+)
+[Guide de Migration d'Astro](/fr/migrate)
 
 
 ## Contribuez


### PR DESCRIPTION
Upgrading the translation to reflect latest changes.

Files affected:
- `getting-started.md`: Updates on the text and syntax made in the english version
- `nav.ts`: Adding all routes translation for future use when they'll be added
- `ui.ts`: Adding all ui components translations for a better experience
- `docsearch.ts`: Adding Algogia's docsearch translation according to [theirs doc](https://docsearch.algolia.com/docs/api/#translations)

Feel free to review changes and additions, open to discussion on the syntax and changes in sentences which could be misleading