### PR TITLE
Added dir notes in astro:build:done documentation

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -294,7 +294,30 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 
 **Type:** [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL)
 
-A URL path to the build output directory. We wrap the path in a URL object for easier parsing. If you just want the path as a string, try `dir.pathname` 🙂
+A URL path to the build output directory. We wrap the path in a URL object for easier parsing.
+
+e.g. If you just want the path as a string.  
+Use fileURLToPath to get it.  
+The reason dir.pathname is not used here is that in Windows environments, dir.pathname starts with `/` in the URL syntax, so codes like `path.join` will cause errors.
+
+```js
+import { fileURLToPath } from 'url';
+
+// ...
+'astro:build:done': async ({ dir }) => {
+  // Windows
+  console.log(dir.pathname)
+  // /C:/~~~ omission ~~~
+  console.log(path.join(dir.pathname, 'dir'))
+  // C:\C:\~~~ omission ~~~\dir
+
+  console.log(path.join(fileURLToPath(dir), 'dir'))
+  // C:\~~~ omission ~~~\dir
+  // Also,
+  console.log(fileURLToPath(new URL('./dir', dir)))
+  // C:\~~~ omission ~~~\dir
+}
+```
 
 #### `routes` option
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [x] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

I described some notes on the dir parameter in the astro:build:done hook of the integration API.
The URL object is designed to have a pathname value starting with `/` in Windows environment.
Using it causes an error in `path.join` and so on.
Therefore, it is necessary to use `fileURLToPath`.

relation: https://github.com/withastro/astro/issues/3607

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
