### PR TITLE
Increase height of mobile contents navigation entries

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -436,7 +436,6 @@ h2.heading {
 
 .header-link {
 	font-size: 1rem;
-	padding: 0.1rem 0 0.1rem 0;
 	transition: border-inline-start-color 100ms ease-out, background-color 200ms ease-out;
 }
 
@@ -447,6 +446,7 @@ h2.heading {
 	font: inherit;
 	color: var(--theme-text-lighter);
 	text-decoration: none;
+	min-height: 48px;
 }
 
 .header-link:hover,


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Place an X in the [ ] for any of these that apply -->

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description

This PR improves the SEO Lighthouse score (together with other PR #834) from `92` to `100`.

The lighthouse SEO report said, that the nav content entries are too small for mobile phones and should have at least a height of 48px. So this PR does exactly that.

Before:
![docs astro build_en_getting-started_](https://user-images.githubusercontent.com/275268/175563650-cbf0348f-4a10-4806-8129-b9600cd766b4.png)

After:
![localhost_3001_en_getting-started_(Moto G4)](https://user-images.githubusercontent.com/275268/175563684-482d6d00-310e-4a78-8116-cd656e89486b.png)

