### PR TITLE
import and use ImportMetaEnv component

### DIFF
--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -2,6 +2,8 @@
 layout: ~/layouts/MainLayout.astro
 title: RSS
 description: An intro to RSS in Astro
+setup : |
+  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro supports fast, automatic RSS feed generation for blogs and other content websites. For more information about RSS feeds in general, see [aboutfeeds.com](https://aboutfeeds.com/).
@@ -39,7 +41,7 @@ export const get = () => rss({
     // `<description>` field in output xml
     description: 'A humble Astronaut’s guide to the stars',
     // base URL for RSS <item> links
-    // import.meta.env.SITE will use "site" from your project's astro.config.
+    <p>// <ImportMetaEnv path=".SITE" /> will use "site" from your project's astro.config.</p>
     canonicalUrl: import.meta.env.SITE,
     // list of `<item>`s in output xml
     // simple example: generate items for every md file in /src/pages


### PR DESCRIPTION
@bholmesdev - please check this, and adjust as necessary to get it to render properly.  This might require fiddling, but the ideas are:

1. Where ever you're seeing `{{}}` in the preview render instead of `import.meta.env`, then you need to import (I've done) and use (I've done) this component instead of typing the phrase out directly. The rest of the expression can be passed as the`path=" "` attribute, and it will be formatted as code.

2. This component must be inside an HTML element, and can't be written inside regular Markdown. I've tried the simplest version first (just `<p>` tags enclosing the single line it's in). If this isn't sufficient, or screws up the rest of the rendering, then you'll have to "work your way out" converting larger and larger chunks to HTML until you have the rendering you need.

(Or, you figure out whether it's ABSOLUTELY NECESSARY to write the phrase import.meta.env. Dealer's choice.) Hope this helps.