### PR TITLE
migration guide improvement re: `<script type="module">`

### DIFF
--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -63,7 +63,7 @@ Read [RFC0017](https://github.com/withastro/rfcs/blob/main/proposals/0017-markdo
 
 This includes a few changes to be aware of:
 
-- **BREAKING:** `<script hoist>` is the new default `<script>` behavior. The `hoist` attribute has been removed.
+- **BREAKING:** `<script hoist type="module">` is the new default `<script>` behavior. The `hoist` and `type="module"` attributes hav been removed.
 - New `<script is:inline>` directive, to revert a `<script>` tag to previous default behavior (unbuilt, unbundled, untouched by Astro).
 - New `<style is:inline>` directive, to leave a style tag inline in the page template (similar to previous `<script>` behavior).
 - New `<style is:global>` directive to replace `<style global>` in a future release.
@@ -71,10 +71,12 @@ This includes a few changes to be aware of:
 
 ```diff
 // v0.25
-- <script hoist>
+- <script hoist type="module">
 // v0.26+
 + <script>
 ```
+
+See how to use [client-side scripts](/en/core-concepts/astro-components/#client-side-scripts) in Astro for full details.
 
 Read [RFC0016](https://github.com/withastro/rfcs/blob/main/proposals/0016-style-script-defaults.md) for more background on these changes.
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -63,7 +63,7 @@ Read [RFC0017](https://github.com/withastro/rfcs/blob/main/proposals/0017-markdo
 
 This includes a few changes to be aware of:
 
-- **BREAKING:** `<script hoist type="module">` is the new default `<script>` behavior. The `hoist` and `type="module"` attributes hav been removed.
+- **BREAKING:** `<script hoist type="module">` is the new default `<script>` behavior. The `hoist` and `type="module"` attributes have been removed.
 - New `<script is:inline>` directive, to revert a `<script>` tag to previous default behavior (unbuilt, unbundled, untouched by Astro).
 - New `<style is:inline>` directive, to leave a style tag inline in the page template (similar to previous `<script>` behavior).
 - New `<style is:global>` directive to replace `<style global>` in a future release.

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -63,7 +63,7 @@ Read [RFC0017](https://github.com/withastro/rfcs/blob/main/proposals/0017-markdo
 
 This includes a few changes to be aware of:
 
-- **BREAKING:** `<script hoist type="module">` is the new default `<script>` behavior. The `hoist` and `type="module"` attributes have been removed.
+- **BREAKING:** `<script hoist>` is the new default `<script>` behavior. The `hoist` attribute has been removed. To use the new default behaviour, make sure there are no other attributes on the `<script>` tag. For example remove `type="module"` if you were using it before.
 - New `<script is:inline>` directive, to revert a `<script>` tag to previous default behavior (unbuilt, unbundled, untouched by Astro).
 - New `<style is:inline>` directive, to leave a style tag inline in the page template (similar to previous `<script>` behavior).
 - New `<style is:global>` directive to replace `<style global>` in a future release.


### PR DESCRIPTION
The migration guide mentions to remove the `hoist` attribute from `<script>` tags when upgrading, but doesn't mention removing `type="module"` which causes unexpected behaviour when not removed.

Changes: 
Adds mention that, like hoist, type="module" should be removed as its default behaviour now
Also, links directly to the section in docs that does fully document current behaviour.

NOTE: No need to fully explain behaviour here on this page. It's well documented at the (now added) link in docs proper. And, this page is just for "steps to take to upgrade" so it only needs to exist in "do this!" form.

- [ X] New or updated content


