### PR TITLE
Fix: Use canonical URLs in tab group component

### DIFF
--- a/src/components/TabGroup/InstallGuideTabGroup.astro
+++ b/src/components/TabGroup/InstallGuideTabGroup.astro
@@ -8,10 +8,10 @@ const lang = getLanguageFromURL(currentPage);
 const segments = currentPage.split('/');
 ---
 <div class="TabGroup no-flex pull-wide">
-	<a href={`/${lang}/install/auto`} class={segments.includes('auto') ? 'active' : ''}>
+	<a href={`/${lang}/install/auto/`} class={segments.includes('auto') ? 'active' : ''}>
 		<UIString key="install.autoTab" />
 	</a>
-	<a href={`/${lang}/install/manual`} class={segments.includes('manual') ? 'active' : ''}>
+	<a href={`/${lang}/install/manual/`} class={segments.includes('manual') ? 'active' : ''}>
 		<UIString key="install.manualTab" />
 	</a>
 </div>


### PR DESCRIPTION
The tab group component used on the install pages was missing the trailing slash of the pages' canonical URLs, causing an inconsistency with the left sidebar URLs. This PR fixes the inconsistency.