### PR TITLE
Fix: Place theme toggle title attribute correctly

### DIFF
--- a/src/components/RightSidebar/ThemeToggleButton.tsx
+++ b/src/components/RightSidebar/ThemeToggleButton.tsx
@@ -49,14 +49,13 @@ const ThemeToggle: FunctionalComponent<Props> = ({ labels }) => {
 				const checked = t === theme;
 				const themeLabel = t === 'light' ? labels.useLight : labels.useDark;
 				return (
-					<label class={checked ? 'checked' : ''}>
+					<label title={themeLabel} class={checked ? 'checked' : ''}>
 						{icon}
 						<input
 							type="radio"
 							name="theme-toggle"
 							checked={checked}
 							value={t}
-							title={themeLabel}
 							aria-label={themeLabel}
 							onChange={() => {
 								const matchesDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

- Fixes a bug in the theme toggle control that prevented its `title` attributes from being used - instead, the title of the entire table of contents aka right sidebar popped up. Bug was confirmed on Chrome and Firefox:
  ![before-fix](https://user-images.githubusercontent.com/6137925/169139017-b9872049-769d-4fff-bb66-c9b6bc4d623c.png)
- This PR fixes this by moving the title attribute up in the tree to make it work.
  ![after-fix](https://user-images.githubusercontent.com/6137925/169139030-7c862f3e-ba85-4790-9f26-ab6dbc6c54b4.png)

(In both screenshots, please imagine a mouse cursor pointing to the little sun icon.)

**Important:** I don't know if it would be a good idea to also move the `aria-label` attribute. I've kept it at the actual input element because this is the element with the semantic `checked` attribute and I was hoping that a screen reader would read this as something like "Checked option: Use dark theme". If anyone with access to a screen reader can verify if this is the correct solution, that would be awesome.



<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
