### PR TITLE
Added two basic COC & CONTRIBUTING pages

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+See [GOVERNANCE.md](GOVERNANCE.md#Moderation) for instructions on reporting a Code of Conduct violation and a full description of the review process.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,46 @@ We welcome contributions of any size and skill level. As an open source project,
 
 This document is a work in progress! Most information on contributing can be found in the main README.md file. But, we need a place to begin to document some of our tools and processes, like our `Aside` Markdown feature.
 
+## Contributing with a Fork
+
+Not sure how to get started with GitHub, forks, pull requests, or want a quick refresher? You might want to check out this free video series:
+
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+### Forks
+On GitHub you’ll need a “fork” of this repository to work on. This is your own copy where you can make changes. [Read more about forks in GitHub’s docs](https://guides.github.com/activities/forking/).
+
+#### Creating a fork
+To create your copy, click the <kbd>Fork</kbd> button at the top right of any page in this repository.
+
+#### Maintaining a fork
+When you first create your fork, it will be an exact copy of this repository. Over time, `withastro/docs` will change as the docs are updated, but your fork won’t automatically stay up-to-date. Here are some ways to keep your fork in sync with this repo.
+
+##### Manually via the GitHub UI
+1. Navigate to your fork on GitHub
+2. Click <kbd>Fetch upstream</kbd> and then <kbd>Fetch and merge</kbd>
+
+##### Manually from the command line
+In the terminal on your computer:
+1. Make sure you’re on the main branch: `git checkout main`
+2. Fetch and merge updates: `git pull upstream main`
+3. Push the updates back to your fork on GitHub: `git push origin main`
+
+##### Automatically with a GitHub app
+1. Go to [the “Pull” Github app page](https://github.com/apps/pull)
+2. Click <kbd>Install</kbd>
+3. Follow the instructions to select your fork
+
+### Opening a PR
+
+One you have made your changes, you’re ready to create a “Pull Request”! This will let the Astro docs team know you have some changes to propose. At this point we can give you feedback and might request changes. In general, we like to have at least one other person who knows the language you are translating into review the PR.
+
+[Read more about making a pull request in GitHub’s docs](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-a-pull-request)
+
+## Style Guide
+
+We are developing a full Style Guide to help our contributors provide new content with a consistent style and voice! For now, here are some specific items you should know about when writing new docs content.
+
 ## Writing Asides (aka how not to abuse `blockquote`)
 
 Sometimes in documentation you want to provide information that is complementary but not strictly part of the current text or call out something that is particularly important. For example, maybe you want to include a tip that isn’t essential but could be helpful or warn a reader about a potential pitfall.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributor Manual
+
+We welcome contributions of any size and skill level. As an open source project, we believe in giving back to our contributors and are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
+
+> **Tip for new contributors:**
+> Take a look at [https://github.com/firstcontributions/first-contributions](https://github.com/firstcontributions/first-contributions) for helpful information on contributing
+
+This document is a work in progress! Most information on contributing can be found in the main README.md file. But, we need a place to begin to document some of our tools and processes, like our `Aside` Markdown feature.
+
+## Writing Asides (aka how not to abuse `blockquote`)
+
+This is an accessible component, based on the [recommended markup from the BBC’s GEL design system](https://bbc.github.io/gel/components/breakout-boxes/#recommended-markup).
+
+The component has **note**, **tip**, **caution** and **danger** variants with colour, iconography, and default labelling distinct for each.
+
+This is an Astro integration/remark plugin that allows us to use a simple syntax to use the component in Markdown and also avoid needing to import it in the frontmatter all the time.
+
+```
+:::tip
+It’s best to avoid using `<blockquote>` for things that aren’t quotes.
+:::
+```
+
+The syntax also supports custom titles for the asides:
+
+```
+:::caution[Deprecated]
+Using `<blockquote>` for notes is deprecated.
+:::
+```
+
+You can see all three currently-used styles (we don't have any "danger" yet!) in action on the [Astro Components Page](https://docs.astro.build/en/core-concepts/astro-components/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We welcome contributions of any size and skill level. As an open source project, we believe in giving back to our contributors and are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
 > **Tip for new contributors:**
-> Take a look at [https://github.com/firstcontributions/first-contributions](https://github.com/firstcontributions/first-contributions) for helpful information on contributing
+> Take a look at <https://github.com/firstcontributions/first-contributions> for helpful information on contributing
 
 This document is a work in progress! Most information on contributing can be found in the main README.md file. But, we need a place to begin to document some of our tools and processes, like our `Aside` Markdown feature.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,13 @@ This document is a work in progress! Most information on contributing can be fou
 
 ## Writing Asides (aka how not to abuse `blockquote`)
 
-This is an accessible component, based on the [recommended markup from the BBC’s GEL design system](https://bbc.github.io/gel/components/breakout-boxes/#recommended-markup).
+Sometimes in documentation you want to provide information that is complementary but not strictly part of the current text or call out something that is particularly important. For example, maybe you want to include a tip that isn’t essential but could be helpful or warn a reader about a potential pitfall.
+
+For these use cases you can use our aside component. This is an accessible component, based on the [recommended markup from the BBC’s GEL design system](https://bbc.github.io/gel/components/breakout-boxes/#recommended-markup).
 
 The component has **note**, **tip**, **caution** and **danger** variants with colour, iconography, and default labelling distinct for each.
 
-This is an Astro integration/remark plugin that allows us to use a simple syntax to use the component in Markdown and also avoid needing to import it in the frontmatter all the time.
+You can use a simple custom syntax to use the component in Markdown and also avoid needing to import it in the frontmatter all the time.
 
 ```
 :::tip

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Please only add new text content to the docs **in English**, only modifying **`.
 
 We have automated systems in place for notifying our community translators that there is new material to be translated, so there is no need to make changes to additional languages yourself. 
 
+Please see CONTRIBUTING.md for other specific items to note when contributing to the documentation.
+
 ## Translate a Page
 
 Speak another language natively? Join our i18n gang on Discord or jump into the PRs to help with translating or reviewing translations!

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please only add new text content to the docs **in English**, only modifying **`.
 
 We have automated systems in place for notifying our community translators that there is new material to be translated, so there is no need to make changes to additional languages yourself. 
 
-Please see CONTRIBUTING.md for other specific items to note when contributing to the documentation.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for other specific items to note when contributing to the documentation.
 
 ## Translate a Page
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Discussions are threads where you can offer feedback on things that might not ex
 
 If you can see what the problem is, and you know how to fix it, then you can make a PR (pull request) with the change and contribute to the docs repo yourself!
 
+> Please also see [CONTRIBUTING.md](CONTRIBUTING.md) for more details
+
+### Edit a Page via GitHub
+
 Every page on [docs.astro.build](https://docs.astro.build/) has an **Edit this page** button in the sidebar.
 You can click that button to edit the source code for that page in **GitHub**.
 
@@ -52,21 +56,20 @@ This will automatically create a [fork](https://docs.github.com/en/pull-requests
 Once your edits are ready in GitHub, follow the prompts to **create a pull request** and submit your changes for review.
 Every pull request needs to be reviewed by our contributors and approved by a maintainer.
 
+
 **Important Note re: Internationalization (i18n)**
 
 Please only add new text content to the docs **in English**, only modifying **`.md` files located within `src/pages/en/`**. 
 
 We have automated systems in place for notifying our community translators that there is new material to be translated, so there is no need to make changes to additional languages yourself. 
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for other specific items to note when contributing to the documentation.
-
-## Translate a Page
+### Translate a Page
 
 Speak another language natively? Join our i18n gang on Discord or jump into the PRs to help with translating or reviewing translations!
 
 Check out the dedicated [i18n guide](src/i18n/README.md) for more details.
 
-## Develop
+### Develop Locally
 
 To begin developing locally, checkout this project from your machine.
 
@@ -101,11 +104,11 @@ As you [open a pull request](https://github.com/withastro/astro/compare), please
 Thank you for helping make the docs awesome.
 And please, [come chat with us](https://astro.build/chat) if you have any questions.
 
-## Deploy
+### Preview your Changes
 
-Every pull request generates a preview using **Netlify** for anyone to see.
+Every pull request generates a preview of the docs site, including your proposed changes, using **Netlify** for anyone to see.
 
-Use the **Deploy Preview** of your pull request to review and share your changes.
+Use the **Deploy Preview** link in your pull request to review and share your changes.
 
 The docs site will be automatically updated whenever pull requests are merged.
 

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -85,39 +85,7 @@ If you spot something on [docs.astro.build](https://docs.astro.build/) that you 
 
 ## Contributing to translations
 
-Not sure how to get started with GitHub, forks, pull requests, or want a quick refresher? You might want to check out this free video series:
-
-[How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
-### Forks
-On GitHub you’ll need a “fork” of this repository to work on. This is your own copy where you can make changes. [Read more about forks in GitHub’s docs](https://guides.github.com/activities/forking/).
-
-#### Creating a fork
-To create your copy, click the <kbd>Fork</kbd> button at the top right of any page in this repository.
-
-#### Maintaining a fork
-When you first create your fork, it will be an exact copy of this repository. Over time, `withastro/docs` will change as the docs are updated, but your fork won’t automatically stay up-to-date. Here are some ways to keep your fork in sync with this repo.
-
-##### Manually via the GitHub UI
-1. Navigate to your fork on GitHub
-2. Click <kbd>Fetch upstream</kbd> and then <kbd>Fetch and merge</kbd>
-
-##### Manually from the command line
-In the terminal on your computer:
-1. Make sure you’re on the main branch: `git checkout main`
-2. Fetch and merge updates: `git pull upstream main`
-3. Push the updates back to your fork on GitHub: `git push origin main`
-
-##### Automatically with a GitHub app
-1. Go to [the “Pull” Github app page](https://github.com/apps/pull)
-2. Click <kbd>Install</kbd>
-3. Follow the instructions to select your fork
-
-### Opening a PR
-
-One you have made your changes, you’re ready to create a “Pull Request”! This will let the Astro docs team know you have some changes to propose. At this point we can give you feedback and might request changes. In general, we like to have at least one other person who knows the language you are translating into review the PR.
-
-[Read more about making a pull request in GitHub’s docs](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-a-pull-request)
-
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributing via a fork, our Style Guide, and more!
 ---
 
 ## Adding a new language


### PR DESCRIPTION
- [ X] New or updated content

Adds 2 new pages to the repository: CONTRIBUTING.md and CODE_OF_CONDUCT.md

COC: copied from withastro/astro. We can discuss the possibility of an automated mirroring to replace this.

CONTRIBUTING: Only a basic skeleton of a page to start, BUT we needed a place to document the new `Aside` usage without the main README getting cluttered.

(Also updated README section on contributing with a note to consult CONTRIBUTING.md for specific items of note. This will get better!  😅 )