### PR TITLE
docs: add target property to open in playground buttons

### DIFF
--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -24,8 +24,8 @@ Visit [astro.new](https://astro.new/) for the easiest way to "try before you buy
 Or, **instantly launch our basic starter project** with just one click of a button:
 
 <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-    <Button href="https://astro.new/basics?on=codesandbox">Open in CodeSandbox</Button>
-    <Button href="https://astro.new/basics?on=stackblitz">Open in StackBlitz</Button>
+    <Button href="https://astro.new/basics?on=codesandbox" target="_blank">Open in CodeSandbox</Button>
+    <Button href="https://astro.new/basics?on=stackblitz" target="_blank">Open in StackBlitz</Button>
 </div>
 
 ### Install Astro Locally


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description

I was reading the docs and clicked on Open in CodeSandbox which made a redirect and took me from the documentation (which is not ideal).

By providing `target="_blank"` to the "Open in Playground" buttons, the user will have a new tab opened and keep the documentation in the original one. No visual changes.