### PR TITLE
Feat: Allow skipping issue search by configuring issue number

### DIFF
--- a/.github/workflows/translation-status.yml
+++ b/.github/workflows/translation-status.yml
@@ -36,3 +36,4 @@ jobs:
         run: pnpm run github:translation-status
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: 438

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -21,6 +21,7 @@ class GitHubTranslationStatus {
 		githubRepo,
 		githubRefName,
 		issueTitle,
+		issueNumber,
 	}) {
 		this.pageSourceDir = pageSourceDir;
 		this.sourceLanguage = sourceLanguage;
@@ -30,6 +31,8 @@ class GitHubTranslationStatus {
 		this.githubRepo = githubRepo;
 		this.githubRefName = githubRefName;
 		this.issueTitle = issueTitle;
+		/** Optional, issue search is skipped if provided */
+		this.issueNumber = issueNumber;
 		this.git = simpleGit();
 
 		if (!this.githubToken) {
@@ -140,28 +143,49 @@ class GitHubTranslationStatus {
 	}
 
 	async tryGetExistingIssue () {
-		const foundIssues = await issues.search({
-			repo: this.githubRepo,
-			title: this.issueTitle,
-			githubToken: this.githubToken,
-		});
-		let issueNumber = foundIssues &&
-			foundIssues.length > 0 &&
-			foundIssues[0].number || 0;
+		let issueNumber = this.issueNumber;
 
-		// Get the issue directly to avoid caching issues with the search result
-		// (search may return a slightly outdated version of the issue)
+		// If no valid-looking issue number was configured in the GitHub workflow,
+		// try to find it by searching for the issue title
+		if (!(issueNumber > 0)) {
+			let foundIssues = await issues.search({
+				repo: this.githubRepo,
+				title: this.issueTitle,
+				githubToken: this.githubToken,
+			});
+			issueNumber = foundIssues &&
+				foundIssues.length > 0 &&
+				foundIssues[0].number || 0;
+		}
+
+		// If we have an issue number at this point, retrieve its contents
 		const issue = issueNumber > 0 && await issues.get({
 			repo: this.githubRepo,
 			issueNumber,
 			githubToken: this.githubToken,
 		});
-		let issueBody = issue && issue.body || '';
+		const issueBody = issue && issue.body || '';
+
+		// Safety check: If the issue number was configured in the GitHub workflow,
+		// ensure that the retrieved issue actually has the expected title
+		// to avoid updating the wrong issue
+		if (this.issueNumber > 0 && issue.title !== this.issueTitle)
+			throw new Error(dedentMd`
+				The configured GitHub issue #${issueNumber} does not match the expected title
+				(expected="${this.issueTitle}", actual="${issue.title}").
+				
+				Please ensure that the env variable ISSUE_NUMBER in the GitHub workflow is correct.
+				If the number is correct and you've changed the issue title, you can add/update
+				the ISSUE_TITLE env variable.`);
 
 		if (issueNumber > 0) {
-			output.debug(`Found existing issue #${issueNumber} with title "${issue.title}"`);
+			output.debug(dedentMd`
+				${this.issueNumber > 0 ? 'Using configured' : 'Found existing'}
+				issue #${issueNumber} with title "${issue.title}"`);
 		} else {
-			output.warning(`Didn't find an issue matching title "${this.issueTitle}", will need to create a new one`);
+			output.warning(dedentMd`
+				Didn't find an issue matching title "${this.issueTitle}",
+				will need to create a new one`);
 		}
 
 		return {
@@ -472,7 +496,8 @@ const githubTranslationStatus = new GitHubTranslationStatus({
 	githubToken: process.env.GITHUB_TOKEN,
 	githubRepo: process.env.GITHUB_REPOSITORY || 'withastro/docs',
 	githubRefName: process.env.GITHUB_REF_NAME,
-	issueTitle: '[i18n] Translation Status Overview',
+	issueTitle: process.env.ISSUE_TITLE || '[i18n] Translation Status Overview',
+	issueNumber: parseInt(process.env.ISSUE_NUMBER) || 0,
 });
 
 githubTranslationStatus.update();


### PR DESCRIPTION
This PR adds support for two new optional env variables to the translation status script:
- `ISSUE_NUMBER`: If set, the script skips the issue search and uses the given issue number. If this optional env variable is set in the workflow and the referenced issue is not found, the script will throw an error and abort.
- `ISSUE_TITLE`: I'm making this configurable through env variables as well in case we want to change the issue title in the future. This is especially important because the script validates the issue title to avoid accidentally changing the wrong issue.

I'm also updating the workflow to set the new `ISSUE_NUMBER` env variable to our existing issue #438. This should hopefully reduce the amount of rate limiting that occurs in our workflow.