### PR TITLE
Moves the Routing page's sidebar entry into Learn > Basics

### DIFF
--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -27,8 +27,9 @@ export default [
 	{ text: 'Pages', slug: 'core-concepts/astro-pages', key: 'core-concepts/astro-pages' },
 	{ text: 'Layouts', slug: 'core-concepts/layouts', key: 'core-concepts/layouts' },
 	{ text: 'Markdown', slug: 'guides/markdown-content', key: 'guides/markdown-content' },
-	{ text: 'Static Assets', slug: 'guides/imports', key: 'guides/imports' },
 	{ text: 'Routing', slug: 'core-concepts/routing', key: 'core-concepts/routing' },
+	{ text: 'Static Assets', slug: 'guides/imports', key: 'guides/imports' },
+
 
 	{ text: 'Features', header: true, type: 'learn', key: 'features' },
 	{ text: 'Configuring Astro', slug: 'guides/configuring-astro', key: 'guides/configuring-astro' },

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -29,6 +29,7 @@ export default [
 	{ text: 'Layouts', slug: 'core-concepts/layouts', key: 'core-concepts/layouts' },
 	{ text: 'Markdown', slug: 'guides/markdown-content', key: 'guides/markdown-content' },
 	{ text: 'Static Assets', slug: 'guides/imports', key: 'guides/imports' },
+	{ text: 'Routing', slug: 'core-concepts/routing', key: 'core-concepts/routing' },
 
 	{ text: 'Features', header: true, type: 'learn', key: 'features' },
 	{ text: 'Configuring Astro', slug: 'guides/configuring-astro', key: 'guides/configuring-astro' },
@@ -50,7 +51,6 @@ export default [
 	{ text: 'Runtime API', slug: 'reference/api-reference', key: 'reference/api-reference' },
 	{ text: 'Integrations API', slug: 'reference/integrations-reference', key: 'reference/integrations-reference' },
 	{ text: 'Adapter API (experimental)', slug: 'reference/adapter-reference', key: 'reference/adapter-reference' },
-	{ text: 'Routing Rules', slug: 'core-concepts/routing', key: 'core-concepts/routing' },
 	{ text: 'Template Directives', slug: 'reference/directives-reference', key: 'reference/directives-reference' },
 	// ADD: Astro Component Syntax
 	// ADD: Markdown Syntax


### PR DESCRIPTION
This only moves where the Routing page shows up in the Left Sidebar. The file stays in the same location, so no links should have to change. (No RIP link checker! 😅 )

Moving into Learn for now, tabling a later discussion on WHERE EXACTLY.

Also removing placeholders for hypothetical pages that have been scrapped and will not be written.

- [X ] New or updated content
- [X ] Changes to the docs site code

