### PR TITLE
update the config-reference generated header for i18n

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -11,6 +11,7 @@ const HEADER = `---
 
 layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
+i18nReady: true
 setup: |
   import Since from '../../../components/Since.astro';
 ---


### PR DESCRIPTION
This file is auto-generated (never manually edited) in English, but we decided that translations would be manual.

Adding `i18nReady: true` to the generated header so that this page shows up in our pinned status tracking issue for translators.

Paging Dr. @delucis for approval. 😄