### PR TITLE
Prev/next nav: Add trailing slash, use `rel` prop

### DIFF
--- a/src/components/PageContent/ArticleNavigationButton.astro
+++ b/src/components/PageContent/ArticleNavigationButton.astro
@@ -9,7 +9,7 @@ export interface Props {
 const { item, rel } = Astro.props as Props;
 ---
 
-<a class={rel === 'next' ? 'rtl' : 'ltr'} rel="prev" href={new URL(item.link, Astro.site).pathname}>
+<a class={rel === 'next' ? 'rtl' : 'ltr'} rel={rel} href={new URL(item.link, Astro.site).pathname}>
 	{rel === 'prev' && (
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" height="32" width="32" fill="currentColor">
 			<path d="M447.1 256C447.1 273.7 433.7 288 416 288H109.3l105.4 105.4c12.5 12.5 12.5 32.75 0 45.25C208.4 444.9 200.2 448 192 448s-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25l160-160c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25L109.3 224H416C433.7 224 447.1 238.3 447.1 256z" />

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -11,7 +11,7 @@ const headers = content.astro?.headers;
 const lang = getLanguageFromURL(Astro.canonicalURL.pathname);
 const links = (await getNav(Astro)).filter((x) => !('header' in x) && x.slug) as { text: string; slug: string; }[];
 const index = links.findIndex((x) => currentPage.includes(x.slug));
-const makeLinkItem = ({ text, slug }) => ({ text, link: `/${lang}/${slug}` });
+const makeLinkItem = ({ text, slug }) => ({ text, link: `/${lang}/${slug}/` });
 let next, previous;
 if (index > 0) previous = makeLinkItem(links[index - 1]);
 if (index !== -1 && index < links.length - 1) next = makeLinkItem(links[index + 1]);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

This PR fixes two small bugs in the prev/next links in the page footer:
- The links were not using the proper canonical URLs of the target pages due to missing trailing slashes.
- The `rel="..."` attribute of the links was always set to `prev`, even for the `next` links.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
