### PR TITLE
Debugging page no longer i18nReady

### DIFF
--- a/src/pages/en/guides/debugging.md
+++ b/src/pages/en/guides/debugging.md
@@ -2,7 +2,6 @@
 layout: ~/layouts/MainLayout.astro
 title: Debugging
 description: Debug in Astro using the Debug component
-i18nReady: true
 ---
 
 Astro provides several different tools to help you debug your code easier and faster.


### PR DESCRIPTION
Removes i18nReady: true from this Debugging page until we figure out what we want to call it and where it goes.
