### PR TITLE
i18n(fr): Adding `astro-components.md` & `astro-pages.md` translations

### DIFF
--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -1,0 +1,388 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Composants
+description: Une introduction à la syntaxe des composants en .astro.
+---
+
+**Les composants Astro** sont les blocs de fondation de tout projet Astro. Ce sont des composants contenant seulement le code modèle en HTML sans code rendu à l'utilisateur.
+
+La syntaxe des composants Astro est une surcouche de l'HTML. Elle a été conçue pour [ressembler à ceux qui écrivent du HTML ou du JSX](/fr/comparing-astro-vs-other-tools/#astro-vs-jsx), et ajoute la possibilité d'inclure des composants et des expressions JavaScript. Vous pouvez remarquer un composant Astro par son extension de fichier : `.astro`.
+
+Les composants Astro sont extrêmement flexibles. Il y a souvent des composants qui contiennent des **UI réutilisables sur la page**, comme un header ou un profil. D'autres composants peuvent contenir un morceau de HTML, comme un ensemble de balises `<meta>` qui rendent le SEO facile à utiliser. Les composants Astro peuvent aussi contenir un Layout entier de page.
+
+La chose la plus importante à savoir sur les composants Astro est qu'**ils rendent leurs contenus HTML durant la compilation**. Cela signifie que si vous utilisez du JavaScript dans vos composants, ils seront tous exécutés avant la compilation, et que le résultat sera un site plus rapide, avec aucun chargement de JavaScript ajoutée par défaut.
+
+## Vue d'ensemble des composants
+
+Un composant Astro est composé de deux parties principales : le **Script du composant** et le **Template du composant**. Chacune de ces parties s'occupe de faire une tâche différente, mais ensemble, fait un cadre qui est facile à utiliser et qui est assez expressif pour gérer la plupart des cas.
+
+```astro
+---
+// Script du composant (JavaScript)
+---
+<!-- Template du composant (HTML + Expressions JS) -->
+```
+
+Vous pouvez utiliser des composants dans d'autres composants, pour construire des interfaces plus avancées. Par exemple, un composant `Button` peut être utilisé pour créer un composant `ButtonGroup` comme ceci :
+
+```astro
+---
+// Example: ButtonGroup.astro
+import Button from './Button.astro';
+---
+<div>
+  <Button title="Button 1" />
+  <Button title="Button 2" />
+  <Button title="Button 3" />
+</div>
+```
+
+### Le script du composant
+
+Astro utilise des barres de code (`---`) pour identifier le script du composant dans votre composant Astro. Si vous avez déjà écrit du Markdown avant, vous pourriez être déjà familier avec un concept similaire appelé *frontmatter*. Astro est directement inspiré de cela.
+
+Vous pouvez utiliser le script du composant pour écrire du code JavaScript qui vous aidera à construire votre template. Cela peut inclure :
+
+- Importer d'autres composants Astro
+- Importer des composants de framework, comme React
+- Importer des données, comme un fichier JSON
+- Récupérer le contenu d'une API ou une base de données
+- Créer des variables que vous voulez référencer dans votre template
+
+```astro
+---
+// Note: Les importations doivent être placées en haut de votre fichier.
+import SomeAstroComponent from '../components/SomeAstroComponent.astro';
+import SomeReactComponent from '../components/SomeReactComponent.jsx';
+import someData from '../data/pokemon.json';
+
+// Acceder aux propriétés passées dans le composant, comme `<X title="Hello, World" />`
+const {title} = Astro.props;
+// Récupérer des données externes, même depuis une API privée ou une base de données
+const data = await fetch('SOME_SECRET_API_URL/users').then(r => r.json());
+---
+<!-- Votre template ici ! -->
+```
+
+Les barrières de code sont conçues pour garantir que le code JavaScript que vous écrivez à l'interieur "ne puisse pas s'échapper". Elles ne sortiront pas de votre application frontend, ou tomberont pas dans les mains de l'utilisateur. Vous pouvez écrire du code JavaScript qui peux être coûteux ou sensible (comme un appel à votre base de données privée) sans vous inquiéter de ce qui finis dans le navigateur de l'utilisateur.
+
+>💡 *Vous pouvez également écrire du TypeScript dans votre script de composant !*
+
+### Le template du composant
+
+En dessous du script du composant se trouve le template du composant. Le template du composant détermine le HTML de votre composant.
+
+Si vous écrivez du HTML simple ici, votre composant rendra cet HTML dans n'importe quelle page que vous importiez et utilisez.
+
+Par contre, la syntaxe du template du composant Astro supporte également les **expressions JavaScript**, les **composants importés** et les [**directives spéciales Astro**](/fr/reference/directives-reference/). Les données et les valeurs définies (à la compilation) dans le script du composant peuvent être utilisées dans le template du composant pour produire du HTML dynamique.
+
+```astro
+---
+// Votre script du composant ici !
+import ReactPokemonComponent from '../components/ReactPokemonComponent.jsx';
+const myFavoritePokemon = [/* ... */];
+---
+<!-- les commentaires HTML sont supportés ! -->
+
+<h1>Hello, world!</h1>
+
+<!-- Utilisez les propriétés et autres variables du script du composant : -->
+<p>Mon pokemon favoris est : {Astro.props.title}</p>
+
+<!-- Inclure d'autres composants avec une directive `client:` pour l'hydrater : -->
+<ReactPokemonComponent client:visible />
+
+<!-- Mixez HTML avec des expressions JavaScript, similaire à JSX : -->
+<ul>
+  {myFavoritePokemon.map((data) => <li>{data.name}</li>)}
+<ul>
+
+<!-- Utilisez une directive `template:` pour injecter un code HTML sans l'échapper : -->
+<p set:html={rawHTMLString} />
+```
+
+### Expressions dynamiques JSX
+
+Les composants Astro peuvent également définir des variables locales dans le script du composant. Toutes les variables sont alors automatiquement disponibles dans le template HTML du composant juste en dessous.
+
+#### Valeurs dynamiques
+
+Ces variables locales peuvent être utilisées dans des accolades pour passer des valeurs à utiliser comme texte HTML :
+
+```astro
+---
+const name = "Astro";
+---
+<div>
+  <h1>Hello {name}!</h1>
+</div>
+```
+
+#### Attributs dynamiques
+
+Ces variables locales peuvent être utilisées dans des accolades pour passer des valeurs à utiliser comme attributs d'éléments HTML et de composants :
+
+```astro
+---
+const name = "Astro";
+---
+<h1 class={name}>Les expressions d'attributs sont supportés</h1>
+
+<MyComponent templateLiteralNameAttribute={`MonNomEst${name}`} />
+```
+
+#### HTML dynamique
+
+Ces variables locales peuvent être utilisées dans des fonctions ressemblantes au JSX pour produire des éléments HTML dynamiques :
+
+```astro
+---
+const items = ["Chien", "Chat", "Ornithorynque"];
+---
+<ul>
+  {items.map((item) => (
+    <li>{item}</li>
+  ))}
+</ul>
+```
+
+#### Fragments & valeurs multiples
+
+Souvenez vous : un composant Astro peut rendre plusieurs éléments sans avoir à les entourer d'une balise `<div>` ou `<>`.
+
+Attention, quand vous utilisez une expression JSX pour créer plusieurs éléments dynamiques, vous devez entourer ces éléments à l'intérieur d'un **Fragment** comme vous le feriez dans du JavaScript ou du JSX. Astro supporte l'utilisation de `<Fragment> </Fragment>` ou des `<> </>`.
+
+```astro
+---
+const items = ["Chien", "Chat", "Ornithorynque"];
+---
+<ul>
+  {items.map((item) => (
+    <>
+      <li>Red {item}</li>
+      <li>Blue {item}</li>
+      <li>Green {item}</li>
+    </>
+  ))}
+</ul>
+```
+
+### Propriétés de composants
+
+Un composant Astro peut définir et accepter des propriétés. Ces propriétés sont alors disponibles dans le template du composant pour rendre du HTML. Les propriétés sont disponibles sur la variable globale `Astro.props` dans le script de votre frontmatter.
+
+Voici un exemple de composant qui reçoit une propriété `greeting` et une propriété `name`. Notez que les propriétés à recevoir sont déstructurés de l'objet global `Astro.props`
+
+```astro
+---
+// Example : GreetingHeadline.astro
+// Utilisation : <GreetingHeadline greeting="Salutation" name="Partenaire" />
+const { greeting, name } = Astro.props
+---
+<h2>{greeting}, {name} !</h2>
+````
+
+Vous pouvez aussi définir vos propres propriétés et leur types avec TypeScript en exposant une interface `Props`. Astro va automatiquement prendre toutes les interfaces `Props` exportées et donner des avertissements/erreurs de type pour votre projet. Ces propriétés peuvent aussi être données des valeurs par défaut lorsqu'elles sont déstructurées de `Astro.props`.
+
+```astro
+---
+// src/components/GreetingHeadline.astro
+export interface Props {
+  name: string;
+  greeting?: string;
+}
+
+const { greeting = "Salut", name } = Astro.props as Props;
+---
+<h2>{greeting}, {name} !</h2>
+```
+
+Ce composant, lorsqu'il est importé et rendu dans d'autres composants Astro, layouts ou pages, peut être ajouté de ces propriétés comme attributs :
+
+```astro
+---
+// src/components/GreetingCard.astro
+import GreetingHeadline from './GreetingHeadline.astro';
+const name = "Astro"
+---
+<h1>Carte de bienvenue</h1>
+<GreetingHeadline greeting="Hey" name={name} />
+<p>J'espère que vous passez une exellente journée !</p>
+```
+
+### Emplacements
+
+L'élément `<slot />` est un espace réservé de l'HTML externe, vous permettant d'injecter (ou "insérer" de l'anglais "slot") des éléments HTML enfants depuis d'autres fichiers dans votre template composant.
+
+Par défaut, tout élément enfant d'un composant Astro est inséré dans son `<slot />`.
+
+> 💡 Différemment de _props_, auquel ses attributs sont passés à un composant Astro avec `Astro.props()`, les _slots_ affichent directement des éléments HTML où ils sont écrits.
+
+```astro
+---
+// src/components/Wrapper.astro
+import Header from './Header.astro';
+import Logo from './Logo.astro';
+import Footer from './Footer.astro';
+
+const { title } = Astro.props
+---
+<div id="content-wrapper">
+  <Header />
+  <Logo />
+  <h1>{title}</h1>
+  <slot />  <!-- l'enfant ira ici -->
+  <Footer />
+</div>
+```
+
+```astro
+---
+// src/pages/fred.astro
+import Wrapper from '../components/Wrapper.astro';
+---
+
+<Wrapper title="Page de Fred">
+  <h2>Tout ce qui est a savoir sur Fred</h2>
+  <p>Voici quelques truc à propos de Fred.</p>
+</Wrapper>
+```
+
+Ce modèle de structure est la base d'un composant de "Layout" Astro : une page entière de HTML peut être « englobée » par des balises `<Layout></Layout>` et envoyée au composant de mise en page pour être affichée dans des éléments communs de page.
+
+#### Emplacements nommés
+
+Un composant Astro peut aussi avoir des "slots" nommés. Cela vous permet de passer uniquement des éléments HTML avec le nom de l'emplacement correspondant à sa position.
+
+```astro
+---
+// src/components/Wrapper.astro
+import Header from './Header.astro';
+import Logo from './Logo.astro';
+import Footer from './Footer.astro';
+
+const { title } = Astro.props
+---
+<div id="content-wrapper">
+  <Header />
+  <slot name="after-header"/>  <!-- l'enfant avec l'attribut `slot="after-header"` ira ici -->
+  <Logo />
+  <h1>{title}</h1>
+  <slot />  <!-- l'enfant sans un `slot`, ou avec l'attribut `slot="default"` ira ici -->
+  <Footer />
+  <slot name="after-footer"/>  <!-- l'enfant avec l'attribut `slot="after-footer"` ira ici -->
+</div>
+```
+
+```astro
+---
+// src/pages/fred.astro
+import Wrapper from '../components/Wrapper.astro';
+---
+
+<Wrapper title="Page de Fred">
+  <img src="https://my.photo/fred.jpg" slot="after-header">
+  <h2>Tout ce qui est a savoir sur Fred</h2>
+  <p>Voici quelques truc à propos de Fred.</p>
+  <p slot="after-footer">Copyright 2022</p>
+</Wrapper>
+
+```
+
+Utilisez un attribut `slot="my-slot"` sur l'élément enfant que vous voulez passer à un emplacement correspondant à `<slot name="my-slot" />` dans votre composant.
+
+> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](fr/guides/framework-components) dans des fichiers Astro.
+
+#### Contenu de remplacement pour les emplacements
+
+Les emplacements peuvent aussi afficher des **contenus de remplacement**. Quand il n'y a pas d'enfants correspondants passés à un emplacement, un élément `<slot />` affichera ses propres enfants.
+
+```astro
+---
+// src/components/Wrapper.astro
+import Header from './Header.astro';
+import Logo from './Logo.astro';
+import Footer from './Footer.astro';
+
+const { title } = Astro.props
+---
+<div id="content-wrapper">
+  <Header />
+  <Logo />
+  <h1>{title}</h1>
+  <slot>
+    <p>Ceci est mon contenu de remplacement, seulement s'il n'y a pas d'enfants passés dans l'emplacement</p>
+  </slot>
+  <Footer />
+</div>
+```
+
+### Styles CSS
+
+Les balises `<style>` CSS sont également supportées dans le template du composant.
+
+Elles peuvent être utilisées pour styliser vos composants, et toutes les règles de style sont automatiquement portées à l'intérieur du composant pour éviter les conflits de CSS dans de grosses applications.
+
+```astro
+---
+// Votre script du composant ici !
+---
+<style>
+  /* restreint au composant, les autres balises H1 sur la page restent les mêmes */
+  h1 { color: red }
+</style>
+
+<h1>Hello, world!</h1>
+```
+
+> ⚠️ Les styles définis ici s'appliquent uniquement au contenu écrit directement dans le template du composant lui-même. Les enfants et tous les composants importés ne seront **pas** stylisés par défaut.
+
+📚 Allez voir notre [Guide de stylisation](/fr/guides/styling) pour plus d'informations sur l'application de styles.
+
+### Scripts côté client
+
+Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framework](/fr/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) ou une [intégration Astro](https://astro.build/integrations/) (par ex: `astro-XElement`), vous pouvez utiliser une balise `<script>` dans votre template du composant Astro et envoyer du JavaScript au navigateur qui s'exécute dans le contexte global.
+
+
+```astro
+<script>
+  // Optimisé ! Groupé ! Les imports ESM fonctionnent, même pour les packages npm.
+</script>
+
+<script is:inline>
+  // Va être affiché dans l'HTML exactement comme écrit !
+  // Les imports ESM ne seront pas résolus par rapport au fichier.
+</script>
+```
+
+📚 Jetez un oeil à notre [référence de directives](/fr/reference/directives-reference#balises-script-et-style) pour plus d'informations sur les directives disponibles sur les balises `<script>`.
+
+#### Chargement de scripts externes
+
+**Quand utiliser cette fonctionnalité :** Si votre fichier JavaScript se trouve dans `public/`.
+
+Notez que cette approche évite le traitement, le bundling et les optimisations JavaScript fournies par Astro lorsque vous utilisez la méthode d'importation décrite ci-dessous.
+
+```astro
+// Chemin absolu vers le fichier JavaScript
+<script is:inline src="/some-external-script.js"></script>
+```
+
+#### Utilisation des scripts hoistés
+
+**Quand utiliser cette fonctionnalité :** Si votre script externe se trouve dans `src/` _et_ supporte l'importation par module ESM.
+
+Astro détecte ces importations JavaScript côté client, les compile, optimise et les ajoute automatiquement le JS au code HTML.
+
+```astro
+// importation ESM
+<script>
+  import './some-external-script.js';
+</script>
+```
+
+## Étapes suivantes
+
+📚 En savoir plus sur les [composants inclus dans Astro](/fr/reference/api-reference/#built-in-components).
+
+📚 Apprendre à utiliser des [composants de framework JavaScript](/fr/core-concepts/framework-components/) dans votre projet Astro.

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -291,7 +291,7 @@ import Wrapper from '../components/Wrapper.astro';
 
 Utilisez un attribut `slot="my-slot"` sur l'élément enfant que vous voulez passer à un emplacement correspondant à `<slot name="my-slot" />` dans votre composant.
 
-> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](fr/guides/framework-components) dans des fichiers Astro.
+> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](/fr/guides/framework-components/) dans des fichiers Astro.
 
 #### Contenu par défaut pour les emplacements
 
@@ -337,11 +337,11 @@ Elles peuvent être utilisées donner un style à vos composants, et toutes les 
 
 > ⚠️ Les styles définis ici s'appliquent uniquement au contenu écrit directement dans le template du composant lui-même. Les enfants et tous les composants importés ne seront **pas** stylisés par défaut.
 
-📚 Allez voir notre [Guide des styles](/fr/guides/styling) pour plus d'informations sur l'application de styles.
+📚 Allez voir notre [Guide des styles](/fr/guides/styling/) pour plus d'informations sur l'application de styles.
 
 ### Scripts côté client
 
-Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framework](/fr/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) ou une [intégration Astro](https://astro.build/integrations/) (par ex: `astro-XElement`), vous pouvez utiliser une balise `<script>` dans votre template du composant Astro et envoyer du JavaScript au navigateur qui s'exécute dans le contexte global.
+Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framework](/fr/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) ou une [intégration Astro](https://astro.build/integrations/) (par ex: `astro-XElement`), vous pouvez utiliser une balise `<script>` dans votre template du composant Astro et envoyer du JavaScript au navigateur qui s'exécute dans le contexte global.
 
 
 ```astro
@@ -355,7 +355,7 @@ Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framewor
 </script>
 ```
 
-📚 Jetez un oeil à notre [référence de directives](/fr/reference/directives-reference#balises-script-et-style) pour plus d'informations sur les directives disponibles sur les balises `<script>`.
+📚 Jetez un oeil à notre [référence de directives](/fr/reference/directives-reference/#script--style-directives) pour plus d'informations sur les directives disponibles sur les balises `<script>`.
 
 #### Chargement de scripts externes
 

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -4,9 +4,9 @@ title: Composants
 description: Une introduction à la syntaxe des composants en .astro.
 ---
 
-**Les composants Astro** sont les blocs de fondation de tout projet Astro. Ce sont des composants contenant seulement le code modèle en HTML sans code rendu à l'utilisateur.
+**Les composants Astro** sont les blocs de base de tout projet Astro. Il permettent de mettre en forme uniquement avec du HTML, sans code exécuté sur le navigateur.
 
-La syntaxe des composants Astro est une surcouche de l'HTML. Elle a été conçue pour [ressembler à ceux qui écrivent du HTML ou du JSX](/fr/comparing-astro-vs-other-tools/#astro-vs-jsx), et ajoute la possibilité d'inclure des composants et des expressions JavaScript. Vous pouvez remarquer un composant Astro par son extension de fichier : `.astro`.
+La syntaxe des composants Astro est une surcouche du HTML. Elle a été conçue pour [ressembler à HTML et JSX](/fr/comparing-astro-vs-other-tools/#astro-vs-jsx), et ajoute la possibilité d'inclure des composants et des expressions JavaScript. Vous pouvez identifier un composant Astro par son extension de fichier : `.astro`.
 
 Les composants Astro sont extrêmement flexibles. Il y a souvent des composants qui contiennent des **UI réutilisables sur la page**, comme un header ou un profil. D'autres composants peuvent contenir un morceau de HTML, comme un ensemble de balises `<meta>` qui facilitent la SEO. Les composants Astro peuvent aussi contenir une mise en page entière (appelée _Layout_).
 
@@ -14,7 +14,7 @@ La chose la plus importante à savoir sur les composants Astro est qu'ils **prod
 
 ## Vue d'ensemble des composants
 
-Un composant Astro est composé de deux parties principales : le **Script du composant** et le **Template du composant**. Chacune de ces parties s'occupe de faire une tâche différente, mais ensemble, fait un cadre qui est facile à utiliser et qui est assez expressif pour gérer la plupart des cas.
+Un composant Astro est composé de deux parties principales : le **Script du composant** et le **Template du composant**. Chacune de ces parties s'occupe de faire une tâche différente, mais ensemble, constituent un cadre facile d'utilisation et assez expressif pour gérer n'importe quelle situation.
 
 ```astro
 ---
@@ -169,7 +169,7 @@ const items = ["Chien", "Chat", "Ornithorynque"];
 
 ### Propriétés de composants
 
-Un composant Astro peut définir et accepter des propriétés. Ces propriétés sont alors disponibles dans le template du composant pour rendre du HTML. Les propriétés sont disponibles sur la variable globale `Astro.props` dans le script de votre frontmatter.
+Un composant Astro peut définir et accepter des propriétés. Ces propriétés sont alors disponibles dans le template du composant pour le rendu du HTML. Les propriétés sont disponibles dans la variable globale `Astro.props` dans le script de composant.
 
 Voici un exemple de composant qui reçoit une propriété `greeting` et une propriété `name`. Notez que les propriétés à recevoir sont obtenues via la destructuration de l'objet global `Astro.props`
 

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -10,7 +10,7 @@ La syntaxe des composants Astro est une surcouche du HTML. Elle a été conçue 
 
 Les composants Astro sont extrêmement flexibles. Il y a souvent des composants qui contiennent des **UI réutilisables sur la page**, comme un header ou un profil. D'autres composants peuvent contenir un morceau de HTML, comme un ensemble de balises `<meta>` qui facilitent la SEO. Les composants Astro peuvent aussi contenir une mise en page entière (appelée _Layout_).
 
-La chose la plus importante à savoir sur les composants Astro est qu'ils **produisent leur rendu HTML durant la compilation**. Cela signifie que si vous utilisez du JavaScript dans vos composants, ils seront tous exécutés avant la compilation. Le résultat sera un site plus rapide, avec aucun chargement de JavaScript ajoutée par défaut.
+La chose la plus importante à savoir sur les composants Astro est qu'ils **produisent leur rendu HTML durant la compilation**. Cela signifie que même si vous utilisez du JavaScript dans vos composants, tout sera exécuté pendant la compilation. Le résultat sera un site plus rapide, avec aucun chargement de JavaScript ajouté par défaut.
 
 ## Vue d'ensemble des composants
 
@@ -70,7 +70,7 @@ Les barrières de code sont conçues pour garantir que le code JavaScript que vo
 
 ### Le template du composant
 
-En dessous du script du composant se trouve le template du composant. Le template du composant défini le HTML de sortie de votre composant.
+En dessous du script du composant se trouve le template du composant. Le template du composant définit le HTML de sortie de votre composant.
 
 Si vous écrivez du HTML simple ici, votre composant affichera cet HTML dans toutes les pages où il est importé et utilisé.
 
@@ -133,7 +133,7 @@ const name = "Astro";
 
 #### HTML dynamique
 
-Ces variables locales peuvent être utilisées dans des fonctions ressemblantes au JSX pour produire des éléments HTML dynamiques :
+Ces variables locales peuvent être utilisées dans des fonctions ressemblantes au JSX pour produire dynamiquement des éléments HTML :
 
 ```astro
 ---
@@ -321,7 +321,7 @@ const { title } = Astro.props
 
 Les balises `<style>` CSS sont également permises dans le template du composant.
 
-Elles peuvent être utilisées donner un style à vos composants, et toutes les règles de style sont automatiquement limitées pour agir uniquement à l'intérieur du composant. Cela permet d'éviter les conflits de CSS dans de grosses applications.
+Elles peuvent être utilisées pour donner un style à vos composants, et toutes les règles de style sont automatiquement limitées pour agir uniquement à l'intérieur du composant. Cela permet d'éviter les conflits de CSS dans de grosses applications.
 
 ```astro
 ---

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -291,7 +291,7 @@ import Wrapper from '../components/Wrapper.astro';
 
 Utilisez un attribut `slot="my-slot"` sur l'élément enfant que vous voulez passer à un emplacement correspondant à `<slot name="my-slot" />` dans votre composant.
 
-> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](/fr/guides/framework-components/) dans des fichiers Astro.
+> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](/fr/core-concepts/framework-components/) dans des fichiers Astro.
 
 #### Contenu par défaut pour les emplacements
 

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -8,9 +8,9 @@ description: Une introduction à la syntaxe des composants en .astro.
 
 La syntaxe des composants Astro est une surcouche de l'HTML. Elle a été conçue pour [ressembler à ceux qui écrivent du HTML ou du JSX](/fr/comparing-astro-vs-other-tools/#astro-vs-jsx), et ajoute la possibilité d'inclure des composants et des expressions JavaScript. Vous pouvez remarquer un composant Astro par son extension de fichier : `.astro`.
 
-Les composants Astro sont extrêmement flexibles. Il y a souvent des composants qui contiennent des **UI réutilisables sur la page**, comme un header ou un profil. D'autres composants peuvent contenir un morceau de HTML, comme un ensemble de balises `<meta>` qui rendent le SEO facile à utiliser. Les composants Astro peuvent aussi contenir un Layout entier de page.
+Les composants Astro sont extrêmement flexibles. Il y a souvent des composants qui contiennent des **UI réutilisables sur la page**, comme un header ou un profil. D'autres composants peuvent contenir un morceau de HTML, comme un ensemble de balises `<meta>` qui facilitent la SEO. Les composants Astro peuvent aussi contenir une mise en page entière (appelée _Layout_).
 
-La chose la plus importante à savoir sur les composants Astro est qu'**ils rendent leurs contenus HTML durant la compilation**. Cela signifie que si vous utilisez du JavaScript dans vos composants, ils seront tous exécutés avant la compilation, et que le résultat sera un site plus rapide, avec aucun chargement de JavaScript ajoutée par défaut.
+La chose la plus importante à savoir sur les composants Astro est qu'ils **produisent leur rendu HTML durant la compilation**. Cela signifie que si vous utilisez du JavaScript dans vos composants, ils seront tous exécutés avant la compilation. Le résultat sera un site plus rapide, avec aucun chargement de JavaScript ajoutée par défaut.
 
 ## Vue d'ensemble des composants
 
@@ -64,17 +64,17 @@ const data = await fetch('SOME_SECRET_API_URL/users').then(r => r.json());
 <!-- Votre template ici ! -->
 ```
 
-Les barrières de code sont conçues pour garantir que le code JavaScript que vous écrivez à l'interieur "ne puisse pas s'échapper". Elles ne sortiront pas de votre application frontend, ou tomberont pas dans les mains de l'utilisateur. Vous pouvez écrire du code JavaScript qui peux être coûteux ou sensible (comme un appel à votre base de données privée) sans vous inquiéter de ce qui finis dans le navigateur de l'utilisateur.
+Les barrières de code sont conçues pour garantir que le code JavaScript que vous écrivez à l’intérieur "ne puisse pas s'échapper". Ce code n'apparaîtra pas dans le code final de votre page, il ne sera pas visible par l'utilisateur. Vous pouvez écrire du code JavaScript coûteux (en terme de performance) ou sensible (comme un appel à votre base de données privée) sans vous inquiéter de ce qui finit dans le navigateur de l'utilisateur.
 
 >💡 *Vous pouvez également écrire du TypeScript dans votre script de composant !*
 
 ### Le template du composant
 
-En dessous du script du composant se trouve le template du composant. Le template du composant détermine le HTML de votre composant.
+En dessous du script du composant se trouve le template du composant. Le template du composant défini le HTML de sortie de votre composant.
 
-Si vous écrivez du HTML simple ici, votre composant rendra cet HTML dans n'importe quelle page que vous importiez et utilisez.
+Si vous écrivez du HTML simple ici, votre composant affichera cet HTML dans toutes les pages où il est importé et utilisé.
 
-Par contre, la syntaxe du template du composant Astro supporte également les **expressions JavaScript**, les **composants importés** et les [**directives spéciales Astro**](/fr/reference/directives-reference/). Les données et les valeurs définies (à la compilation) dans le script du composant peuvent être utilisées dans le template du composant pour produire du HTML dynamique.
+De plus, la syntaxe du template du composant Astro prend également en charge les **expressions JavaScript**, les **composants importés** et les [**directives spéciales Astro**](/fr/reference/directives-reference/). Les données et les valeurs définies (à la compilation) dans le script du composant peuvent être utilisées dans le template du composant pour produire du HTML dynamiquement.
 
 ```astro
 ---
@@ -89,7 +89,7 @@ const myFavoritePokemon = [/* ... */];
 <!-- Utilisez les propriétés et autres variables du script du composant : -->
 <p>Mon pokemon favoris est : {Astro.props.title}</p>
 
-<!-- Inclure d'autres composants avec une directive `client:` pour l'hydrater : -->
+<!-- Incluez d'autres composants avec une directive `client:` pour l'hydrater : -->
 <ReactPokemonComponent client:visible />
 
 <!-- Mixez HTML avec des expressions JavaScript, similaire à JSX : -->
@@ -126,7 +126,7 @@ Ces variables locales peuvent être utilisées dans des accolades pour passer de
 ---
 const name = "Astro";
 ---
-<h1 class={name}>Les expressions d'attributs sont supportés</h1>
+<h1 class={name}>Les expressions d'attributs sont prises en charge</h1>
 
 <MyComponent templateLiteralNameAttribute={`MonNomEst${name}`} />
 ```
@@ -148,9 +148,9 @@ const items = ["Chien", "Chat", "Ornithorynque"];
 
 #### Fragments & valeurs multiples
 
-Souvenez vous : un composant Astro peut rendre plusieurs éléments sans avoir à les entourer d'une balise `<div>` ou `<>`.
+Souvenez vous : un composant Astro peut faire le rendu de plusieurs éléments sans avoir à les entourer d'une balise `<div>` ou `<>`.
 
-Attention, quand vous utilisez une expression JSX pour créer plusieurs éléments dynamiques, vous devez entourer ces éléments à l'intérieur d'un **Fragment** comme vous le feriez dans du JavaScript ou du JSX. Astro supporte l'utilisation de `<Fragment> </Fragment>` ou des `<> </>`.
+Par contre, quand vous utilisez une expression JSX pour créer dynamiquement plusieurs éléments, vous devez entourer ces éléments d'un **Fragment** comme vous le feriez dans du JavaScript ou du JSX. Astro permet l'utilisation de `<Fragment> </Fragment>` ou des `<> </>`.
 
 ```astro
 ---
@@ -171,7 +171,7 @@ const items = ["Chien", "Chat", "Ornithorynque"];
 
 Un composant Astro peut définir et accepter des propriétés. Ces propriétés sont alors disponibles dans le template du composant pour rendre du HTML. Les propriétés sont disponibles sur la variable globale `Astro.props` dans le script de votre frontmatter.
 
-Voici un exemple de composant qui reçoit une propriété `greeting` et une propriété `name`. Notez que les propriétés à recevoir sont déstructurés de l'objet global `Astro.props`
+Voici un exemple de composant qui reçoit une propriété `greeting` et une propriété `name`. Notez que les propriétés à recevoir sont obtenues via la destructuration de l'objet global `Astro.props`
 
 ```astro
 ---
@@ -182,7 +182,7 @@ const { greeting, name } = Astro.props
 <h2>{greeting}, {name} !</h2>
 ````
 
-Vous pouvez aussi définir vos propres propriétés et leur types avec TypeScript en exposant une interface `Props`. Astro va automatiquement prendre toutes les interfaces `Props` exportées et donner des avertissements/erreurs de type pour votre projet. Ces propriétés peuvent aussi être données des valeurs par défaut lorsqu'elles sont déstructurées de `Astro.props`.
+Vous pouvez aussi définir vos propres propriétés et leur type avec TypeScript en exposant une interface `Props`. Astro va automatiquement récupérer toutes les interfaces `Props` exportées pour vous avertir s'il y a des erreurs de type dans votre projet. Des valeurs par défaut peuvent aussi être définies pour ces propriétés lors de la destructuration de `Astro.props`.
 
 ```astro
 ---
@@ -197,7 +197,7 @@ const { greeting = "Salut", name } = Astro.props as Props;
 <h2>{greeting}, {name} !</h2>
 ```
 
-Ce composant, lorsqu'il est importé et rendu dans d'autres composants Astro, layouts ou pages, peut être ajouté de ces propriétés comme attributs :
+Ce composant, lorsqu'il est importé et utilisé dans d'autres composants Astro, layouts ou pages, peut recevoir ces propriétés définies sous forme d'attributs :
 
 ```astro
 ---
@@ -212,11 +212,11 @@ const name = "Astro"
 
 ### Emplacements
 
-L'élément `<slot />` est un espace réservé de l'HTML externe, vous permettant d'injecter (ou "insérer" de l'anglais "slot") des éléments HTML enfants depuis d'autres fichiers dans votre template composant.
+L'élément `<slot />` est un espace réservé pour du HTML externe, vous permettant d'injecter (ou "insérer" de l'anglais "slot") des éléments HTML enfants depuis d'autres fichiers dans votre template de composant.
 
 Par défaut, tout élément enfant d'un composant Astro est inséré dans son `<slot />`.
 
-> 💡 Différemment de _props_, auquel ses attributs sont passés à un composant Astro avec `Astro.props()`, les _slots_ affichent directement des éléments HTML où ils sont écrits.
+> 💡 Contrairement aux _propriétés_, qui sont les attributs accessibles avec `Astro.props()` dans un composant Astro, les _slots_ affichent directement des éléments HTML là où ils sont écrits.
 
 ```astro
 ---
@@ -248,11 +248,11 @@ import Wrapper from '../components/Wrapper.astro';
 </Wrapper>
 ```
 
-Ce modèle de structure est la base d'un composant de "Layout" Astro : une page entière de HTML peut être « englobée » par des balises `<Layout></Layout>` et envoyée au composant de mise en page pour être affichée dans des éléments communs de page.
+Ce modèle de structure est la base d'un composant de "_Layout_" Astro : une page entière de HTML peut être « englobée » par des balises `<Layout></Layout>` et envoyée au composant `Layout` pour être affichée dans des éléments de page communs.
 
 #### Emplacements nommés
 
-Un composant Astro peut aussi avoir des "slots" nommés. Cela vous permet de passer uniquement des éléments HTML avec le nom de l'emplacement correspondant à sa position.
+Un composant Astro peut aussi avoir des "slots" nommés. Cela vous permet de passer à un _slot_ uniquement les éléments HTML avec un nom de _slot_ correspondant.
 
 ```astro
 ---
@@ -293,9 +293,9 @@ Utilisez un attribut `slot="my-slot"` sur l'élément enfant que vous voulez pas
 
 > ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](fr/guides/framework-components) dans des fichiers Astro.
 
-#### Contenu de remplacement pour les emplacements
+#### Contenu par défaut pour les emplacements
 
-Les emplacements peuvent aussi afficher des **contenus de remplacement**. Quand il n'y a pas d'enfants correspondants passés à un emplacement, un élément `<slot />` affichera ses propres enfants.
+Les emplacements peuvent aussi afficher du **contenu par défaut**. Quand aucun enfant correspondant à un emplacement n'est passé à un composant, l'élément `<slot />` affecté affichera ses propres enfants.
 
 ```astro
 ---
@@ -319,9 +319,9 @@ const { title } = Astro.props
 
 ### Styles CSS
 
-Les balises `<style>` CSS sont également supportées dans le template du composant.
+Les balises `<style>` CSS sont également permises dans le template du composant.
 
-Elles peuvent être utilisées pour styliser vos composants, et toutes les règles de style sont automatiquement portées à l'intérieur du composant pour éviter les conflits de CSS dans de grosses applications.
+Elles peuvent être utilisées donner un style à vos composants, et toutes les règles de style sont automatiquement limitées pour agir uniquement à l'intérieur du composant. Cela permet d'éviter les conflits de CSS dans de grosses applications.
 
 ```astro
 ---
@@ -337,7 +337,7 @@ Elles peuvent être utilisées pour styliser vos composants, et toutes les règl
 
 > ⚠️ Les styles définis ici s'appliquent uniquement au contenu écrit directement dans le template du composant lui-même. Les enfants et tous les composants importés ne seront **pas** stylisés par défaut.
 
-📚 Allez voir notre [Guide de stylisation](/fr/guides/styling) pour plus d'informations sur l'application de styles.
+📚 Allez voir notre [Guide des styles](/fr/guides/styling) pour plus d'informations sur l'application de styles.
 
 ### Scripts côté client
 
@@ -361,7 +361,7 @@ Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framewor
 
 **Quand utiliser cette fonctionnalité :** Si votre fichier JavaScript se trouve dans `public/`.
 
-Notez que cette approche évite le traitement, le bundling et les optimisations JavaScript fournies par Astro lorsque vous utilisez la méthode d'importation décrite ci-dessous.
+Notez que cette approche ne permet pas à Astro d'appliquer le traitement, le bundling et les optimisations JavaScript qui sont fournis lorsque vous utilisez la méthode d'importation décrite ci-dessous.
 
 ```astro
 // Chemin absolu vers le fichier JavaScript
@@ -372,7 +372,7 @@ Notez que cette approche évite le traitement, le bundling et les optimisations 
 
 **Quand utiliser cette fonctionnalité :** Si votre script externe se trouve dans `src/` _et_ supporte l'importation par module ESM.
 
-Astro détecte ces importations JavaScript côté client, les compile, optimise et les ajoute automatiquement le JS au code HTML.
+Astro détecte ces importations JavaScript côté client, les compile, optimise et ajoute automatiquement le JS au code HTML.
 
 ```astro
 // importation ESM

--- a/src/pages/fr/core-concepts/astro-components.md
+++ b/src/pages/fr/core-concepts/astro-components.md
@@ -44,7 +44,7 @@ Astro utilise des barres de code (`---`) pour identifier le script du composant 
 Vous pouvez utiliser le script du composant pour écrire du code JavaScript qui vous aidera à construire votre template. Cela peut inclure :
 
 - Importer d'autres composants Astro
-- Importer des composants de framework, comme React
+- Importer des composants de Framework, comme React
 - Importer des données, comme un fichier JSON
 - Récupérer le contenu d'une API ou une base de données
 - Créer des variables que vous voulez référencer dans votre template
@@ -197,7 +197,7 @@ const { greeting = "Salut", name } = Astro.props as Props;
 <h2>{greeting}, {name} !</h2>
 ```
 
-Ce composant, lorsqu'il est importé et utilisé dans d'autres composants Astro, layouts ou pages, peut recevoir ces propriétés définies sous forme d'attributs :
+Ce composant, lorsqu'il est importé et utilisé dans d'autres composants Astro, Layouts ou Pages, peut recevoir ces propriétés définies sous forme d'attributs :
 
 ```astro
 ---
@@ -212,11 +212,11 @@ const name = "Astro"
 
 ### Emplacements
 
-L'élément `<slot />` est un espace réservé pour du HTML externe, vous permettant d'injecter (ou "insérer" de l'anglais "slot") des éléments HTML enfants depuis d'autres fichiers dans votre template de composant.
+L'élément `<slot />` est un espace réservé pour du HTML externe, vous permettant d'injecter (ou "insérer" de l'anglais "Slot") des éléments HTML enfants depuis d'autres fichiers dans votre template de composant.
 
 Par défaut, tout élément enfant d'un composant Astro est inséré dans son `<slot />`.
 
-> 💡 Contrairement aux _propriétés_, qui sont les attributs accessibles avec `Astro.props()` dans un composant Astro, les _slots_ affichent directement des éléments HTML là où ils sont écrits.
+> 💡 Contrairement aux _propriétés_, qui sont les attributs accessibles avec `Astro.props()` dans un composant Astro, les _Slots_ affichent directement des éléments HTML là où ils sont écrits.
 
 ```astro
 ---
@@ -252,7 +252,7 @@ Ce modèle de structure est la base d'un composant de "_Layout_" Astro : une pag
 
 #### Emplacements nommés
 
-Un composant Astro peut aussi avoir des "slots" nommés. Cela vous permet de passer à un _slot_ uniquement les éléments HTML avec un nom de _slot_ correspondant.
+Un composant Astro peut aussi avoir des "Slots" nommés. Cela vous permet de passer à un _Slot_ uniquement les éléments HTML avec un nom de _Slot_ correspondant.
 
 ```astro
 ---
@@ -268,7 +268,7 @@ const { title } = Astro.props
   <slot name="after-header"/>  <!-- l'enfant avec l'attribut `slot="after-header"` ira ici -->
   <Logo />
   <h1>{title}</h1>
-  <slot />  <!-- l'enfant sans un `slot`, ou avec l'attribut `slot="default"` ira ici -->
+  <slot />  <!-- l'enfant sans l'attibut `slot`, ou avec l'attribut `slot="default"` ira ici -->
   <Footer />
   <slot name="after-footer"/>  <!-- l'enfant avec l'attribut `slot="after-footer"` ira ici -->
 </div>
@@ -291,7 +291,7 @@ import Wrapper from '../components/Wrapper.astro';
 
 Utilisez un attribut `slot="my-slot"` sur l'élément enfant que vous voulez passer à un emplacement correspondant à `<slot name="my-slot" />` dans votre composant.
 
-> ⚠️ Ceci ne fonctionne que si vous passez des slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [framework](/fr/core-concepts/framework-components/) dans des fichiers Astro.
+> ⚠️ Ceci ne fonctionne que si vous passez des Slots à d'autres composants Astro. Apprenez plus sur l'inclusion d'autres composants de [Framework](/fr/core-concepts/framework-components/) dans des fichiers Astro.
 
 #### Contenu par défaut pour les emplacements
 
@@ -341,7 +341,7 @@ Elles peuvent être utilisées donner un style à vos composants, et toutes les 
 
 ### Scripts côté client
 
-Pour envoyer du JavaScript au navigateur sans utiliser un [composant de framework](/fr/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) ou une [intégration Astro](https://astro.build/integrations/) (par ex: `astro-XElement`), vous pouvez utiliser une balise `<script>` dans votre template du composant Astro et envoyer du JavaScript au navigateur qui s'exécute dans le contexte global.
+Pour envoyer du JavaScript au navigateur sans utiliser un [composant de Framework](/fr/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) ou une [intégration Astro](https://astro.build/integrations/) (par ex: `astro-XElement`), vous pouvez utiliser une balise `<script>` dans votre template du composant Astro et envoyer du JavaScript au navigateur qui s'exécute dans le contexte global.
 
 
 ```astro
@@ -385,4 +385,4 @@ Astro détecte ces importations JavaScript côté client, les compile, optimise 
 
 📚 En savoir plus sur les [composants inclus dans Astro](/fr/reference/api-reference/#built-in-components).
 
-📚 Apprendre à utiliser des [composants de framework JavaScript](/fr/core-concepts/framework-components/) dans votre projet Astro.
+📚 Apprendre à utiliser des [composants de Framework JavaScript](/fr/core-concepts/framework-components/) dans votre projet Astro.

--- a/src/pages/fr/core-concepts/astro-pages.md
+++ b/src/pages/fr/core-concepts/astro-pages.md
@@ -1,0 +1,123 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Pages
+description: Une introduction au pages Astro
+---
+
+Les **pages** sont des [composants Astro](/fr/core-concepts/astro-components) spécifiques qui vivent dans le sous-dossier `src/pages/`. Ils ont la responsabilité de gérer le routage, le chargement de données et la mise en page pour chaque page HTML de votre site web.
+
+### Routage basé sur les fichiers
+Astro met en place un système de routage basé sur les fichiers. Chaque fichier `.astro` dans le dossier `src/pages` est une page de votre site web, créant une route URL basée sur le chemin du fichier dans le dossier.
+
+📚 Lire plus à propos du [Routage dans Astro](/fr/core-concepts/routing)
+
+### Page HTML
+
+Les pages Astro doivent retourner une réponse complète `<html>...</html>`, incluant `<head>` et `<body>`. (`<!doctype html>` est optionnel, et sera ajouté automatiquement.)
+
+```astro
+---
+// Example: src/pages/index.astro
+---
+<html>
+  <head>
+    <title>Ma page d'accueil</title>
+  </head>
+  <body>
+    <h1>Bienvenue sur mon site web !</h1>
+  </body>
+</html>
+```
+
+### Mettre en place un Layout de page
+
+Pour éviter de répéter les mêmes éléments HTML sur chaque page, vous pouvez déplacer les éléments communs tels que `<head>` et `<body>` dans vos propres [composants Layout](/fr/core-concepts/layouts). Vous pouvez utiliser autant de composants de layout que vous le souhaitez.
+
+```astro
+---
+// Example: src/pages/index.astro
+import MySiteLayout from '../layouts/MySiteLayout.astro';
+---
+<MySiteLayout>
+  <p>Le contenu de ma page, contenu dans un Layout !</p>
+</MySiteLayout>
+```
+
+📚 Lire plus à propos des [composants Layout](/fr/core-concepts/layouts) dans Astro.
+
+## Pages Markdown
+
+Astro traite les fichiers Markdown (`.md`) dans le dossier `src/pages/` comme des pages de votre site web. Ces pages sont généralement utilisées pour des pages de blog et de documentation.
+
+Les Layouts sont très utiles pour les [fichiers Markdown](#pages-markdown). Ils peuvent utiliser la propriété `layout` pour spécifier un [composant Layout](/fr/core-concepts/layouts) qui va entourer le contenu Markdown dans un fichier HTML `<html>...</html>` complet.
+
+```md
+---
+# Example: src/pages/page.md
+layout: '../layouts/MySiteLayout.astro'
+title: 'Ma page Markdown'
+---
+# Titre
+
+Ceci est ma page, écrite en **Markdown.**
+```
+
+📚 Lire plus à propos du [Markdown](/fr/guides/markdown-content) dans Astro.
+
+
+## Pages non-HTML
+
+Pour les pages qui ne sont pas de l'HTML, comme le `.json` ou l'`.xml`, ou même des fichiers non-texte comme des images peuvent être générés à partir de **Routes de Fichiers**.
+
+Les **Routes de Fichiers** doivent terminer par l'extension `.js` ou `.ts` et le fichier source doit exister dans le dossier `src/pages/`.
+
+Les fichiers générés sont basés sur le nom du fichier source, ex: `src/pages/data.json.ts` sera généré pour correspondre à la route `/data.json` dans votre build final.
+
+Lorsque le mode SSR (server-side rendering) l'extension importe peu et peut être omis, car aucun fichier n'est généré à la compilation.
+
+```js
+// Example: src/pages/builtwith.json.ts
+// Génères: /builtwith.json
+// Les routes de fichiers doivent exporter une fonction get() qui est appellée et génère le fichier.
+// Retournez un objet avec `body` pour sauvegarder le contenu du fichier dans votre build final.
+export async function get() {
+  return {
+    body: JSON.stringify({
+      name: 'Astro',
+      url: 'https://astro.build/',
+    }),
+  };
+}
+```
+
+Les routes de l'API recevent un objet `APIContext` qui contient les paramètres [`params`](/fr/reference/api-reference/#params) de la requête et une requête [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request):
+
+```ts
+import type { APIContext } from 'astro';
+export async function get({ params, request }: APIContext) {
+  return {
+    body: JSON.stringify({
+      path: new URL(request.url).pathname
+    })
+  };
+}
+```
+
+Optionellement, vous pouvez également utiliser le typage d'`APIRoute` pour votre route API. Cela vous donnera des messages d'erreur plus précis lorsque votre route API retourne un type incorrect.
+
+```ts
+import type { APIRoute } from 'astro';
+export const get: APIRoute = ({ params, request }) => {
+  return {
+    body: JSON.stringify({
+      path: new URL(request.url).pathname
+    })
+  };
+};
+```
+
+## Page d'erreur 404 customisée
+
+Pour une page d'erreur 404 personnalisée, vous pouvez créer un fichier `404.astro` dans `/src/pages`.
+
+Cela va générer une page `404.html`. La plupart des [services de déploiement](/fr/guides/deploy) la trouveront et l'utiliseront.

--- a/src/pages/fr/core-concepts/astro-pages.md
+++ b/src/pages/fr/core-concepts/astro-pages.md
@@ -49,7 +49,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 Astro traite les fichiers Markdown (`.md`) dans le dossier `src/pages/` comme des pages de votre site web. Ces pages sont généralement utilisées pour des pages de blog et de documentation.
 
-Les Layouts sont très utiles pour les [fichiers Markdown](#pages-markdown). Ils peuvent utiliser la propriété `layout` pour spécifier un [composant Layout](/fr/core-concepts/layouts) qui va entourer le contenu Markdown dans un fichier HTML `<html>...</html>` complet.
+Les Layouts sont très utiles pour les [fichiers Markdown](#pages-markdown). Il est possible de définir la variable `layout` dans le _frontmatter_ pour spécifier un [composant Layout](/fr/core-concepts/layouts) qui va englober le contenu Markdown dans un fichier HTML `<html>...</html>` complet.
 
 ```md
 ---
@@ -67,13 +67,13 @@ Ceci est ma page, écrite en **Markdown.**
 
 ## Pages non-HTML
 
-Pour les pages qui ne sont pas de l'HTML, comme le `.json` ou l'`.xml`, ou même des fichiers non-texte comme des images peuvent être générés à partir de **Routes de Fichiers**.
+Des pages qui ne sont pas du HTML, comme des `.json` ou des `.xml`, ou même des fichiers non-textuels comme des images peuvent être générées à partir de **Routes de Fichiers**.
 
-Les **Routes de Fichiers** doivent terminer par l'extension `.js` ou `.ts` et le fichier source doit exister dans le dossier `src/pages/`.
+Les **Routes de Fichiers** doivent se terminer par l'extension `.js` ou `.ts` et le fichier source doit exister dans le dossier `src/pages/`.
 
-Les fichiers générés sont basés sur le nom du fichier source, ex: `src/pages/data.json.ts` sera généré pour correspondre à la route `/data.json` dans votre build final.
+Les fichiers générés sont basés sur le nom du fichier source, ex: le résultat de la compilation de `src/pages/data.json.ts` correspondra à la route `/data.json` dans votre build final.
 
-Lorsque le mode SSR (server-side rendering) l'extension importe peu et peut être omis, car aucun fichier n'est généré à la compilation.
+En mode SSR (_server-side rendering_) l'extension importe peu et peut être omise, car le fichier n'est pas généré à la compilation.
 
 ```js
 // Example: src/pages/builtwith.json.ts
@@ -90,7 +90,7 @@ export async function get() {
 }
 ```
 
-Les routes de l'API recevent un objet `APIContext` qui contient les paramètres [`params`](/fr/reference/api-reference/#params) de la requête et une requête [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request):
+Les routes d'API reçoivent un objet `APIContext` qui contient les paramètres [`params`](/fr/reference/api-reference/#params) de la requête et une requête [`Request`](https://developer.mozilla.org/fr/docs/Web/API/Request):
 
 ```ts
 import type { APIContext } from 'astro';
@@ -103,7 +103,7 @@ export async function get({ params, request }: APIContext) {
 }
 ```
 
-Optionellement, vous pouvez également utiliser le typage d'`APIRoute` pour votre route API. Cela vous donnera des messages d'erreur plus précis lorsque votre route API retourne un type incorrect.
+Optionnellement, vous pouvez également utiliser le type `APIRoute` pour votre route d'API. Cela vous donnera des messages d'erreur plus précis lorsque votre route d'API retourne un type incorrect.
 
 ```ts
 import type { APIRoute } from 'astro';
@@ -116,7 +116,7 @@ export const get: APIRoute = ({ params, request }) => {
 };
 ```
 
-## Page d'erreur 404 customisée
+## Page d'erreur 404 personnalisée
 
 Pour une page d'erreur 404 personnalisée, vous pouvez créer un fichier `404.astro` dans `/src/pages`.
 

--- a/src/pages/fr/core-concepts/astro-pages.md
+++ b/src/pages/fr/core-concepts/astro-pages.md
@@ -4,12 +4,12 @@ title: Pages
 description: Une introduction au pages Astro
 ---
 
-Les **pages** sont des [composants Astro](/fr/core-concepts/astro-components) spécifiques qui vivent dans le sous-dossier `src/pages/`. Ils ont la responsabilité de gérer le routage, le chargement de données et la mise en page pour chaque page HTML de votre site web.
+Les **pages** sont des [composants Astro](/fr/core-concepts/astro-components/) spécifiques qui vivent dans le sous-dossier `src/pages/`. Ils ont la responsabilité de gérer le routage, le chargement de données et la mise en page pour chaque page HTML de votre site web.
 
 ### Routage basé sur les fichiers
 Astro met en place un système de routage basé sur les fichiers. Chaque fichier `.astro` dans le dossier `src/pages` est une page de votre site web, créant une route URL basée sur le chemin du fichier dans le dossier.
 
-📚 Lire plus à propos du [Routage dans Astro](/fr/core-concepts/routing)
+📚 Lire plus à propos du [Routage dans Astro](/fr/core-concepts/routing/)
 
 ### Page HTML
 
@@ -31,7 +31,7 @@ Les pages Astro doivent retourner une réponse complète `<html>...</html>`, inc
 
 ### Mettre en place un Layout de page
 
-Pour éviter de répéter les mêmes éléments HTML sur chaque page, vous pouvez déplacer les éléments communs tels que `<head>` et `<body>` dans vos propres [composants Layout](/fr/core-concepts/layouts). Vous pouvez utiliser autant de composants de layout que vous le souhaitez.
+Pour éviter de répéter les mêmes éléments HTML sur chaque page, vous pouvez déplacer les éléments communs tels que `<head>` et `<body>` dans vos propres [composants Layout](/fr/core-concepts/layouts/). Vous pouvez utiliser autant de composants de layout que vous le souhaitez.
 
 ```astro
 ---
@@ -43,13 +43,13 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 </MySiteLayout>
 ```
 
-📚 Lire plus à propos des [composants Layout](/fr/core-concepts/layouts) dans Astro.
+📚 Lire plus à propos des [composants Layout](/fr/core-concepts/layouts/) dans Astro.
 
 ## Pages Markdown
 
 Astro traite les fichiers Markdown (`.md`) dans le dossier `src/pages/` comme des pages de votre site web. Ces pages sont généralement utilisées pour des pages de blog et de documentation.
 
-Les Layouts sont très utiles pour les [fichiers Markdown](#pages-markdown). Il est possible de définir la variable `layout` dans le _frontmatter_ pour spécifier un [composant Layout](/fr/core-concepts/layouts) qui va englober le contenu Markdown dans un fichier HTML `<html>...</html>` complet.
+Les Layouts sont très utiles pour les [fichiers Markdown](#pages-markdown). Il est possible de définir la variable `layout` dans le _frontmatter_ pour spécifier un [composant Layout](/fr/core-concepts/layouts/) qui va englober le contenu Markdown dans un fichier HTML `<html>...</html>` complet.
 
 ```md
 ---
@@ -62,7 +62,7 @@ title: 'Ma page Markdown'
 Ceci est ma page, écrite en **Markdown.**
 ```
 
-📚 Lire plus à propos du [Markdown](/fr/guides/markdown-content) dans Astro.
+📚 Lire plus à propos du [Markdown](/fr/guides/markdown-content/) dans Astro.
 
 
 ## Pages non-HTML
@@ -120,4 +120,4 @@ export const get: APIRoute = ({ params, request }) => {
 
 Pour une page d'erreur 404 personnalisée, vous pouvez créer un fichier `404.astro` dans `/src/pages`.
 
-Cela va générer une page `404.html`. La plupart des [services de déploiement](/fr/guides/deploy) la trouveront et l'utiliseront.
+Cela va générer une page `404.html`. La plupart des [services de déploiement](/fr/guides/deploy/) la trouveront et l'utiliseront.

--- a/src/pages/fr/core-concepts/astro-pages.md
+++ b/src/pages/fr/core-concepts/astro-pages.md
@@ -78,7 +78,7 @@ En mode SSR (_server-side rendering_) l'extension importe peu et peut être omis
 ```js
 // Example: src/pages/builtwith.json.ts
 // Génères: /builtwith.json
-// Les routes de fichiers doivent exporter une fonction get() qui est appellée et génère le fichier.
+// Les routes de fichiers doivent exporter une fonction get() qui est appelée et génère le fichier.
 // Retournez un objet avec `body` pour sauvegarder le contenu du fichier dans votre build final.
 export async function get() {
   return {


### PR DESCRIPTION
Adding both `core-concepts/astro-components.md` & `core-concepts/astro-pages.md` into the french translation.

Open and ready for review !