### PR TITLE
minor: Remove mkdir step from Getting Started install summary

### DIFF
--- a/src/pages/de/getting-started.md
+++ b/src/pages/de/getting-started.md
@@ -34,9 +34,6 @@ Du bist bereit für eine lokale Installation? Super!
 Mit unserem Assistenten `create-astro` kannst du im Handumdrehen ein Astro-Projekt direkt von deiner Kommandozeile aus anlegen:
 
 ```bash
-# Erstelle ein Projektverzeichnis und wechsle dorthin
-mkdir my-astro-project && cd $_
-
 # Erzeuge ein neues Astro-Projekt mit npm
 npm create astro@latest
 

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -35,9 +35,6 @@ Ready to install?
 Get a new project up and running locally in no time with our easy `create-astro` CLI wizard!
 
 ```bash
-# make a new project directory and jump into it
-mkdir my-astro-project && cd $_
-
 # create a new project with npm
 npm create astro@latest
 

--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -442,9 +442,6 @@ You can deploy your Astro project using the steps in the following sections.
 If you don't have an existing Astro site, you can create one by running:
 
 ```bash
-# Make a new project directory, and navigate directly into it
-mkdir my-astro-project && cd $_
-
 # prepare for liftoff...
 npm create astro@latest
 

--- a/src/pages/es/getting-started.md
+++ b/src/pages/es/getting-started.md
@@ -33,9 +33,6 @@ Listo para instalar Astro?
 Pon en marcha un nuevo proyecto local de manera instantánea con nuestro asistente de instalación (CLI) `create-astro`! 
 
 ```bash
-# creamos una carpeta para el proyecto e ingresamos
-mkdir my-astro-project && cd $_
-
 # creamos un nuevo proyecto con npm
 npm create astro@latest
 

--- a/src/pages/fr/getting-started.md
+++ b/src/pages/fr/getting-started.md
@@ -34,9 +34,6 @@ Prêt à installer ?
 Créez un nouveau projet prêt localement et en un rien de temps avec notre assistant de création via terminal de commande `create-astro` !
 
 ```bash
-# Faites un nouveau dossier pour votre projet et accédez-y
-mkdir my-astro-project && cd $_
-
 # Créez un nouveau projet avec npm
 npm create astro@latest
 

--- a/src/pages/ja/getting-started.md
+++ b/src/pages/ja/getting-started.md
@@ -34,9 +34,6 @@ Astroはブラウザでも、ローカル環境でも、できるだけ簡単に
 簡単な `create-astro` CLI ウィザードで、新しいプロジェクトをローカルですぐに立ち上げられます！
 
 ```bash
-# 新しいプロジェクトディレクトリを作成し、そこに移動します。
-mkdir my-astro-project && cd $_
-
 # npmで新しいプロジェクトを作成する
 npm create astro@latest
 

--- a/src/pages/pt-BR/getting-started.md
+++ b/src/pages/pt-BR/getting-started.md
@@ -36,9 +36,6 @@ Pronto para instalar?
 Tenha um projeto novo rodando localmente em instantes com o nosso fácil assistente de linha de comando `create-astro`!
 
 ```bash
-# crie um novo diretório para o projeto e entre nele
-mkdir my-astro-project && cd $_
-
 # crie um novo projeto com o npm
 npm create astro@latest
 

--- a/src/pages/zh-TW/getting-started.md
+++ b/src/pages/zh-TW/getting-started.md
@@ -33,9 +33,6 @@ description: 介紹 Astro 基礎。
 我們的 `create-astro` CLI 精靈可以立即讓新專案設定好並跑起來！
 
 ```bash
-# 新增專案資料夾，然後跳進去
-mkdir my-astro-project && cd $_
-
 # 以 npm 新增專案
 npm create astro@latest
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [X] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

As per the `install/auto` docs:

> No need to create a new directory first! The wizard will create a project folder for you.

But on the Getting Started page we still include an initial `mkdir && cd` step. This PR removes that from all languages that currently include it.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
