### PR TITLE
minor: adding end-slashes when needed

### DIFF
--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -5,18 +5,18 @@ description: Comparing Astro with other static site generators like Gatsby, Next
 i18nReady: true
 ---
 <!-- TODO: UNcomment out the parts re: number of bytes of JS etc, once we decide which values/markers we'd like to use here. -->
-We often get asked the question, "How does Astro compare to my favorite project, **\_\_\_\_**?" 
+We often get asked the question, "How does Astro compare to my favorite project, **\_\_\_\_**?"
 
 This guide was written to help answer that question for several popular site builders and Astro alternatives.
 
 Two key features make Astro different from most alternatives:
 
-- [Partial hydration](/en/core-concepts/partial-hydration)
-- [Use your favorite framework(s)](/en/core-concepts/framework-components)
+- [Partial hydration](/en/core-concepts/partial-hydration/)
+- [Use your favorite framework(s)](/en/core-concepts/framework-components/)
 
 For more details, you can see our in-depth comparisons on this page.
 
-If you don't see your favorite site builder listed here, [ask us in Discord](https://astro.build/chat).
+If you don't see your favorite site builder listed here, [ask us in Discord](https://astro.build/chat/).
 
 ## Docusaurus vs. Astro
 
@@ -26,7 +26,7 @@ Docusaurus was designed to build documentation websites and has some built-in, d
 
 #### Comparing Docusaurus vs. Astro Performance
 
-In most cases, Astro websites will load significantly faster than Docusaurus websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load significantly faster than Docusaurus websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 Docusaurus doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. There is no way to disable this behavior in Docusaurus.
 
@@ -37,7 +37,7 @@ Docusaurus doesn't support partial hydration, and instead makes the user load an
 - **Docusaurus performance score**: 53 out of 100 [(full audit)](/lighthouse/docusaurus/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
 
-<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [docusaurus.io/docs](https://docusaurus.io/docs) loads **238kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (67% less JavaScript, overall) _after_ first load.) -->
+<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [docusaurus.io/docs](https://docusaurus.io/docs) loads **238kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build/) loads **78.7kb** (67% less JavaScript, overall) _after_ first load.) -->
 
 ## Elder.js vs. Astro
 
@@ -45,9 +45,9 @@ Docusaurus doesn't support partial hydration, and instead makes the user load an
 
 Elder.js uses Svelte to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro’s HTML-like component syntax which is similar to HTML + JSX.
 
-Elder.js is unique on this list as the only other site builder to support [partial hydration](/en/core-concepts/partial-hydration). Both Astro and Elder.js automatically strip unnecessary JavaScript from the page, hydrating only the individual components that need it. Elder’s API for partial hydration is a bit different and Astro supports a few features that Elder.js doesn't (like `client:media`). However performance-wise, both projects will build very similar sites.
+Elder.js is unique on this list as the only other site builder to support [partial hydration](/en/core-concepts/partial-hydration/). Both Astro and Elder.js automatically strip unnecessary JavaScript from the page, hydrating only the individual components that need it. Elder’s API for partial hydration is a bit different and Astro supports a few features that Elder.js doesn't (like `client:media`). However performance-wise, both projects will build very similar sites.
 
-Elder.js uses a custom routing solution that may feel unfamiliar to new developers. Astro uses [file-based routing](/en/core-concepts/routing) which should feel familiar to anyone coming from Next.js, SvelteKit, and even other static site builders like Eleventy.
+Elder.js uses a custom routing solution that may feel unfamiliar to new developers. Astro uses [file-based routing](/en/core-concepts/routing/) which should feel familiar to anyone coming from Next.js, SvelteKit, and even other static site builders like Eleventy.
 
 Elder.js was designed to run on large websites, and claims to build one website of ~20k pages in less than 10 minutes (on a modest VM). At the time of writing, Astro builds ~1k pages in 66 seconds but has not yet been tested on 20k+ page projects.
 
@@ -65,7 +65,7 @@ Conceptually, Eleventy is aligned with Astro’s "minimal client-side JavaScript
 
 Eleventy achieves this by pushing you to avoid JavaScript entirely. Eleventy sites are often written with little to no JavaScript at all. This becomes an issue when you do need client-side JavaScript. It is up to you to create your own asset build pipeline for Eleventy. This can be time consuming and forces you to set up bundling, minification, and other complex optimizations yourself.
 
-By contrast, Astro automatically builds your client-side JavaScript & CSS for you. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration). While it is possible to achieve this yourself in Eleventy, Astro offers it built in by default.
+By contrast, Astro automatically builds your client-side JavaScript & CSS for you. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/). While it is possible to achieve this yourself in Eleventy, Astro offers it built in by default.
 
 #### Case Study: Building a Documentation Website
 
@@ -86,7 +86,7 @@ Gatsby requires a custom GraphQL API for working with all of your site content. 
 
 #### Comparing Gatsby vs. Astro Performance
 
-In most cases, Astro websites will load significantly faster than Gatsby websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load significantly faster than Gatsby websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 Gatsby doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. Gatsby has [a community plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-no-javascript/) for removing all JavaScript from the page, but this would break many websites. This leaves you with an all-or-nothing decision for interactivity on each page.
 
@@ -99,7 +99,7 @@ Gatsby has a great plugin ecosystem, while Astro's [collections of integrations]
 - **Gatsby performance score**: 46 out of 100 [(full audit)](/lighthouse/gatsby/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
 
-<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [gatsbyjs.com/docs](https://www.gatsbyjs.com/docs/quick-start/) loads **417kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (81% less JavaScript, overall) _after_ first load. -->
+<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [gatsbyjs.com/docs](https://www.gatsbyjs.com/docs/quick-start/) loads **417kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build/) loads **78.7kb** (81% less JavaScript, overall) _after_ first load. -->
 
 ## Hugo vs. Astro
 
@@ -111,7 +111,7 @@ Hugo uses a custom [templating language](https://gohugo.io/templates/introductio
 
 Conceptually, Hugo is aligned with Astro’s "minimal client-side JavaScript" approach to web development. Hugo and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 
-Both Hugo and Astro offers built-in support for building, bundling and minifying JavaScript. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration). While it is possible to achieve this yourself in Hugo, Astro offers it built in by default.
+Both Hugo and Astro offers built-in support for building, bundling and minifying JavaScript. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/). While it is possible to achieve this yourself in Hugo, Astro offers it built in by default.
 
 #### Case Study: Building a Documentation Website
 
@@ -154,7 +154,7 @@ SvelteKit supports both Static Site Generation (SSG) and Server-Side Rendering (
 
 #### Comparing SvelteKit vs. Astro Performance
 
-In most cases, Astro websites will load faster than SvelteKit websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load faster than SvelteKit websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 SvelteKit doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. SvelteKit does offer support for [page-level static, zero-JavaScript pages](https://kit.svelte.dev/docs#ssr-and-javascript-hydrate). However, there is no planned support for hydrating individual components on the page. This leaves you with an all-or-nothing decision for interactivity on each page.
 
@@ -181,7 +181,7 @@ Next.js supports both Static Site Generation (SSG) and Server-Side Rendering (SS
 
 #### Comparing Next.js vs. Astro Performance
 
-In most cases, Astro websites will load significantly faster than Next.js websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load significantly faster than Next.js websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 Next.js doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. Next.js has [experimental support](https://piccalil.li/blog/new-year-new-website/#heading-no-client-side-react-code) for fully-static, zero-JavaScript pages. However, there is no planned support for hydrating individual components on the page. This leaves you with an all-or-nothing decision for interactivity on each page.
 
@@ -194,7 +194,7 @@ Next.js has great built-in image optimizations. While Astro does not have a comp
 - **Next.js performance score**: 71 out of 100 [(full audit)](/lighthouse/next/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
 
-<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [nextjs.org/docs](https://nextjs.org/docs/getting-started) loads **463kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (83% less JavaScript, overall) _after_ first load. -->
+<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [nextjs.org/docs](https://nextjs.org/docs/getting-started) loads **463kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build/) loads **78.7kb** (83% less JavaScript, overall) _after_ first load. -->
 
 ## Nuxt vs. Astro
 
@@ -208,7 +208,7 @@ Nuxt supports both Static Site Generation (SSG) and Server-Side Rendering (SSR).
 
 #### Comparing Nuxt vs. Astro Performance
 
-In most cases, Astro websites will load significantly faster than Nuxt websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load significantly faster than Nuxt websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 Nuxt doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. There is no way to disable this behavior in Nuxt.
 
@@ -221,11 +221,11 @@ Nuxt has great built-in image optimizations. While Astro does not have a compara
 - **Nuxt performance score**: 50 out of 100 [(full audit)](/lighthouse/nuxt/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
 
-<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [nuxtjs.org/docs](https://nuxtjs.org/docs/2.x/get-started/installation) loads **469kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (83% less JavaScript), _after_ first load. -->
+<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [nuxtjs.org/docs](https://nuxtjs.org/docs/2.x/get-started/installation) loads **469kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build/) loads **78.7kb** (83% less JavaScript), _after_ first load. -->
 
 ## Remix vs. Astro
 
-[Remix](https://remix.run) is a React framework based on React Router.
+[Remix](https://remix.run/) is a React framework based on React Router.
 
 Remix uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro’s HTML-like component syntax which is similar to HTML + JSX.
 
@@ -248,7 +248,7 @@ Evan You (creator of Vue.js) is currently working on a new version of Vuepress c
 
 #### Comparing VuePress vs. Astro Performance
 
-In most cases, Astro websites will load significantly faster than VuePress websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration).
+In most cases, Astro websites will load significantly faster than VuePress websites. This is because Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/).
 
 VuePress doesn't support partial hydration, and instead makes the user load and rehydrate the entire page in the browser, even if most of the page content is static. This creates a slower page load and worse performance for your website. There is no way to disable this behavior in VuePress.
 
@@ -259,7 +259,7 @@ VuePress doesn't support partial hydration, and instead makes the user load and 
 - **Vuepress performance score**: 67 out of 100 [(full audit)](/lighthouse/vuepress/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
 
-<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [vuepress.vuejs.org](https://vuepress.vuejs.org/guide/) loads **166kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build) loads **78.7kb** (53% less JavaScript, overall) _after_ first load. -->
+<!-- One big reason behind this performance difference is Astro’s smaller JavaScript payload: [vuepress.vuejs.org](https://vuepress.vuejs.org/guide/) loads **166kb** of JavaScript on first page load while [docs.astro.build](https://docs.astro.build/) loads **78.7kb** (53% less JavaScript, overall) _after_ first load. -->
 
 ## Zola vs. Astro
 
@@ -271,11 +271,11 @@ Zola uses [Tera](https://tera.netlify.app/) to render your website. Astro lets y
 
 Conceptually, Zola is aligned with Astro’s "minimal client-side JavaScript" approach to web development. Zola and Astro both offer similar, zero-JavaScript-by-default performance baselines.
 
-Astro offers built-in support for building, bundling and minifying JavaScript. Zola requires using another build tool like Webpack to bundle and process JavaScript. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration). While it is possible to achieve this yourself in Zola, Astro offers it built in by default.
+Astro offers built-in support for building, bundling and minifying JavaScript. Zola requires using another build tool like Webpack to bundle and process JavaScript. Astro automatically strips unnecessary JavaScript from the page, hydrating only the individual components that need it. This feature is called [partial hydration](/en/core-concepts/partial-hydration/). While it is possible to achieve this yourself in Zola, Astro offers it built in by default.
 
 #### Case Study: Building a Documentation Website
 
-[getzola.org/documentation](https://getzola.org/documentation) is the official Zola documentation website, built with Zola. The website offers a similar enough design and feature set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders.
+[getzola.org/documentation](https://www.getzola.org/documentation/getting-started/overview/) is the official Zola documentation website, built with Zola. The website offers a similar enough design and feature set to compare against the official Astro documentation website. This gives us a **_rough, real-world_** comparison between the two site builders.
 
 - **Zola performance score**: 91 out of 100 [(full audit)](/lighthouse/zola/)
 - **Astro performance score**: 92 out of 100 [(full audit)](/lighthouse/astro/)
@@ -295,7 +295,7 @@ Astro component syntax is a superset of HTML. It was designed to feel familiar t
 | Boolean Attributes           | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}` |
 | Inline Functions             | `{items.map(item => <li>{item}</li>)}`  | `{items.map(item => <li>{item}</li>)}` |
 | Conditional Rendering             | `{condition &&  <p>text<p>}`  | `{condition &&  <p>text<p>}` |
-| IDE Support                  | [VS Code (incl. Open VSX), Nova](/en/editor-setup) | Phenomenal |
+| IDE Support                  | [VS Code (incl. Open VSX), Nova](/en/editor-setup/) | Phenomenal |
 | Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
 | Fragments                    | Automatic top-level, `<Fragment>` or `<>` inside functions | Wrap with `<Fragment>` or `<>` |
 | Multiple frameworks per-file | Yes | No |

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -342,11 +342,11 @@ They can be used to style your components, and all style rules are automatically
 
 > ⚠️ The styles defined here apply only to content written directly in the component's own component template. Children, and any imported components will **not** be styled by default.
 
-📚 See our [Styling Guide](/en/guides/styling) for more information on applying styles.
+📚 See our [Styling Guide](/en/guides/styling/) for more information on applying styles.
 
 ### Client-Side Scripts
 
-To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
+To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
 
 By default, `<script>` tags are processed by Astro.
 
@@ -375,7 +375,7 @@ Multiple `<script>` tags can be used in the same `.astro` file using any combina
 
 > **Note:** Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
 
-📚 See our [directives reference](/en/reference/directives-reference#script--style-directives) page for more information about the directives available on `<script>` tags.
+📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.
 
 #### Loading External Scripts
 

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -5,13 +5,13 @@ description: An introduction to Astro pages
 i18nReady: true
 ---
 
-**Pages** are a special type of [Astro component](/en/core-concepts/astro-components) that live in the `src/pages/` subdirectory. They are responsible for handling routing, data loading, and overall page layout for every HTML page in your website.
+**Pages** are a special type of [Astro component](/en/core-concepts/astro-components/) that live in the `src/pages/` subdirectory. They are responsible for handling routing, data loading, and overall page layout for every HTML page in your website.
 
 ### File-based routing
 
 Astro leverages a routing strategy called **file-based routing.** Every `.astro` file in your `src/pages` directory becomes a page or an endpoint on your site based on its file path.
 
-📚 Read more about [Routing in Astro](/en/core-concepts/routing)
+📚 Read more about [Routing in Astro](/en/core-concepts/routing/)
 
 ### Page HTML
 
@@ -33,7 +33,7 @@ Astro Pages must return a full `<html>...</html>` page response, including `<hea
 
 ### Leveraging Page Layouts
 
-To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [layout components](/en/core-concepts/layouts). You can use as many or as few layout components as you'd like.
+To avoid repeating the same HTML elements on every page, you can move common `<head>` and `<body>` elements into your own [layout components](/en/core-concepts/layouts/). You can use as many or as few layout components as you'd like.
 
 ```astro
 ---
@@ -45,14 +45,14 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 </MySiteLayout>
 ```
 
-📚 Read more about [layout components](/en/core-concepts/layouts) in Astro.
+📚 Read more about [layout components](/en/core-concepts/layouts/) in Astro.
 
 
 ## Markdown Pages
 
-Astro also treats any Markdown (`.md`) files inside of `/src/pages/` as pages in your final website. These are commonly used for text-heavy pages like blog posts and documentation. 
+Astro also treats any Markdown (`.md`) files inside of `/src/pages/` as pages in your final website. These are commonly used for text-heavy pages like blog posts and documentation.
 
-Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layouts) that will wrap their Markdown content in a full `<html>...</html>` page document. 
+Page layouts are especially useful for [Markdown files.](#markdown-pages) Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layouts/) that will wrap their Markdown content in a full `<html>...</html>` page document.
 
 ```md
 ---
@@ -65,12 +65,12 @@ title: 'My Markdown page'
 This is my page, written in **Markdown.**
 ```
 
-📚 Read more about [Markdown](/en/guides/markdown-content) in Astro.
+📚 Read more about [Markdown](/en/guides/markdown-content/) in Astro.
 
 
 ## Non-HTML Pages
 
-Non-HTML pages, like `.json` or `.xml`, or even assets such as images, can be built using API routes commonly referred to as **File Routes**. 
+Non-HTML pages, like `.json` or `.xml`, or even assets such as images, can be built using API routes commonly referred to as **File Routes**.
 
 **File Routes** are script files that end with the `.js` or `.ts` extension and are located within the `src/pages/` directory.
 
@@ -124,6 +124,6 @@ export const get: APIRoute = ({ params, request }) => {
 
 ## Custom 404 Error Page
 
-For a custom 404 error page, you can create a `404.astro` file in `/src/pages`. 
+For a custom 404 error page, you can create a `404.astro` file in `/src/pages`.
 
-This will build to a `404.html` page. Most [deploy services](/en/guides/deploy) will find and use it.
+This will build to a `404.html` page. Most [deploy services](/en/guides/deploy/) will find and use it.

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -4,9 +4,9 @@ title: Framework Components
 description: Learn how to use React, Svelte, etc.
 i18nReady: true
 ---
-Build your Astro website without sacrificing your favorite component framework. 
+Build your Astro website without sacrificing your favorite component framework.
 
-Astro supports a variety of popular frameworks including [React](https://reactjs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Vue](https://vuejs.org/), [SolidJS](https://www.solidjs.com/), [AlpineJS](https://alpinejs.dev/) and [Lit](https://lit.dev/). 
+Astro supports a variety of popular frameworks including [React](https://reactjs.org/), [Preact](https://preactjs.com/), [Svelte](https://svelte.dev/), [Vue](https://vuejs.org/), [SolidJS](https://www.solidjs.com/), [AlpineJS](https://alpinejs.dev/) and [Lit](https://lit.dev/).
 
 ## Installing Integrations
 
@@ -35,15 +35,15 @@ export default defineConfig({
 });
 ```
 
-⚙️ View the [Integrations Guide](/en/guides/integrations-guide) for more details on installing and configuring Astro integrations.
+⚙️ View the [Integrations Guide](/en/guides/integrations-guide/) for more details on installing and configuring Astro integrations.
 
-⚙️ Want to see an example for the framework of your choice? Visit [astro.new](https://astro.new) and select one of the framework templates.
+⚙️ Want to see an example for the framework of your choice? Visit [astro.new](https://astro.new/) and select one of the framework templates.
 
 ## Using Framework Components
 
 Use your JavaScript framework components in your Astro pages, layouts and components just like Astro components! All your components can live together in `/src/components`, or can be organized in any way you like.
 
-To use a framework component, import it from its relative path (including file extension) in your Astro component script. Then, use the component alongside other components, HTML elements and JSX-like expressions in the component template. 
+To use a framework component, import it from its relative path (including file extension) in your Astro component script. Then, use the component alongside other components, HTML elements and JSX-like expressions in the component template.
 
 ```astro
 ---
@@ -78,7 +78,7 @@ import InteractiveCounter from '../components/InteractiveCounter.jsx';
 <!-- This component's JS will begin importing when the page loads -->
 <InteractiveButton client:load />
 
-<!-- This component's JS will not be sent to the client until 
+<!-- This component's JS will not be sent to the client until
 the user scrolls down and the component is visible on the page -->
 <InteractiveCounter client:visible />
 ```
@@ -89,7 +89,7 @@ the user scrolls down and the component is visible on the page -->
 
 There are serveral hydration directives available for UI framework components: `client:load`, `client:idle`, `client:visible`, `client:media={QUERY}` and `client:only=" "`.
 
-📚 See our [directives reference](/en/reference/directives-reference#client-directives) page for a full description of these hydration directives, and their usage.
+📚 See our [directives reference](/en/reference/directives-reference/#client-directives) page for a full description of these hydration directives, and their usage.
 
 ## Mixing Frameworks
 
@@ -131,7 +131,7 @@ import MySvelteButton from '../components/MySvelteButton.svelte';
 
 This allows you to build entire "apps" in your preferred JavaScript framework and render them, via a parent component, to an Astro page. This is a convenient pattern to allow related components to share state or context.
 
-Each framework has its own patterns for nesting: `children` props and [render props](https://reactjs.org/docs/render-props.html) for React and Solid; `<slot />` with or without names for Svelte and Vue, for example. 
+Each framework has its own patterns for nesting: `children` props and [render props](https://reactjs.org/docs/render-props.html) for React and Solid; `<slot />` with or without names for Svelte and Vue, for example.
 
 Note, however, that you can't pass render props or named slots to a framework component from a `.astro` file, even if the framework component supports it. This is due to a limitation in Astro's compiler.
 
@@ -139,10 +139,10 @@ Note, however, that you can't pass render props or named slots to a framework co
 
  If you try to hydrate an Astro component with a `client:` modifier, you will get an error.
 
-[Astro components](/en/core-concepts/astro-components) are HTML-only templating components with no client-side runtime. But, you can use a `<script>` tag in your Astro component template to send JavaScript to the browser that executes in the global scope.
+[Astro components](/en/core-concepts/astro-components/) are HTML-only templating components with no client-side runtime. But, you can use a `<script>` tag in your Astro component template to send JavaScript to the browser that executes in the global scope.
 
 
-📚 Learn more about [client-side `<scripts>` in Astro components](/en/core-concepts/astro-components#client-side-scripts) 
+📚 Learn more about [client-side `<scripts>` in Astro components](/en/core-concepts/astro-components/#client-side-scripts)
 
 
 [mdn-io]: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -5,9 +5,9 @@ description: An intro to layouts, a type of Astro component that is shared betwe
 i18nReady: true
 ---
 
-**Layouts** are a special type of [Astro component](/en/core-concepts/astro-components) useful for creating reusable page templates. 
+**Layouts** are a special type of [Astro component](/en/core-concepts/astro-components/) useful for creating reusable page templates.
 
-A layout component is conventionally used to provide an [`.astro` or `.md` page](/en/core-concepts/astro-pages) both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot />` to specify where in the layout page content should be injected.
+A layout component is conventionally used to provide an [`.astro` or `.md` page](/en/core-concepts/astro-pages/) both a **page shell** (`<html>`, `<head>` and `<body>` tags) and a `<slot />` to specify where in the layout page content should be injected.
 
 Layouts often provide common `<head>` elements and common UI elements for the page such as headers, navigation bars and footers.
 
@@ -47,7 +47,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 ```
 
 
-📚 Learn more about [slots](/en/core-concepts/astro-components#slots).
+📚 Learn more about [slots](/en/core-concepts/astro-components/#slots).
 
 
 ## Nesting Layouts
@@ -71,7 +71,7 @@ const {content} = Astro.props;
 
 ## Markdown Layouts
 
-Page layouts are especially useful for [Markdown files.](/en/guides/markdown-content#markdown-pages) Markdown files can use the special `layout` front matter property to specify a layout component that will wrap their Markdown content in a full page HTML document. 
+Page layouts are especially useful for [Markdown files.](/en/guides/markdown-content/#markdown-pages) Markdown files can use the special `layout` front matter property to specify a layout component that will wrap their Markdown content in a full page HTML document.
 
 When a Markdown page uses a layout, it passes the layout a single `content` prop that includes all of the Markdown front matter data and final HTML output.  See the `BlogPostLayout.astro` example above for an example of how you would use this `content` prop in your layout component.
 
@@ -86,4 +86,4 @@ layout: ../layouts/BlogPostLayout.astro
 This is a post written in Markdown.
 ```
 
-📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content).
+📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content/).

--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -50,12 +50,12 @@ A common project directory might look like this:
 
 The src folder is where most of your project source code lives. This includes:
 
-- [Pages](/en/core-concepts/astro-pages)
-- [Layouts](/en/core-concepts/layouts)
-- [Astro components](/en/core-concepts/astro-components)
-- [Frontend components (React, etc.)](/en/core-concepts/framework-components)
-- [Styles (CSS, Sass)](/en/guides/styling)
-- [Markdown](/en/guides/markdown-content)
+- [Pages](/en/core-concepts/astro-pages/)
+- [Layouts](/en/core-concepts/layouts/)
+- [Astro components](/en/core-concepts/astro-components/)
+- [Frontend components (React, etc.)](/en/core-concepts/framework-components/)
+- [Styles (CSS, Sass)](/en/guides/styling/)
+- [Markdown](/en/guides/markdown-content/)
 
 Astro processes, optimizes, and bundles your `src/` files to create the final website that is shipped to the browser.  Unlike the static `public/` directory, your `src/` files are built and handled for you by Astro.
 
@@ -63,19 +63,19 @@ Some files (like Astro components) are not even sent to the browser as written, 
 
 ### `src/components`
 
-**Components** are reusable units of code for your HTML pages. These could be [Astro components](/en/core-concepts/astro-components), or [Frontend components](/en/core-concepts/framework-components) like React or Vue.  It is common to group and organize all of your project components together in this folder.
+**Components** are reusable units of code for your HTML pages. These could be [Astro components](/en/core-concepts/astro-components/), or [Frontend components](/en/core-concepts/framework-components/) like React or Vue.  It is common to group and organize all of your project components together in this folder.
 
 This is a common convention in Astro projects, but it is not required. Feel free to organize your components however you like!
 
 ### `src/layouts`
 
-[Layouts](/en/core-concepts/layouts) are special kind of component that wrap some content in a larger page layout. These are most often used by [Astro pages](/en/core-concepts/astro-pages) and [Markdown pages](/en/guides/markdown-content) to define the layout of the page.
+[Layouts](/en/core-concepts/layouts/) are special kind of component that wrap some content in a larger page layout. These are most often used by [Astro pages](/en/core-concepts/astro-pages/) and [Markdown pages](/en/guides/markdown-content/) to define the layout of the page.
 
 Just like `src/components`, this directory is a common convention but not required.
 
 ### `src/pages`
 
-[Pages](/en/core-concepts/astro-pages) are special kind of component used to create new pages on your site. A page can be an Astro component, or a Markdown file that represents some page of content for your site.
+[Pages](/en/core-concepts/astro-pages/) are special kind of component used to create new pages on your site. A page can be an Astro component, or a Markdown file that represents some page of content for your site.
 
 > ⚠️  `src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!
 
@@ -97,10 +97,10 @@ You can place CSS and JavaScript in your `public/` directory, but be aware that 
 
 This is a file used by JavaScript package managers to manage your dependencies. It also defines the scripts that are commonly used to run Astro (ex: `npm start`, `npm run build`).
 
-For help creating a new `package.json` file for your project, check out the [manual setup](/en/install/manual) instructions.
+For help creating a new `package.json` file for your project, check out the [manual setup](/en/install/manual/) instructions.
 
 ### `astro.config.mjs`
 
 This file is generated in every starter template and includes configuration options for your Astro project. Here you can specify integrations to use, build options, server options, and more.
 
-See the [Configuration Reference](https://docs.astro.build/en/reference/configuration-reference/#article) for details on setting configurations.
+See the [Configuration Reference](/en/reference/configuration-reference/#article) for details on setting configurations.

--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -9,7 +9,7 @@ Astro uses **file-based routing** to generate your build URLs based on the file 
 
 ## Static routes
 
-Astro Components (`.astro`) and Markdown Files (`.md`) in the `src/pages` directory **automatically become pages on your website**. Each page’s route corresponds to its path and filename within the `src/pages` directory. 
+Astro Components (`.astro`) and Markdown Files (`.md`) in the `src/pages` directory **automatically become pages on your website**. Each page’s route corresponds to its path and filename within the `src/pages` directory.
 
 ```bash
 # Example: Static routes
@@ -28,7 +28,7 @@ A single Astro Page component can also specify dynamic route parameters in its f
 
 > 💡 Even dynamically-created pages and routes are generated at build time.
 
-Astro pages that create dynamic routes must: 
+Astro pages that create dynamic routes must:
 
 1. use `[bracket]` notation to identify the dynamic parameters
 
@@ -37,7 +37,7 @@ Astro pages that create dynamic routes must:
 
 ### Named Parameters
 
-You can generate routes with a `[named]` parameter by providing your `getStaticPaths()` function the values to use like so: 
+You can generate routes with a `[named]` parameter by providing your `getStaticPaths()` function the values to use like so:
 
 ```astro
 ---
@@ -56,7 +56,7 @@ export function getStaticPaths() {
 ---
 ```
 
-📚 Learn more about [`getStaticPaths()`](/en/reference/api-reference#getstaticpaths).
+📚 Learn more about [`getStaticPaths()`](/en/reference/api-reference/#getstaticpaths).
 
 Routes can be generated from multiple named parameters, at any level of the filepath:
 
@@ -80,7 +80,7 @@ const { id } = Astro.params;
 { "id": "abc" }
 ```
 
-Multiple dynamic route segments can be combined to work the same way. 
+Multiple dynamic route segments can be combined to work the same way.
 
 ```astro
 ---
@@ -94,7 +94,7 @@ const { id, comment } = Astro.params;
 
 ### Rest parameters
 
-If you need more flexibility in your URL routing, you can use a rest parameter in your `.astro` filename as a universal catch-all for file paths of any depth by adding three dots (`...`) inside your brackets. 
+If you need more flexibility in your URL routing, you can use a rest parameter in your `.astro` filename as a universal catch-all for file paths of any depth by adding three dots (`...`) inside your brackets.
 
 For example:
 
@@ -179,7 +179,7 @@ Pagination is useful when you need to generate multiple, numbered pages from a l
 
 ### The `page` prop
 
-When you use the `paginate()` function, each page in the collection will be passed its data via a `page` prop. The `page` prop has several useful properties, but the most important one is `page.data`. This is the array containing the page’s slice of data that you passed to the `paginate()` function. 
+When you use the `paginate()` function, each page in the collection will be passed its data via a `page` prop. The `page` prop has several useful properties, but the most important one is `page.data`. This is the array containing the page’s slice of data that you passed to the `paginate()` function.
 
 ```astro
 ---
@@ -235,7 +235,7 @@ For example, if you want to group your paginated Markdown posts by some tag, you
 - `/blue/1` (tag=blue)
 - `/green/1` (tag=green)
 
-Nested pagination works by returning an array of `paginate()` results from `getStaticPaths()`, one for each grouping. 
+Nested pagination works by returning an array of `paginate()` results from `getStaticPaths()`, one for each grouping.
 
 In the following example, we will implement nested pagination to build the URLs listed above:
 

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -11,7 +11,7 @@ Customize your code editor to improve the Astro developer experience and unlock 
 
 ## VS Code
 
-[VS Code](https://code.visualstudio.com) is a popular code editor for web developers, built by Microsoft. The VS Code engine also powers popular in-browser code editors like [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io).
+[VS Code](https://code.visualstudio.com/) is a popular code editor for web developers, built by Microsoft. The VS Code engine also powers popular in-browser code editors like [GitHub Codespaces](https://github.com/features/codespaces) and [Gitpod](https://gitpod.io/).
 
 Astro works with any code editor. However, VS Code is our recommended editor for Astro projects. We maintain an official [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) that unlocks several key features and developer experience improvements for Astro projects.
 
@@ -34,6 +34,6 @@ Our amazing community maintains several extensions for other popular editors, in
 
 In addition to local editors, Astro also runs well on in-browser hosted editors, including:
 
-- [StackBlitz](https://stackblitz.com) and [CodeSandbox](https://codesandbox.io) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
-- [GitHub.dev](https://github.dev) - allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
-- [Gitpod](https://gitpod.io) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.
+- [StackBlitz](https://stackblitz.com/) and [CodeSandbox](https://codesandbox.io/) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
+- [GitHub.dev](https://github.dev/) - allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
+- [Gitpod](https://gitpod.io/) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -10,7 +10,7 @@ i18nReady: true
 Static Site Generator  🚀  Bring your own Framework  🚀  Ship Less JavaScript
 
 
-> Have an older project? Follow the [migration guide](/en/migrate) to upgrade to v1.0 beta!
+> Have an older project? Follow the [migration guide](/en/migrate/) to upgrade to v1.0 beta!
 
 
 ## Try Astro
@@ -19,7 +19,7 @@ We've made it as easy as possible to get started with Astro either in your brows
 
 ### Online Playgrounds
 
-Visit [astro.new](https://astro.new) for the easiest way to "try before you buy." Choose from a variety of starter templates and start building a full, working version of Astro right in your browser!
+Visit [astro.new](https://astro.new/) for the easiest way to "try before you buy." Choose from a variety of starter templates and start building a full, working version of Astro right in your browser!
 
 Or, **instantly launch our basic starter project** with just one click of a button:
 
@@ -48,7 +48,7 @@ yarn create astro
 pnpm create astro@latest
 ```
 
-⚙️ Our [Installation Guide](/en/install/auto) has full, step-by-step instructions for installing Astro with your favourite package manager.
+⚙️ Our [Installation Guide](/en/install/auto/) has full, step-by-step instructions for installing Astro with your favourite package manager.
 
 ⚙️ See instructions for [manual setup](/en/install/manual/) instead.
 
@@ -57,11 +57,11 @@ pnpm create astro@latest
 
 Jump right in and add some content and features to your site!
 
-🏗️ Add new [Astro (.astro) pages](/en/core-concepts/astro-pages) and/or [Markdown (.md) pages](/en/guides/markdown-content) to your site.
+🏗️ Add new [Astro (.astro) pages](/en/core-concepts/astro-pages/) and/or [Markdown (.md) pages](/en/guides/markdown-content/) to your site.
 
-🏗️ Create your first [Layout](/en/core-concepts/layouts).
+🏗️ Create your first [Layout](/en/core-concepts/layouts/).
 
-🏗️ Add additional [CSS and styling](/en/guides/styling) to your site. 
+🏗️ Add additional [CSS and styling](/en/guides/styling/) to your site.
 
 *... check out even more under **Features***
 
@@ -71,30 +71,30 @@ Jump right in and add some content and features to your site!
 
 See examples of some of the key concepts and patterns of an Astro site!
 
-📚 Read more about Astro’s [project structure](/en/core-concepts/project-structure).
+📚 Read more about Astro’s [project structure](/en/core-concepts/project-structure/).
 
-📚 Learn about Astro's [template directives](/en/reference/directives-reference).
+📚 Learn about Astro's [template directives](/en/reference/directives-reference/).
 
-📚 Explore Astro’s [runtime API](/en/reference/api-reference).
+📚 Explore Astro’s [runtime API](/en/reference/api-reference/).
 
 *... find more material under **Reference***
 
 
 ## Extend Astro
 
-🧰 Start your next project with a [prebuilt theme](https://astro.build/themes)
+🧰 Start your next project with a [prebuilt theme](https://astro.build/themes/)
 
 🧰 Customize your site with official and community [plugins and components](https://astro.build/integrations/).
 
-🧰 Get inspired by visiting our [site showcase](https://astro.build/showcase).
+🧰 Get inspired by visiting our [site showcase](https://astro.build/showcase/).
 
-*... see our [guide to using integrations](/en/guides/integrations-guide)*
+*... see our [guide to using integrations](/en/guides/integrations-guide/)*
 
 
 
 ## Join our Community
 
-Join us in the [Astro Discord](https://astro.build/chat) to share with and get help from an active, friendly community!
+Join us in the [Astro Discord](https://astro.build/chat/) to share with and get help from an active, friendly community!
 
 💬 Say hi in our `#introduce-yourself` channel!
 
@@ -109,7 +109,7 @@ Join us in the [Astro Discord](https://astro.build/chat) to share with and get h
 
 [Astro changelog](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)
 
-[Astro Migration guide](/en/migrate)
+[Astro Migration guide](/en/migrate/)
 
 
 ## Contribute

--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -9,7 +9,7 @@ i18nReady: true
 
 ## `fetch()` in Astro
 
-All [Astro components](/en/core-concepts/astro-components) have access to the [global `fetch()` function](https://developer.mozilla.org/en-US/docs/Web/API/fetch) in their component script to make HTTP requests to APIs. This fetch call will be executed at build time, and the data will be available to the component template for generating dynamic HTML. 
+All [Astro components](/en/core-concepts/astro-components) have access to the [global `fetch()` function](https://developer.mozilla.org/en-US/docs/Web/API/fetch) in their component script to make HTTP requests to APIs. This fetch call will be executed at build time, and the data will be available to the component template for generating dynamic HTML.
 
 💡 Take advantage of [**top-level await**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) inside of your Astro component script.
 
@@ -36,11 +36,11 @@ const randomUser = data.results[0]
 
 ### GraphQL queries
 
-Astro can also use `fetch()` to query a GraphQL server with any valid GraphQL query. 
+Astro can also use `fetch()` to query a GraphQL server with any valid GraphQL query.
 
 ```astro
 ---
-const response = await fetch("https://graphql-weather-api.herokuapp.com", 
+const response = await fetch("https://graphql-weather-api.herokuapp.com",
   {
     method:'POST',
     headers: {'Content-Type':'application/json'},
@@ -71,13 +71,13 @@ const weather = json.data
 <h2>{weather.getCityByName.name}, {weather.getCityByName.country}</h2>
 <p>Weather: {weather.getCityByName.weather.summary.description}</p>
 ```
-> 💡 Remember, all data in Astro components is fetched when a component is rendered. 
+> 💡 Remember, all data in Astro components is fetched when a component is rendered.
 
-Your deployed Astro site will fetch data **once, at build time**. In dev, you will see data fetches on component refreshes. If you need to re-fetch data multiple times client-side, use a [framework component](/en/core-concepts/framework-components) or a [client-side script](/en/core-concepts/astro-components/#client-side-scripts) in an Astro component. 
+Your deployed Astro site will fetch data **once, at build time**. In dev, you will see data fetches on component refreshes. If you need to re-fetch data multiple times client-side, use a [framework component](/en/core-concepts/framework-components/) or a [client-side script](/en/core-concepts/astro-components/#client-side-scripts) in an Astro component.
 
 ## `fetch()` in Framework Components
 
-The `fetch()` function is also globally available to any [framework components](/en/core-concepts/framework-components):
+The `fetch()` function is also globally available to any [framework components](/en/core-concepts/framework-components/):
 
 ```tsx
 // Movies.tsx

--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -9,7 +9,7 @@ i18nReady: true
 
 ## `fetch()` in Astro
 
-All [Astro components](/en/core-concepts/astro-components) have access to the [global `fetch()` function](https://developer.mozilla.org/en-US/docs/Web/API/fetch) in their component script to make HTTP requests to APIs. This fetch call will be executed at build time, and the data will be available to the component template for generating dynamic HTML.
+All [Astro components](/en/core-concepts/astro-components/) have access to the [global `fetch()` function](https://developer.mozilla.org/en-US/docs/Web/API/fetch) in their component script to make HTTP requests to APIs. This fetch call will be executed at build time, and the data will be available to the component template for generating dynamic HTML.
 
 💡 Take advantage of [**top-level await**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) inside of your Astro component script.
 

--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -6,7 +6,7 @@ description: Multiple different methods to deploy a website with Astro.
 
 The following guides are based on some shared assumptions:
 
-- You are using the default build output location (`dist/`). This location [can be changed using the `dist` configuration option](/en/reference/configuration-reference).
+- You are using the default build output location (`dist/`). This location [can be changed using the `dist` configuration option](/en/reference/configuration-reference/).
 - You are using npm. You can use equivalent commands to run the scripts if you are using Yarn or other package managers.
 - Astro is installed as a local dev dependency in your project, and you have set up the following npm scripts:
 
@@ -215,18 +215,18 @@ Using [`pnpm` on Netlify?](https://answers.netlify.com/t/using-pnpm-and-pnpm-wor
   publish = 'dist'
 ```
 
-Push the new `netlify.toml` file up to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com) for your git repository. Netlify will read this file and automatically configure your deployment.
+Push the new `netlify.toml` file up to your hosted git repository. Then, set up a new project on [Netlify](https://netlify.com/) for your git repository. Netlify will read this file and automatically configure your deployment.
 
 ### Netlify Website UI
 
-You can skip the `netlify.toml` file and go directly to [Netlify](https://netlify.com) to configure your project. Netlify should now detect Astro projects automatically and pre-fill the configuration for you. Make sure that the following settings are entered before hitting the "Deploy" button:
+You can skip the `netlify.toml` file and go directly to [Netlify](https://netlify.com/) to configure your project. Netlify should now detect Astro projects automatically and pre-fill the configuration for you. Make sure that the following settings are entered before hitting the "Deploy" button:
 
 - **Build Command:** `astro build` or `npm run build`
 - **Publish directory:** `dist`
 
 ## Google Cloud
 
-Different from most available deploy options here, [Google Cloud](https://cloud.google.com) requires some UI clicks to deploy projects. (Most of these actions can also be done using the gcloud CLI).
+Different from most available deploy options here, [Google Cloud](https://cloud.google.com/) requires some UI clicks to deploy projects. (Most of these actions can also be done using the gcloud CLI).
 
 ### Cloud Run
 
@@ -299,7 +299,7 @@ You can also deploy to a [custom domain](http://surge.sh/help/adding-a-custom-do
 
 1. Install [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
 
-2. Create a Heroku account by [signing up](https://signup.heroku.com).
+2. Create a Heroku account by [signing up](https://signup.heroku.com/).
 
 3. Run `heroku login` and fill in your Heroku credentials:
 
@@ -346,7 +346,7 @@ You can also deploy to a [custom domain](http://surge.sh/help/adding-a-custom-do
 
 ## Vercel
 
-You can deploy Astro to [Vercel](http://vercel.com) through the CLI or the Vercel git integrations with zero-configuration.
+You can deploy Astro to [Vercel](http://vercel.com/) through the CLI or the Vercel git integrations with zero-configuration.
 
 ### CLI
 
@@ -376,8 +376,8 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 You can deploy your Astro project with Microsoft Azure [Static Web Apps](https://aka.ms/staticwebapps) service. You need:
 
 - An Azure account and a subscription key. You can create a [free Azure account here](https://azure.microsoft.com/free).
-- Your app code pushed to [GitHub](https://github.com).
-- The [SWA Extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) in [Visual Studio Code](https://code.visualstudio.com).
+- Your app code pushed to [GitHub](https://github.com/).
+- The [SWA Extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) in [Visual Studio Code](https://code.visualstudio.com/).
 
 Install the extension in VS Code and navigate to your app root. Open the Static Web Apps extension, sign in to Azure, and click the '+' sign to create a new Static Web App. You will be prompted to designate which subscription key to use.
 
@@ -387,10 +387,10 @@ The action will work to deploy your app (watch its progress in your repo’s Act
 
 ## Cloudflare Pages
 
-You can deploy your Astro project on [Cloudflare Pages](https://pages.cloudflare.com). You need:
+You can deploy your Astro project on [Cloudflare Pages](https://pages.cloudflare.com/). You need:
 
 - A Cloudflare account. If you don’t already have one, you can create a free Cloudflare account during the process.
-- Your app code pushed to a [GitHub](https://github.com) or a [GitLab](https://about.gitlab.com/) repository.
+- Your app code pushed to a [GitHub](https://github.com/) or a [GitLab](https://about.gitlab.com/) repository.
 
 Then, set up a new project on Cloudflare Pages.
 
@@ -399,7 +399,7 @@ Use the following build settings:
 - **Framework preset**: `Astro`
 - **Build command:** `npm run build`
 - **Build output directory:** `dist`
-- **Environment variables (advanced)**: Currently, Cloudflare Pages supports `NODE_VERSION = 12.18.0` in the Pages build environment by default. Astro requires `14.15.0`, `v16.0.0`, or higher. You can add an environment variable with the **Variable name** of `NODE_VERSION` and a **Value** of a [Node version that’s compatible with Astro](/en/install/auto#prerequisites) or by specifying the node version of your project in a `.nvmrc` or `.node-version` file.
+- **Environment variables (advanced)**: Currently, Cloudflare Pages supports `NODE_VERSION = 12.18.0` in the Pages build environment by default. Astro requires `14.15.0`, `v16.0.0`, or higher. You can add an environment variable with the **Variable name** of `NODE_VERSION` and a **Value** of a [Node version that’s compatible with Astro](/en/install/auto/#prerequisites) or by specifying the node version of your project in a `.nvmrc` or `.node-version` file.
 
 Then click the **Save and Deploy** button.
 
@@ -417,7 +417,7 @@ You can deploy your Astro project on [Render](https://render.com/) following the
 
 ## Buddy
 
-You can deploy your Astro project using [Buddy](https://buddy.works). To do so you'll need to:
+You can deploy your Astro project using [Buddy](https://buddy.works/). To do so you'll need to:
 
 1. Create a **Buddy** account [here](https://buddy.works/sign-up).
 2. Create a new project and connect it with a git repository (GitHub, GitLab, BitBucket, any private Git Repository or you can use Buddy Git Hosting).

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -43,7 +43,7 @@ import { getUser } from './user.ts';
 import type { UserType } from './user.ts';
 ```
 
-Astro includes built-in support for [TypeScript](https://www.typescriptlang.org/). You can import `.ts` and `.tsx` files directly in your Astro project, and even write TypeScript code directly inside your [Astro component](/en/core-concepts/astro-components/#the-component-script). 
+Astro includes built-in support for [TypeScript](https://www.typescriptlang.org/). You can import `.ts` and `.tsx` files directly in your Astro project, and even write TypeScript code directly inside your [Astro component](/en/core-concepts/astro-components/#the-component-script).
 
 **Astro doesn't perform any type checking itself.** Type checking should be taken care of outside of Astro, either by your IDE or through a separate script. The [Astro VSCode Extension](/en/editor-setup/) automatically provides TypeScript hints and errors in your open files.
 
@@ -57,7 +57,7 @@ import { MyComponent } from './MyComponent.jsx';
 
 Astro includes built-in support for JSX (`*.jsx` and `*.tsx`) files in your project. JSX syntax is automatically transpiled to JavaScript.
 
-While Astro understands JSX syntax out-of-the-box, you will need to include a framework integration to properly render frameworks like React, Preact and Solid. Check out our [Using Integrations](/en/guides/integrations-guide) guide to learn more.
+While Astro understands JSX syntax out-of-the-box, you will need to include a framework integration to properly render frameworks like React, Preact and Solid. Check out our [Using Integrations](/en/guides/integrations-guide/) guide to learn more.
 
 **Note: Astro does not support JSX in `.js`/`.ts` files.** JSX will only be handled inside of files that end with the `.jsx` and `.tsx` file extensions.
 

--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -6,7 +6,7 @@ title: Using Integrations
 i18nReady: true
 ---
 
-**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from [npm](https://www.npmjs.com/search?q=keywords%3Aastro-component&ranking=popularity). 
+**Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, or grab popular ones from [npm](https://www.npmjs.com/search?q=keywords%3Aastro-component&ranking=popularity).
 
 - Unlock React, Vue, Svelte, Solid, and other popular UI frameworks.
 - Integrate tools like Tailwind, Turbolinks, and Partytown with a few lines of code.
@@ -14,7 +14,7 @@ i18nReady: true
 - Write custom code that hooks into the build process, dev server, and more.
 
 > Integrations are still new, and the API has not yet been finalized. Only official Astro integrations (those published to `@astrojs/` on npm) are currently supported to protect users from breaking changes.
-> 
+>
 > **To enable 3rd-party integrations:** Run Astro with the `--experimental-integrations` CLI flag.
 
 ## Tutorial: Adding React to Your Project
@@ -23,9 +23,9 @@ In this example, we will add the `@astrojs/react` integration to add React suppo
 
 <blockquote>
   <Badge variant="accent">Feeling adventurous?</Badge>
-  
-  Astro recently launched an **experimental** `astro add` command to automate this process! Instead of the steps below, you can run `npx astro add react`. That's it! 
-  
+
+  Astro recently launched an **experimental** `astro add` command to automate this process! Instead of the steps below, you can run `npx astro add react`. That's it!
+
   Skip down to [Automatic Integration Setup](/en/guides/integrations-guide/#automatic-integration-setup) for more details.
 
 </blockquote>
@@ -36,7 +36,7 @@ First, you will need to install both the integration and any related packages th
 npm install --save-dev @astrojs/react
 ```
 
-Once your packages have been installed, add two new lines to your `astro.config.mjs` project configuration file. 
+Once your packages have been installed, add two new lines to your `astro.config.mjs` project configuration file.
 
 ```diff
   // astro.config.mjs
@@ -46,11 +46,11 @@ Once your packages have been installed, add two new lines to your `astro.config.
   export default defineConfig({
 +   integrations: [react()],
   });
-``` 
+```
 
 The first line is the import statement that imports the integration into your configuration file. The second line calls the integration function (`react()`) and adds the integration so that Astro knows to use it.
 
-That's it! Restart Astro, and the new integration should take effect immediately. 
+That's it! Restart Astro, and the new integration should take effect immediately.
 
 If you see an error on startup, make sure that you:
 
@@ -107,9 +107,9 @@ In the future, a helpful `astro add` command will be able to handle all of this 
 
 ## Using Integrations
 
-Astro integrations are always added through the `integrations` property in your  `astro.config.mjs` file. 
+Astro integrations are always added through the `integrations` property in your  `astro.config.mjs` file.
 
-> Want to know more about using or configuring a specific integration? Find it in our [integrations directory](https://astro.build/integrations) and follow the link to its repository on GitHub.
+> Want to know more about using or configuring a specific integration? Find it in our [integrations directory](https://astro.build/integrations/) and follow the link to its repository on GitHub.
 
 There are three common ways to import an integration into your Astro project:
 1. Installing an npm package integration.
@@ -125,7 +125,7 @@ import localIntegration from './my-integration.js';
 export default defineConfig({
   integrations: [
     // 1. Imported from an installed npm package
-    installedIntegration(), 
+    installedIntegration(),
     // 2. Imported from a local JS file
     localIntegration(),
     // 3. An inline object
@@ -134,7 +134,7 @@ export default defineConfig({
 })
 ```
 
-Check out the [Integration API](/en/reference/integrations-reference) reference to learn all of the different ways that you can write an integration.
+Check out the [Integration API](/en/reference/integrations-reference/) reference to learn all of the different ways that you can write an integration.
 
 ### Custom Options
 
@@ -163,4 +163,4 @@ integrations: [
 
 Astro's Integration API is inspired by Rollup and Vite, and designed to feel familiar to anyone who has ever written a Rollup or Vite plugin before.
 
-Check out the [Integration API](/en/reference/integrations-reference) reference to learn what integrations can do and how to write one yourself.
+Check out the [Integration API](/en/reference/integrations-reference/) reference to learn what integrations can do and how to write one yourself.

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -11,11 +11,11 @@ Markdown content is commonly used to author text-heavy content like blog posts a
 
 Astro treats any `.md` file inside of the `/src/pages` directory as a page. Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file.
 
-📚 Read more about Astro's [file-based routing](/en/core-concepts/routing).
+📚 Read more about Astro's [file-based routing](/en/core-concepts/routing/).
 
 ### Basic Example
 
-The easiest way to start using Markdown in Astro is to create a `src/pages/index.md` homepage route in your project. Copy the basic template below into your project, and then view the rendered HTML at the homepage route of your project. Usually, this is at [http://localhost:3000](http://localhost:3000/).
+The easiest way to start using Markdown in Astro is to create a `src/pages/index.md` homepage route in your project. Copy the basic template below into your project, and then view the rendered HTML at the homepage route of your project. Usually, this is at [http://localhost:3000/](http://localhost:3000/).
 
 ```markdown
 ---
@@ -33,7 +33,7 @@ To learn more about adding a layout to your page, read the next section on **Mar
 
 ### Markdown Layouts
 
-Markdown pages have a special frontmatter property for `layout` that defines the relative path to an Astro [layout component](/en/core-concepts/layouts). This component will wrap your Markdown content, providing a page shell and any other included page template elements.
+Markdown pages have a special frontmatter property for `layout` that defines the relative path to an Astro [layout component](/en/core-concepts/layouts/). This component will wrap your Markdown content, providing a page shell and any other included page template elements.
 
 ```markdown
 ---
@@ -44,7 +44,7 @@ layout: ../layouts/BaseLayout.astro
 A typical layout for Markdown pages includes:
 
 1. the content prop to access the Markdown page's frontmatter data.
-2. a default [`<slot />`](/en/core-concepts/astro-components#slots) to indicate where the page's Markdown content should be rendered.
+2. a default [`<slot />`](/en/core-concepts/astro-components/#slots) to indicate where the page's Markdown content should be rendered.
 
 ```astro
 ---
@@ -252,9 +252,9 @@ const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
 
 ## Markdown Component
 
-> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a separate `.md` file and then [`import` Markdown](/en/guides/markdown-content#importing-markdown) into your template as a component.
+> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a separate `.md` file and then [`import` Markdown](/en/guides/markdown-content/#importing-markdown) into your template as a component.
 
-You can import the [built-in Astro Markdown component](/en/reference/api-reference#markdown-) in your component script and then write any Markdown you want between `<Markdown></Markdown>` tags.
+You can import the [built-in Astro Markdown component](/en/reference/api-reference/#markdown-) in your component script and then write any Markdown you want between `<Markdown></Markdown>` tags.
 
 ````astro
 ---

--- a/src/pages/en/guides/publish-to-npm.md
+++ b/src/pages/en/guides/publish-to-npm.md
@@ -117,7 +117,7 @@ We recommend using `"type": "module"` so that your `index.js` can be used as an 
 
 ### `package.json#homepage`
 
-The url to the project homepage. 
+The url to the project homepage.
 
 ```json
 {
@@ -165,7 +165,7 @@ We recommend adding `astro-component` as a special keyword to maximize its disco
 }
 ```
 
-> Keywords are also used by our [integrations library](https://astro.build/integrations)! [See below](#integrations-library) for a full list of keywords we look for in NPM.
+> Keywords are also used by our [integrations library](https://astro.build/integrations/)! [See below](#integrations-library) for a full list of keywords we look for in NPM.
 
 ---
 
@@ -223,7 +223,7 @@ If you are extracting components from an existing project, you can even continue
 
 ## Testing your component
 
-Astro does not currently ship a test runner. This is something that we would like to tackle. _(If you are interested in helping out, [join us on Discord!](https://astro.build/chat))_
+Astro does not currently ship a test runner. This is something that we would like to tackle. _(If you are interested in helping out, [join us on Discord!](https://astro.build/chat/))_
 
 In the meantime, our current recommendation for testing is:
 
@@ -251,7 +251,7 @@ If you need some other file type that isn't natively supported by Astro, you are
 
 ## Integrations Library
 
-Share your hard work by adding your integration to our [integrations library](https://astro.build/integrations)!
+Share your hard work by adding your integration to our [integrations library](https://astro.build/integrations/)!
 
 ### `package.json` data
 
@@ -279,4 +279,4 @@ In addition to the required `astro-component` keyword, special keywords are also
 
 ## Share
 
-We encourage you to share your work, and we really do love seeing what our talented Astronauts create. Come and share what you create with us in our [Discord](https://discord.gg/YQRVveAgED) or mention [@astrodotbuild](https://twitter.com/astrodotbuild) in a Tweet!
+We encourage you to share your work, and we really do love seeing what our talented Astronauts create. Come and share what you create with us in our [Discord](https://astro.build/chat/) or mention [@astrodotbuild](https://twitter.com/astrodotbuild) in a Tweet!

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -24,7 +24,7 @@ pnpm i @astrojs/rss
 
 Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links in your RSS feed [via the `SITE` environment variable](/en/guides/environment-variables/#default-environment-variables).
 
-> Note: The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `site` manually if this isn't possible (see examples below). 
+> Note: The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `site` manually if this isn't possible (see examples below).
 
 Now, let's generate our first RSS feed! Create an `rss.xml.js` file under your `src/pages/` directory. `rss.xml` will be the output URL, so feel free to rename this if you prefer.
 
@@ -79,7 +79,7 @@ See [Vite's glob import documentation](https://vitejs.dev/guide/features.html#gl
 
 #### 2. List of RSS feed objects
 
-We recommend this option for `.md` files outside of the `pages` directory. This is common when generating routes [via `getStaticPaths`](/en/reference/api-reference/#getstaticpaths). 
+We recommend this option for `.md` files outside of the `pages` directory. This is common when generating routes [via `getStaticPaths`](/en/reference/api-reference/#getstaticpaths).
 
 For instance, say your `.md` posts are stored under a `src/posts/` directory. Each post has a `title`, `pubDate`, and `slug` in its frontmatter, where `slug` corresponds to the output URL on your site. We can generate an RSS feed using [Vite's `import.meta.globEager` helper](https://vitejs.dev/guide/features.html#glob-import) like so:
 
@@ -122,7 +122,7 @@ If you don't have an RSS stylesheet in mind, we recommend the [Pretty Feed v3 de
 
 > **Note:** This method has been deprecated, and will be removed before the official `v1.0.0` release. Please use `@astrojs/rss` instead.
 
-You can also create an RSS feed from any Astro page that uses a `getStaticPaths()` function for routing. Only dynamic routes can use `getStaticPaths()` today (see [Routing](/en/core-concepts/routing)).
+You can also create an RSS feed from any Astro page that uses a `getStaticPaths()` function for routing. Only dynamic routes can use `getStaticPaths()` today (see [Routing](/en/core-concepts/routing/)).
 
 Create an RSS Feed by calling the `rss()` function that is passed as an argument to `getStaticPaths()`. This will create an `rss.xml` file in your final build (or whatever you specify using `dest`) based on the data that you provide using the `items` array.
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -21,7 +21,7 @@ Styling an Astro component is as easy as adding a `<style>` tag to your componen
 
 ### Scoped Styles
 
-Astro `<style>` CSS rules are automatically **scoped by default**. Scoped styles are compiled behind-the-scenes to only apply to HTML written inside of that same component. The CSS that you write inside of an Astro component is automatically encapsulated inside of that component. 
+Astro `<style>` CSS rules are automatically **scoped by default**. Scoped styles are compiled behind-the-scenes to only apply to HTML written inside of that same component. The CSS that you write inside of an Astro component is automatically encapsulated inside of that component.
 
 ```diff
 <style>
@@ -32,9 +32,9 @@ Astro `<style>` CSS rules are automatically **scoped by default**. Scoped styles
 </style>
 ```
 
-Scopes styles don't leak and won't impact the rest of your site. In Astro, it is okay to use low-specificity selectors like `h1 {}` or `p {}` because they will be compiled with scopes in the final output. 
+Scopes styles don't leak and won't impact the rest of your site. In Astro, it is okay to use low-specificity selectors like `h1 {}` or `p {}` because they will be compiled with scopes in the final output.
 
-Scoped styles also won't apply to other Astro components contained inside of your template. If you need to style a child component, consider wrapping that component in a `<div>` (or other element) that you can then style. 
+Scoped styles also won't apply to other Astro components contained inside of your template. If you need to style a child component, consider wrapping that component in a `<div>` (or other element) that you can then style.
 #### Global Styles
 
 While we recommend scoped styles for most components, you may eventually find a valid reason to write global, unscoped CSS. You can opt-out of automatic CSS scoping with the `<style is:global>` attribute.
@@ -85,13 +85,13 @@ const backgroundColor = "rgb(24 121 78)";
 <h1>Hello</h1>
 ```
 
-📚 See our [directives reference](/en/reference/directives-reference#definevars) page to learn more about `define:vars`.
+📚 See our [directives reference](/en/reference/directives-reference/#definevars) page to learn more about `define:vars`.
 
 ## External Styles
 
-There are two ways to resolve external global stylesheets: an ESM import for files located within your project source, and an absolute URL link for files in your `public/` directory, or hosted outside of your project. 
+There are two ways to resolve external global stylesheets: an ESM import for files located within your project source, and an absolute URL link for files in your `public/` directory, or hosted outside of your project.
 
-📚 Read more about using [static assets](/en/guides/imports) located in `public/` or `src/`.
+📚 Read more about using [static assets](/en/guides/imports/) located in `public/` or `src/`.
 
 ### Import a Stylesheet
 
@@ -110,7 +110,7 @@ CSS `import` via ESM are supported inside of any JavaScript file, including JSX 
 
 ### Load an External Stylesheet
 
-You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or an URL to an external website. Relative `<link>` href values are not supported. 
+You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or an URL to an external website. Relative `<link>` href values are not supported.
 
 ```html
 <head>
@@ -126,7 +126,7 @@ Because this approach uses the `public/` directory, it skips the normal CSS proc
 
 ## CSS Integrations
 
-Astro comes with support for adding popular CSS libraries, tools and frameworks to your project like [Tailwind][tailwind] and more! 
+Astro comes with support for adding popular CSS libraries, tools and frameworks to your project like [Tailwind][tailwind] and more!
 
 📚 See the [Integrations Guide](/en/guides/integrations-guide/) for instructions on installing, importing and configuring these integrations.
 
@@ -147,7 +147,7 @@ Use  `<style lang="scss">` or `<style lang="sass">` in `.astro` files
 
 ```
 npm install -D stylus
-``` 
+```
 
 Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files
 
@@ -155,7 +155,7 @@ Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files
 
 ```
 npm install -D less
-``` 
+```
 
 Use `<style lang="less">` in `.astro` files.
 
@@ -245,7 +245,7 @@ import stylesUrl from '../styles/main.css?url';
 <link rel="stylesheet" href={stylesUrl}>
 ```
 
-See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details. 
+See [Vite's docs](https://vitejs.dev/guide/assets.html#importing-asset-as-url) for full details.
 
 
 [less]: https://lesscss.org/

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -13,7 +13,7 @@ Astro doesn't perform any type checking itself. Type checking should be taken ca
 
 It is **strongly recommended** that you create a `tsconfig.json` file in your project, so that tools like Astro and VSCode know how to understand your project. Some features (like npm package imports) aren't fully supported in TypeScript without a `tsconfig.json` file.
 
-Some TypeScript configuration options require special attention in Astro. Below is our recommended starter `tsconfig.json` file, which you can copy-and-paste into your own project. Every [astro.new template](https://astro.new) includes this `tsconfig.json` file by default.
+Some TypeScript configuration options require special attention in Astro. Below is our recommended starter `tsconfig.json` file, which you can copy-and-paste into your own project. Every [astro.new template](https://astro.new/) includes this `tsconfig.json` file by default.
 
 ```json
 // Example: starter tsconfig.json for Astro projects
@@ -81,5 +81,5 @@ const { greeting = 'Hello', name } = Astro.props
 ```
 
 
-📚 Read more about [`.ts` file imports](/en/guides/imports#typescript) in Astro.
-📚 Read more about [TypeScript Configuration](https://www.typescriptlang.org/tsconfig).
+📚 Read more about [`.ts` file imports](/en/guides/imports/#typescript) in Astro.
+📚 Read more about [TypeScript Configuration](https://www.typescriptlang.org/tsconfig/).

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -52,10 +52,10 @@ Use the arrow keys (up and down) to navigate to the template you want to install
 ### Install Dependencies (optional)
 The wizard will offer to run an `install` command for you at this time, which is optional.
 
-> ⚠️ If you do not do so at this time, you will need to [install dependencies](/en/install/auto#2-install-dependencies) after the wizard has finished, before starting your project.
+> ⚠️ If you do not do so at this time, you will need to [install dependencies](/en/install/auto/#2-install-dependencies) after the wizard has finished, before starting your project.
 
 ### Install any Official Astro Integrations (optional)
-You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
+You will be given the option at this time to add any [additional UI frameworks](/en/core-concepts/framework-components/) (React, Svelte, Vue, Solid, Preact, Lit) and then other Astro official integrations (Tailwind, Turbolinks, Partytown, Sitemap) by running `astro add --yes`
 
 
 To select which Astro integrations, if any, you would like to include in your project, use the arrow keys (up and down) to navigate and the space bar to toggle between selected states. You can select multiple items at once, or you can continue without selecting any integrations.
@@ -63,7 +63,7 @@ To select which Astro integrations, if any, you would like to include in your pr
 
 When you are satisfied with your selection, press return (enter) to submit.
 
-> These integrations, and any [Astro community integrations](https://astro.build/integrations), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide).
+> These integrations, and any [Astro community integrations](https://astro.build/integrations/), can also be added later by following the instructions in our [integrations guide](/en/guides/integrations-guide/).
 
 
 After selecting your integrations to add, you should see the following terminal message notifying you of the changes that `create-astro` will apply to your project's `astro.config.mjs`:
@@ -117,7 +117,7 @@ yarn start
 pnpm run dev
 ```
 
-If all goes well, Astro should now be serving your project on [http://localhost:3000](http://localhost:3000)!
+If all goes well, Astro should now be serving your project on [http://localhost:3000/](http://localhost:3000/)!
 
 Astro will listen for live file changes in your `src/` directory, so you will not need to restart the server as you make changes during development.
 
@@ -140,14 +140,14 @@ pnpm run build
 
 When the command finishes, you should have a new `dist/` folder in your project that you can deploy directly to your favorite web host.
 
-To get started hosting your website for free, check out our proud hosting partner, [Netlify](https://www.netlify.com/). For instructions on deploying to whatever host you choose, read our detailed [deployment guide](/en/guides/deploy).
+To get started hosting your website for free, check out our proud hosting partner, [Netlify](https://www.netlify.com/). For instructions on deploying to whatever host you choose, read our detailed [deployment guide](/en/guides/deploy/).
 
 ## Next Steps
 
 Success! Now you're ready to start developing!
 
-📚 Learn more about Astro’s project structure in our [Project Structure guide](/en/core-concepts/project-structure).
+📚 Learn more about Astro’s project structure in our [Project Structure guide](/en/core-concepts/project-structure/).
 
-📚 Learn more about Astro’s component syntax in our [Astro Components guide](/en/core-concepts/astro-components).
+📚 Learn more about Astro’s component syntax in our [Astro Components guide](/en/core-concepts/astro-components/).
 
-📚 Learn more about Astro’s file-based routing in our [Routing guide](/en/core-concepts/astro-pages).
+📚 Learn more about Astro’s file-based routing in our [Routing guide](/en/core-concepts/astro-pages/).

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -111,7 +111,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({});
 ```
 
-If you want to include [UI framework components](/en/core-concepts/framework-components/) such as React, Svelte, etc. or use other tools such as Tailwind or Partytown in your project, here is where you will [manually import and configure integrations](/en/guides/integrations-guide).
+If you want to include [UI framework components](/en/core-concepts/framework-components/) such as React, Svelte, etc. or use other tools such as Tailwind or Partytown in your project, here is where you will [manually import and configure integrations](/en/guides/integrations-guide/).
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 
@@ -133,4 +133,4 @@ If you have followed the steps above, your project directory should now look lik
 
 Congratulations, you're now set up to use Astro!
 
-If you followed this guide completely, you can jump directly to [Step 3: Start](/en/install/auto#3-start-astro-) to continue and learn how to run Astro for the first time.
+If you followed this guide completely, you can jump directly to [Step 3: Start](/en/install/auto/#3-start-astro-) to continue and learn how to run Astro for the first time.

--- a/src/pages/en/integrations/integrations.md
+++ b/src/pages/en/integrations/integrations.md
@@ -8,23 +8,23 @@ Members of the Astro community have been successfully integrating several third-
 
 Here are some production sites, repositories, blog posts and videos from the community demonstrating how you can connect Astro with a variety of popular CMS, eCommerce, Authentication/Authorization, Search and Comment technologies.
 
-> Looking for a specific integration? Check out our new [integrations library](https://astro.build/integrations), and learn how to [add your integrations](/en/guides/publish-to-npm/#integrations-library) to the library!
+> Looking for a specific integration? Check out our new [integrations library](https://astro.build/integrations/), and learn how to [add your integrations](/en/guides/publish-to-npm/#integrations-library) to the library!
 
 ## Production Sites
 
-[Replicant Band](https://replicant.band) - Astro / GraphCMS / Snipcart / Tailwind
+[Replicant Band](https://replicant.band/) - Astro / GraphCMS / Snipcart / Tailwind
 
-[Design Buddy](https://design-buddy.netlify.app) - Astro / Tailwind / React / Cloudinary
+[Design Buddy](https://design-buddy.netlify.app/) - Astro / Tailwind / React / Cloudinary
 
-[Spread Bagelry](https://spreadbagelry.com) - Astro / Vue / Tailwind / Strapi CMS / Cloudinary
+[Spread Bagelry](https://spreadbagelry.com/) - Astro / Vue / Tailwind / Strapi CMS / Cloudinary
 
 [Public Transport Forum New Zealand](https://publictransportforum.nz/articles) - Astro / Netlify CMS
 
-[My Workshops Live](https://myworkshops.live) - Astro / Svelte / Firebase / Vonage / Web Speech API / reveal.js
+[My Workshops Live](https://myworkshops.live/) - Astro / Svelte / Firebase / Vonage / Web Speech API / reveal.js
 
 [Rafid Muhymin Wafi](https://softhardsystem.com/) -  Astro / Tailwind / WordPress: Headless CMS, comments, search
 
-[meizuflux](https://meizuflux.com) - Astro / GraphCMS
+[meizuflux](https://meizuflux.com/) - Astro / GraphCMS
 
 [Sarah Rainsberger](https://www.rainsberger.ca/) - Astro / GitHub Giscus (Comments)
 
@@ -55,7 +55,7 @@ Here are some production sites, repositories, blog posts and videos from the com
 
 ## Repositories / Starter Templates
 
-[delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms/) - Astro Starter Template with Netlify CMS
+[delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms) - Astro Starter Template with Netlify CMS
 
 [PhilDL/astro-starter-ghost](https://github.com/PhilDL/astro-starter-ghost) - A starter template for a static blog using Ghost CMS and Astro
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -102,7 +102,7 @@ Read [RFC0018](https://github.com/withastro/rfcs/blob/main/proposals/0018-astro-
 
 ### Astro Integrations
 
-The `renderers` config has been replaced by a new, official integration system! This unlocks some really exciting new features for Astro. You can read our [Using Integrations](/en/guides/integrations-guide) guide for more details on how to use this new system.
+The `renderers` config has been replaced by a new, official integration system! This unlocks some really exciting new features for Astro. You can read our [Using Integrations](/en/guides/integrations-guide/) guide for more details on how to use this new system.
 
 Integrations replace our original `renderers` concept, and come with a few breaking changes and new defaults for existing users. These changes are covered below.
 
@@ -110,7 +110,7 @@ Integrations replace our original `renderers` concept, and come with a few break
 
 Previously, React, Preact, Svelte, and Vue were all included with Astro by default. Starting in v0.25.0, Astro no longer comes with any built-in renderers. If you did not have a `renderers` configuration entry already defined for your project, you will now need to install those frameworks yourself.
 
-Read our [step-by-step walkthrough](/en/guides/integrations-guide) to learn how to add a new Astro integration for the framework(s) that you currently use.
+Read our [step-by-step walkthrough](/en/guides/integrations-guide/) to learn how to add a new Astro integration for the framework(s) that you currently use.
 #### Deprecated: Renderers
 
 > *Read this section if you have custom "renderers" already defined in your configuration file.*
@@ -119,7 +119,7 @@ The new integration system replaces the previous `renderers` system, including t
 
 **To migrate:** update Astro to `v0.25.0` and then run `astro dev` or `astro build` with your old configuration file containing the outdated `"renderers"` config. You will immediately see a notice telling you the exact changes you need to make to your `astro.config.mjs` file, based on your current config. You can also update your packages yourself, using the table below.
 
-For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide) to learn how to replace existing renderers with a new Astro framework integration.
+For a deeper walkthrough, read our [step-by-step guide](/en/guides/integrations-guide/) to learn how to replace existing renderers with a new Astro framework integration.
 
 ```diff
 # Install your new integrations and frameworks:
@@ -180,7 +180,7 @@ import { Prism } from '@astrojs/prism';
 ---
 ```
 
-Since the `@astrojs/prism` package is still bundled with `astro` core, you won't need to install anything new, nor add Prism as an integration! However, note that we _do_ plan to extract `@astrojs/prism` (and Prism syntax highlighting in general) to a separate, installable package in the future. See [the `<Prism />` component API reference](/en/reference/api-reference#prism-) for more.
+Since the `@astrojs/prism` package is still bundled with `astro` core, you won't need to install anything new, nor add Prism as an integration! However, note that we _do_ plan to extract `@astrojs/prism` (and Prism syntax highlighting in general) to a separate, installable package in the future. See [the `<Prism />` component API reference](/en/reference/api-reference/#prism-) for more.
 
 ### CSS Parser Upgrade
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -87,7 +87,7 @@ Other files may have various different interfaces, but `Astro.glob()` accepts a 
 interface CustomDataFile {
   default: Record<string, any>;
 }
-const data = await Astro.glob<CustomDataFile>('../data/**/*.js'); 
+const data = await Astro.glob<CustomDataFile>('../data/**/*.js');
 ---
 ```
 
@@ -458,7 +458,7 @@ Astro includes several built-in components for you to use in your projects. All 
 
 ### `<Markdown />`
 
-> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then [`import` Markdown](/en/guides/markdown-content#importing-markdown) into your template as a component.
+> NOTE: The `<Markdown />` component does not work in SSR and may be removed before v1.0. It should should be avoided if possible. To use Markdown in your templates, use a seperate `.md` file and then [`import` Markdown](/en/guides/markdown-content/#importing-markdown) into your template as a component.
 
 ```astro
 ---
@@ -469,7 +469,7 @@ import { Markdown } from 'astro/components';
 </Markdown>
 ```
 
-See our [Markdown Guide](/en/guides/markdown-content) for more info.
+See our [Markdown Guide](/en/guides/markdown-content/) for more info.
 
 <!-- TODO: We should move some of the specific component info here. -->
 
@@ -500,7 +500,7 @@ import { Prism } from '@astrojs/prism';
 
 > **`@astrojs/prism`** is built-in as part of the `astro` package. No need to install as a separate dependency just yet! However, note that we do plan to extract `@astrojs/prism` to a separate, installable package in the future.
 
-This component provides language-specific syntax highlighting for code blocks by applying Prism's CSS classes. Note that **you need to provide a Prism CSS stylesheet** (or bring your own) for syntax highlighting to appear! See the [Prism configuration section](/en/guides/markdown-content#prism-configuration) for more details.
+This component provides language-specific syntax highlighting for code blocks by applying Prism's CSS classes. Note that **you need to provide a Prism CSS stylesheet** (or bring your own) for syntax highlighting to appear! See the [Prism configuration section](/en/guides/markdown-content/#prism-configuration) for more details.
 
 See the [list of languages supported by Prism](https://prismjs.com/#supported-languages) where you can find a language’s corresponding alias. And, you can also display your Astro code blocks with `lang="astro"`!
 

--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -7,7 +7,7 @@ title: CLI Reference
 
 ### `astro dev`
 
-Runs  Astro's `dev` server. It starts an HTTP server which responds to requests for routes or pages that are specified within `src/pages` directory (unless overridden by your `pages` option set in the project [configuration](/en/reference/configuration-reference)).
+Runs  Astro's `dev` server. It starts an HTTP server which responds to requests for routes or pages that are specified within `src/pages` directory (unless overridden by your `pages` option set in the project [configuration](/en/reference/configuration-reference/)).
 
 **Flags**
 
@@ -29,7 +29,7 @@ Builds your site for production.
 
 Starts a local static file server to serve your built `dist/` directory. Useful for previewing your static build locally, before deploying it.
 
-This command is meant for local testing only, and is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy).
+This command is meant for local testing only, and is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy/).
 
 ### `astro check`
 

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -74,7 +74,7 @@ const cmsContent = await fetchHTMLFromMyCMS();
 This is equivalent to just passing a variable into a template expression directly (ex: `<div>{someText}</div>`) and therefore this directive is not commonly used.
 ## Client Directives
 
-These directives control how [UI Framework components](/en/core-concepts/framework-components) are hydrated on the page.
+These directives control how [UI Framework components](/en/core-concepts/framework-components/) are hydrated on the page.
 
 By default, a UI Framework component is not hydrated in the client. If no `client:*` directive is provided, its HTML is rendered onto the page without JavaScript.
 

--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -6,7 +6,7 @@ i18nReady: true
 
 **Astro Integrations** add new functionality and behaviors for your project with only a few lines of code.
 
-This reference page is for anyone writing their own integration. To learn how to use an integration in your project, check out our [Using Integrations](/en/guides/integrations-guide) guide instead.
+This reference page is for anyone writing their own integration. To learn how to use an integration in your project, check out our [Using Integrations](/en/guides/integrations-guide/) guide instead.
 
 
 ## Examples
@@ -84,7 +84,7 @@ A read-only copy of the user-supplied [Astro config](/en/reference/configuration
 
 A callback function to update the user-supplied [Astro config](/en/reference/configuration-reference/). Any config you provide **will be merged with the user config + other integration config updates,** so you are free to omit keys!
 
-For example, say you need to supply a [Vite](https://vitejs.dev) plugin to the user's project:
+For example, say you need to supply a [Vite](https://vitejs.dev/) plugin to the user's project:
 
 ```js
 import bananaCSS from '@vitejs/official-banana-css-plugin';


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [x] Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? change *"small"* parts of the `/en/` docs links to include backslashes when needed to avoid unnessessary redirections.
