### PR TITLE
a11y: Fix contrast issues in Aside component

### DIFF
--- a/src/components/Aside.astro
+++ b/src/components/Aside.astro
@@ -72,9 +72,12 @@ const { viewBox, d } = icons[type];
 	}
 
 	aside :global(p),
-	aside.content :global(ul),
-	aside :global(code:not([class*='language'])) {
+	aside.content :global(ul) {
 		color: var(--theme-text);
+	}
+
+	:global(.theme-dark) aside :global(code:not([class*='language'])) {
+		color: var(--theme-code-text);
 	}
 
 	aside :global(pre) {

--- a/src/components/Aside.astro
+++ b/src/components/Aside.astro
@@ -72,7 +72,7 @@ const { viewBox, d } = icons[type];
 	}
 
 	aside :global(p),
-	aside :global(.content ul),
+	aside.content :global(ul),
 	aside :global(code:not([class*='language'])) {
 		color: var(--theme-text);
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

This PR fixes two small colour contrast issues in text within the new Aside component I spotted while investigating #620 (thanks @mayank99!)

Inside the Aside component

- text in bullet points is now the same colour as surrounding body copy (I’d intended this initially but messed up the CSS selector)
- text in inline `<code>` snippets is now a little brighter in dark mode to ensure sufficient contrast

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
