### PR TITLE
Adding slashes for tags when needed according to HTML's spec

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -9,7 +9,7 @@ i18nReady: true
 
 Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](/en/comparing-astro-vs-other-tools/#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
-Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
+Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta />` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
 
 The most important thing to know about Astro components is that they **render to HTML during your build.** Even if you run JavaScript code inside of your components, it will all run ahead-of-time, stripped from the final page that you send to your users. The result is a faster site, with zero JavaScript footprint added by default.
 
@@ -46,7 +46,7 @@ Astro uses a code fence (`---`) to identify the component script in your Astro c
 
 You can use the component script to write any JavaScript code that you need to render your template. This can include:
 
-- Importing other Astro components 
+- Importing other Astro components
 - Importing other framework components, like React
 - Importing data, like a JSON file
 - fetching content from an API or database
@@ -74,7 +74,7 @@ The code fence is designed to guarantee that the JavaScript that you write in it
 
 ### The Component Template
 
-Below the component script, sits the component template. The component template decides the HTML output of your component. 
+Below the component script, sits the component template. The component template decides the HTML output of your component.
 
 If you write plain HTML here, your component will render that HTML in any Astro page it is imported and used.
 
@@ -294,13 +294,13 @@ import Wrapper from '../components/Wrapper.astro';
 ```
 
 
-Use a `slot="my-slot"` attribute on the child element that you want to pass through to a matching `<slot name="my-slot" />` placeholder in your component. 
+Use a `slot="my-slot"` attribute on the child element that you want to pass through to a matching `<slot name="my-slot" />` placeholder in your component.
 
 > ⚠️ This only works when you’re passing slots to other Astro components. Learn more about including other [UI framework components](en/guides/framework-components) in Astro files.
 
 
 #### Fallback Content for Slots
-Slots can also render **fallback content**. When there are no matching children passed to a `<slot>`, a `<slot>` element will render its own placeholder children.
+Slots can also render **fallback content**. When there are no matching children passed to a slot, a `<slot />` element will render its own placeholder children.
 
 ```astro
 ---
@@ -324,9 +324,9 @@ const { title } = Astro.props
 
 ### CSS Styles
 
-CSS `<style>` tags are also supported inside of the component template. 
+CSS `<style>` tags are also supported inside of the component template.
 
-They can be used to style your components, and all style rules are automatically scoped to the component itself to prevent CSS conflicts in large apps. 
+They can be used to style your components, and all style rules are automatically scoped to the component itself to prevent CSS conflicts in large apps.
 
 ```astro
 ---
@@ -338,9 +338,9 @@ They can be used to style your components, and all style rules are automatically
 </style>
 
 <h1>Hello, world!</h1>
-``` 
+```
 
-> ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default. 
+> ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default.
 
 📚 See our [Styling Guide](/en/guides/styling) for more information on applying styles.
 
@@ -365,7 +365,7 @@ To send JavaScript to the browser without [using a framework component](/en/core
 
 **When to use this:** If your JavaScript file lives inside of `public/`.
 
-Note that this approach skips the JavaScript processing, bundling and optimizations that are provided by Astro when you use the `import` method described below. 
+Note that this approach skips the JavaScript processing, bundling and optimizations that are provided by Astro when you use the `import` method described below.
 
 ```astro
 // absolute URL path
@@ -375,7 +375,7 @@ Note that this approach skips the JavaScript processing, bundling and optimizati
 
 **When to use this:** If your external script lives inside of `src/` _and_ it supports the ESM module type.
 
-Astro detects these JavaScript client-side imports and then builds, optimizes, and adds the JS to the page automatically. 
+Astro detects these JavaScript client-side imports and then builds, optimizes, and adds the JS to the page automatically.
 
 ```astro
 // ESM import

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -9,7 +9,7 @@ i18nReady: true
 
 Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](/en/comparing-astro-vs-other-tools/#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
-Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta />` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
+Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
 
 The most important thing to know about Astro components is that they **render to HTML during your build.** Even if you run JavaScript code inside of your components, it will all run ahead-of-time, stripped from the final page that you send to your users. The result is a faster site, with zero JavaScript footprint added by default.
 

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -131,7 +131,7 @@ import MySvelteButton from '../components/MySvelteButton.svelte';
 
 This allows you to build entire "apps" in your preferred JavaScript framework and render them, via a parent component, to an Astro page. This is a convenient pattern to allow related components to share state or context.
 
-Each framework has its own patterns for nesting: `children` props and [render props](https://reactjs.org/docs/render-props.html) for React and Solid; `<slot>` with or without names for Svelte and Vue, for example. 
+Each framework has its own patterns for nesting: `children` props and [render props](https://reactjs.org/docs/render-props.html) for React and Solid; `<slot />` with or without names for Svelte and Vue, for example. 
 
 Note, however, that you can't pass render props or named slots to a framework component from a `.astro` file, even if the framework component supports it. This is due to a limitation in Astro's compiler.
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -252,9 +252,9 @@ const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
 
 ## Markdown Component
 
-> NOTE: The `<Markdown>` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then [`import` Markdown](/en/guides/markdown-content#importing-markdown) into your template as a component.
+> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then [`import` Markdown](/en/guides/markdown-content#importing-markdown) into your template as a component.
 
-You can import the [built-in Astro Markdown component](/en/reference/api-reference#markdown-) in your component script and then write any Markdown you want between `<Markdown> </Markdown>` tags.
+You can import the [built-in Astro Markdown component](/en/reference/api-reference#markdown-) in your component script and then write any Markdown you want between `<Markdown></Markdown>` tags.
 
 ````astro
 ---
@@ -289,7 +289,7 @@ const expressions = 'Lorem ipsum';
 
 ### Remote Markdown
 
-> NOTE: The `<Markdown>` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then `import` it into your template as a component. Read this [RFC Discussion](https://github.com/withastro/rfcs/discussions/179) to learn more.
+> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then `import` it into your template as a component. Read this [RFC Discussion](https://github.com/withastro/rfcs/discussions/179) to learn more.
 
 If you have Markdown in a remote source, you may pass it directly to the Markdown component through the `content` attribute.
 
@@ -306,9 +306,9 @@ const content = await fetch('https://raw.githubusercontent.com/withastro/docs/ma
 
 ### Nested Markdown
 
-> NOTE: The `<Markdown>` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then `import` it into your template as a component. Read this [RFC Discussion](https://github.com/withastro/rfcs/discussions/179) to learn more.
+> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then `import` it into your template as a component. Read this [RFC Discussion](https://github.com/withastro/rfcs/discussions/179) to learn more.
 
-`<Markdown>` components can be nested. 
+`<Markdown />` components can be nested.
 
 ```astro
 ---

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -13,13 +13,13 @@ Read the guide below for major highlights and instructions on how to handle brea
 
 On April 4, 2022 we released the Astro 1.0 Beta! 🎉
 
-**We do not plan to make any more breaking changes during this beta period, leading up to the official v1.0.0 release (planned for June 8, 2022).** 
+**We do not plan to make any more breaking changes during this beta period, leading up to the official v1.0.0 release (planned for June 8, 2022).**
 
 If any breaking changes must be made, we will call them out in this section.
 
 ## Migrate to v1.0.0-beta.0
 
-The `v1.0.0-beta.0` release of Astro contained no breaking changes. 
+The `v1.0.0-beta.0` release of Astro contained no breaking changes.
 
 If you are coming from v0.25 or earlier, make sure you have read and followed the [v0.26 Migration Guide](#migrate-to-v026) below, which contained several major breaking changes.
 
@@ -32,7 +32,7 @@ Our Configuration API has been redesigned to solve a few glaring points of confu
 - `.markdownOptions` has been replaced with `.markdown`, a mostly similar config object with some small changes to simplify Markdown configuration.
 - `.sitemap` has been moved into the [@astrojs/sitemap](https://www.npmjs.com/package/@astrojs/sitemap) integration.
 
-If you run Astro with legacy configuration, you will see a warning with instructions on how to update. See our updated [Configuration Reference](/en/reference/configuration-reference/) for more information on upgrading. 
+If you run Astro with legacy configuration, you will see a warning with instructions on how to update. See our updated [Configuration Reference](/en/reference/configuration-reference/) for more information on upgrading.
 
 Read [RFC0019](https://github.com/withastro/rfcs/blob/main/proposals/0019-config-finalization.md) for more background on these changes.
 
@@ -42,7 +42,7 @@ Astro v0.26 releases a brand new Markdown API for your content. This included th
 - You can now `import`/`import()` markdown content directly using an ESM import.
 - A new `Astro.glob()` API, for easier glob imports (especially for Markdown).
 - **BREAKING CHANGE:** `Astro.fetchContent()` has been removed and replaced by `Astro.glob()`
-- **BREAKING CHANGE:** Markdown objects have an updated interface. 
+- **BREAKING CHANGE:** Markdown objects have an updated interface.
 
 ```diff
 // v0.25
@@ -53,13 +53,13 @@ Astro v0.26 releases a brand new Markdown API for your content. This included th
 
 When migrating, be careful about the new Markdown object interface. Frontmatter, for example, has been moved to the `.frontmatter` property, so references like `post.title` should change to `post.frontmatter.title`.
 
-This should solve many issues for Markdown users, including some nice performance boosts for larger sites. 
+This should solve many issues for Markdown users, including some nice performance boosts for larger sites.
 
 Read [RFC0017](https://github.com/withastro/rfcs/blob/main/proposals/0017-markdown-content-redesign.md) for more background on these changes.
 
 ### New Default Script Behavior
 
-`<script>` tags in Astro components are now built, bundled and optimized by default. This completes a long-term move to make our Astro component syntax more consistent, matching the default-optimized behavior our `<style>` tags have today. 
+`<script>` tags in Astro components are now built, bundled and optimized by default. This completes a long-term move to make our Astro component syntax more consistent, matching the default-optimized behavior our `<style>` tags have today.
 
 This includes a few changes to be aware of:
 
@@ -111,17 +111,17 @@ Integrations replace our original `renderers` concept, and come with a few break
 Previously, React, Preact, Svelte, and Vue were all included with Astro by default. Starting in v0.25.0, Astro no longer comes with any built-in renderers. If you did not have a `renderers` configuration entry already defined for your project, you will now need to install those frameworks yourself.
 
 Read our [step-by-step walkthrough](/en/guides/integrations-guide) to learn how to add a new Astro integration for the framework(s) that you currently use.
-#### Deprecated: Renderers 
+#### Deprecated: Renderers
 
 > *Read this section if you have custom "renderers" already defined in your configuration file.*
 
-The new integration system replaces the previous `renderers` system, including the published `@astrojs/renderer-*` packages on npm. Going forward, `@astrojs/renderer-react` becomes `@astrojs/react`, `@astrojs/renderer-vue` becomes `@astrojs/vue`, and so on. 
+The new integration system replaces the previous `renderers` system, including the published `@astrojs/renderer-*` packages on npm. Going forward, `@astrojs/renderer-react` becomes `@astrojs/react`, `@astrojs/renderer-vue` becomes `@astrojs/vue`, and so on.
 
-**To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.mjs` file, based on your current config. You can also update your packages yourself, using the table below. 
+**To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.mjs` file, based on your current config. You can also update your packages yourself, using the table below.
 
 For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide) to learn how to replace existing renderers with a new Astro framework integration.
 
-```diff  
+```diff
 # Install your new integrations and frameworks:
 # (Read the full walkthrough: https://docs.astro.build/en/guides/integrations-guide)
 + npm install @astrojs/lit lit
@@ -152,7 +152,7 @@ export default {
 
 > *Read this section if: You are on Node v14 **or** if you use any package manager other than npm.*
 
-Unlike the old renderers, integrations no longer mark the frameworks themselves ("react", "svelte", "vue", etc.) as direct dependencies of the integration. Instead, you should now install your framework packages *in addition to* your integrations. 
+Unlike the old renderers, integrations no longer mark the frameworks themselves ("react", "svelte", "vue", etc.) as direct dependencies of the integration. Instead, you should now install your framework packages *in addition to* your integrations.
 
 ```diff
 # Example: Install integrations and frameworks together
@@ -195,13 +195,13 @@ To migrate for the transition, be aware of the following changes that will be re
 
 ### Deprecated: Astro.resolve()
 
-`Astro.resolve()` allows you to get resolved URLs to assets that you might want to reference in the browser. This was most commonly used inside of  `<link>` and `<img>` tags to load CSS files and images as needed. Unfortunately, this will no longer work due to Astro now building assets at *build time* rather than at *render time*. You'll want to upgrade your asset references to one of the following future-proof options available going forward:
+`Astro.resolve()` allows you to get resolved URLs to assets that you might want to reference in the browser. This was most commonly used inside of  `<link>` and `<img />` tags to load CSS files and images as needed. Unfortunately, this will no longer work due to Astro now building assets at *build time* rather than at *render time*. You'll want to upgrade your asset references to one of the following future-proof options available going forward:
 
 #### How to Resolve CSS Files
 
 **1. ESM Import (Recommended)**
 
-**Example:** `import './style.css';`  
+**Example:** `import './style.css';`
 **When to use this:** If your CSS file lives inside of the `src/` directory, and you want automatic CSS build and optimization features.
 
 Use an ESM import to add some CSS onto the page. Astro detects these CSS imports and then builds, optimizes, and adds the CSS to the page automatically. This is the easiest way to migrate from `Astro.resolve()` while keeping the automatic building/bundling that Astro provides.
@@ -225,7 +225,7 @@ When a CSS file is imported using this method, any `@import` statements are also
 
 **2. Absolute URL Path**
 
-**Example:** `<link href="/style.css">`  
+**Example:** `<link href="/style.css">`
 **When to use this:** If your CSS file lives inside of `public/`, and you prefer to create your HTML `link` element yourself.
 
 You can references any file inside of the `public/` directory by absolute URL path in your component template. This is a good option if you want to control the `<link>` tag on the page yourself. However, this approach also skips the CSS processing, bundling and optimizations that are provided by Astro when you use the `import` method described above.
@@ -237,16 +237,16 @@ We recommend using the `import` approach over the abolute URL approach, since it
 
 **1. Absolute URL Path**
 
-**Example:** `<script src="/some-external-script.js" />`  
+**Example:** `<script src="/some-external-script.js" />`
 **When to use this:** If your JavaScript file lives inside of `public/`.
 
-You can references any file inside of the `public/` directory by absolute URL path in your Astro component templates. This is a good default option for external scripts, because it lets you control the `<script >` tag on the page yourself. 
+You can references any file inside of the `public/` directory by absolute URL path in your Astro component templates. This is a good default option for external scripts, because it lets you control the `<script>` tag on the page yourself.
 
 Note that this approach skips the JavaScript processing, bundling and optimizations that are provided by Astro when you use the `import` method described below. However, this may be preferred for any external scripts that have already been published and minified seperately from Astro. If your script was downloaded from an external source, then this method is probably preferred.
 
 **2. ESM Import via `<script hoist>`**
 
-**Example:** `<script hoist>import './some-external-script.js';</script>`  
+**Example:** `<script hoist>import './some-external-script.js';</script>`
 **When to use this:** If your external script lives inside of `src/` _and_ it supports the ESM module type.
 
 Use an ESM import inside of a `<script hoist>` element in your Astro template, and Astro will include the JavaScript file in your final build. Astro detects these JavaScript client-side imports and then builds, optimizes, and adds the JavaScript to the page automatically. This is the easiest way to migrate from `Astro.resolve()` while keeping the automatic building/bundling that Astro provides.
@@ -263,10 +263,10 @@ Note that Astro will bundle this external script with the rest of your client-si
 
 **1. Absolute URL Path (Recommended)**
 
-**Example:** `<img src="/penguin.png">`
+**Example:** `<img src="/penguin.png" />`
 **When to use this:** If your asset lives inside of `public/`.
 
-If you place your images inside of `public/` you can safely reference them by absolute URL path directly in your component templates. This is the simplest way to reference an asset that you can use today, and it is recommended for most users who are getting started with Astro. 
+If you place your images inside of `public/` you can safely reference them by absolute URL path directly in your component templates. This is the simplest way to reference an asset that you can use today, and it is recommended for most users who are getting started with Astro.
 
 **2. ESM Import**
 
@@ -310,7 +310,7 @@ Previously, all `<script>` elements were read from the final HTML output and pro
 Preprocessor dependency "sass" not found. Did you install it?
 ```
 
-In our quest to reduce npm install size, we've moved [Sass](https://sass-lang.com/) out to an optional dependency. If you use Sass in your project, you'll want to make sure that you run `npm install sass --save-dev` to save it as a dependency. 
+In our quest to reduce npm install size, we've moved [Sass](https://sass-lang.com/) out to an optional dependency. If you use Sass in your project, you'll want to make sure that you run `npm install sass --save-dev` to save it as a dependency.
 
 ### Deprecated: Unescaped HTML
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -195,7 +195,7 @@ To migrate for the transition, be aware of the following changes that will be re
 
 ### Deprecated: Astro.resolve()
 
-`Astro.resolve()` allows you to get resolved URLs to assets that you might want to reference in the browser. This was most commonly used inside of  `<link>` and `<img />` tags to load CSS files and images as needed. Unfortunately, this will no longer work due to Astro now building assets at *build time* rather than at *render time*. You'll want to upgrade your asset references to one of the following future-proof options available going forward:
+`Astro.resolve()` allows you to get resolved URLs to assets that you might want to reference in the browser. This was most commonly used inside of  `<link>` and `<img>` tags to load CSS files and images as needed. Unfortunately, this will no longer work due to Astro now building assets at *build time* rather than at *render time*. You'll want to upgrade your asset references to one of the following future-proof options available going forward:
 
 #### How to Resolve CSS Files
 
@@ -263,7 +263,7 @@ Note that Astro will bundle this external script with the rest of your client-si
 
 **1. Absolute URL Path (Recommended)**
 
-**Example:** `<img src="/penguin.png" />`
+**Example:** `<img src="/penguin.png">`
 **When to use this:** If your asset lives inside of `public/`.
 
 If you place your images inside of `public/` you can safely reference them by absolute URL path directly in your component templates. This is the simplest way to reference an asset that you can use today, and it is recommended for most users who are getting started with Astro.

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -3,9 +3,9 @@ layout: ~/layouts/MainLayout.astro
 title: Template Directives Reference
 ---
 
-**Template directives** are a special kind of HTML attribute available inside of any Astro component template (`.astro` files). 
+**Template directives** are a special kind of HTML attribute available inside of any Astro component template (`.astro` files).
 
-Template directives are used to control an element or component's behavior in some way. A template directive could enable some compiler feature that makes your life easier (like using `class:list` instead of `class`). Or, a directive could tell the Astro compiler to do something special with that component (like hydrating with `client:load`). 
+Template directives are used to control an element or component's behavior in some way. A template directive could enable some compiler feature that makes your life easier (like using `class:list` instead of `class`). Or, a directive could tell the Astro compiler to do something special with that component (like hydrating with `client:load`).
 
 This page describes all of the template directives available to you in Astro, and how they work.
 ## Rules
@@ -43,7 +43,7 @@ Duplicate values are removed automatically.
 
 ### `set:html`
 
-`set:html={string}` injects an HTML string into an element, similar to setting `el.innerHTML`. 
+`set:html={string}` injects an HTML string into an element, similar to setting `el.innerHTML`.
 
 **The value is not automatically escaped by Astro!** Be sure that you trust the value, or that you have escaped it manually before passing it to the template. Forgetting to do this will open you up to [Cross Site Scripting (XSS) attacks.](https://owasp.org/www-community/attacks/xss/)
 
@@ -51,9 +51,9 @@ Duplicate values are removed automatically.
 ---
 const rawHTMLString = "Hello <strong>World</strong>"
 ---
-<h1>{rawHTMLString}</h1> 
+<h1>{rawHTMLString}</h1>
   <!-- Output: <h1>Hello &lt;strong&gt;World&lt;/strong&gt;</h1> -->
-<h1 set:html={rawHTMLString} /> 
+<h1 set:html={rawHTMLString} />
   <!-- Output: <h1>Hello <strong>World</strong></h1> -->
 ```
 
@@ -102,7 +102,7 @@ Load and hydrate the component JavaScript once the page is done with its initial
 - **Priority:** Low
 - **Useful for:** Low-priority UI elements that are either far down the page ("below the fold") or so resource-intensive to load that you would prefer not to load them at all if the user never saw the element.
 
-Load and hydrate the component JavaScript once the component has entered the user's viewport. This uses an `IntersectionObserver` internally to keep track of visibility. 
+Load and hydrate the component JavaScript once the component has entered the user's viewport. This uses an `IntersectionObserver` internally to keep track of visibility.
 
 ```astro
 <HeavyImageCarousel client:visible />
@@ -113,7 +113,7 @@ Load and hydrate the component JavaScript once the component has entered the use
 - **Priority:** Low
 - **Useful for:** Sidebar toggles, or other elements that might only be visible on certain screen sizes.
 
-`client:media={string}` loads and hydrates the component JavaScript once a certain CSS media query is met. 
+`client:media={string}` loads and hydrates the component JavaScript once a certain CSS media query is met.
 
 Note: If the component is already hidden and shown by a media query in your CSS, then it can be easier to just use `client:visible` and not pass that same media query into the directive.
 
@@ -214,10 +214,10 @@ const message = "Astro is awsome!";
 
 `is:raw` instructs the Astro compiler to treat any children of that element as text. This means that all special Astro templating syntax will be ignored inside of this component.
 
-Used internally by the `<Markdown>` component.
+Used internally by the `<Markdown />` component.
 
 For example, if you had a custom Katex component that converted some text to HTML, you could have users do this:
-  
+
 ```astro
 ---
 import Katex from '../components/Katex.astro';


### PR DESCRIPTION
Updating files from the `/en/` docs regarding self closing tags technically wrong (according to spec) when specified in the docs

- changing `<slot>` to `<slot />`
- ~changing `<img>` to `<img />`~ — reverted
- changing `<Markdown>` to `<Markdown />`
- ~changing `<meta>` to `<meta />`~ — reverted

(contain also change for `migrate.md` removing useless spaces at end of line, (ty my IDE))