### PR TITLE
Self-host IBM Plex Mono

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@astropub/icons": "^0.2.0",
+    "@fontsource/ibm-plex-mono": "^4.5.10",
     "jsdoc-api": "^7.1.1",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@astropub/icons': ^0.2.0
   '@babel/core': ^7.17.9
   '@docsearch/react': ^3.1.0
+  '@fontsource/ibm-plex-mono': ^4.5.10
   '@types/mdast': ^3.0.10
   '@types/react': ^18.0.14
   '@typescript-eslint/eslint-plugin': ^5.27.0
@@ -45,6 +46,7 @@ specifiers:
 
 dependencies:
   '@astropub/icons': 0.2.0_astro@1.0.0-beta.51
+  '@fontsource/ibm-plex-mono': 4.5.10
   jsdoc-api: 7.1.1
   rehype-autolink-headings: 6.1.1
   rehype-slug: 5.0.1
@@ -760,6 +762,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fontsource/ibm-plex-mono/4.5.10:
+    resolution: {integrity: sha512-YmyewD+qHgo4ylcNSg6T9zpneRS34HhFd8cpF2TrJMbM3iKOW59XwmZqzdKyctzU0UQoHUFzjAAzDJ4THElFRA==}
+    dev: false
 
   /@humanwhocodes/config-array/0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -1,3 +1,7 @@
+---
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/400-italic.css';
+---
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
@@ -10,11 +14,6 @@
 <!-- Global CSS -->
 <link rel="stylesheet" href="/theme.css" />
 <link rel="stylesheet" href="/index.css" />
-
-<!-- Preload Fonts -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital@0;1&display=swap" rel="stylesheet" />
 
 <!-- Scrollable a11y code helper -->
 <script type="module" src="/make-scrollable-code-focusable.js"></script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

Move away from Google Fonts to self-host IBM Plex Mono via a fontsource npm module.

~~This is currently blocked until we can get #746 merged because we need to be on beta.42 to make use of the recent fix that adds support for fontsource (https://github.com/withastro/astro/pull/3537)~~ Unblocked!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
