### PR TITLE
Fix typo in Routing guide

### DIFF
--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -66,7 +66,7 @@ Routes can be generated from multiple named parameters, at any level of the file
 
 #### The `Astro.params` object
 
-Astro components that generate routes dynamically have acess to an `Astro.params` object for each route. This allows you to use those generated parts of the URL in your component script and template.
+Astro components that generate routes dynamically have access to an `Astro.params` object for each route. This allows you to use those generated parts of the URL in your component script and template.
 
 ```astro
 ---


### PR DESCRIPTION
`acess` => `access`

I really don't want to be the annoying person who just fixes typos, but I noticed one while reading the docs.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [x] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- What does this PR change? Give us a brief description.
  Fixes typo in `acess` => `access`
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
