### PR TITLE
minor: Fix base config option link on `enviroment-variables.md`

### DIFF
--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -27,7 +27,7 @@ Astro includes a few environment variables out-of-the-box:
 <ul>
 <li> <ImportMetaEnv path=".MODE" /> (<code>development</code> | <code>production</code>): the mode your site is running in. This is <code>development</code> when running <code>astro dev</code> and <code>production</code> when running <code>astro build</code>.</li>
 
-<li> <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): the base url your site is being served from. This is determined by the [base config option](/en/reference/configuration-reference/#base).</li>
+<li> <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base"><code>base</code> config option</a>.</li>
 
 <li> <ImportMetaEnv path=".PROD" /> (<code>boolean</code>): whether your site is running in production.</li>
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [x] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

On the current docs, the base config link doesn't work because it is using Markdown syntax inside HTML. This PR fixes this changing the Markdown link with an HTML `<a>` tag.

Original:
![image](https://user-images.githubusercontent.com/61414485/168403172-1885cab6-1123-4c28-ad3d-ee23b62b74be.png)
PR:
![image](https://user-images.githubusercontent.com/61414485/168403185-aabd357b-c318-45e6-97a3-3c5184bc4c64.png)


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
