### PR TITLE
commenting out broken astro.self example

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -160,12 +160,14 @@ if (Astro.slots.has('default')) {
 ---
 <Fragment set:html={html} />
 ```
+<!-- Waiting for bug fix from Nate; reformat CAREFULLY when un-uncommenting out!
+
 
 `Astro.slots.render` optionally accepts a second argument, an array of parameters that will be forwarded to any function children. This is extremely useful for custom utility components.
 
 Given the following `Message.astro` component...
 
-```astro
+tick tick tick astro
 ---
 let html: string = '';
 if (Astro.slots.has('default')) {
@@ -177,11 +179,12 @@ if (Astro.slots.has('default')) {
 
 You could pass a callback function that renders our the message:
 
-```astro
+tick tick tick astro
 <div><Message messages={['Hello', 'world!']}>{(messages) => messages.join(' ')}</Message></div>
-<!-- renders as -->
+ renders as // make this a code comment again
 <div>Hello world!</div>
 ```
+-->
 
 ### `Astro.self`
 


### PR DESCRIPTION
In response to https://github.com/withastro/docs/issues/595 re: non-working code example 

- [ x] New or updated content

The offending code example has been commented out, pending a bug fix.https://github.com/withastro/astro/issues/3562

As noted in the code itself, in order to comment out code that had its own code comments... I had to get creative. Please take care when reverting.