### PR TITLE
Replace image with translatable IslandsDiagram

### DIFF
--- a/src/pages/en/core-concepts/partial-hydration.md
+++ b/src/pages/en/core-concepts/partial-hydration.md
@@ -2,6 +2,8 @@
 layout: ~/layouts/MainLayout.astro
 title: Partial Hydration in Astro
 description: Learn how partial hydration works using "Islands Architecture" in Astro.
+setup: |
+  import IslandsDiagram from '~/components/IslandsDiagram.astro';
 i18nReady: true
 ---
 
@@ -56,5 +58,15 @@ Besides the obvious performance benefits of sending less JavaScript down to the 
 - **Components load individually.** A lightweight component (like a sidebar toggle) will load and render quickly without being blocked by the heavier components on the page.
 - **Components render in isolation.** Each part of the page is an isolated unit, and a performance issue in one unit won't directly affect the others.
 
-![A diagram breaking down a typical web page into various components (e.g. header, footer, carousel). Some components are described as "apps" (interactive) and others that do not require interactivity are labeled as server-rendered.](https://res.cloudinary.com/wedding-website/image/upload/v1596766231/islands-architecture-1.png)
-_image source: [Islands Architecture: Jason Miller](https://jasonformat.com/islands-architecture/)_
+<IslandsDiagram>
+    <Fragment slot="headerApp">Header "app"</Fragment>
+    <Fragment slot="sidebarApp">Sidebar "app"</Fragment>
+    <Fragment slot="main">
+        Server-rendered HTML content like text, images, etc.
+    </Fragment>
+    <Fragment slot="carouselApp">Image carousel "app"</Fragment>
+    <Fragment slot="advertisement">Advertisement<br/>(server-rendered)</Fragment>
+    <Fragment slot="footer">Footer (server-rendered HTML)</Fragment>
+</IslandsDiagram>
+
+_Source: [Islands Architecture: Jason Miller](https://jasonformat.com/islands-architecture/)_


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [X] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- Replaces the static islands architecture image with our new, accessible `IslandsDiagram` component, allowing its contents to be translated in i18n versions of the page.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
