### PR TITLE
fix: Improve a11y

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -128,9 +128,12 @@ const t = useTranslations(Astro);
 
 	.logo a:hover,
 	.logo a:focus {
-		outline: none;
 		opacity: 1;
 		transform: translateY(-2px);
+	}
+
+	.logo a:focus:not(:focus-visible) {
+		outline: none;
 	}
 
 	.logo h1 {

--- a/src/components/Header/LanguageSelect.css
+++ b/src/components/Header/LanguageSelect.css
@@ -17,7 +17,6 @@
 	flex-grow: 1;
 	padding: 0.55em 1.75rem;
 	line-height: inherit;
-	outline: 0;
 	/* Add dropdown arrow */
 	background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
 	background-position: 97%;
@@ -28,10 +27,6 @@
 
 [dir='rtl'] .language-select {
 	background-position: 3%;
-}
-
-.language-select:focus-visible {
-	border-color: var(--border-color-hocus);
 }
 
 @media (hover: hover) {

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -34,7 +34,7 @@ for (const section of sidebarSections) {
 }
 ---
 
-<nav aria-labelledby="grid-left">
+<nav aria-label={t('leftSidebar.a11yTitle')}>
 	<SidebarToggleTabGroup 
 		client:load 
 		defaultActiveTab={activeTab} 

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -10,7 +10,7 @@ const { content, githubEditUrl } = Astro.props;
 const headers = content.astro?.headers;
 ---
 
-<nav class="sidebar-nav" aria-labelledby="grid-right">
+<nav class="sidebar-nav" aria-label={t('rightSidebar.a11yTitle')}>
 	<div class="sidebar-nav-inner">
 		{headers && (
 			<TableOfContents

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -137,17 +137,17 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 	<body>
 		<Header {currentPage} />
 		<main class="layout">
-			<aside id="grid-left" class="grid-sidebar" title={t('leftSidebar.a11yTitle')}>
+			<aside id="grid-left" class="grid-sidebar">
 				<LeftSidebar {currentPage} />
+			</aside>
+			<aside id="grid-right" class="grid-sidebar">
+				{!hideRightSidebar && <RightSidebar content={content} githubEditUrl={githubEditUrl} />}
 			</aside>
 			<div id="grid-main" lang={isFallback && 'en'}>
 				<PageContent {content} {githubEditUrl} {currentPage} {isFallback}>
 					<slot />
 				</PageContent>
 			</div>
-			<aside id="grid-right" class="grid-sidebar" title={t('rightSidebar.a11yTitle')}>
-				{!hideRightSidebar && <RightSidebar content={content} githubEditUrl={githubEditUrl} />}
-			</aside>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

### Description

General accessibility improvements to the issues found in #620. No visible changes other than the focus indicators described below.

#### `MainLayout.astro`

Reordered right sidebar to come before the main page content. This makes the DOM order more sensible. No CSS changes were necessary because it already has a grid-column set.

This also affects the "More" list and the theme button, which I feel like do not belong inside a "table of contents" section, but I didn't want to make huge visual changes.

Also removed the `title` attribute from both sidebars because it didn't make sense to me and was causing duplicate announcements in NVDA.

#### `LeftSidebar.astro` and `RightSidebar.astro`

Fixed accessible name. Previously, NVDA was announcing the entire contents of the `nav` instead of just "Site navigation" or "Table of contents".

#### `Header.astro`

Added visible focus indicator to logo

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/9084735/170894385-918dd14a-ed48-4b5d-b631-d273efb45406.png) | ![](https://user-images.githubusercontent.com/9084735/170894376-cce5fcb2-a949-4aea-aaac-a76c3bdf953f.png) |

#### `LanguageSelect.css`

Updated focus indicator of select button to be more prominent

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/9084735/170894406-095b2010-4d79-430c-98cb-dae1653c55b8.png) | ![](https://user-images.githubusercontent.com/9084735/170894426-b51fdb2b-3c94-4a01-9dea-846d0522ce29.png) |
