### PR TITLE
Feat: Add link checker to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, feat/add-ci-linkcheck]
+    branches: [main]
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-      branches: [main]
+    branches: [main, feat/add-ci-linkcheck]
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:
@@ -12,23 +12,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  slugcheck:
+    name: Check for Mismatched Slugs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2.2.1
+      - name: Install Tools & Dependencies
+        uses: ./.github/actions/install
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Check for mismatched slugs
+      - name: Run Check
         run: pnpm run lint:slugcheck
+  linkcheck:
+    name: Check Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Tools & Dependencies
+        uses: ./.github/actions/install
+
+      - name: Run Check
+        run: pnpm run lint:linkcheck

--- a/scripts/lint-linkcheck.mjs
+++ b/scripts/lint-linkcheck.mjs
@@ -235,7 +235,8 @@ class BrokenLinkChecker {
 
 		// Always output a summary first because GitHub only displays the first 10 annotations
 		const totalLines = annotations.length;
-		core.error(`Found ${totalLines} ${totalLines === 1 ? 'line' : 'lines'} containing broken links in Markdown sources, please check changed files view`);
+		core.error(`Found ${totalLines} ${totalLines === 1 ? 'line' : 'lines'} containing ` +
+			`broken links in Markdown sources, please check changed files view`);
 
 		// Now output all line annotations
 		annotations.forEach(annotation => core.error(annotation.message, annotation.location));

--- a/scripts/lint-linkcheck.mjs
+++ b/scripts/lint-linkcheck.mjs
@@ -191,7 +191,7 @@ class BrokenLinkChecker {
 		const annotations = [];
 
 		// Collect all unique pathnames that had broken links
-		const pathnames = [...new Set(brokenLinks.map(brokenLink => brokenLink.page.pathname))];
+		const pathnames = new Set(brokenLinks.map(brokenLink => brokenLink.page.pathname));
 
 		// Go through the collected pathnames
 		pathnames.forEach(pathname => {
@@ -281,8 +281,8 @@ class BrokenLinkChecker {
 		let i = input.indexOf(href);
 		while (i !== -1) {
 			// Get the characters surrounding the current match (if any)
-			let charBefore = input.substring(i - 1, i);
-			let charAfter = input.substr(i + href.length, 1);
+			let charBefore = input[i - 1] || '';
+			let charAfter = input[i + href.length] || '';
 			// If both characters are not a part of URLs in Markdown,
 			// we have a proper (non-partial) match, so return the index
 			if ((charBefore + charAfter).match(/^[\s"'()[\],.]*$/))
@@ -290,7 +290,7 @@ class BrokenLinkChecker {
 			// Otherwise, keep searching for other matches
 			i = input.indexOf(href, i + 1);
 		}
-		return -1; 
+		return -1;
 	}
 }
 

--- a/scripts/lint-linkcheck.mjs
+++ b/scripts/lint-linkcheck.mjs
@@ -198,7 +198,8 @@ class BrokenLinkChecker {
 		// Go through the collected pathnames
 		pathnames.forEach(pathname => {
 			// Try to find the Markdown source file for the current pathname
-			const sourceFilePath = this.tryFindSourceFileForPathname(pathname);
+			const sourceFilePath = this.tryFindSourceFileForPathname(pathname)
+				.replace(/\\/g, '/');
 
 			// If we could not find the source file, we can't create annotations for it
 			if (!sourceFilePath)
@@ -212,13 +213,16 @@ class BrokenLinkChecker {
 			// including line and column numbers
 			const brokenLinksOnCurrentPage = brokenLinks
 				.filter(brokenLink => brokenLink.page.pathname === pathname);
-			lines.forEach((line, lineNumber) => {
+			lines.forEach((line, idx) => {
+				const lineNumber = idx + 1;
 				brokenLinksOnCurrentPage.forEach(brokenLink => {
 					const startColumn = line.indexOf(brokenLink.unresolvedHref);
 					if (startColumn === -1)
 						return;
 					
-					core.error(`Broken ${brokenLink.isMissingHash ? 'fragment' : 'page'} link: ${brokenLink.href}`, {
+					const message = `Broken ${brokenLink.isMissingHash ? 'fragment' : 'page'} ` +
+						`link in ${sourceFilePath}, line ${lineNumber}: ${brokenLink.href}`;
+					core.error(message, {
 						file: sourceFilePath,
 						startLine: lineNumber,
 						startColumn,


### PR DESCRIPTION
This adds our link checker to the CI workflow. It shows up independently from the slug checker in the PR & push checks.

If any broken links are found, it returns an error code, which causes the CI check to show a red cross. It also attempts to find the Markdown source files containing the broken links and annotates the lines containing the broken links. The annotations can be seen in the "changed files" view of PRs and commits.