### PR TITLE
Feat: Add fallback language indicator to links

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -8,6 +8,7 @@ import { h } from 'hastscript';
 
 import { tokens, foregroundPrimary, backgroundPrimary } from './syntax-highlighting-theme';
 import { astroAsides } from './integrations/astro-asides';
+import { remarkFallbackLang } from './plugins/remark-fallback-lang';
 
 import { escapeHtml } from './src/util';
 
@@ -52,6 +53,8 @@ export default defineConfig({
 			// These are here because setting custom plugins disables the default plugins
 			'remark-gfm',
 			['remark-smartypants', { dashes: false }],
+			// Add our custom plugin that marks links to fallback language pages
+			remarkFallbackLang(),
 		],
 		rehypePlugins: [
 			'rehype-slug',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "^7.17.9",
     "@docsearch/react": "^3.1.0",
     "@types/mdast": "^3.0.10",
+    "@types/node": "^18.0.0",
     "@types/react": "^18.0.14",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",

--- a/plugins/remark-fallback-lang.ts
+++ b/plugins/remark-fallback-lang.ts
@@ -1,0 +1,82 @@
+import type { Root } from 'mdast';
+import type { Plugin, Transformer } from 'unified';
+import { visit } from 'unist-util-visit';
+import path from 'path';
+import fs from 'fs';
+
+export function remarkFallbackLang(): Plugin<[], Root> {
+	const pageSourceDir = path.resolve('./src/pages');
+	const baseUrl = 'https://docs.astro.build/';
+
+	const transformer: Transformer<Root> = (tree, file) => {
+		const pageUrl = mdFilePathToUrl(file.path, pageSourceDir, baseUrl);
+		const pageLang = getLanguageCodeFromPathname(pageUrl.pathname);
+
+		// Ignore pages without language prefix and English pages
+		if (!pageLang || pageLang === 'en')
+			return;
+
+		visit(tree, 'link', (link) => {
+			const linkUrl = new URL(link.url, pageUrl);
+
+			// Ignore external links
+			if (pageUrl.host !== linkUrl.host)
+				return;
+
+			// Ignore link targets without language prefix
+			const linkLang = getLanguageCodeFromPathname(linkUrl.pathname);
+			if (!linkLang)
+				return;
+
+			// Ignore link targets that have a valid source file
+			const linkSourceFileName = tryFindSourceFileForPathname(linkUrl.pathname, pageSourceDir);
+			if (linkSourceFileName)
+				return;
+			
+			link.children.push({
+				type: 'html',
+				value: `&nbsp;(EN)`,
+			});
+		});
+	};
+
+	return function attacher() {
+		return transformer;
+	};
+}
+
+function mdFilePathToUrl(mdFilePath: string, pageSourceDir: string, baseUrl: string) {
+	const pathBelowRoot = path.relative(pageSourceDir, mdFilePath);
+	const pathname = pathBelowRoot.replace(/\\/g, '/').replace(/\.md$/i, '/');
+
+	return new URL(pathname, baseUrl);
+}
+
+function getLanguageCodeFromPathname(pathname: string) {
+	// Assuming that `pathname` always starts with a `/`, retrieve the first path part,
+	// which is usually the language code
+	const firstPathPart = pathname.split('/')[1];
+	// Only return parts that look like a two-letter language code
+	// with optional two-letter country code
+	if (firstPathPart.match(/^[a-z]{2}(-[a-zA-Z]{2})?$/))
+		return firstPathPart;
+}
+
+/**
+ * Attempts to find a Markdown source file for the given `pathname`.
+ * 
+ * Example: Given a pathname of `/en/some-page` or `/en/some-page/`,
+ * searches for the source file in the following locations
+ * and returns the first matching path:
+ * - `${this.pageSourceDir}/en/some-page.md`
+ * - `${this.pageSourceDir}/en/some-page/index.md`
+ * 
+ * If no existing file is found, returns `undefined`.
+ */
+export function tryFindSourceFileForPathname (pathname: string, pageSourceDir: string) {
+	const possibleSourceFilePaths = [
+		path.join(pageSourceDir, pathname, '.') + '.md',
+		path.join(pageSourceDir, pathname, 'index.md'),
+	];
+	return possibleSourceFilePaths.find(possiblePath => fs.existsSync(possiblePath));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@docsearch/react': ^3.1.0
   '@fontsource/ibm-plex-mono': ^4.5.10
   '@types/mdast': ^3.0.10
+  '@types/node': ^18.0.0
   '@types/react': ^18.0.14
   '@typescript-eslint/eslint-plugin': ^5.27.0
   '@typescript-eslint/parser': ^5.27.0
@@ -63,6 +64,7 @@ devDependencies:
   '@babel/core': 7.17.9
   '@docsearch/react': 3.1.0_twyhzqqpkwvvgrmyeapdo6i4my
   '@types/mdast': 3.0.10
+  '@types/node': 18.0.0
   '@types/react': 18.0.14
   '@typescript-eslint/eslint-plugin': 5.27.0_523ueztkooxdrjszuewjoeoedq
   '@typescript-eslint/parser': 5.27.0_vjep2yp2sits3sqnodefgcbnfi
@@ -934,6 +936,10 @@ packages:
     resolution: {integrity: sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==}
     dependencies:
       '@types/unist': 2.0.6
+
+  /@types/node/18.0.0:
+    resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+    dev: true
 
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [X] Changes to the docs site code
- [ ] Something else!

#### Description

- Fixes https://github.com/withastro/docs/issues/646.
- Adds an `(EN)` suffix to the link text of links pointing to pages that have not been translated yet.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
