### PR TITLE
Suggested edits to Step 1

### DIFF
--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -17,7 +17,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Installation
 
-`create-astro` is the fastest, easiest way to start a new Astro project from scratch.
+`create-astro` is the fastest way to start a new Astro project from scratch.
 
 :::tip[Online previews]
 Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to browse our starter templates and spin up a new Astro project without ever leaving your browser.
@@ -37,16 +37,37 @@ yarn create astro
 pnpm create astro@latest
 ```
 
-The `create-astro` wizard will walk you through setting up a new Astro project, including:
+The `create-astro` wizard will walk you through setting up a new Astro project, by asking the following questions:
 
-1. Setting a new project directory.
-2. Selecting a starter project template (browse templates on [astro.new](https://astro.new/)).
-3. Optionally installing your new npm dependencies.
-4. Optionally initializing a new git repo for your project.
+1. Where would you like to create your new Astro project?
+    
+    Astro must be installed in an empty folder. Type in a name for your new project directory.
+    
+    ```bash
+    ./my-astro-site
+    ```
 
-You do not need to create a new directory for your project before running the wizard. As a part of setup, the `create-astro` wizard will ask you where your new project should live and will create a new folder for it if needed.
+1. Which template would you like to use? (browse all templates on [astro.new](https://astro.new/)).
+    
+    Select from the following list:
+    - [Just the Basics](https://github.com/withastro/astro/tree/main/examples/basics) - includes a typical project structure as a model
+    - [Blog](https://github.com/withastro/astro/tree/main/examples/blog) - includes an index page and a folder with first blog post
+    - [Docs](https://github.com/withastro/astro/tree/main/examples/docs) - includes sidebar navigation, "On this page" contents and more!
+    - [Portfolio](https://github.com/withastro/astro/tree/main/examples/portfolio) - styled and ready to go portfolio and about pages!
+    - [Completely Empty](https://github.com/withastro/astro/tree/main/examples/minimal) - just a single page
 
-Before running, some package managers may prompt you to confirm that you want to install the latest version of `create-astro` (`create-astro@latest`). This is expected, and it is okay to accept this prompt so that the `create-astro` wizard can run on your machine.
+
+1. Would you like to run npm install? (Y/n)
+
+    **Optional**: You can install dependencies yourself after setup!
+
+1. Initialize a Git repository? (Y/n)
+
+    **Optional**: You can run `git init` later!
+
+<!-- You do not need to create a new directory for your project before running the wizard. As a part of setup, the `create-astro` wizard will ask you where your new project should live and will create a new folder for it if needed.
+
+Before running, some package managers may prompt you to confirm that you want to install the latest version of `create-astro` (`create-astro@latest`). This is expected, and it is okay to accept this prompt so that the `create-astro` wizard can run on your machine. -->
 
 ## 2. Install NPM Dependencies
 


### PR DESCRIPTION
Finally had a chance to pay proper attention to this. Firstly, as @delucis said, this new CLI is WAY easier to document 🥳 and I do like that we can streamline this page a bit!

But, I do have THOUGHTS about Step 1, and the easiest way to comment was with a quick draft of an example!  :)

The new Step 1 steps are short and sweet, but I think they are actually less readable this way. They are short, but I find they are acting themselves like a short wall of text.  I think they could provide much more value (as I suggest below, to the people who I believe are likely to actually use this page). I'm not proposing major changes, but I do think they might go against your thinking for this restructuring, which is why I'm explaining in such detail my reaction and instinct to take a slightly different path.

I will also point out that **every** bit of user feedback from external users has been about information *missing* from this page. (Internally, we have had several discussions re: "Do we actually need this...?") We have never had anyone say there was too much information on this page, and have even had people file issues for things we couldn't believe anyone would suggest adding to this page. So I do believe it's really worth keeping that in mind, and certainly we can plan to do some proper user testing in the future.

Hereare my thoughts behind proposing a change *like this* (doesn't have to be exactly this, and our docs site doesn't yet handle lists and bullets well re: spacing etc. so bear in mind I'm just indicating general content/structure) for your consideration:

1. Especially with create-astro being MUCH easier to use now (yay!) I really think it's all the more likely that **the only people really using and relying on this page will be the people who DON'T just follow the one line instruction on getting started** and go on their merry way. I do believe we are writing here for people who NEED or WANT a *little* more to go on.

1. If we're going to have a numbered list of things that will happen, and the questions from create-astro themselves are basically the same length as the points, **it is lower cognitive load to just use the exact questions rather than describe the steps**. It allows people to "follow along," lets them know what to expect, that they're on the right track, allows them to see exactly what's coming and for all these reasons is more user-friendly. It also means that this is entirely descriptive for someone reading through this but not at their computer. They don't even have to run create-astro to know exactly what is in create-astro. (again, now that it's so simple and we can do this!)

1. The last 2 questions don't really add very much, but **visually it's much better** and provides scanability. It makes everything *else* easier to read.

1. Again, re: the last couple of questions: I've copied the helpful, friend messages that create-astro will give when you say no, but this way, **people can see the consequences of saying no upfront**. It's one thing to have a friendly message AFTER they've said no to something that maybe they don't know they need. But, this way they can be confident in saying no.

1. Listing out the templates: yes, it takes up more room but again, it's much easier to read, even if you don't read them! I also added links to each individual repository. Again, not everyone is reading this page WHILE running create-astro, and this is a helpful resource for them to explore the templates. And, **astro.new has SO MANY templates**, going there doesn't otherwise tell the reader which ones they'll be able to choose from. 

1.  A short description of what the template is and link to the repository (which you actually can NOT get to from astro.new) is **something we have seen multiple people ask for while watching them on streams**.. including at least one stream Ben was on! It's helpful without being taxing visually and in fact "fills out" the list. (NB: the exact text can of course be edited.)

So.. that's my contribution to this discussion!