### PR TITLE
Edit: add "routes" to `astro:build:done` integration API reference

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -287,20 +287,63 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 **Why:** To access generated routes and assets for extension (ex. copy content into the generated `/assets` directory). If you plan to transform generated assets, we recommend exploring the [Vite Plugin API](https://vitejs.dev/guide/api-plugin.html) and [configuring via `astro:config:setup`](#updateconfig-option) instead.
 
 ```js
-'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL; routes: RouteData[] }) => void | Promise<void>;
+'astro:build:done'?: (options: { dir: URL; routes: RouteData[] }) => void | Promise<void>;
 ```
-
-#### `pages` option
-
-**Type:** `{ pathname: string }[]`
-
-An array of all generated routes. This currently includes the `pathname` alone, though we plan to include metadata in the future. Note: this will be empty when using an SSR adapter!
 
 #### `dir` option
 
 **Type:** [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL)
 
 A URL path to the build output directory. We wrap the path in a URL object for easier parsing. If you just want the path as a string, try `dir.pathname` 🙂
+
+#### `routes` option
+
+**Type:** [`RouteData[]`](https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts#L973)
+
+A list of all generated routes alongside their associated metadata. **This will be empty when using an SSR adapter!**
+
+You can reference the full `RouteData` type below, but the most common properties are:
+
+- `component` - the input file path relative to the project root
+- `pathname` - the output file URL (undefined for routes using `[dynamic]` and `[...spread]` params)
+
+**`RouteData` type reference**
+
+```ts
+interface RouteData {
+  /** Whether a given route is an HTML page or non-HTML endpoint */
+  type: 'page' | 'endpoint';
+  /** Source component URL */
+  component: string;
+  /**
+   * Output URL pathname where this route will be served
+   * note: will be undefined for [dynamic] and [...spread] routes
+   */
+  pathname?: string;
+  /** 
+   * regex used for matching an input URL against a requested route
+   * ex. "[fruit]/about.astro" will generate the pattern: /^\/([^/]+?)\/about\/?$/
+   * where pattern.test("banana/about") is "true"
+   */
+  pattern: RegExp;
+  /**
+   * Dynamic and spread route params
+   * ex. "/pages/[lang]/[..slug].astro" will output the params ['lang', '...slug']
+   */
+  params: string[];
+  /**
+   * Similar to the "params" field, but with more associated metadata
+   * ex. "/pages/[lang]/index.astro" will output the segments
+   * [[ { content: 'lang', dynamic: true, spread: false } ]]
+   */
+  segments: { content: string; dynamic: boolean; spread: boolean; }[][];
+  /** 
+   * Function to render component in-place from a set of input data.
+   * This is typically for internal use, so call with caution!
+   */
+  generate: (data?: any) => string;
+}
+```
 
 ## Integration Ordering
 

--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -8,7 +8,6 @@ i18nReady: true
 
 This reference page is for anyone writing their own integration. To learn how to use an integration in your project, check out our [Using Integrations](/en/guides/integrations-guide/) guide instead.
 
-
 ## Examples
 
 The official Astro integrations can act as reference for you as you go to build your own integrations.
@@ -51,9 +50,10 @@ interface AstroIntegration {
 
 ### `astro:config:setup`
 
-**Next hook:** [astro:config:done](#astroconfigdone)
+**Next hook:** [`astro:config:done`](#astroconfigdone)
 
 **When:** On initialization, before either the [Vite](https://vitejs.dev/config/) or [Astro config](/en/reference/configuration-reference/) have resolved.
+
 **Why:** To extend the project config. This inludes updating the [Astro config](/en/reference/configuration-reference/), applying [Vite plugins](https://vitejs.dev/guide/api-plugin.html), adding component renderers, and injecting scripts onto the page.
 
 ```js
@@ -111,20 +111,22 @@ export default {
 **Examples:** [`lit`](https://github.com/withastro/astro/blob/main/packages/integrations/lit/src/index.ts), [`svelte`](https://github.com/withastro/astro/blob/main/packages/integrations/svelte/src/index.ts), [`react`](https://github.com/withastro/astro/blob/main/packages/integrations/react/src/index.ts), [`preact`](https://github.com/withastro/astro/blob/main/packages/integrations/preact/src/index.ts), [`vue`](https://github.com/withastro/astro/blob/main/packages/integrations/vue/src/index.ts), [`solid`](https://github.com/withastro/astro/blob/main/packages/integrations/solid/src/index.ts)
 
 A callback function to add a component framework renderer (i.e. React, Vue, Svelte, etc). You can browse the examples and type definition above for more advanced options, but here are the 2 main options to be aware of:
+
 - `clientEntrypoint` - path to a file that executes on the client whenever your component is used. This is mainly for rendering or hydrating your component with JS.
 - `serverEntrypoint` - path to a file that executes during server-side requests or static builds whenever your component is used. These should render components to static markup, with hooks for hydration where applicable. [React's `renderToString` callback](https://reactjs.org/docs/react-dom-server.html#rendertostring) is a classic example.
 
 #### `injectRoute` option
+
 **Type:** `({ pattern: string, entryPoint: string }) => void;`
 
 A callback function to inject routes into an Astro project. Injected routes can be [`.astro` pages](/en/core-concepts/astro-pages/) or [`.js` and `.ts` route handlers](/en/core-concepts/astro-pages/#non-html-pages).
 
-`injectRoute` takes an object with a `pattern` and an `entryPoint`. 
+`injectRoute` takes an object with a `pattern` and an `entryPoint`.
 
 - `pattern` - where the route should be output in the browser, for example `/foo/bar`. A `pattern` can use Astro's filepath syntax for denoting dynamic routes, for example `/foo/[bar]` or `/foo/[...bar]`. Note that a file extension is **not** needed in the `pattern`.
 - `entryPoint` - a bare module specifier pointing towards the `.astro` page or `.js`/`.ts` route handler that handles the route denoted in the `pattern`.
 
-Example usage: 
+Example usage:
 
 ```js
 injectRoute({
@@ -148,10 +150,12 @@ The **`stage`** denotes how this script (the `content`) should be inserted. Some
 
 ### `astro:config:done`
 
-**Previous hook:** [astro:config:setup](#astroconfigsetup)
-**Next hook:** [astro:server:setup](#astroserversetup) when running in "dev" or "preview" mode, or [astro:build:start](#astrobuildstart) during production builds
+**Previous hook:** [`astro:config:setup`](#astroconfigsetup)
+
+**Next hook:** [`astro:server:setup`](#astroserversetup) when running in "dev" or "preview" mode, or [astro:build:start](#astrobuildstart) during production builds
 
 **When:** After the Astro config has resolved and other integrations have run their `astro:config:setup` hooks.
+
 **Why:** To retrieve the final config for use in other hooks.
 
 ```js
@@ -166,10 +170,12 @@ A read-only copy of the user-supplied [Astro config](/en/reference/configuration
 
 ### `astro:server:setup`
 
-**Previous hook:** [astro:config:done](#astroconfigdone)
-**Next hook:** [astro:server:start](#astroserverstart)
+**Previous hook:** [`astro:config:done`](#astroconfigdone)
+
+**Next hook:** [`astro:server:start`](#astroserverstart)
 
 **When:** Just after the Vite server is created in "dev" or "preview" mode, but before the `listen()` event is fired. [See Vite's createServer API](https://vitejs.dev/guide/api-javascript.html#createserver) for more.
+
 **Why:** To update Vite server options and middleware.
 
 ```js
@@ -197,10 +203,12 @@ import
 
 ### `astro:server:start`
 
-**Previous hook:** [astro:server:setup](#astroserversetup)
-**Next hook:** [astro:server:done](#astroserverdone)
+**Previous hook:** [`astro:server:setup`](#astroserversetup)
+
+**Next hook:** [`astro:server:done`](#astroserverdone)
 
 **When:** Just after the server's `listen()` event has fired.
+
 **Why:** To intercept network requests at the specified address. If you intend to use this address for middleware, consider using `astro:server:setup` instead.
 
 ```js
@@ -215,9 +223,10 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 ### `astro:server:done`
 
-**Previous hook:** [astro:server:start](#astroserverstart)
+**Previous hook:** [`astro:server:start`](#astroserverstart)
 
 **When:** Just after the dev server is closed.
+
 **Why:** To run any cleanup events you may trigger during the `astro:server:setup` or `astro:server:start` hooks.
 
 ```js
@@ -226,10 +235,12 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 ### `astro:build:start`
 
-**Previous hook:** [astro:config:done](#astroconfigdone)
-**Next hook:** [astro:build:setup](#astrobuildsetup)
+**Previous hook:** [`astro:config:done`](#astroconfigdone)
+
+**Next hook:** [`astro:build:setup`](#astrobuildsetup)
 
 **When:** After the `astro:config:done` event, but before the production build begins.
+
 **Why:** To set up any global objects or clients needed during a production build. This can also extend the build configuration options in the [adapter API](/en/reference/adapter-reference/).
 
 ```js
@@ -238,10 +249,12 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 ### `astro:build:setup`
 
-**Previous hook:** [astro:build:start](#astrobuildstart)
-**Next hook:** [astro:build:ssr](#astrobuildssr)
+**Previous hook:** [`astro:build:start`](#astrobuildstart)
+
+**Next hook:** [`astro:build:ssr`](#astrobuildssr)
 
 **When:** After the `astro:build:start` hook, runs immediately before the build.
+
 **Why:** At this point, the Vite config for the build has been completely constructed, this is your final chance to modify it. This can be useful for example to overwrite some defaults. If you're not sure whether you should use this hook or `astro:build:start`, use `astro:build:start` instead.
 
 ```js
@@ -255,9 +268,10 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 ### `astro:build:ssr`
 
-**Previous hook:** [astro:build:setup](#astrobuildsetup)
+**Previous hook:** [`astro:build:setup`](#astrobuildsetup)
 
 **When:** After a production build (SSG or SSR) has completed.
+
 **Why:** To get access the SSR manifest, this is useful when creating custom SSR builds in plugins or integrations.
 
 ```js
@@ -266,9 +280,10 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 ### `astro:build:done`
 
-**Previous hook:** [astro:build:ssr](#astrobuildssr)
+**Previous hook:** [`astro:build:ssr`](#astrobuildssr)
 
 **When:** After a production build (SSG or SSR) has completed.
+
 **Why:** To access generated routes and assets for extension (ex. copy content into the generated `/assets` directory). If you plan to transform generated assets, we recommend exploring the [Vite Plugin API](https://vitejs.dev/guide/api-plugin.html) and [configuring via `astro:config:setup`](#updateconfig-option) instead.
 
 ```js
@@ -293,10 +308,9 @@ All integrations are run in the order that they are configured. For instance, fo
 
 Your integration should ideally run in any order. If this isn't possible, we recommend documenting that your integration needs to come first or last in your user's `integrations` configuration array.
 
-
 ## Combine integrations into presets
 
-An integration can also be written as a collection of multiple, smaller integrations. We call these collections **presets.** Instead of creating a factory function that returns a single integration object, a preset returns an *array* of integration objects. This is useful for building complex features out of multiple integrations.
+An integration can also be written as a collection of multiple, smaller integrations. We call these collections **presets.** Instead of creating a factory function that returns a single integration object, a preset returns an _array_ of integration objects. This is useful for building complex features out of multiple integrations.
 
 ```js
 integrations: [


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [X] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

- update to `en` integration API reference: add `routes` to `astro:build:done` hook
- include `RouteData` type references to understand metadata options available
- chore: fix missing newlines on "when" and "why" sections. These were likely broken with the recent markdown enhancements in the latest beta.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
