### PR TITLE
Only use gradient background for main scrollbar

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -14,9 +14,13 @@
 }
 
 /* Webkit */
-
+/* Make scrollbars transparent except for main page scrollbar. */
 ::-webkit-scrollbar,
 ::-webkit-scrollbar-track {
+	background-color: transparent;
+}
+body::-webkit-scrollbar,
+body::-webkit-scrollbar-track {
 	/* same as --theme-bg-gradient but without 'fixed' */
 	background: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
 }


### PR DESCRIPTION
This is a follow-up to #426 to resolve the mismatched gradient backgrounds of scrollbars other than the main page scrollbar. (See https://github.com/withastro/docs/pull/426#discussion_r867543794)

Does this look OK for you @Yan-Thomas & @aFuzzyBear?