### PR TITLE
Edit: make RSS canonicalUrl required

### DIFF
--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -2,8 +2,6 @@
 layout: ~/layouts/MainLayout.astro
 title: RSS
 description: An intro to RSS in Astro
-setup : |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro supports fast, automatic RSS feed generation for blogs and other content websites. For more information about RSS feeds in general, see [aboutfeeds.com](https://aboutfeeds.com/).

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -23,7 +23,7 @@ pnpm i @astrojs/rss
 
 Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links in your RSS feed [via the `SITE` environment variable](/en/guides/environment-variables/#default-environment-variables).
 
-> Note: The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `canonicalUrl` manually if this isn't possible (see examples below). 
+> Note: The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `site` manually if this isn't possible (see examples below). 
 
 Now, let's generate our first RSS feed! Create an `rss.xml.js` file under your `src/pages/` directory. `rss.xml` will be the output URL, so feel free to rename this if you prefer.
 
@@ -40,7 +40,7 @@ export const get = () => rss({
     description: 'A humble Astronaut’s guide to the stars',
     // base URL for RSS <item> links
     // import.meta.env.SITE will use "site" from your project's astro.config.
-    canonicalUrl: import.meta.env.SITE,
+    site: import.meta.env.SITE,
     // list of `<item>`s in output xml
     // simple example: generate items for every md file in /src/pages
     // see "Generating items" section for required frontmatter and advanced use cases
@@ -69,7 +69,7 @@ import rss from '@astrojs/rss';
 export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
-    canonicalUrl: import.meta.env.SITE,
+    site: import.meta.env.SITE,
     items: import.meta.glob('./blog/**/*.md'),
   });
 ```
@@ -92,7 +92,7 @@ const posts = Object.values(postImportResult);
 export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
-    canonicalUrl: import.meta.env.SITE,
+    site: import.meta.env.SITE,
     items: posts.map((post) => ({
       link: post.frontmatter.slug,
       title: post.frontmatter.title,

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -41,7 +41,7 @@ export const get = () => rss({
     // `<description>` field in output xml
     description: 'A humble Astronaut’s guide to the stars',
     // base URL for RSS <item> links
-    <p>// <ImportMetaEnv path=".SITE" /> will use "site" from your project's astro.config.</p>
+    // SITE will use "site" from your project's astro.config.
     site: import.meta.env.SITE,
     // list of `<item>`s in output xml
     // simple example: generate items for every md file in /src/pages

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -21,11 +21,13 @@ yarn add @astrojs/rss
 pnpm i @astrojs/rss
 ```
 
-Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. We will use this to generate links in your RSS feed.
+Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links in your RSS feed [via the `SITE` environment variable](/en/guides/environment-variables/#default-environment-variables).
+
+> Note: The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `canonicalUrl` manually if this isn't possible (see examples below). 
 
 Now, let's generate our first RSS feed! Create an `rss.xml.js` file under your `src/pages/` directory. `rss.xml` will be the output URL, so feel free to rename this if you prefer.
 
-Now, import the `rss` helper from the `@astrojs/rss` package and call with the following parameters:
+Next, import the `rss` helper from the `@astrojs/rss` package and call with the following parameters:
 
 ```js
 // src/pages/rss.xml.js
@@ -36,6 +38,9 @@ export const get = () => rss({
     title: 'Buzz’s Blog',
     // `<description>` field in output xml
     description: 'A humble Astronaut’s guide to the stars',
+    // base URL for RSS <item> links
+    // import.meta.env.SITE will use "site" from your project's astro.config.
+    canonicalUrl: import.meta.env.SITE,
     // list of `<item>`s in output xml
     // simple example: generate items for every md file in /src/pages
     // see "Generating items" section for required frontmatter and advanced use cases
@@ -64,6 +69,7 @@ import rss from '@astrojs/rss';
 export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
+    canonicalUrl: import.meta.env.SITE,
     items: import.meta.glob('./blog/**/*.md'),
   });
 ```
@@ -86,6 +92,7 @@ const posts = Object.values(postImportResult);
 export const get = () => rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
+    canonicalUrl: import.meta.env.SITE,
     items: posts.map((post) => ({
       link: post.frontmatter.slug,
       title: post.frontmatter.title,

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -2,6 +2,8 @@
 layout: ~/layouts/MainLayout.astro
 title: RSS
 description: An intro to RSS in Astro
+setup : |
+  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro supports fast, automatic RSS feed generation for blogs and other content websites. For more information about RSS feeds in general, see [aboutfeeds.com](https://aboutfeeds.com/).
@@ -39,7 +41,7 @@ export const get = () => rss({
     // `<description>` field in output xml
     description: 'A humble Astronaut’s guide to the stars',
     // base URL for RSS <item> links
-    // import.meta.env.SITE will use "site" from your project's astro.config.
+    <p>// <ImportMetaEnv path=".SITE" /> will use "site" from your project's astro.config.</p>
     site: import.meta.env.SITE,
     // list of `<item>`s in output xml
     // simple example: generate items for every md file in /src/pages


### PR DESCRIPTION
We discovered that `canonicalUrl` did _not_ work as expected in the `@astrojs/rss` package. So, we're asking users to apply this value manually as a required prop.

**Changes made**
- rename `canonicalUrl` option to `site`
- add note that `import.meta.env.SITE` only works in the latest 1.0 beta
- add `site` to all code examples, with explainer comments where applicable