### PR TITLE
Adding more accurate information about client side scripts

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -348,9 +348,13 @@ They can be used to style your components, and all style rules are automatically
 
 To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
 
-By default, `<script>` tags are hoisted and `type="module"`. They will be placed in the `<head>` of the document and will be bundled with your imports. This is useful for sending client-side scripts to the browser that are not tied to a specific component.
+By default, `<script>` tags are processed by Astro.
 
-> ⚠️ TypeScript support is not currently available for client-side scripts, but we [are discussing](https://github.com/withastro/rfcs/discussions/193) adding this feature.
+- Any imports will be bundled, allowing you to import local files or Node modules.
+- The processed script will be injected into your page’s `<head>` with `type="module"`.
+- If your component is used several times on a page, the script tag will only be included once.
+
+> ⚠️ You can’t currently write TypeScript in client-side scripts, but you _can_ import a Typescript file if you prefer writing with that syntax.
 
 ```astro
 <script>
@@ -369,7 +373,7 @@ To avoid bundling the script, you can use the `is:inline` attribute.
 
 Multiple `<script>` tags can be used on the same Astro component with methods above.
 
-> **Note :** Adding `type="module"` or any other attribute to the `<script>` tag will prevent it from being bundled by Astro.
+> **Note:** Adding `type="module"` or any other attribute to a `<script>` tag will cause it to be treated as if it had an `is:inline` directive and remove the default behavior, disabling bundling for the tag.
 
 📚 See our [directives reference](/en/reference/directives-reference#script--style-directives) page for more information about the directives available on `<script>` tags.
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -348,7 +348,7 @@ They can be used to style your components, and all style rules are automatically
 
 To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
 
-By default, the `<script>` tag will be placed in the `<head>` of the document and will be bundled with your imports. This is useful for sending client-side scripts to the browser that are not tied to a specific component.
+By default, `<script>` tags are hoisted and `type="module"`. They will be placed in the `<head>` of the document and will be bundled with your imports. This is useful for sending client-side scripts to the browser that are not tied to a specific component.
 
 > ⚠️ TypeScript support is not currently available for client-side scripts. Please a look at the [RFC](https://github.com/withastro/rfcs/discussions/193) for more information on the status of this feature.
 
@@ -358,19 +358,12 @@ By default, the `<script>` tag will be placed in the `<head>` of the document an
 </script>
 ```
 
-In some cases, you may avoid bundling the script and using it as it is via the `is:inline` attribute. Or even inject one or more variables from your component script into a `<script>` tag using the `define:vars` attribute.
+In some cases, you may avoid bundling the script and using it as it is via the `is:inline` attribute.
 
 ```astro
 <script is:inline>
   // Will be rendered into the HTML exactly as written!
   // ESM imports will not be resolved relative to the file.
-</script>
-
-<script define:vars={{someVar: 'foo', title: 'Hello world'}}>
-  // Astro will automatically inject the variables defined above into the script.
-  console.log(someVar);
-
-  document.getElementById('title').textContent = title;
 </script>
 ```
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -371,7 +371,7 @@ To avoid bundling the script, you can use the `is:inline` attribute.
 </script>
 ```
 
-Multiple `<script>` tags can be used on the same Astro component with methods above.
+Multiple `<script>` tags can be used in the same `.astro` file using any combination of the methods above.
 
 > **Note:** Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -348,18 +348,37 @@ They can be used to style your components, and all style rules are automatically
 
 To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
 
+By default, the `<script>` tag will be placed in the `<head>` of the document and will be bundled with your imports. This is useful for sending client-side scripts to the browser that are not tied to a specific component.
+
+> ⚠️ TypeScript support is not currently available for client-side scripts. Please a look at the [RFC](https://github.com/withastro/rfcs/discussions/193) for more information on the status of this feature.
+
 ```astro
 <script>
   // Processed! Bundled! ESM imports work, even to npm packages.
 </script>
+```
 
+In some cases, you may avoid bundling the script and using it as it is via the `is:inline` attribute. Or even inject one or more variables from your component script into a `<script>` tag using the `define:vars` attribute.
+
+```astro
 <script is:inline>
   // Will be rendered into the HTML exactly as written!
   // ESM imports will not be resolved relative to the file.
 </script>
+
+<script define:vars={{someVar: 'foo', title: 'Hello world'}}>
+  // Astro will automatically inject the variables defined above into the script.
+  console.log(someVar);
+
+  document.getElementById('title').textContent = title;
+</script>
 ```
 
-📚 See our [directives reference](/en/reference/directives-reference#script--style-directives) page for more information about the directives available  on `<script>` tags.
+Multiple `<script>` tags can be used on the same Astro page with methods above.
+
+> **Note :** Adding `type="module"` or any other attribute to the `<script>` tag will prevent it from being bundled by Astro.
+
+📚 See our [directives reference](/en/reference/directives-reference#script--style-directives) page for more information about the directives available on `<script>` tags.
 
 #### Loading External Scripts
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -374,7 +374,7 @@ In some cases, you may avoid bundling the script and using it as it is via the `
 </script>
 ```
 
-Multiple `<script>` tags can be used on the same Astro page with methods above.
+Multiple `<script>` tags can be used on the same Astro component with methods above.
 
 > **Note :** Adding `type="module"` or any other attribute to the `<script>` tag will prevent it from being bundled by Astro.
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -351,7 +351,7 @@ To send JavaScript to the browser without [using a framework component](/en/core
 By default, `<script>` tags are processed by Astro.
 
 - Any imports will be bundled, allowing you to import local files or Node modules.
-- The processed script will be injected into your page’s `<head>` with `type="module"`.
+- The processed script will be injected into your page’s `<head>` with [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 - If your component is used several times on a page, the script tag will only be included once.
 
 > ⚠️ You can’t currently write TypeScript in client-side scripts, but you _can_ import a Typescript file if you prefer writing with that syntax.

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -358,7 +358,7 @@ By default, `<script>` tags are hoisted and `type="module"`. They will be placed
 </script>
 ```
 
-In some cases, you may avoid bundling the script and using it as it is via the `is:inline` attribute.
+To avoid bundling the script, you can use the `is:inline` attribute.
 
 ```astro
 <script is:inline>

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -350,7 +350,7 @@ To send JavaScript to the browser without [using a framework component](/en/core
 
 By default, `<script>` tags are hoisted and `type="module"`. They will be placed in the `<head>` of the document and will be bundled with your imports. This is useful for sending client-side scripts to the browser that are not tied to a specific component.
 
-> ⚠️ TypeScript support is not currently available for client-side scripts. Please a look at the [RFC](https://github.com/withastro/rfcs/discussions/193) for more information on the status of this feature.
+> ⚠️ TypeScript support is not currently available for client-side scripts, but we [are discussing](https://github.com/withastro/rfcs/discussions/193) adding this feature.
 
 ```astro
 <script>

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -373,7 +373,7 @@ To avoid bundling the script, you can use the `is:inline` attribute.
 
 Multiple `<script>` tags can be used on the same Astro component with methods above.
 
-> **Note:** Adding `type="module"` or any other attribute to a `<script>` tag will cause it to be treated as if it had an `is:inline` directive and remove the default behavior, disabling bundling for the tag.
+> **Note:** Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
 
 📚 See our [directives reference](/en/reference/directives-reference#script--style-directives) page for more information about the directives available on `<script>` tags.
 


### PR DESCRIPTION
Adding more information regarding #521 

Including:

- Typescript support status with RFC link
- Script behavior depending of being `is:inline` or with `define:vars` attribute
- Exemples added for a better understanding
- Mention of multiple `<script>` tags on the same component not being an issue
- Note about defining other attribute than directives ones will break the bundling