### PR TITLE
♻️ clarify that a string or number can be used

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -274,7 +274,7 @@ export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
     { params: { id: '2' } },
-    { params: { id:  3  }  }  // Can be a number too!
+    { params: { id:  3  } }  // Can be a number too!
   ];
 }
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -274,7 +274,7 @@ export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
     { params: { id: '2' } },
-    { params: { id:  3 // Can be a number too! Only strings and numbers are supported values. } }
+    { params: { id:  3  }  }  // Can be a number too! Only strings and numbers are supported values.
   ];
 }
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -274,7 +274,7 @@ export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
     { params: { id: '2' } },
-    { params: { id:  3  }  }  // Can be a number too! Only strings and numbers are supported values.
+    { params: { id:  3  }  }  // Can be a number too!
   ];
 }
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -274,7 +274,7 @@ export async function getStaticPaths() {
   return [
     { params: { id: '1' } },
     { params: { id: '2' } },
-    { params: { id:  3 } }
+    { params: { id:  3 // Can be a number too! Only strings and numbers are supported values. } }
   ];
 }
 


### PR DESCRIPTION
It's a bit confusing that `id: 3` is a number whereas the other two are strings. When I first read this I thought it was a bug until I read above where it mentioned that strings and numbers can be used as parameters. I think it'd be nice to reflect that in the code block as well just to make it concrete.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [x] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
