### PR TITLE
Add i18n instructions for English PRs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,11 @@ Please only add new text content to the docs **in English**, only modifying **`.
 
 We have automated systems in place for notifying our community translators that there is new material to be translated, so there is no need to make changes to additional languages yourself. 
 
-_Speak another language natively? Join our i18n gang on Discord or jump into the PRs to help with translating or reviewing translations!_ 
-
-
 ## Translate a Page
 
-Help us translate our content! Check out the dedicated [i18n guide](src/i18n/README.md) for more details.
+Speak another language natively? Join our i18n gang on Discord or jump into the PRs to help with translating or reviewing translations!
+
+Check out the dedicated [i18n guide](src/i18n/README.md) for more details.
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,6 @@ git checkout -b add/partial-hydration-typo-fix
 That’s it.
 As you [open a pull request](https://github.com/withastro/astro/compare), please include a clear title. The description will be pre-filled with questions that you can answer by editing right in the text field.
 
-```markdown
-# Fixes a typo on Partial Hydration page
-
-This fixes a typo in the page on partial hydration, and additionally removes an unnecessary extra space.
-```
-
 Thank you for helping make the docs awesome.
 And please, [come chat with us](https://astro.build/chat) if you have any questions.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ git checkout -b add/partial-hydration-typo-fix
 ```
 
 That’s it.
-As you [open a pull request](https://github.com/withastro/astro/compare), please include a clear title and description.
+As you [open a pull request](https://github.com/withastro/astro/compare), please include a clear title. The description will be pre-filled with questions that you can answer by editing right in the text field.
 
 ```markdown
 # Fixes a typo on Partial Hydration page

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Is something wrong?
 
 Creating a new Issue puts a problem on our radar!
 
-[See if your issue has already been reported](https://github.com/withastro/docs/issues), and if not, create a new one.
+[See if your issue has already been reported](https://github.com/withastro/docs/issues), and if not, [create a new one](https://github.com/withastro/docs/issues/new/choose).
 
 ## Share an Idea
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,23 @@ You can learn more about Astro, get support, and meet other devs in [our Discord
 
 Is something missing?
 Is something wrong?
+
+Creating a new Issue puts a problem on our radar!
+
+[See if your issue has already been reported](https://github.com/withastro/docs/issues), and if not, create a new one.
+
+## Share an Idea
+
 Could something be better?
-Issues are a quick way for you to offer us feedback about the docs.
+Want to share an idea with us?
 
-Before you share, please [see if your issue has already been reported](https://github.com/withastro/docs/issues).
+Discussions are threads where you can offer feedback on things that might not exactly be problems to be fixed but are ideas to be explored. 
 
-## Edit a Page
+[Join the Docs Discussions](https://github.com/withastro/docs/discussions) where we brainstorm, ask questions, share hopes and dreams...
+
+## Make a Fix or Contribution
+
+If you can see what the problem is, and you know how to fix it, then you can make a PR (pull request) with the change and contribute to the docs repo yourself!
 
 Every page on [docs.astro.build](https://docs.astro.build/) has an **Edit this page** button in the sidebar.
 You can click that button to edit the source code for that page in **GitHub**.
@@ -39,7 +50,16 @@ After you make your changes, click **Commit changes**.
 This will automatically create a [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) of the docs in your GitHub account with the changes.
 
 Once your edits are ready in GitHub, follow the prompts to **create a pull request** and submit your changes for review.
-Every pull request needs to be reviewed by our contributors.
+Every pull request needs to be reviewed by our contributors and approved by a Maintainer.
+
+**Important Note re: Internationalization (i18n)**
+
+Please only add new text content to the docs **in English**, only modifying **`.md` files located within `src/pages/en/`**. 
+
+We have automated systems in place for notifying our community translators that there is new material to be translated, so there is no need to make changes to additional languages yourself. 
+
+_Speak another language natively? Join our i18n gang on Discord or jump into the PRs to help with translating or reviewing translations!_ 
+
 
 ## Translate a Page
 
@@ -71,16 +91,16 @@ At any point, create a branch for your contribution.
 We are not strict about branch names.
 
 ```shell
-git checkout -b add/klingon-language
+git checkout -b add/partial-hydration-typo-fix
 ```
 
 That’s it.
 As you [open a pull request](https://github.com/withastro/astro/compare), please include a clear title and description.
 
 ```markdown
-# Add Klingon language to Getting Started page
+# Fixes a typo on Partial Hydration page
 
-This adds the Klingon language and also updates the sidebar and language selection components.
+This fixes a typo in the page on partial hydration, and additionally removes an unnecessary extra space.
 ```
 
 Thank you for helping make the docs awesome.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After you make your changes, click **Commit changes**.
 This will automatically create a [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) of the docs in your GitHub account with the changes.
 
 Once your edits are ready in GitHub, follow the prompts to **create a pull request** and submit your changes for review.
-Every pull request needs to be reviewed by our contributors and approved by a Maintainer.
+Every pull request needs to be reviewed by our contributors and approved by a maintainer.
 
 **Important Note re: Internationalization (i18n)**
 


### PR DESCRIPTION

- [X ] New or updated content

Added note re: only add new content in English
Additionally: 
- adjusted call to create Issues and highlighted Discussions as an alternative for providing ideas/feedback

- updated example PR title/description to be a typo fix, not something that involves adding a new language and making changes to a sidebar (since our process for doing those things is now so much more involved than when that example was written, and we no longer want to encourage people adding a new language themselves!  😅 )