### PR TITLE
Fix: Ignore minor updates when determining i18n freshness

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -412,7 +412,7 @@ class GitHubTranslationStatus {
 				content.translations[lang] = {
 					page: i18nPage,
 					isMissing: !i18nPage,
-					isOutdated: i18nPage && sourcePage.lastMajorChange > i18nPage.lastChange,
+					isOutdated: i18nPage && sourcePage.lastMajorChange > i18nPage.lastMajorChange,
 					githubUrl: this.getPageUrl({ lang, subpath }),
 					sourceHistoryUrl: this.getPageUrl({
 						lang: 'en',

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -470,7 +470,7 @@ const githubTranslationStatus = new GitHubTranslationStatus({
 	targetLanguages: ['de', 'es', 'fr', 'ja', 'pt-BR', 'zh-CN'],
 	languageLabels: { de: 'Deutsch', es: 'Español', fr: 'Français', ja: '日本語', 'pt-BR': 'Português do Brasil', 'zh-CN': '简体中文' },
 	githubToken: process.env.GITHUB_TOKEN,
-	githubRepo: process.env.GITHUB_REPOSITORY,
+	githubRepo: process.env.GITHUB_REPOSITORY || 'withastro/docs',
 	githubRefName: process.env.GITHUB_REF_NAME,
 	issueTitle: '[i18n] Translation Status Overview',
 });


### PR DESCRIPTION
Repo-wide search & replace actions like fixing certain broken links could cause outdated translations to be suddenly considered "up to date". This PR fixes this logic and only allows "major" commits to cause a translation to become up to date.

Important: Please edit the summary issue https://github.com/withastro/docs/issues/438 and remove the footer section with the JSON state before merging this PR. This will cause all the i18n page freshness dates to be recalculated. This should also cause the `ja/getting-started.md` page to become outdated again after merging this PR.

I also added an automatic fallback to `withastro/docs` if the `GITHUB_REPOSITORY` env variable is not set, which makes running the script locally to test it more seamless.