### PR TITLE
Feat: Add links to translated pages in status table

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -329,8 +329,8 @@ class GitHubTranslationStatus {
 				if (translation.isMissing)
 					return '<span title="Missing">❌</span>';
 				if (translation.isOutdated)
-					return '<span title="Needs updating">🔄</span>';
-				return '<span title="Completed">✔</span>';
+					return `<a href="${translation.githubUrl}" title="Needs updating">🔄</a>`;
+				return `<a href="${translation.githubUrl}" title="Completed">✔</a>`;
 			}));
 			lines.push(`| ${cols.join(' | ')} |`);
 		});

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -383,12 +383,12 @@ class GitHubTranslationStatus {
 	 * @param {string} lang Language tag to create page for
 	 * @param {string} filename Subpath of page to create
 	 */
-	renderCreatePageButton(lang, filename) {
+	renderCreatePageButton (lang, filename) {
 		// We include `lang` twice because GitHub eats the last path segment when setting filename.
 		const createUrl = new URL(`https://github.com/withastro/docs/new/main/src/pages/${lang}`);
 		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\nlayout: ~/layouts/MainLayout.astro\ntitle:\ndescription:\n---\n');
-		return `[**\`Create page +\`**](${createUrl.href})`;
+		return `[**\`Create\xa0page\xa0+\`**](${createUrl.href})`;
 	}
 
 	getTranslationStatusByContent ({ pages }) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -418,7 +418,7 @@ class GitHubTranslationStatus {
 						lang: 'en',
 						subpath,
 						type: 'commits',
-						query: i18nPage ? `?since=${i18nPage.lastChange}` : '',
+						query: i18nPage ? `?since=${i18nPage.lastMajorChange}` : '',
 					}),
 				};
 			});


### PR DESCRIPTION
Did you ever wish you could quickly jump to any existing translation right from the `Translation status by content` table in our [translation status overview issue](https://github.com/withastro/docs/issues/438)?

Well, today's your lucky day, because this PR adds that feature! No more clicks on 🔄 and ✔ symbols that do nothing - now they take you to the translated page!

Oh, and I've also made some previously invisible non-breaking spaces more visible to stop eslint from yelling at me. And fixed a bug that could cause links to the source change history for outdated translations to start at the wrong date.