### PR TITLE
Added commands/flags to cli-reference

### DIFF
--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -37,6 +37,15 @@ Runs diagnostics (such as type-checking) against your project and reports errors
 
 This command is intended to be used in CI workflows.
 
+### `astro add`
+
+Adds an integration to your configuration.
+
+
+### `astro docs`
+
+Launches Astro's Doc site directly from the terminal.
+
 ### `astro telemetry`
 
 Sets telemetry configuration for the current user. Telemetry is anonymous data that provides insights into which features are most often used.
@@ -96,6 +105,10 @@ Enables silent logging, which is helpful when you don't want to see Astro logs.
 ### `--version`
 
 Prints the Astro version number and exits.
+
+### `--drafts`
+
+Includes markdown draft pages in the build.
 
 ### `--help`
 

--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -108,7 +108,7 @@ Prints the Astro version number and exits.
 
 ### `--drafts`
 
-Includes markdown draft pages in the build.
+Includes Markdown draft pages in the build.
 
 ### `--help`
 

--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -44,7 +44,7 @@ Adds an integration to your configuration.
 
 ### `astro docs`
 
-Launches Astro's Doc site directly from the terminal.
+Launches the Astro Docs website directly from the terminal.
 
 ### `astro telemetry`
 


### PR DESCRIPTION
Closes #516 

Some missing commands/flags to the cli-reference.

Would still be nice to explore automating this as mentioned in #209, but this is a manual fix for what @tony-sull has identified as currently missing. 