### PR TITLE
Use a more targeted npm link for integrations

### DIFF
--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -6,7 +6,7 @@ title: Using Integrations
 i18nReady: true
 ---
 
-**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from [npm](https://www.npmjs.com/). 
+**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from [npm](https://www.npmjs.com/search?q=keywords%3Aastro-component&ranking=popularity). 
 
 - Unlock React, Vue, Svelte, Solid, and other popular UI frameworks.
 - Integrate tools like Tailwind, Turbolinks, and Partytown with a few lines of code.


### PR DESCRIPTION
Instead of linking to the npm front page, this changes the integrations guide link to use a targeted search for the recommended astro integration keyword (`astro-component`): https://www.npmjs.com/search?q=keywords:astro-component&ranking=popularity

Thoughts on whether that is helpful?