### PR TITLE
Adding missing slash before link to avoid wrong linking

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -65,7 +65,7 @@ By default, your framework components will render as static HTML. This is useful
 
 A framework component can be made interactive (hydrated) using one of the `client:*` directives. This is a component attribute to define how your component should be **rendered** and **hydrated**.
 
-This [client directive](en/reference/directives-reference/#client-directives) describes whether or not your component should be rendered at build-time, and when your component's JavaScript should be loaded by the browser, client-side.
+This [client directive](/en/reference/directives-reference/#client-directives) describes whether or not your component should be rendered at build-time, and when your component's JavaScript should be loaded by the browser, client-side.
 
 Most directives will render the component on the server at build time. Component JS will be sent to the client according to the specific directive. The component will hydrate when its JS has finished importing.
 


### PR DESCRIPTION
Adding a small slash to avoid being redirected to `https://docs.astro.build/en/core-concepts/framework-components/en/reference/directives-reference/#client-directives` and not `https://docs.astro.build/en/reference/directives-reference/#client-directives`