### PR TITLE
i18n(pt-BR): Fix typo on `install/auto.md`

### DIFF
--- a/src/pages/pt-BR/install/auto.md
+++ b/src/pages/pt-BR/install/auto.md
@@ -139,7 +139,7 @@ Para iniciar a hospedagem gratuita do seu site, conheça o nosso parceiro de hos
 
 ## Próximos Passos
 
-Succeso! Agora você está pronto para começar a desenvolver!
+Sucesso! Agora você está pronto para começar a desenvolver!
 
 📚 Aprenda mais sobre a estrutura de projetos Astro em nosso [Guia de Estrutura de Projeto](/pt-BR/core-concepts/project-structure).
 


### PR DESCRIPTION
Spotted by @victor0x16 

Typo: `succeso` -> `sucesso`