### PR TITLE
minor: Fix colons position on `integrations-reference.md`

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -67,7 +67,7 @@ interface AstroIntegration {
 
 #### `config` option
 
-**Type**: `AstroConfig`
+**Type:** `AstroConfig`
 
 A read-only copy of the user-supplied [Astro config](/en/reference/configuration-reference/). This is resolved _before_ any other integrations have run. If you need a copy of the config after all integrations have completed their config updates, [see the `astro:config:done` hook](#astroconfigdone).
 
@@ -139,7 +139,7 @@ The **`stage`** denotes how this script (the `content`) should be inserted. Some
 
 #### `config` option
 
-**Type**: `AstroConfig`
+**Type:** `AstroConfig`
 
 A read-only copy of the user-supplied [Astro config](/en/reference/configuration-reference/). This is resolved _after_ other integrations have run.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [x] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

Some colons were positioned after the bold markup, so they weren't bold as well. Now all my precious colons are bold.