### PR TITLE
Fix scrollbar overlapping issue on Firefox

### DIFF
--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -4,7 +4,9 @@ import ThemeToggleButton from './ThemeToggleButton.tsx';
 import ContributeMenu from './ContributeMenu.astro';
 import CommunityMenu from './CommunityMenu.astro';
 import { useTranslations } from "../../i18n/util.ts";
+
 const t = useTranslations(Astro);
+
 const { content, githubEditUrl } = Astro.props;
 const headers = content.astro?.headers;
 ---

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -14,19 +14,14 @@ const headers = content.astro?.headers;
 <nav class="sidebar-nav" aria-label={t('rightSidebar.a11yTitle')}>
 	<div class="sidebar-nav-inner">
 		{headers && (
-			<TableOfContents
-				client:media="(min-width: 50em)"
-				headers={headers}
-				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
-			/>
+		<TableOfContents client:media="(min-width: 50em)" headers={headers} labels={{ onThisPage:
+			t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }} />
 		)}
 		<ContributeMenu editHref={githubEditUrl} />
-		<CommunityMenu/>
+		<CommunityMenu />
 		<div style="margin: 2rem 0; text-align: center;">
-			<ThemeToggleButton 
-				client:visible 
-				labels={{  useLight: t('themeToggle.useLight'), useDark: t('themeToggle.useDark')  }} 
-			/>
+			<ThemeToggleButton client:visible labels={{ useLight: t('themeToggle.useLight'), useDark:
+				t('themeToggle.useDark') }} />
 		</div>
 	</div>
 </nav>
@@ -37,10 +32,18 @@ const headers = content.astro?.headers;
 		position: sticky;
 		top: 0;
 	}
+
 	.sidebar-nav-inner {
 		height: 100%;
 		padding: 0;
 		padding-top: var(--doc-padding);
 		overflow: auto;
+	}
+
+	/* style applied only on Firefox, this avoids scrollbars overlapping. */
+	@supports (-moz-appearance: none) {
+		.sidebar-nav {
+			padding-inline-end: 1.5rem;
+		}
 	}
 </style>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -4,9 +4,7 @@ import ThemeToggleButton from './ThemeToggleButton.tsx';
 import ContributeMenu from './ContributeMenu.astro';
 import CommunityMenu from './CommunityMenu.astro';
 import { useTranslations } from "../../i18n/util.ts";
-
 const t = useTranslations(Astro);
-
 const { content, githubEditUrl } = Astro.props;
 const headers = content.astro?.headers;
 ---
@@ -14,14 +12,19 @@ const headers = content.astro?.headers;
 <nav class="sidebar-nav" aria-label={t('rightSidebar.a11yTitle')}>
 	<div class="sidebar-nav-inner">
 		{headers && (
-		<TableOfContents client:media="(min-width: 50em)" headers={headers} labels={{ onThisPage:
-			t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }} />
+			<TableOfContents
+				client:media="(min-width: 50em)"
+				headers={headers}
+				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
+			/>
 		)}
 		<ContributeMenu editHref={githubEditUrl} />
 		<CommunityMenu />
 		<div style="margin: 2rem 0; text-align: center;">
-			<ThemeToggleButton client:visible labels={{ useLight: t('themeToggle.useLight'), useDark:
-				t('themeToggle.useDark') }} />
+			<ThemeToggleButton 
+				client:visible 
+				labels={{  useLight: t('themeToggle.useLight'), useDark: t('themeToggle.useDark')  }} 
+			/>
 		</div>
 	</div>
 </nav>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description
This PR adds padding to the `RightSidebar` component, so the component scrollbar (and the page scrollbar) don't overlap (if they're overlapping you can only drag the page scrollbar). This change only affects Firefox, since Chrome scrollbars automatically add padding to elements, unlike Firefox. This is important because some people can't use the mouse scroll wheel or are in their sister's laptops where the touchpad doesn't work well (this is not personal experience)

Here's a gif demonstrating what happens:
![](https://i.imgur.com/9rRd2NU.gif)

|  Before  | PR  |
|------------|-------|
| ![](https://i.imgur.com/zYYGGyu.png) | ![](https://i.imgur.com/Pp4Te9u.png)  |

Before merging, I want to confirm two things:

- Does this same problem happen in other non-Chromium browsers like Safari?
- Maybe we should add padding not only in browsers where scrollbars overlap but to all of them, just because this way both sidebars have the same padding **AND** we avoid having styles for specific browsers?