### PR TITLE
Use language-specific link from docs logo

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -46,7 +46,7 @@ const t = useTranslations(Astro);
 					></path>
 				</svg>
 			</a>
-			<a href={new URL((lang || '') + '/', Astro.site).href}>
+			<a href={`/${lang || 'en'}/getting-started/`}>
 				<h1 class="sr-only">Docs</h1>
 				<svg xmlns="http://www.w3.org/2000/svg" width="226" height="102" viewBox="0 0 226 102" fill="none">
 					<path

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -46,7 +46,7 @@ const t = useTranslations(Astro);
 					></path>
 				</svg>
 			</a>
-			<a href="https://docs.astro.build/">
+			<a href={new URL((lang || '') + '/', Astro.site).href}>
 				<h1 class="sr-only">Docs</h1>
 				<svg xmlns="http://www.w3.org/2000/svg" width="226" height="102" viewBox="0 0 226 102" fill="none">
 					<path


### PR DESCRIPTION
The docs logo at the top-left currently always links to `https://docs.astro.build/` which gets redirected to the English version of the docs. This change means that we link to the current language, e.g. `https://docs.astro.build/fr/` to keep users on their current language if they use that link.

H/T to @hippotastic for spotting this.