### PR TITLE
Minor: Remove import.meta.env workaround, use Markdown syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^18.0.14",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
-    "astro": "1.0.0-beta.48",
+    "astro": "1.0.0-beta.51",
     "astro-eslint-parser": "^0.2.2",
     "bcp-47-normalize": "^2.1.0",
     "dedent-js": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   '@types/react': ^18.0.14
   '@typescript-eslint/eslint-plugin': ^5.27.0
   '@typescript-eslint/parser': ^5.27.0
-  astro: 1.0.0-beta.48
+  astro: 1.0.0-beta.51
   astro-eslint-parser: ^0.2.2
   bcp-47-normalize: ^2.1.0
   dedent-js: ^1.0.1
@@ -44,7 +44,7 @@ specifiers:
   unist-util-visit: ^4.1.0
 
 dependencies:
-  '@astropub/icons': 0.2.0_astro@1.0.0-beta.48
+  '@astropub/icons': 0.2.0_astro@1.0.0-beta.51
   jsdoc-api: 7.1.1
   rehype-autolink-headings: 6.1.1
   rehype-slug: 5.0.1
@@ -64,7 +64,7 @@ devDependencies:
   '@types/react': 18.0.14
   '@typescript-eslint/eslint-plugin': 5.27.0_523ueztkooxdrjszuewjoeoedq
   '@typescript-eslint/parser': 5.27.0_vjep2yp2sits3sqnodefgcbnfi
-  astro: 1.0.0-beta.48_sass@1.50.0
+  astro: 1.0.0-beta.51_sass@1.50.0
   astro-eslint-parser: 0.2.2
   bcp-47-normalize: 2.1.0
   dedent-js: 1.0.1
@@ -377,12 +377,12 @@ packages:
     dependencies:
       node-fetch: 3.2.6
 
-  /@astropub/icons/0.2.0_astro@1.0.0-beta.48:
+  /@astropub/icons/0.2.0_astro@1.0.0-beta.51:
     resolution: {integrity: sha512-qM/ldW/9rVHULNOZgz/23Yzgm2r3Iy2JJ1FuvJB6sFU67n61o1ImuXdHiaWSNoEHubD+IUkD9WG0hbhINgszqA==}
     peerDependencies:
       astro: '*'
     dependencies:
-      astro: 1.0.0-beta.48_sass@1.50.0
+      astro: 1.0.0-beta.51_sass@1.50.0
     dev: false
 
   /@babel/code-frame/7.16.7:
@@ -1248,8 +1248,8 @@ packages:
       - supports-color
     dev: true
 
-  /astro/1.0.0-beta.48_sass@1.50.0:
-    resolution: {integrity: sha512-43MyQVCGlOcRHfbVdRYYXUu2ZkxZzY7G3GuRRYiyOs4wrYMFhtUuD6Q595YhJy0pxW1nGgnqki79+xKnpKyeIw==}
+  /astro/1.0.0-beta.51_sass@1.50.0:
+    resolution: {integrity: sha512-arFrSrJ3d93+mvQbq8V4khEP+Et01ZdDV80jWfuFxtAnZpdZ+Qsv/ZkVbYmwSJdClJAxYt7YqVfeZKxUXHCcwg==}
     engines: {node: ^14.15.0 || >=16.0.0, npm: '>=6.14.0'}
     hasBin: true
     dependencies:

--- a/src/components/ImportMetaEnv.astro
+++ b/src/components/ImportMetaEnv.astro
@@ -1,8 +1,0 @@
----
-export interface Props {
-	path?: string;
-}
-const { path = '' } = Astro.props as Props;
----
-
-<code><Fragment set:html={'i'} />mport.meta.env{path}</code>

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -15,23 +15,18 @@ See the official [Environment Variables example](https://github.com/withastro/as
 SECRET_PASSWORD=password123
 PUBLIC_ANYBODY=there
 ```
-<p>
+
 In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
-</p>
 
 ## Default environment Variables
 
 Astro includes a few environment variables out-of-the-box:
-<ul>
-<li> `import.meta.env.MODE` (`development` | `production`): the mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.</li>
 
-<li> `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base">`base` config option</a>.</li>
-
-<li> `import.meta.env.PROD` (`boolean`): whether your site is running in production.</li>
-
-<li> `import.meta.env.DEV` (`boolean`): whether your site is running in development (always the opposite of `import.meta.env.PROD`).</li>
-<li>`import.meta.env.SITE` (`string`): <a href="/en/reference/configuration-reference/#site">The `site` option</a> specified in your project's `astro.config`.</li>
-</ul>
+- `import.meta.env.MODE` (`development` | `production`): the mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.
+- `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base">`base` config option</a>.
+- `import.meta.env.PROD` (`boolean`): whether your site is running in production.
+- `import.meta.env.DEV` (`boolean`): whether your site is running in development (always the opposite of `import.meta.env.PROD`).
+- `import.meta.env.SITE` (`string`): <a href="/en/reference/configuration-reference/#site">The `site` option</a> specified in your project's `astro.config`.
 
 ## Setting environment variables
 
@@ -58,19 +53,13 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 ## Getting environment variables
 
-<p>
-
 Instead of using `process.env`, with Vite you use `import.meta.env`, which uses the `import.meta` feature added in ES2020.
-</p>
 
 :::tip[Don't worry about browser support!]
 Vite replaces all `import.meta.env` mentions with static values.
 :::
 
-<p>
-
 For example, use `import.meta.env.PUBLIC_POKEAPI` to get the `PUBLIC_POKEAPI` environment variable.
-</p>
 
 ```js
 // When import.meta.env.SSR === true
@@ -84,13 +73,9 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
 
-
 ## IntelliSense for TypeScript
 
-<p>
-
 By default, Vite provides type definition for `import.meta.env` in `vite/client.d.ts`. 
-</p>
 
 While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables which are prefixed with `PUBLIC_`.
 

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -23,10 +23,10 @@ In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBOD
 Astro includes a few environment variables out-of-the-box:
 
 - `import.meta.env.MODE` (`development` | `production`): the mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.
-- `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base">`base` config option</a>.
+- `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the [`base` config option](/en/reference/configuration-reference/#base).
 - `import.meta.env.PROD` (`boolean`): whether your site is running in production.
 - `import.meta.env.DEV` (`boolean`): whether your site is running in development (always the opposite of `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): <a href="/en/reference/configuration-reference/#site">The `site` option</a> specified in your project's `astro.config`.
+- `import.meta.env.SITE` (`string`): [The `site` option](/en/reference/configuration-reference/#site) specified in your project's `astro.config`.
 
 ## Setting environment variables
 

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -3,8 +3,6 @@ layout: ~/layouts/MainLayout.astro
 title: Using environment variables
 description: Learn how to use environment variables in an Astro project.
 i18nReady: true
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro uses Vite for environment variables, and allows you to [use any of its methods](https://vitejs.dev/guide/env-and-mode.html) to get and set environment variables.
@@ -18,21 +16,21 @@ SECRET_PASSWORD=password123
 PUBLIC_ANYBODY=there
 ```
 <p>
-In this example, <code>PUBLIC_ANYBODY</code> (accessible via <ImportMetaEnv path=".PUBLIC_ANYBODY" />) will be available in server or client code, while <code>SECRET_PASSWORD</code> (accessible via <ImportMetaEnv path=".SECRET_PASSWORD" />) will be server-side only.
+In this example, <code>PUBLIC_ANYBODY</code> (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while <code>SECRET_PASSWORD</code> (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 </p>
 
 ## Default environment Variables
 
 Astro includes a few environment variables out-of-the-box:
 <ul>
-<li> <ImportMetaEnv path=".MODE" /> (<code>development</code> | <code>production</code>): the mode your site is running in. This is <code>development</code> when running <code>astro dev</code> and <code>production</code> when running <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (<code>development</code> | <code>production</code>): the mode your site is running in. This is <code>development</code> when running <code>astro dev</code> and <code>production</code> when running <code>astro build</code>.</li>
 
-<li> <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base"><code>base</code> config option</a>.</li>
+<li> `import.meta.env.BASE_URL` (<code>string</code>): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base"><code>base</code> config option</a>.</li>
 
-<li> <ImportMetaEnv path=".PROD" /> (<code>boolean</code>): whether your site is running in production.</li>
+<li> `import.meta.env.PROD` (<code>boolean</code>): whether your site is running in production.</li>
 
-<li> <ImportMetaEnv path=".DEV" /> (<code>boolean</code>): whether your site is running in development (always the opposite of <ImportMetaEnv path=".PROD" />).</li>
-<li><ImportMetaEnv path=".SITE" /> (<code>string</code>): <a href="/en/reference/configuration-reference/#site">The <code>site</code> option</a> specified in your project's <code>astro.config</code>.</li>
+<li> `import.meta.env.DEV` (<code>boolean</code>): whether your site is running in development (always the opposite of `import.meta.env.PROD`).</li>
+<li>`import.meta.env.SITE` (<code>string</code>): <a href="/en/reference/configuration-reference/#site">The <code>site</code> option</a> specified in your project's <code>astro.config</code>.</li>
 </ul>
 
 ## Setting environment variables
@@ -62,16 +60,16 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 <p>
 
-Instead of using `process.env`, with Vite you use <ImportMetaEnv />, which uses the `import.meta` feature added in ES2020.
+Instead of using `process.env`, with Vite you use `import.meta.env`, which uses the `import.meta` feature added in ES2020.
 </p>
 
 :::tip[Don't worry about browser support!]
-Vite replaces all <ImportMetaEnv /> mentions with static values.
+Vite replaces all `import.meta.env` mentions with static values.
 :::
 
 <p>
 
-For example, use <ImportMetaEnv path=".PUBLIC_POKEAPI" /> to get the `PUBLIC_POKEAPI` environment variable.
+For example, use `import.meta.env.PUBLIC_POKEAPI` to get the `PUBLIC_POKEAPI` environment variable.
 </p>
 
 ```js
@@ -83,7 +81,7 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
 :::caution
-Because Vite statically replaces <ImportMetaEnv />, you cannot access it with dynamic keys like <ImportMetaEnv path="[key]" />.
+Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
 
 
@@ -91,7 +89,7 @@ Because Vite statically replaces <ImportMetaEnv />, you cannot access it with dy
 
 <p>
 
-By default, Vite provides type definition for <ImportMetaEnv /> in `vite/client.d.ts`. 
+By default, Vite provides type definition for `import.meta.env` in `vite/client.d.ts`. 
 </p>
 
 While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables which are prefixed with `PUBLIC_`.

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -16,21 +16,21 @@ SECRET_PASSWORD=password123
 PUBLIC_ANYBODY=there
 ```
 <p>
-In this example, <code>PUBLIC_ANYBODY</code> (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while <code>SECRET_PASSWORD</code> (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
+In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 </p>
 
 ## Default environment Variables
 
 Astro includes a few environment variables out-of-the-box:
 <ul>
-<li> `import.meta.env.MODE` (<code>development</code> | <code>production</code>): the mode your site is running in. This is <code>development</code> when running <code>astro dev</code> and <code>production</code> when running <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (`development` | `production`): the mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.</li>
 
-<li> `import.meta.env.BASE_URL` (<code>string</code>): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base"><code>base</code> config option</a>.</li>
+<li> `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the <a href="/en/reference/configuration-reference/#base">`base` config option</a>.</li>
 
-<li> `import.meta.env.PROD` (<code>boolean</code>): whether your site is running in production.</li>
+<li> `import.meta.env.PROD` (`boolean`): whether your site is running in production.</li>
 
-<li> `import.meta.env.DEV` (<code>boolean</code>): whether your site is running in development (always the opposite of `import.meta.env.PROD`).</li>
-<li>`import.meta.env.SITE` (<code>string</code>): <a href="/en/reference/configuration-reference/#site">The <code>site</code> option</a> specified in your project's <code>astro.config</code>.</li>
+<li> `import.meta.env.DEV` (`boolean`): whether your site is running in development (always the opposite of `import.meta.env.PROD`).</li>
+<li>`import.meta.env.SITE` (`string`): <a href="/en/reference/configuration-reference/#site">The `site` option</a> specified in your project's `astro.config`.</li>
 </ul>
 
 ## Setting environment variables

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -2,8 +2,6 @@
 layout: ~/layouts/MainLayout.astro
 title: API Reference
 i18nReady: true
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 ## `Astro` global
@@ -450,10 +448,10 @@ interface RSSArgument {
 
 <p>
 
-All ESM modules include a `import.meta` property. Astro adds <ImportMetaEnv /> through [Vite](https://vitejs.dev/guide/env-and-mode.html).
+All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
 </p>
 
-**<ImportMetaEnv path=".SSR" />** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
+**`import.meta.env.SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 
 ```jsx
 import { h } from 'preact';

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -446,10 +446,7 @@ interface RSSArgument {
 
 ## `import.meta`
 
-<p>
-
 All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
-</p>
 
 **`import.meta.env.SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, for example a component that should only be rendered in the client:
 

--- a/src/pages/es/guides/environment-variables.md
+++ b/src/pages/es/guides/environment-variables.md
@@ -3,8 +3,6 @@ layout: ~/layouts/MainLayout.astro
 title: Usando variables de entorno
 description: Aprende a usar variables de entorno en un proyecto de Astro.
 i18nReady: true
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro usa Vite para las variables de entorno y le permite [usar cualquiera de sus métodos](https://vitejs.dev/guide/env-and-mode.html) para obtener y establecer variables de entorno.
@@ -18,7 +16,7 @@ CLAVE_SECRETA=clave123
 PUBLIC_VARIABLE=clave_pública
 ```
 <p>
-En este ejemplo, <code>PUBLIC_VARIABLE</code> (accesible mediante <ImportMetaEnv path=".PUBLIC_VARIABLE" />) estará disponible tanto en el servidor como el cliente, mientras que <code>CLAVE_SECRETA</code> (accesible mediante <ImportMetaEnv path=".CLAVE_SECRETA" />) estará disponible solo en el servidor.
+En este ejemplo, <code>PUBLIC_VARIABLE</code> (accesible mediante `import.meta.env.PUBLIC_VARIABLE`) estará disponible tanto en el servidor como el cliente, mientras que <code>CLAVE_SECRETA</code> (accesible mediante `import.meta.env.CLAVE_SECRETA`) estará disponible solo en el servidor.
 </p>
 
 ## Variables de entorno predeterminadas
@@ -26,15 +24,15 @@ En este ejemplo, <code>PUBLIC_VARIABLE</code> (accesible mediante <ImportMetaEnv
 Astro incluye algunas variables de entorno predeterminadas:
 <ul>
 
-<li> <ImportMetaEnv path=".MODE" /> (<code>development</code> | <code>production</code>): el modo en el que se ejecuta su proyecto. Esto es <code>development</code > al ejecutar <code>astro dev</code> y <code>production</code> al ejecutar <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (<code>development</code> | <code>production</code>): el modo en el que se ejecuta su proyecto. Esto es <code>development</code > al ejecutar <code>astro dev</code> y <code>production</code> al ejecutar <code>astro build</code>.</li>
 
-<li> <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base"><code>base</code></a>.</li>
+<li> `import.meta.env.BASE_URL` (<code>string</code>): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base"><code>base</code></a>.</li>
 
-<li> <ImportMetaEnv path=".PROD" /> (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo producción. </li>
+<li> `import.meta.env.PROD` (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo producción. </li>
 
-<li> <ImportMetaEnv path=".DEV" /> (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a <ImportMetaEnv path=".PROD" />).</li>
+<li> `import.meta.env.DEV` (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).</li>
 
-<li><ImportMetaEnv path=".SITE" /> (<code>string</code>): <a href="/es/reference/configuration-reference/#site">la opción de configuración <code>site</code></a> especificada en el <code>astro.config</code> de su proyecto.</li>
+<li>`import.meta.env.SITE` (<code>string</code>): <a href="/es/reference/configuration-reference/#site">la opción de configuración <code>site</code></a> especificada en el <code>astro.config</code> de su proyecto.</li>
 </ul>
 
 ## Configurando variables de entorno
@@ -63,15 +61,15 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 ## Obteniendo variables de entorno
 
 <p>
-En lugar de usar `process.env`, Vite usa <ImportMetaEnv />, que usa la función `import.meta` agregada en ES2020.
+En lugar de usar `process.env`, Vite usa `import.meta.env`, que usa la función `import.meta` agregada en ES2020.
 </p>
 
 :::tip[¡No se preocupe por la compatibilidad con el navegador!]
-Vite reemplazará todas las menciones de <ImportMetaEnv /> con valores estáticos.
+Vite reemplazará todas las menciones de `import.meta.env` con valores estáticos.
 :::
 
 <p>
-Por ejemplo, use <ImportMetaEnv path=".PUBLIC_POKEAPI" /> para obtener la variable de entorno `PUBLIC_POKEAPI`.
+Por ejemplo, use `import.meta.env.PUBLIC_POKEAPI` para obtener la variable de entorno `PUBLIC_POKEAPI`.
 </p>
 
 ```js
@@ -83,14 +81,14 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
 :::caution
-Debido a que Vite reemplaza estáticamente a <ImportMetaEnv />, no puedes acceder a él con claves dinámicas como <ImportMetaEnv path="[key]" />.
+Debido a que Vite reemplaza estáticamente a `import.meta.env`, no puedes acceder a él con claves dinámicas como `import.meta.env[key]`.
 :::
 
 ## IntelliSense para TypeScript
 
 <p>
 
-De forma predeterminada, Vite proporciona una definición de tipos para <ImportMetaEnv /> en `vite/client.d.ts`.
+De forma predeterminada, Vite proporciona una definición de tipos para `import.meta.env` en `vite/client.d.ts`.
 </p>
 
 Si bien puedes definir más variables de entorno personalizadas en los archivos `.env.[mode]`, es posible que desees obtener TypeScript IntelliSense para las variables de entorno definidas por el usuario que tienen el prefijo `PUBLIC_`.

--- a/src/pages/es/guides/environment-variables.md
+++ b/src/pages/es/guides/environment-variables.md
@@ -16,7 +16,7 @@ CLAVE_SECRETA=clave123
 PUBLIC_VARIABLE=clave_pública
 ```
 <p>
-En este ejemplo, <code>PUBLIC_VARIABLE</code> (accesible mediante `import.meta.env.PUBLIC_VARIABLE`) estará disponible tanto en el servidor como el cliente, mientras que <code>CLAVE_SECRETA</code> (accesible mediante `import.meta.env.CLAVE_SECRETA`) estará disponible solo en el servidor.
+En este ejemplo, `PUBLIC_VARIABLE` (accesible mediante `import.meta.env.PUBLIC_VARIABLE`) estará disponible tanto en el servidor como el cliente, mientras que `CLAVE_SECRETA` (accesible mediante `import.meta.env.CLAVE_SECRETA`) estará disponible solo en el servidor.
 </p>
 
 ## Variables de entorno predeterminadas
@@ -24,15 +24,15 @@ En este ejemplo, <code>PUBLIC_VARIABLE</code> (accesible mediante `import.meta.e
 Astro incluye algunas variables de entorno predeterminadas:
 <ul>
 
-<li> `import.meta.env.MODE` (<code>development</code> | <code>production</code>): el modo en el que se ejecuta su proyecto. Esto es <code>development</code > al ejecutar <code>astro dev</code> y <code>production</code> al ejecutar <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (`development` | `production`): el modo en el que se ejecuta su proyecto. Esto es `development</code > al ejecutar <code>astro dev` y `production` al ejecutar `astro build`.</li>
 
-<li> `import.meta.env.BASE_URL` (<code>string</code>): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base"><code>base</code></a>.</li>
+<li> `import.meta.env.BASE_URL` (`string`): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base">`base`</a>.</li>
 
-<li> `import.meta.env.PROD` (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo producción. </li>
+<li> `import.meta.env.PROD` (`boolean`): es verdadero si su proyecto se está ejecutando en modo producción. </li>
 
-<li> `import.meta.env.DEV` (<code>boolean</code>): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).</li>
+<li> `import.meta.env.DEV` (`boolean`): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).</li>
 
-<li>`import.meta.env.SITE` (<code>string</code>): <a href="/es/reference/configuration-reference/#site">la opción de configuración <code>site</code></a> especificada en el <code>astro.config</code> de su proyecto.</li>
+<li>`import.meta.env.SITE` (`string`): <a href="/es/reference/configuration-reference/#site">la opción de configuración `site`</a> especificada en el `astro.config` de su proyecto.</li>
 </ul>
 
 ## Configurando variables de entorno

--- a/src/pages/es/guides/environment-variables.md
+++ b/src/pages/es/guides/environment-variables.md
@@ -23,10 +23,10 @@ En este ejemplo, `PUBLIC_VARIABLE` (accesible mediante `import.meta.env.PUBLIC_V
 Astro incluye algunas variables de entorno predeterminadas:
 
 - `import.meta.env.MODE` (`development` | `production`): el modo en el que se ejecuta su proyecto. Esto es `development` al ejecutar `astro dev` y `production` al ejecutar `astro build`.
-- `import.meta.env.BASE_URL` (`string`): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base">`base`</a>.
+- `import.meta.env.BASE_URL` (`string`): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración [`base`](/es/reference/configuration-reference/#base).
 - `import.meta.env.PROD` (`boolean`): es verdadero si su proyecto se está ejecutando en modo producción.
 - `import.meta.env.DEV` (`boolean`): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): <a href="/es/reference/configuration-reference/#site">la opción de configuración `site`</a> especificada en el `astro.config` de su proyecto.
+- `import.meta.env.SITE` (`string`): [la opción de configuración `site`](/es/reference/configuration-reference/#site) especificada en el `astro.config` de su proyecto.
 
 ## Configurando variables de entorno
 

--- a/src/pages/es/guides/environment-variables.md
+++ b/src/pages/es/guides/environment-variables.md
@@ -15,25 +15,18 @@ Consulte el [ejemplo de variables de entorno](https://github.com/withastro/astro
 CLAVE_SECRETA=clave123
 PUBLIC_VARIABLE=clave_pública
 ```
-<p>
+
 En este ejemplo, `PUBLIC_VARIABLE` (accesible mediante `import.meta.env.PUBLIC_VARIABLE`) estará disponible tanto en el servidor como el cliente, mientras que `CLAVE_SECRETA` (accesible mediante `import.meta.env.CLAVE_SECRETA`) estará disponible solo en el servidor.
-</p>
 
 ## Variables de entorno predeterminadas
 
 Astro incluye algunas variables de entorno predeterminadas:
-<ul>
 
-<li> `import.meta.env.MODE` (`development` | `production`): el modo en el que se ejecuta su proyecto. Esto es `development</code > al ejecutar <code>astro dev` y `production` al ejecutar `astro build`.</li>
-
-<li> `import.meta.env.BASE_URL` (`string`): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base">`base`</a>.</li>
-
-<li> `import.meta.env.PROD` (`boolean`): es verdadero si su proyecto se está ejecutando en modo producción. </li>
-
-<li> `import.meta.env.DEV` (`boolean`): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).</li>
-
-<li>`import.meta.env.SITE` (`string`): <a href="/es/reference/configuration-reference/#site">la opción de configuración `site`</a> especificada en el `astro.config` de su proyecto.</li>
-</ul>
+- `import.meta.env.MODE` (`development` | `production`): el modo en el que se ejecuta su proyecto. Esto es `development` al ejecutar `astro dev` y `production` al ejecutar `astro build`.
+- `import.meta.env.BASE_URL` (`string`): la URL base desde la que se sirve su proyecto. Esto está determinado por la opción de configuración <a href="/es/reference/configuration-reference/#base">`base`</a>.
+- `import.meta.env.PROD` (`boolean`): es verdadero si su proyecto se está ejecutando en modo producción.
+- `import.meta.env.DEV` (`boolean`): es verdadero si su proyecto se está ejecutando en modo desarrollo (siempre lo contrario a `import.meta.env.PROD`).
+- `import.meta.env.SITE` (`string`): <a href="/es/reference/configuration-reference/#site">la opción de configuración `site`</a> especificada en el `astro.config` de su proyecto.
 
 ## Configurando variables de entorno
 
@@ -60,17 +53,13 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 ## Obteniendo variables de entorno
 
-<p>
 En lugar de usar `process.env`, Vite usa `import.meta.env`, que usa la función `import.meta` agregada en ES2020.
-</p>
 
 :::tip[¡No se preocupe por la compatibilidad con el navegador!]
 Vite reemplazará todas las menciones de `import.meta.env` con valores estáticos.
 :::
 
-<p>
 Por ejemplo, use `import.meta.env.PUBLIC_POKEAPI` para obtener la variable de entorno `PUBLIC_POKEAPI`.
-</p>
 
 ```js
 // Cuando import.meta.env.SSR === true
@@ -86,10 +75,7 @@ Debido a que Vite reemplaza estáticamente a `import.meta.env`, no puedes accede
 
 ## IntelliSense para TypeScript
 
-<p>
-
 De forma predeterminada, Vite proporciona una definición de tipos para `import.meta.env` en `vite/client.d.ts`.
-</p>
 
 Si bien puedes definir más variables de entorno personalizadas en los archivos `.env.[mode]`, es posible que desees obtener TypeScript IntelliSense para las variables de entorno definidas por el usuario que tienen el prefijo `PUBLIC_`.
 

--- a/src/pages/fr/guides/environment-variables.md
+++ b/src/pages/fr/guides/environment-variables.md
@@ -22,10 +22,10 @@ Dans cet exemple, `PUBLIC_ANYBODY` ( disponible en tant que `import.meta.env.PUB
 Astro inclut quelques variables d'environnement par défaut :
 
 - `import.meta.env.MODE` (`development` | `production`): Représente le mode dans lequel le site tourne actuellement. Défini comme `development` en utilisant la commande `astro dev` et à `production` en utilisant `astro build`.
-- `import.meta.env.BASE_URL` (`string`): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option `base` dans votre configuration</a>.
+- `import.meta.env.BASE_URL` (`string`): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par [l'option `base` dans votre configuration](/fr/reference/configuration-reference/#base).
 - `import.meta.env.PROD` (`boolean`): Si votre site tourne en mode <i>"production"</i>.
 - `import.meta.env.DEV` (`boolean`): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): <a href="/fr/reference/configuration-reference/#site">L'option `site` dans votre configuration</a> spécifié dans le fichier `astro.config.mjs` de votre projet.
+- `import.meta.env.SITE` (`string`): [L'option `site` dans votre configuration](/fr/reference/configuration-reference/#site) spécifié dans le fichier `astro.config.mjs` de votre projet.
 
 ## Définir des variables d'environnement
 

--- a/src/pages/fr/guides/environment-variables.md
+++ b/src/pages/fr/guides/environment-variables.md
@@ -16,7 +16,7 @@ PUBLIC_ANYBODY=juste là
 ```
 
 <p>
-  Dans cet exemple, <code>PUBLIC_ANYBODY</code> ( disponible en tant que `import.meta.env.PUBLIC_ANYBODY` ) sera accessible à la fois dans le code côté serveur et côté client, alors que <code>SECRET_PASSWORD</code> ( disponible en tant que `import.meta.env.SECRET_PASSWORD` ) ne sera accessible que côté serveur.
+  Dans cet exemple, `PUBLIC_ANYBODY` ( disponible en tant que `import.meta.env.PUBLIC_ANYBODY` ) sera accessible à la fois dans le code côté serveur et côté client, alors que `SECRET_PASSWORD` ( disponible en tant que `import.meta.env.SECRET_PASSWORD` ) ne sera accessible que côté serveur.
 </p>
 
 ## Variables d'environnement par défaut
@@ -25,23 +25,23 @@ Astro inclut quelques variables d'environnement par défaut :
 
 <ul>
   <li>
-    `import.meta.env.MODE` (<code>development</code> | <code>production</code>): Représente le mode dans lequel le site tourne actuellement. Défini comme <code>development</code> en utilisant la commande <code>astro dev</code> et à <code>production</code> en utilisant <code>astro build</code>.
+    `import.meta.env.MODE` (`development` | `production`): Représente le mode dans lequel le site tourne actuellement. Défini comme `development` en utilisant la commande `astro dev` et à `production` en utilisant `astro build`.
   </li>
 
   <li>
-    `import.meta.env.BASE_URL` (<code>string</code>): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option <code>base</code> dans votre configuration</a>.
+    `import.meta.env.BASE_URL` (`string`): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option `base` dans votre configuration</a>.
   </li>
 
   <li>
-    `import.meta.env.PROD` (<code>boolean</code>): Si votre site tourne en mode <i>"production"</i>.
+    `import.meta.env.PROD` (`boolean`): Si votre site tourne en mode <i>"production"</i>.
   </li>
 
   <li>
-    `import.meta.env.DEV` (<code>boolean</code>): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
+    `import.meta.env.DEV` (`boolean`): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
   </li>
 
   <li>
-    `import.meta.env.SITE` (<code>string</code>): <a href="/fr/reference/configuration-reference/#site">L'option <code>site</code> dans votre configuration</a> spécifié dans le fichier <code>astro.config.mjs</code> de votre projet.
+    `import.meta.env.SITE` (`string`): <a href="/fr/reference/configuration-reference/#site">L'option `site` dans votre configuration</a> spécifié dans le fichier `astro.config.mjs` de votre projet.
   </li>
 </ul>
 

--- a/src/pages/fr/guides/environment-variables.md
+++ b/src/pages/fr/guides/environment-variables.md
@@ -2,8 +2,6 @@
 layout: ~/layouts/MainLayout.astro
 title: Utiliser des variables d'environnement
 description: Apprenez comment utiliser les variables d'environnement dans un projet Astro.
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro utilise Vite pour les variables d'environnement, et permet d'utiliser [n'importe quelle méthode de Vite](https://vitejs.dev/guide/env-and-mode.html) pour obtenir et définir des variables d'environnement.
@@ -18,7 +16,7 @@ PUBLIC_ANYBODY=juste là
 ```
 
 <p>
-  Dans cet exemple, <code>PUBLIC_ANYBODY</code> ( disponible en tant que <ImportMetaEnv path=".PUBLIC_ANYBODY" /> ) sera accessible à la fois dans le code côté serveur et côté client, alors que <code>SECRET_PASSWORD</code> ( disponible en tant que <ImportMetaEnv path=".SECRET_PASSWORD" /> ) ne sera accessible que côté serveur.
+  Dans cet exemple, <code>PUBLIC_ANYBODY</code> ( disponible en tant que `import.meta.env.PUBLIC_ANYBODY` ) sera accessible à la fois dans le code côté serveur et côté client, alors que <code>SECRET_PASSWORD</code> ( disponible en tant que `import.meta.env.SECRET_PASSWORD` ) ne sera accessible que côté serveur.
 </p>
 
 ## Variables d'environnement par défaut
@@ -27,23 +25,23 @@ Astro inclut quelques variables d'environnement par défaut :
 
 <ul>
   <li>
-    <ImportMetaEnv path=".MODE" /> (<code>development</code> | <code>production</code>): Représente le mode dans lequel le site tourne actuellement. Défini comme <code>development</code> en utilisant la commande <code>astro dev</code> et à <code>production</code> en utilisant <code>astro build</code>.
+    `import.meta.env.MODE` (<code>development</code> | <code>production</code>): Représente le mode dans lequel le site tourne actuellement. Défini comme <code>development</code> en utilisant la commande <code>astro dev</code> et à <code>production</code> en utilisant <code>astro build</code>.
   </li>
 
   <li>
-    <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option <code>base</code> dans votre configuration</a>.
+    `import.meta.env.BASE_URL` (<code>string</code>): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option <code>base</code> dans votre configuration</a>.
   </li>
 
   <li>
-    <ImportMetaEnv path=".PROD" /> (<code>boolean</code>): Si votre site tourne en mode <i>"production"</i>.
+    `import.meta.env.PROD` (<code>boolean</code>): Si votre site tourne en mode <i>"production"</i>.
   </li>
 
   <li>
-    <ImportMetaEnv path=".DEV" /> (<code>boolean</code>): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de <ImportMetaEnv path=".PROD" />).
+    `import.meta.env.DEV` (<code>boolean</code>): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
   </li>
 
   <li>
-    <ImportMetaEnv path=".SITE" /> (<code>string</code>): <a href="/fr/reference/configuration-reference/#site">L'option <code>site</code> dans votre configuration</a> spécifié dans le fichier <code>astro.config.mjs</code> de votre projet.
+    `import.meta.env.SITE` (<code>string</code>): <a href="/fr/reference/configuration-reference/#site">L'option <code>site</code> dans votre configuration</a> spécifié dans le fichier <code>astro.config.mjs</code> de votre projet.
   </li>
 </ul>
 
@@ -73,10 +71,10 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 ## Obtenir des variables d'environnement
 
 <p>
-  Au lieu d'utiliser `process.env`, avec Vite, vous utilisez <ImportMetaEnv />, qui utilise la fonctionnalité `import.meta` ajoutée dans ES2020.
+  Au lieu d'utiliser `process.env`, avec Vite, vous utilisez `import.meta.env`, qui utilise la fonctionnalité `import.meta` ajoutée dans ES2020.
 </p>
 <p>
-  Par exemple, utilisez <ImportMetaEnv path=".PUBLIC_POKEAPI" /> pour obtenir la variable d'environnement `PUBLIC_POKEAPI`.
+  Par exemple, utilisez `import.meta.env.PUBLIC_POKEAPI` pour obtenir la variable d'environnement `PUBLIC_POKEAPI`.
 </p>
 
 ```js
@@ -87,15 +85,15 @@ const data = await db(import.meta.env.DB_PASSWORD);
 const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
-_Ne vous inquiétez pas si votre navigateur ne supporte pas <ImportMetaEnv />, Vite remplace toutes les mentions de <ImportMetaEnv /> par des valeurs statiques._
+_Ne vous inquiétez pas si votre navigateur ne supporte pas `import.meta.env`, Vite remplace toutes les mentions de `import.meta.env` par des valeurs statiques._
 
 > ⚠️ATTENTION⚠️ :
-> Étant donné que Vite remplace statiquement <ImportMetaEnv />, vous ne pouvez pas y accéder avec des clés dynamiques comme <ImportMetaEnv path="[key]" />.
+> Étant donné que Vite remplace statiquement `import.meta.env`, vous ne pouvez pas y accéder avec des clés dynamiques comme `import.meta.env[key]`.
 
 ## Autocomplétion pour TypeScript
 
 <p>
-  Par défaut, Vite fournit des définitions de type pour <ImportMetaEnv /> dans `vite/client.d.ts`.
+  Par défaut, Vite fournit des définitions de type pour `import.meta.env` dans `vite/client.d.ts`.
 </p>
 
 Vous pouvez aussi définir d'autres variables d'environnement dans les fichiers `.env.[mode]`, mais vous voulez sûrement accéder à l'autocomplétion pour les variables d'environnement définies par l'utilisateur qui commencent par `PUBLIC_`.

--- a/src/pages/fr/guides/environment-variables.md
+++ b/src/pages/fr/guides/environment-variables.md
@@ -15,35 +15,17 @@ SECRET_PASSWORD=motdepasse123
 PUBLIC_ANYBODY=juste là
 ```
 
-<p>
-  Dans cet exemple, `PUBLIC_ANYBODY` ( disponible en tant que `import.meta.env.PUBLIC_ANYBODY` ) sera accessible à la fois dans le code côté serveur et côté client, alors que `SECRET_PASSWORD` ( disponible en tant que `import.meta.env.SECRET_PASSWORD` ) ne sera accessible que côté serveur.
-</p>
+Dans cet exemple, `PUBLIC_ANYBODY` ( disponible en tant que `import.meta.env.PUBLIC_ANYBODY` ) sera accessible à la fois dans le code côté serveur et côté client, alors que `SECRET_PASSWORD` ( disponible en tant que `import.meta.env.SECRET_PASSWORD` ) ne sera accessible que côté serveur.
 
 ## Variables d'environnement par défaut
 
 Astro inclut quelques variables d'environnement par défaut :
 
-<ul>
-  <li>
-    `import.meta.env.MODE` (`development` | `production`): Représente le mode dans lequel le site tourne actuellement. Défini comme `development` en utilisant la commande `astro dev` et à `production` en utilisant `astro build`.
-  </li>
-
-  <li>
-    `import.meta.env.BASE_URL` (`string`): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option `base` dans votre configuration</a>.
-  </li>
-
-  <li>
-    `import.meta.env.PROD` (`boolean`): Si votre site tourne en mode <i>"production"</i>.
-  </li>
-
-  <li>
-    `import.meta.env.DEV` (`boolean`): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
-  </li>
-
-  <li>
-    `import.meta.env.SITE` (`string`): <a href="/fr/reference/configuration-reference/#site">L'option `site` dans votre configuration</a> spécifié dans le fichier `astro.config.mjs` de votre projet.
-  </li>
-</ul>
+- `import.meta.env.MODE` (`development` | `production`): Représente le mode dans lequel le site tourne actuellement. Défini comme `development` en utilisant la commande `astro dev` et à `production` en utilisant `astro build`.
+- `import.meta.env.BASE_URL` (`string`): Représente l'URL de base sous laquelle votre site est déployé. Déterminé par <a href="/fr/reference/configuration-reference/#base">l'option `base` dans votre configuration</a>.
+- `import.meta.env.PROD` (`boolean`): Si votre site tourne en mode <i>"production"</i>.
+- `import.meta.env.DEV` (`boolean`): Si votre site tourne en mode <i>"development"</i> (toujours opposé à la valeur de `import.meta.env.PROD`).
+- `import.meta.env.SITE` (`string`): <a href="/fr/reference/configuration-reference/#site">L'option `site` dans votre configuration</a> spécifié dans le fichier `astro.config.mjs` de votre projet.
 
 ## Définir des variables d'environnement
 
@@ -70,12 +52,9 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 ## Obtenir des variables d'environnement
 
-<p>
-  Au lieu d'utiliser `process.env`, avec Vite, vous utilisez `import.meta.env`, qui utilise la fonctionnalité `import.meta` ajoutée dans ES2020.
-</p>
-<p>
-  Par exemple, utilisez `import.meta.env.PUBLIC_POKEAPI` pour obtenir la variable d'environnement `PUBLIC_POKEAPI`.
-</p>
+Au lieu d'utiliser `process.env`, avec Vite, vous utilisez `import.meta.env`, qui utilise la fonctionnalité `import.meta` ajoutée dans ES2020.
+
+Par exemple, utilisez `import.meta.env.PUBLIC_POKEAPI` pour obtenir la variable d'environnement `PUBLIC_POKEAPI`.
 
 ```js
 // Quand import.meta.env.SSR === true
@@ -92,9 +71,7 @@ _Ne vous inquiétez pas si votre navigateur ne supporte pas `import.meta.env`, V
 
 ## Autocomplétion pour TypeScript
 
-<p>
-  Par défaut, Vite fournit des définitions de type pour `import.meta.env` dans `vite/client.d.ts`.
-</p>
+Par défaut, Vite fournit des définitions de type pour `import.meta.env` dans `vite/client.d.ts`.
 
 Vous pouvez aussi définir d'autres variables d'environnement dans les fichiers `.env.[mode]`, mais vous voulez sûrement accéder à l'autocomplétion pour les variables d'environnement définies par l'utilisateur qui commencent par `PUBLIC_`.
 

--- a/src/pages/pt-BR/guides/environment-variables.md
+++ b/src/pages/pt-BR/guides/environment-variables.md
@@ -23,10 +23,10 @@ Nesse exemplo, `PUBLIC_TODOS` (acessível via `import.meta.env.PUBLIC_TODOS`) es
 Astro inclui algumas variáveis de ambiente por padrão:
 
 - `import.meta.env.MODE` (`development` (desenvolvimento) | `production` (produção)): o modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.
-- `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção `base` da configuração</a>.
+- `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela [opção `base` da configuração](/pt-BR/reference/configuration-reference/#base).
 - `import.meta.env.PROD` (`boolean`): Se o seu site está sendo executado em produção.
 - `import.meta.env.DEV` (`boolean`): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): <a href="/pt-BR/reference/configuration-reference/#site">A opção `site`</a> especificada no `astro.config` do seu projeto.
+- `import.meta.env.SITE` (`string`): [A opção `site`](/pt-BR/reference/configuration-reference/#site) especificada no `astro.config` do seu projeto.
 
 ## Definindo variáveis de ambiente
 

--- a/src/pages/pt-BR/guides/environment-variables.md
+++ b/src/pages/pt-BR/guides/environment-variables.md
@@ -16,21 +16,21 @@ SENHA_SECRETA=senha123
 PUBLIC_TODOS=aqui
 ```
 <p>
-Nesse exemplo, <code>PUBLIC_TODOS</code> (acessível via `import.meta.env.PUBLIC_TODOS`) estará disponível no código do cliente e do servidor, enquanto <code>SENHA_SECRETA</code> (acessível via `import.meta.env.SENHA_SECRETA`) estará apenas no lado do servidor.
+Nesse exemplo, `PUBLIC_TODOS` (acessível via `import.meta.env.PUBLIC_TODOS`) estará disponível no código do cliente e do servidor, enquanto `SENHA_SECRETA` (acessível via `import.meta.env.SENHA_SECRETA`) estará apenas no lado do servidor.
 </p>
 
 ## Variáveis de ambiente padrões
 
 Astro inclui algumas variáveis de ambiente por padrão:
 <ul>
-<li> `import.meta.env.MODE` (<code>development</code> (desenvolvimento) | <code>production</code> (produção)): o modo no qual o seu site está sendo executado. Seu valor é <code>development</code> quando estiver executando <code>astro dev</code> e será <code>production</code> quando estiver executando <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (`development` (desenvolvimento) | `production` (produção)): o modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.</li>
 
-<li> `import.meta.env.BASE_URL` (<code>string</code>): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção <code>base</code> da configuração</a>.</li>
+<li> `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção `base` da configuração</a>.</li>
 
-<li> `import.meta.env.PROD` (<code>boolean</code>): Se o seu site está sendo executado em produção.</li>
+<li> `import.meta.env.PROD` (`boolean`): Se o seu site está sendo executado em produção.</li>
 
-<li> `import.meta.env.DEV` (<code>boolean</code>): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).</li>
-<li>`import.meta.env.SITE` (<code>string</code>): <a href="/pt-BR/reference/configuration-reference/#site">A opção <code>site</code></a> especificada no <code>astro.config</code> do seu projeto.</li>
+<li> `import.meta.env.DEV` (`boolean`): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).</li>
+<li>`import.meta.env.SITE` (`string`): <a href="/pt-BR/reference/configuration-reference/#site">A opção `site`</a> especificada no `astro.config` do seu projeto.</li>
 </ul>
 
 ## Definindo variáveis de ambiente

--- a/src/pages/pt-BR/guides/environment-variables.md
+++ b/src/pages/pt-BR/guides/environment-variables.md
@@ -15,23 +15,18 @@ Veja o exemplo oficial de [variáveis de ambiente](https://github.com/withastro/
 SENHA_SECRETA=senha123
 PUBLIC_TODOS=aqui
 ```
-<p>
+
 Nesse exemplo, `PUBLIC_TODOS` (acessível via `import.meta.env.PUBLIC_TODOS`) estará disponível no código do cliente e do servidor, enquanto `SENHA_SECRETA` (acessível via `import.meta.env.SENHA_SECRETA`) estará apenas no lado do servidor.
-</p>
 
 ## Variáveis de ambiente padrões
 
 Astro inclui algumas variáveis de ambiente por padrão:
-<ul>
-<li> `import.meta.env.MODE` (`development` (desenvolvimento) | `production` (produção)): o modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.</li>
 
-<li> `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção `base` da configuração</a>.</li>
-
-<li> `import.meta.env.PROD` (`boolean`): Se o seu site está sendo executado em produção.</li>
-
-<li> `import.meta.env.DEV` (`boolean`): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).</li>
-<li>`import.meta.env.SITE` (`string`): <a href="/pt-BR/reference/configuration-reference/#site">A opção `site`</a> especificada no `astro.config` do seu projeto.</li>
-</ul>
+- `import.meta.env.MODE` (`development` (desenvolvimento) | `production` (produção)): o modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.
+- `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção `base` da configuração</a>.
+- `import.meta.env.PROD` (`boolean`): Se o seu site está sendo executado em produção.
+- `import.meta.env.DEV` (`boolean`): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).
+- `import.meta.env.SITE` (`string`): <a href="/pt-BR/reference/configuration-reference/#site">A opção `site`</a> especificada no `astro.config` do seu projeto.
 
 ## Definindo variáveis de ambiente
 
@@ -58,19 +53,13 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 ## Obtendo variáveis de ambiente
 
-<p>
-
 Ao invés de utilizar `process.env` com o Vite, você pode utilizar `import.meta.env`, que usa a funcionalidade `import.meta` adicionado no ES2020.
-</p>
 
 :::tip[Não se preocupe com a compatibilidade dos navegadores!]
 Vite substitui todas as menções de `import.meta.env` por valores estáticos.
 :::
 
-<p>
-
 Por exemplo, utilize `import.meta.env.PUBLIC_POKEAPI` para obter a variável de ambiente `PUBLIC_POKEAPI`.
-</p>
 
 ```js
 // Quando import.meta.env.SSR === true
@@ -87,10 +76,7 @@ Como o Vite estaticamente substitui `import.meta.env`, você não pode acessá-l
 
 ## IntelliSense para TypeScript
 
-<p>
-
 Por padrão, Vite fornece definições de tipo para `import.meta.env` em `vite/client.d.ts`. 
-</p>
 
 Embora você possa definir mais variáveis customizadas em arquivos `.env.[modo]`, você pode querer IntelliSense para TypeScript para variáveis de ambiente definidas por usuários que são prefixadas com `PUBLIC_`.
 

--- a/src/pages/pt-BR/guides/environment-variables.md
+++ b/src/pages/pt-BR/guides/environment-variables.md
@@ -3,8 +3,6 @@ layout: ~/layouts/MainLayout.astro
 title: Usando variáveis de ambiente
 description: Aprenda como utilizar variáveis de ambiente em um projeto Astro.
 i18nReady: true
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 Astro utiliza Vite para suas variáveis de ambiente e o permite [utilizar qualquer um de seus métodos](https://vitejs.dev/guide/env-and-mode.html) para obter e definir variáveis de ambiente.
@@ -18,21 +16,21 @@ SENHA_SECRETA=senha123
 PUBLIC_TODOS=aqui
 ```
 <p>
-Nesse exemplo, <code>PUBLIC_TODOS</code> (acessível via <ImportMetaEnv path=".PUBLIC_TODOS" />) estará disponível no código do cliente e do servidor, enquanto <code>SENHA_SECRETA</code> (acessível via <ImportMetaEnv path=".SENHA_SECRETA" />) estará apenas no lado do servidor.
+Nesse exemplo, <code>PUBLIC_TODOS</code> (acessível via `import.meta.env.PUBLIC_TODOS`) estará disponível no código do cliente e do servidor, enquanto <code>SENHA_SECRETA</code> (acessível via `import.meta.env.SENHA_SECRETA`) estará apenas no lado do servidor.
 </p>
 
 ## Variáveis de ambiente padrões
 
 Astro inclui algumas variáveis de ambiente por padrão:
 <ul>
-<li> <ImportMetaEnv path=".MODE" /> (<code>development</code> (desenvolvimento) | <code>production</code> (produção)): o modo no qual o seu site está sendo executado. Seu valor é <code>development</code> quando estiver executando <code>astro dev</code> e será <code>production</code> quando estiver executando <code>astro build</code>.</li>
+<li> `import.meta.env.MODE` (<code>development</code> (desenvolvimento) | <code>production</code> (produção)): o modo no qual o seu site está sendo executado. Seu valor é <code>development</code> quando estiver executando <code>astro dev</code> e será <code>production</code> quando estiver executando <code>astro build</code>.</li>
 
-<li> <ImportMetaEnv path=".BASE_URL" /> (<code>string</code>): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção <code>base</code> da configuração</a>.</li>
+<li> `import.meta.env.BASE_URL` (<code>string</code>): a URL base na qual o seu site está sendo acessado. Isso é determinado pela <a href="/pt-BR/reference/configuration-reference/#base">opção <code>base</code> da configuração</a>.</li>
 
-<li> <ImportMetaEnv path=".PROD" /> (<code>boolean</code>): Se o seu site está sendo executado em produção.</li>
+<li> `import.meta.env.PROD` (<code>boolean</code>): Se o seu site está sendo executado em produção.</li>
 
-<li> <ImportMetaEnv path=".DEV" /> (<code>boolean</code>): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de <ImportMetaEnv path=".PROD" />).</li>
-<li><ImportMetaEnv path=".SITE" /> (<code>string</code>): <a href="/pt-BR/reference/configuration-reference/#site">A opção <code>site</code></a> especificada no <code>astro.config</code> do seu projeto.</li>
+<li> `import.meta.env.DEV` (<code>boolean</code>): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).</li>
+<li>`import.meta.env.SITE` (<code>string</code>): <a href="/pt-BR/reference/configuration-reference/#site">A opção <code>site</code></a> especificada no <code>astro.config</code> do seu projeto.</li>
 </ul>
 
 ## Definindo variáveis de ambiente
@@ -62,16 +60,16 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 <p>
 
-Ao invés de utilizar `process.env` com o Vite, você pode utilizar <ImportMetaEnv />, que usa a funcionalidade `import.meta` adicionado no ES2020.
+Ao invés de utilizar `process.env` com o Vite, você pode utilizar `import.meta.env`, que usa a funcionalidade `import.meta` adicionado no ES2020.
 </p>
 
 :::tip[Não se preocupe com a compatibilidade dos navegadores!]
-Vite substitui todas as menções de <ImportMetaEnv /> por valores estáticos.
+Vite substitui todas as menções de `import.meta.env` por valores estáticos.
 :::
 
 <p>
 
-Por exemplo, utilize <ImportMetaEnv path=".PUBLIC_POKEAPI" /> para obter a variável de ambiente `PUBLIC_POKEAPI`.
+Por exemplo, utilize `import.meta.env.PUBLIC_POKEAPI` para obter a variável de ambiente `PUBLIC_POKEAPI`.
 </p>
 
 ```js
@@ -83,7 +81,7 @@ const dados = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
 :::caution
-Como o Vite estaticamente substitui <ImportMetaEnv />, você não pode acessá-lo com chaves dinâmicas como <ImportMetaEnv path="[chave]" />.
+Como o Vite estaticamente substitui `import.meta.env`, você não pode acessá-lo com chaves dinâmicas como `import.meta.env[chave]`.
 :::
 
 
@@ -91,7 +89,7 @@ Como o Vite estaticamente substitui <ImportMetaEnv />, você não pode acessá-l
 
 <p>
 
-Por padrão, Vite fornece definições de tipo para <ImportMetaEnv /> em `vite/client.d.ts`. 
+Por padrão, Vite fornece definições de tipo para `import.meta.env` em `vite/client.d.ts`. 
 </p>
 
 Embora você possa definir mais variáveis customizadas em arquivos `.env.[modo]`, você pode querer IntelliSense para TypeScript para variáveis de ambiente definidas por usuários que são prefixadas com `PUBLIC_`.

--- a/src/pages/pt-BR/reference/api-reference.md
+++ b/src/pages/pt-BR/reference/api-reference.md
@@ -445,10 +445,7 @@ interface RSSArgument {
 
 ## `import.meta`
 
-<p>
-
 Todos os módulos ESM incluem a propriedade `import.meta`. Astro adiciona `import.meta.env` através do [Vite](https://vitejs.dev/guide/env-and-mode.html).
-</p>
 
 **`import.meta.env.SSR`** pode ser utilizado para saber quando se está sendo renderizado no servidor. As vezes você pode querer uma lógica diferente, por exemplo, para um componente que deve ser apenas renderizado no cliente:
 

--- a/src/pages/pt-BR/reference/api-reference.md
+++ b/src/pages/pt-BR/reference/api-reference.md
@@ -2,8 +2,6 @@
 layout: ~/layouts/MainLayout.astro
 title: Referência da API
 i18nReady: true
-setup: |
-  import ImportMetaEnv from '~/components/ImportMetaEnv.astro';
 ---
 
 ## Global `Astro`
@@ -449,10 +447,10 @@ interface RSSArgument {
 
 <p>
 
-Todos os módulos ESM incluem a propriedade `import.meta`. Astro adiciona <ImportMetaEnv /> através do [Vite](https://vitejs.dev/guide/env-and-mode.html).
+Todos os módulos ESM incluem a propriedade `import.meta`. Astro adiciona `import.meta.env` através do [Vite](https://vitejs.dev/guide/env-and-mode.html).
 </p>
 
-**<ImportMetaEnv path=".SSR" />** pode ser utilizado para saber quando se está sendo renderizado no servidor. As vezes você pode querer uma lógica diferente, por exemplo, para um componente que deve ser apenas renderizado no cliente:
+**`import.meta.env.SSR`** pode ser utilizado para saber quando se está sendo renderizado no servidor. As vezes você pode querer uma lógica diferente, por exemplo, para um componente que deve ser apenas renderizado no cliente:
 
 ```jsx
 import { h } from 'preact';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [X] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

- Fixes https://github.com/withastro/docs/issues/612.
- Updates Astro to `1.0.0-beta.51`, which includes a fix that allows using `import.meta.env` directly in Markdown code. As this fix made our clever workaround of using an `ImportMetaEnv` Astro component unnecessary, I've removed the component and replaced all references to it with plain Markdown.
- I've also converted unnecessary HTML tags (`<p>`, `<ul>`/`<li>` etc.) to their proper Markdown variants.
- Marking this as "Minor" to avoid affecting translation up-to-dateness. I have also updated the translated content, so this change does not cause todos for translators.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
