### PR TITLE
Added alt-text, credit source for image

### DIFF
--- a/src/pages/en/core-concepts/partial-hydration.md
+++ b/src/pages/en/core-concepts/partial-hydration.md
@@ -56,4 +56,5 @@ Besides the obvious performance benefits of sending less JavaScript down to the 
 - **Components load individually.** A lightweight component (like a sidebar toggle) will load and render quickly without being blocked by the heavier components on the page.
 - **Components render in isolation.** Each part of the page is an isolated unit, and a performance issue in one unit won't directly affect the others.
 
-![diagram](https://res.cloudinary.com/wedding-website/image/upload/v1596766231/islands-architecture-1.png)
+![A diagram breaking down a typical web page into various components (e.g. header, footer, carousel). Some components are described as "apps" (interactive) and others that do not require interactivity are labeled as server-rendered.](https://res.cloudinary.com/wedding-website/image/upload/v1596766231/islands-architecture-1.png)
+_image source: [Islands Architecture: Jason Miller](https://jasonformat.com/islands-architecture/)_


### PR DESCRIPTION
This adds some descriptive alt-text for the lone image/diagram on our site, and also credits the source directly.