### PR TITLE
♻️ update instructions for grabbing the pathname

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -127,17 +127,20 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 
 The [canonical URL][canonical] of the current page. If the `site` option is set, the site's origin will be the origin of this URL.
 
-### `Astro.site`
-
-`Astro.site` returns a `URL` made from `.site` in your Astro config. If undefined, this will return a URL generated from `localhost`.
+You can also use the `canonicalURL` to grab the current page's `pathname`.
 
 ```astro
 ---
-const path = Astro.site.pathname;
+const path = Astro.canonicalURL.pathname;
 ---
 
 <h1>Welcome to {path}</h1>
 ```
+
+### `Astro.site`
+
+`Astro.site` returns a `URL` made from `.site` in your Astro config. If undefined, this will return a URL generated from `localhost`.
+
 
 ### `Astro.slots`
 


### PR DESCRIPTION
I've updated the documentation so that it's more clear for developers on how they should be grabbing the current pathname.

The previous iteration of the docs is ambiguous  and implies that `Astro.site.pathname` will return the current pathname when it should be `Astro.canonicalURL.pathname`.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [x] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
