### PR TITLE
Fix current sidebar item text colour in light mode

### DIFF
--- a/src/components/LeftSidebar/SidebarContent.astro
+++ b/src/components/LeftSidebar/SidebarContent.astro
@@ -111,7 +111,8 @@ const lang = getLanguageFromURL(Astro.canonicalURL.pathname);
 		}
 	}
 
-	:global(:root.theme-dark) .nav-link a[aria-current='page'], .nav-link a[data-current-parent='true'] {
+	:global(:root.theme-dark) .nav-link a[aria-current='page'],
+	:global(:root.theme-dark) .nav-link a[data-current-parent='true'] {
 		color: hsla(var(--color-base-white), 100%, 1);
 	}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Closes #905 <!-- Add an issue number if this PR will close it. -->
- #849 introduced a small bug that the current page item’s text was white even when in light mode. This fixes that.


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
