### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
+
+#### Changes
+
+- What does this PR change? Give us a brief description.
+- Did you change something visual? A before/after screenshot can be helpful.
+- Is this a minor change like fixing a link or a typo?  
+  Include `minor`, `broken link` or `typo` in the PR title
+- Is this a translation PR? Consider pinging your i18n-gang on Discord for a review.
+- Not on Discord? Join us at https://astro.build/chat
+
+<!--
+Here’s what will happen next:
+
+1. Our GitHub bots will run to check your changes.
+   If they spot any broken links you will see some error messages on this PR.
+   Don’t hesitate to ask any questions if you’re not sure what these mean!
+
+2. You’ll be able to see a preview of you changes on Netlify 🥳
+
+3. One or more of our maintainers will take a look and may ask you to make changes.
+   We try to be responsive, but don’t worry if this takes a day or two.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,9 @@
 - Did you change something visual? A before/after screenshot can be helpful.
 - Is this change small enough not to impact translation work?
   If so, please include `minor`, `broken link` or `typo` in the PR title
-- Is this a translation PR? Consider pinging your i18n-gang on Discord for a review.
+- Is this a translation PR?  
+  - It’s helpful to title your PR something like “i18n(lang): PR description”
+  - Consider pinging your i18n-gang on Discord for a review.
 - Not on Discord? Join us at https://astro.build/chat
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,6 @@
 
 - What does this PR change? Give us a brief description.
 - Did you change something visual? A before/after screenshot can be helpful.
-- Is this change small enough not to impact translation work?
-  If so, please include `minor`, `broken link` or `typo` in the PR title
-- Is this a translation PR?  
-  - It’s helpful to title your PR something like “i18n(lang): PR description”
-  - Consider pinging your i18n-gang on Discord for a review.
-- Not on Discord? Join us at https://astro.build/chat
 
 <!--
 Here’s what will happen next:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,15 @@
 <!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
 
-#### Changes
+#### What kind of changes does this PR include?
+<!-- Place an X in the [ ] for any of these that apply -->
+
+- [ ] Minor content fixes (broken links, typos, etc.)
+- [ ] New or updated content
+- [ ] Translated content
+- [ ] Changes to the docs site code
+- [ ] Something else!
+
+#### Description
 
 - What does this PR change? Give us a brief description.
 - Did you change something visual? A before/after screenshot can be helpful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - What does this PR change? Give us a brief description.
 - Did you change something visual? A before/after screenshot can be helpful.
-- Is this change small enough not impact translation work?
+- Is this change small enough not to impact translation work?
   Include `minor`, `broken link` or `typo` in the PR title
 - Is this a translation PR? Consider pinging your i18n-gang on Discord for a review.
 - Not on Discord? Join us at https://astro.build/chat

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 - What does this PR change? Give us a brief description.
 - Did you change something visual? A before/after screenshot can be helpful.
 - Is this change small enough not to impact translation work?
-  Include `minor`, `broken link` or `typo` in the PR title
+  If so, please include `minor`, `broken link` or `typo` in the PR title
 - Is this a translation PR? Consider pinging your i18n-gang on Discord for a review.
 - Not on Discord? Join us at https://astro.build/chat
 
@@ -16,7 +16,7 @@ Here’s what will happen next:
    If they spot any broken links you will see some error messages on this PR.
    Don’t hesitate to ask any questions if you’re not sure what these mean!
 
-2. You’ll be able to see a preview of you changes on Netlify 🥳
+2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
 
 3. One or more of our maintainers will take a look and may ask you to make changes.
    We try to be responsive, but don’t worry if this takes a day or two.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - What does this PR change? Give us a brief description.
 - Did you change something visual? A before/after screenshot can be helpful.
-- Is this a minor change like fixing a link or a typo?  
+- Is this change small enough not impact translation work?
   Include `minor`, `broken link` or `typo` in the PR title
 - Is this a translation PR? Consider pinging your i18n-gang on Discord for a review.
 - Not on Discord? Join us at https://astro.build/chat


### PR DESCRIPTION
This PR suggests adding a template that will be used to pre-fill the PR description when someone opens a new one. It includes some advice and information based on various things that have come up in discussion recently.

What else would it be useful to mention here? Could anything be clearer? And does anything feel superfluous so we can slim this down?