### PR TITLE
docs(en): update integration-reference build end hook

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -41,7 +41,7 @@ interface AstroIntegration {
           target: 'client' | 'server';
         }) => void | Promise<void>;
         'astro:build:ssr'?: (options: { manifest: SerializedSSRManifest }) => void | Promise<void>;
-        'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL }) => void | Promise<void>;
+        'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL; routes: RouteData[] }) => void | Promise<void>;
     };
 }
 ```
@@ -251,7 +251,7 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 **Why:** To access generated routes and assets for extension (ex. copy content into the generated `/assets` directory). If you plan to transform generated assets, we recommend exploring the [Vite Plugin API](https://vitejs.dev/guide/api-plugin.html) and [configuring via `astro:config:setup`](#updateconfig-option) instead.
 
 ```js
-'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL }) => void | Promise<void>;
+'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL; routes: RouteData[] }) => void | Promise<void>;
 ```
 
 #### `pages` option


### PR DESCRIPTION
supersedes https://github.com/withastro/docs/pull/654

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- What does this PR change? Give us a brief description.
Adds the missing `routes` on the `astro:build:done` integration hook: for context https://github.com/withastro/astro/pull/3438#issuecomment-1136473008
- Did you change something visual? A before/after screenshot can be helpful.
No, just the signature for `astro:build:done` integration hook, adding the missing routes
