### PR TITLE
Change `ThemeToggleButton` positioning

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -3,6 +3,7 @@ import SkipToContent from './SkipToContent.astro';
 import SidebarToggle from './SidebarToggle.tsx';
 import LanguageSelect from './LanguageSelect.tsx';
 import Search from './Search.tsx';
+import ThemeToggleButton from './ThemeToggleButton.tsx';
 import { getLanguageFromURL } from '../../util.ts';
 import { getDocSearchStrings, useTranslations } from '../../i18n/util.ts';
 
@@ -53,6 +54,11 @@ const t = useTranslations(Astro);
 				</svg>
 			</a>
 		</div>
+			<ThemeToggleButton 
+				client:visible 
+				labels={{  useLight: t('themeToggle.useLight'), useDark: t('themeToggle.useDark')  }}
+				isInsideHeader={true} 
+			/>
 		{lang && <LanguageSelect lang={lang} client:idle />}
 		<Search {lang} client:idle labels={docsearchStrings} />
 		<SidebarToggle client:idle />

--- a/src/components/Header/ThemeToggleButton.css
+++ b/src/components/Header/ThemeToggleButton.css
@@ -27,6 +27,24 @@
 	opacity: 1;
 }
 
+@media (max-width: 50em) {
+	.theme-toggle {
+		margin-top: 32px;
+	}
+	.hide-toggle-on-smaller-screens {
+		display: none;
+	}
+}
+
+@media (min-width: 50em) {
+	.theme-toggle {
+		display: none;
+	}
+	.hide-toggle-on-smaller-screens {
+		display: inline-flex;
+	}
+}
+
 input[name='theme-toggle'] {
 	position: absolute;
 	opacity: 0;

--- a/src/components/Header/ThemeToggleButton.tsx
+++ b/src/components/Header/ThemeToggleButton.tsx
@@ -8,6 +8,7 @@ interface Props {
 		useLight: string;
 		useDark: string;
 	};
+	isInsideHeader: boolean;
 }
 
 const themes = ['light', 'dark'];
@@ -25,7 +26,7 @@ const icons = [
 	</svg>,
 ];
 
-const ThemeToggle: FunctionalComponent<Props> = ({ labels }) => {
+const ThemeToggle: FunctionalComponent<Props> = ({ labels, isInsideHeader }) => {
 	const [theme, setTheme] = useState(() => {
 		if (import.meta.env.SSR) {
 			return undefined;
@@ -43,7 +44,7 @@ const ThemeToggle: FunctionalComponent<Props> = ({ labels }) => {
 	}, [theme]);
 
 	return (
-		<div class="theme-toggle">
+		<div class={`theme-toggle ${isInsideHeader ? 'hide-toggle-on-smaller-screens' : ''}`}>
 			{themes.map((t, i) => {
 				const icon = icons[i];
 				const checked = t === theme;

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -5,6 +5,7 @@ import { getNav, useTranslations } from "../../i18n/util";
 import SidebarContent from './SidebarContent.astro';
 import SidebarToggleTabGroup from '../TabGroup/SidebarToggleTabGroup.tsx';
 import CommunityMenu from "../RightSidebar/CommunityMenu.astro";
+import ThemeToggleButton from "../Header/ThemeToggleButton.tsx";
 
 export interface Props {
 	currentPage: string;
@@ -45,6 +46,12 @@ for (const section of sidebarSections) {
 		<SidebarContent type={'learn'} defaultActiveTab={activeTab} sidebarSections={learnSections} {currentPageMatch} />
 		<SidebarContent type={'api'} defaultActiveTab={activeTab} sidebarSections={apiSections} {currentPageMatch} />
 		<CommunityMenu hideOnLargerScreens={true} />
+		<li style="text-align: center;">
+			<ThemeToggleButton 
+				client:visible 
+				labels={{  useLight: t('themeToggle.useLight'), useDark: t('themeToggle.useDark')  }} 
+			/>
+		</li>
 		<li>
 			<Sponsors />
 		</li>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -1,6 +1,5 @@
 ---
 import TableOfContents from './TableOfContents.tsx';
-import ThemeToggleButton from './ThemeToggleButton.tsx';
 import ContributeMenu from './ContributeMenu.astro';
 import CommunityMenu from './CommunityMenu.astro';
 import { useTranslations } from "../../i18n/util.ts";
@@ -22,12 +21,6 @@ const headers = content.astro?.headers;
 		)}
 		<ContributeMenu editHref={githubEditUrl} />
 		<CommunityMenu />
-		<div style="margin: 2rem 0; text-align: center;">
-			<ThemeToggleButton 
-				client:visible 
-				labels={{  useLight: t('themeToggle.useLight'), useDark: t('themeToggle.useDark')  }} 
-			/>
-		</div>
 	</div>
 </nav>
 
@@ -41,7 +34,7 @@ const headers = content.astro?.headers;
 	.sidebar-nav-inner {
 		height: 100%;
 		padding: 0;
-		padding-top: var(--doc-padding);
+		padding: var(--doc-padding) 0;
 		overflow: auto;
 	}
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description

Changes made:
- Moved ThemeToggleButton component to the Header directory (since it doesn't even appear in the RightSidebar now).
- Moved ThemeToggleButton to the header on larger viewports.
- Moved ThemeToggleButton to the bottom of the pop-up menu on smaller viewports.
- Added extra bottom padding to the RightSidebar since it doesn't have the ThemeToggle padding anymore, so the Community Menu has some good whitespace to breath.

![mcAHM76](https://user-images.githubusercontent.com/61414485/172494700-f23eb6fa-7bf2-47cf-95ee-570dd5cab9c1.gif)

