### PR TITLE
Don’t italicise keywords in syntax highlighter

### DIFF
--- a/syntax-highlighting-theme.ts
+++ b/syntax-highlighting-theme.ts
@@ -149,7 +149,6 @@ export const tokens: IRawThemeSetting[] = [
 		scope: 'keyword',
 		settings: {
 			foreground: red[0],
-			fontStyle: 'italic',
 		},
 	},
 	{


### PR DESCRIPTION
We had a user run into an issue where they mistook `|` for `/` because it was being italicised by our syntax highlighter (see [Discord support thread](https://discord.com/channels/830184174198718474/973143587044864040)). That doesn’t seem great, so I suggest removing that italic styling.

Here’s the offending code sample:

| before | after |
|---|---|
| ![Screen Shot 2022-05-09 at 16 31 49](https://user-images.githubusercontent.com/357379/167432805-637b0b19-562d-47de-8326-b8dc926b08d2.png) | ![Screen Shot 2022-05-09 at 16 30 58](https://user-images.githubusercontent.com/357379/167432693-f04f55f0-98d6-46db-bf5a-3873d2ccafbf.png) |

It does impact elsewhere, like this below. Anyone know if there’s a way to target those things separately?

| before | after |
|---|---|
| ![Screen Shot 2022-05-09 at 16 33 26](https://user-images.githubusercontent.com/357379/167433306-fbb3d3ff-94ac-49ca-96ca-9887802a7b46.png) | ![Screen Shot 2022-05-09 at 16 34 51](https://user-images.githubusercontent.com/357379/167433410-289e9606-1c3e-4c2b-99d2-e51c230011b1.png) |
