### PR TITLE
Removed "experimental" from Adapter API references

### DIFF
--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -49,7 +49,7 @@ export default [
 	{ text: 'CLI', slug: 'reference/cli-reference', key: 'reference/cli-reference' },
 	{ text: 'Runtime API', slug: 'reference/api-reference', key: 'reference/api-reference' },
 	{ text: 'Integrations API', slug: 'reference/integrations-reference', key: 'reference/integrations-reference' },
-	{ text: 'Adapter API (experimental)', slug: 'reference/adapter-reference', key: 'reference/adapter-reference' },
+	{ text: 'Adapter API', slug: 'reference/adapter-reference', key: 'reference/adapter-reference' },
 	{ text: 'Routing Rules', slug: 'core-concepts/routing', key: 'core-concepts/routing' },
 	{ text: 'Template Directives', slug: 'reference/directives-reference', key: 'reference/directives-reference' },
 	// ADD: Astro Component Syntax

--- a/src/pages/en/reference/adapter-reference.md
+++ b/src/pages/en/reference/adapter-reference.md
@@ -1,12 +1,10 @@
 ---
 layout: ~/layouts/MainLayout.astro
-title: Astro Adapter API (experimental)
+title: Astro Adapter API
 i18nReady: true
 ---
 
 Astro is designed to make it easy to deploy to any cloud provider for SSR (server-side rendering). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/).
-
-> Server-side rendering in Astro is *experimental*. If you are interested in building an adapter for a host now is the perfect time to help shape these APIs. If you are worried about breaking changes this might be a little too soon for you.
 
 ## What is an adapter
 

--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -209,7 +209,7 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 **Next hook:** [astro:build:setup](#astrobuildsetup)
 
 **When:** After the `astro:config:done` event, but before the production build begins.
-**Why:** To set up any global objects or clients needed during a production build. This can also extend the build configuration options in the [experimental adapter API](/en/reference/adapter-reference/).
+**Why:** To set up any global objects or clients needed during a production build. This can also extend the build configuration options in the [adapter API](/en/reference/adapter-reference/).
 
 ```js
 'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;


### PR DESCRIPTION
OK to be merged as soon as we no longer want to refer to Adapters/Adapter API as "experimental." (Now?)
 
Changes:
- Page title in Left Sidebar (under Reference)
- Warning on Adapter API page itself
- Link to the Experimental Adapter API from integrations-reference