### PR TITLE
i18n(de): Add translations for `i18n/de/ui.ts`

### DIFF
--- a/src/i18n/de/ui.ts
+++ b/src/i18n/de/ui.ts
@@ -1,19 +1,42 @@
 import { UIDictionary } from '../translation-checkers';
 
 export default UIDictionary({
+	'a11y.skipLink': 'Zum Inhalt springen',
+	'navbar.a11yTitle': 'Hauptnavigation',
+	// Site settings
+	'site.title': 'Astro-Dokumentation',
+	'site.description': 'Erzeuge schnellere Websites mit weniger ausgeliefertem JavaScript.',
+	'site.og.imageAlt': 'Astro-Logo im Weltraum mit Sternen und einem violetten, Saturn-ähnlichen Planeten rechts im Vordergrund',
+	// Left Sidebar
+	'leftSidebar.a11yTitle': 'Website-Navigation',
 	'leftSidebar.learnTab': 'Lernen',
 	'leftSidebar.referenceTab': 'Referenz',
+	'leftSidebar.noTranslations': 'Keine Übersetzungen gefunden',
+	'leftSidebar.viewInEnglish': 'In Englisch ansehen',
+	// Right Sidebar
+	'rightSidebar.a11yTitle': 'Inhaltsverzeichnis',
 	'rightSidebar.onThisPage': 'Auf dieser Seite',
 	'rightSidebar.overview': 'Überblick',
 	'rightSidebar.more': 'Mehr',
 	'rightSidebar.editPage': 'Bearbeite diese Seite',
 	'rightSidebar.translatePage': 'Übersetze diese Seite',
 	'rightSidebar.joinCommunity': 'Trete unserer Community bei',
+	'rightSidebar.github': 'Astro Docs auf GitHub',
+	// Used in previous/next page links at the bottom of pages
 	'articleNav.nextPage': 'Nächste Seite',
 	'articleNav.prevPage': 'Zurück',
+	// Used in `<Since>`: Added in: v0.24.0 [NEW]
 	'since.addedIn': 'Hinzugefügt in:',
 	'since.new': 'Neu',
+	// Installation Guide
+	'install.autoTab': 'Automatische Installation',
+	'install.manualTab': 'Manuelle Installation',
+	// `<ContributorList>` fallback text
 	'contributors.seeAll': 'Alle Mitwirkenden ansehen',
+	// Fallback content notice shown when a page is not yet translated
+	'fallbackContent.notice': 'Da diese Seite noch nicht auf Deutsch verfügbar ist, siehst du sie auf Englisch. Möchtest du uns helfen?',
+	'fallbackContent.linkText': 'Übersetze diese Seite',
+	// 404 Page
 	'404.title': 'Nicht gefunden',
 	'404.content': 'Diese Seite befindet sich nicht in unserem Sonnensystem.',
 	'404.linkText': 'Bring mich nach Hause.',

--- a/src/i18n/de/ui.ts
+++ b/src/i18n/de/ui.ts
@@ -12,7 +12,7 @@ export default UIDictionary({
 	'leftSidebar.learnTab': 'Lernen',
 	'leftSidebar.referenceTab': 'Referenz',
 	'leftSidebar.noTranslations': 'Keine Übersetzungen gefunden',
-	'leftSidebar.viewInEnglish': 'In Englisch ansehen',
+	'leftSidebar.viewInEnglish': 'Auf Englisch ansehen',
 	// Right Sidebar
 	'rightSidebar.a11yTitle': 'Inhaltsverzeichnis',
 	'rightSidebar.onThisPage': 'Auf dieser Seite',


### PR DESCRIPTION
Adds missing German strings to UI dictionary.