### PR TITLE
Fix `CommunityMenu` padding edge-case

### DIFF
--- a/src/components/RightSidebar/CommunityMenu.astro
+++ b/src/components/RightSidebar/CommunityMenu.astro
@@ -81,19 +81,23 @@ const { hideOnLargerScreens = false } = Astro.props as Props;
 </div>
 
 <style>
-	@media (max-width: 72em) {
+
+h2, ul {
+	padding-left: 32px;
+}
+	
+@media (min-width: 50em) {
 	h2 {
 		padding-left: 16px;
 	}
+	ul {
+		padding-left: 0;
+	}
 }
+
 @media (min-width: 72em) {
 	:global(.hide-on-large-screens) {
 		display: none;
 	}
 }
-	@media (max-width: 50em) {
-		h2, ul {
-			padding-left: 32px;
-		}
-	}
 </style>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description

On 800px screens unwanted `padding-left` was being applied, this PR fixes this edge-case:

| Current  | PR |
| ------------- | ------------- |
| ![NOHlkhB](https://user-images.githubusercontent.com/61414485/172948950-66108446-cfe7-41de-b234-64bfa0f52128.png)  | ![3u0uUmr](https://user-images.githubusercontent.com/61414485/172949102-55e90f3b-a6b9-4d96-8482-e75c6154edf3.png)  |
