### PR TITLE
Add sections to editor-setup about Prettier and ESLint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ pnpm start
 If you’re copying these instructions, remember to [configure this project as a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork).
 
 ```shell
-git remote add upstream git@github.com:csstools/docs.git
+git remote add upstream git@github.com:withastro/docs.git
 ```
 
 At any point, create a branch for your contribution.

--- a/src/pages/en/editor-setup.md
+++ b/src/pages/en/editor-setup.md
@@ -37,3 +37,39 @@ In addition to local editors, Astro also runs well on in-browser hosted editors,
 - [StackBlitz](https://stackblitz.com/) and [CodeSandbox](https://codesandbox.io/) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
 - [GitHub.dev](https://github.dev/) - allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
 - [Gitpod](https://gitpod.io/) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.
+
+## Other tools
+
+### ESLint
+
+[ESLint](https://eslint.org/) is a popular linter for JavaScript and JSX. For Astro support, [a community maintained plugin](https://github.com/ota-meshi/eslint-plugin-astro) can be installed
+
+See [the project's User Guide](https://ota-meshi.github.io/eslint-plugin-astro/user-guide/) for more information on how to install and setup this for your project
+
+### Prettier
+
+[Prettier](https://prettier.io/) is a popular formatter for JavaScript, HTML, CSS and more. To add Astro support (`.astro` files), we created and maintain an [official Prettier Astro plugin](https://github.com/withastro/prettier-plugin-astro)
+
+To get started, first install Prettier and the plugin:
+
+```shell
+npm install --save-dev prettier prettier-plugin-astro
+```
+
+Prettier will then automatically detect the plugin and use it to process `.astro` files when you run it:
+
+```shell
+prettier --write .
+```
+
+For more information about the supported options, how to get it setup when using Prettier inside VS Code and more, see [the plugin's README](https://github.com/withastro/prettier-plugin-astro/blob/main/README.md)
+
+:::caution[Using with pnpm]
+Due to upstream issues inside Prettier, the plugin will not be automatically detected when using [pnpm](https://pnpm.io/). In order to make it find the plugin, the following parameter needs to be added when running Prettier:
+
+```shell
+prettier -w --plugin-search-dir=. .
+```
+
+Additional settings are also required when using Prettier inside VS Code, see the plugin's README for more information
+:::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [x] New or updated content
- [ ] Translated content
- [ ] Changes to the docs site code
- [ ] Something else!

#### Description

**Do not merge yet! This PR refers to the updated Prettier README that is currently not in the main branch of said plugin**

Added a section to the Editor Setup page about how to setup Prettier and ESLint. 

For ESLint, I opted to simply link the the plugin's User Guide. My reasoning being that being an unofficial plugin, changes might change the installation / configuration process without us noticing. (And it shouldn't be the burden of the community members maintaining it to update our docs, in my opinion.)

For Prettier, I documented how to install it and use it in a CLI scenario in our docs and left a link to the README for further information on how to use it in VS Code and possible settings. I however documented how to make it work in pnpm because it's an issue people encounter very very frequently, to the point where people often think the plugin is broken

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
