### PR TITLE
Make fallback content notice sticky & dismissible

### DIFF
--- a/src/components/FallbackNotice.astro
+++ b/src/components/FallbackNotice.astro
@@ -1,9 +1,73 @@
 ---
 import Aside from './Aside.astro';
 import UIString from './UIString.astro';
+import { useTranslations } from '../i18n/util';
+const t = useTranslations(Astro);
 ---
 
-<Aside>
-	<UIString key="fallbackContent.notice" />
-	<a href="https://github.com/withastro/docs/blob/main/src/i18n#readme"><UIString key="fallbackContent.linkText" /></a>
-</Aside>
+<div class="fallback-notice">
+	<input type="checkbox" id="fallback-notice-close-checkbox" class="sr-only" aria-hidden="true">
+	<label for="fallback-notice-close-checkbox" aria-hidden="true">
+		<UIString key="fallbackContent.closeLabel" />
+	</label>
+	<Aside type="caution" title={t('fallbackContent.title')}>
+		<UIString key="fallbackContent.notice" />
+		<a href="https://github.com/withastro/docs/blob/main/src/i18n#readme">
+			<UIString key="fallbackContent.linkText" />
+		</a>
+	</Aside>
+</div>
+
+<style>
+	.fallback-notice {
+		position: fixed;
+		bottom: .5rem;
+		left: 50%;
+		transform: translateX(-50%);
+		width: calc(100% - 1rem);
+		max-width: 35rem;
+		z-index: 5;
+		background: var(--theme-bg-gradient-bottom);
+	}
+
+	@media (min-width: 37.75em) {
+		.fallback-notice {
+			bottom: 1.5rem;
+			z-index: 50;
+		}
+	}
+
+	@media (min-width: 50em) {
+		.fallback-notice {
+			bottom: 2.5rem;
+		}
+	}
+
+	.fallback-notice :global(aside) {
+		box-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
+	}
+
+	label {
+		position: absolute;
+		top: 0;
+		right: 0;
+		font-size: .875rem;
+		padding: .375rem .625rem;
+		color: var(--theme-text-lighter);
+	}
+
+	:global(.theme-dark) label {
+		color: var(--theme-text);
+	}
+
+	/* Highlight label for keyboard users */
+	input[type="checkbox"]:focus-visible~label {
+		outline: 2px solid currentColor;
+	}
+
+	/* Hide fallback notice when checkbox is checked */
+	input[type="checkbox"]:checked,
+	input[type="checkbox"]:checked~ :global(*) {
+		display: none
+	}
+</style>

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -39,6 +39,8 @@ export default {
 	// `<ContributorList>` fallback text
 	'contributors.seeAll': 'See all contributors',
 	// Fallback content notice shown when a page is not yet translated
+	'fallbackContent.closeLabel': 'Close',
+	'fallbackContent.title': 'Not translated',
 	'fallbackContent.notice': 'This page is not yet available in your language, so we’re showing you the English version. You can help by translating it!',
 	'fallbackContent.linkText': 'Learn more about how you can contribute',
 	// 404 Page


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description

Make the notice indicating a page is not translated yet sticky. Closes #646 

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
