### PR TITLE
Don’t convert “--” to “—”

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
 		remarkPlugins: [
 			// These are here because setting custom plugins disables the default plugins
 			'remark-gfm',
-			'remark-smartypants',
+			['remark-smartypants', { dashes: false }],
 		],
 		rehypePlugins: [
 			'rehype-slug',


### PR DESCRIPTION
Disable `remark-smartypants`’s `dashes` option so that `--` is preserved (important for CLI flags for example.)