### PR TITLE
Fix: Make translation status work again in forks

### DIFF
--- a/.github/workflows/translation-status.yml
+++ b/.github/workflows/translation-status.yml
@@ -36,4 +36,4 @@ jobs:
         run: pnpm run github:translation-status
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: 438
+          ISSUE_NUMBER: ${{ github.repository_owner == 'withastro' && 438 || 0 }}


### PR DESCRIPTION
My previous commit that added a fixed issue number to the translation status workflow caused workflow runs in forks to fail because an issue with number 438 does not exist there.

This PR fixes that by checking the repository owner and only using our hardcoded issue number if it's `withastro`. Workflow runs in forks will revert to the previous behavior which searches for the correct issue number based on the issue title.