### PR TITLE
Sidebar: Open current page section on mobile

### DIFF
--- a/src/components/Header/SidebarToggle.tsx
+++ b/src/components/Header/SidebarToggle.tsx
@@ -14,6 +14,7 @@ const MenuToggle: FunctionalComponent = () => {
 			document.querySelectorAll('nav details').forEach((e) => {
 				e.removeAttribute('open');
 			});
+			document.querySelector('details a[aria-current="page"]')?.closest('details')?.setAttribute('open', '');
 		} else {
 			body.classList.remove('mobile-sidebar-toggle');
 			document.querySelectorAll('nav details').forEach((e) => {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- [ ] Minor content fixes (broken links, typos, etc.)
- [ ] New or updated content
- [ ] Translated content
- [x] Changes to the docs site code
- [ ] Something else!

#### Description
This PR changes the mobile hamburger menu behavior (before, it collapsed all sections), opening the current page section by default on mobile. I believe this small change improves the mobile navigation UX a lot. Example gif (as you can see, my sister's laptop isn't fast):

![current-page-opening](https://user-images.githubusercontent.com/61414485/175747472-5cd0f63c-e597-4f89-8bef-9e62b5b9f1db.gif)

NOTE: When we are on `deploy/(service)` or `install/manual` no page is highlighted as the current one, is this something we can easily change as part of this PR (or should we tackle this as a separate issue/PR), so when we are on "nested pages" we are still highlighting the deploy/install page link?


