### PR TITLE
Redirect to the new deploy guides location

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,10 @@
     to = "/en/installation"
 
   [[redirects]]
+    from = "/:lang/deploy/:service"
+    to = "/:lang/guides/deploy/:service"
+
+  [[redirects]]
     from = "/:lang/*"
     to = "/:lang/404/"
     status = 404


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

#849 moved the deploy guides from `/[lang]/deploy/[service]` to `/[lang]/guides/deploy/[service]` causing some 404s from old links like in Discord threads. This Netlify redirect makes sure we redirect from the old URLs to the new ones.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
