### PR TITLE
perf(a11y): add searchbox role

### DIFF
--- a/src/components/Header/Search.tsx
+++ b/src/components/Header/Search.tsx
@@ -49,9 +49,7 @@ export default function Search({ lang = 'en', labels }: Props) {
 					<path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
 				</svg>
 				<span className="search-placeholder">{labels.button} <span class="sr-only">({labels.shortcutLabel})</span></span>
-				<span className="search-hint" role="searchbox" aria-label={labels.shortcutLabel}>
-					<kbd aria-hidden="true">/</kbd>
-				</span>
+				<span className="search-hint"><kbd aria-hidden="true">/</kbd></span>
 			</button>
 			{isOpen &&
 				createPortal(

--- a/src/components/Header/Search.tsx
+++ b/src/components/Header/Search.tsx
@@ -48,7 +48,7 @@ export default function Search({ lang = 'en', labels }: Props) {
 				<svg width="24" height="24" fill="none" role="presentation">
 					<path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
 				</svg>
-				<span className="search-placeholder">{labels.button}</span>
+				<span className="search-placeholder">{labels.button} <span class="sr-only">({labels.shortcutLabel})</span></span>
 				<span className="search-hint" role="searchbox" aria-label={labels.shortcutLabel}>
 					<kbd aria-hidden="true">/</kbd>
 				</span>

--- a/src/components/Header/Search.tsx
+++ b/src/components/Header/Search.tsx
@@ -49,7 +49,7 @@ export default function Search({ lang = 'en', labels }: Props) {
 					<path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
 				</svg>
 				<span className="search-placeholder">{labels.button}</span>
-				<span className="search-hint" aria-label={labels.shortcutLabel}>
+				<span className="search-hint" role="searchbox" aria-label={labels.shortcutLabel}>
 					<kbd aria-hidden="true">/</kbd>
 				</span>
 			</button>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [x] Something else!

#### Description

Aria-label attribute cann't be used on a span with no valid role attribute. So I add `searchbox` role for it.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
