### PR TITLE
Reorder Layout page examples

### DIFF
--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -23,7 +23,9 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 ---
 <html>
   <head>
-    <!-- ... -->
+    <meta charset="utf-8">
+    <title>My Cool Astro Site</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
     <nav>

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -17,7 +17,7 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 
 ```astro
 ---
-// Example: src/layouts/MySiteLayout.astro
+// src/layouts/MySiteLayout.astro
 ---
 <html>
   <head>
@@ -38,7 +38,7 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 
 ```astro
 ---
-// Example: src/pages/index.astro
+// src/pages/index.astro
 import MySiteLayout from '../layouts/MySiteLayout.astro';
 ---
 <MySiteLayout>
@@ -49,6 +49,37 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 📚 Learn more about [slots](/en/core-concepts/astro-components/#slots).
 
+## Markdown Layouts
+
+Page layouts are especially useful for [Markdown files](/en/guides/markdown-content/#markdown-pages). Markdown files can use a special `layout` property at the top of the frontmatter to specify which `.astro` component to use as a page layout.
+
+```markdown
+// src/pages/posts/post-1.md
+---
+layout: ../layouts/BlogPostLayout.astro
+title: Blog Post
+description: My first blog post!
+---
+This is a post written in Markdown.
+```
+
+When a Markdown file includes a layout, it passes a `content` property to the `.astro` component which includes the frontmatter properties and the final HTML output of the page.
+
+
+```astro
+---
+// src/layouts/BlogPostLayout.astro
+import BlogPostLayout from '../layouts/BlogPostLayout.astro'
+const {content} = Astro.props;
+---
+<BlogPostLayout>
+  <h1>{content.title}</h1>
+  <h2>Post author: {content.author}</h2>
+  <slot />
+</BlogPostLayout>
+```
+
+📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content/).
 
 ## Nesting Layouts
 
@@ -58,7 +89,7 @@ For example, a common layout for blog posts may display a title, date and author
 
 ```astro
 ---
-// Example src/layout/BlogPostLayout.astro
+// src/layouts/BlogPostLayout.astro
 import BaseLayout from '../layouts/BaseLayout.astro'
 const {content} = Astro.props;
 ---
@@ -68,23 +99,3 @@ const {content} = Astro.props;
   <slot />
 </BaseLayout>
 ```
-
-## Markdown Layouts
-
-Page layouts are especially useful for [Markdown files](/en/guides/markdown-content/#markdown-pages). Markdown files can use the special `layout` frontmatter property to specify which `.astro` component to use as a page layout.
-
-When a Markdown file includes a layout, it passes a single `{ content }` property to the layout file which includes the frontmatter properties and the final HTML output of the page.
-
-See the above example for how to pass content properties of a Markdown file to a layout.
-
-```markdown
-// src/pages/posts/post-1.md
----
-title: Blog Post
-description: My first blog post!
-layout: ../layouts/BlogPostLayout.astro
----
-This is a post written in Markdown.
-```
-
-📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content/).

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -19,7 +19,6 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 
 ```astro
 ---
-
 ---
 <html>
   <head>

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -62,7 +62,6 @@ Page layouts are especially useful for [Markdown files](/en/guides/markdown-cont
 
 ```markdown
 ---
-# src/pages/posts/post-1.md
 layout: ../layouts/BlogPostLayout.astro
 title: Blog Post
 description: My first blog post!

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -54,8 +54,8 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 Page layouts are especially useful for [Markdown files](/en/guides/markdown-content/#markdown-pages). Markdown files can use a special `layout` property at the top of the frontmatter to specify which `.astro` component to use as a page layout.
 
 ```markdown
-// src/pages/posts/post-1.md
 ---
+# src/pages/posts/post-1.md
 layout: ../layouts/BlogPostLayout.astro
 title: Blog Post
 description: My first blog post!

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -78,11 +78,11 @@ When a Markdown file includes a layout, it passes a `content` property to the `.
 const {content} = Astro.props;
 ---
 <html>
-  ...
+   <!-- ... -->
   <h1>{content.title}</h1>
   <h2>Post author: {content.author}</h2>
   <slot />
-  ...
+   <!-- ... -->
 </html>
 ```
 

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -15,9 +15,11 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 
 ## Sample Layout
 
+**`src/layouts/MySiteLayout.astro`**
+
 ```astro
 ---
-// src/layouts/MySiteLayout.astro
+
 ---
 <html>
   <head>
@@ -36,9 +38,10 @@ Layout components are commonly placed in a `src/layouts` directory in your proje
 </html>
 ```
 
+**`src/pages/index.astro`**
+
 ```astro
 ---
-// src/pages/index.astro
 import MySiteLayout from '../layouts/MySiteLayout.astro';
 ---
 <MySiteLayout>
@@ -53,6 +56,8 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 Page layouts are especially useful for [Markdown files](/en/guides/markdown-content/#markdown-pages). Markdown files can use a special `layout` property at the top of the frontmatter to specify which `.astro` component to use as a page layout.
 
+**`src/pages/posts/post-1.md`**
+
 ```markdown
 ---
 # src/pages/posts/post-1.md
@@ -66,17 +71,19 @@ This is a post written in Markdown.
 When a Markdown file includes a layout, it passes a `content` property to the `.astro` component which includes the frontmatter properties and the final HTML output of the page.
 
 
+**`src/layouts/BlogPostLayout.astro`**
+
 ```astro
 ---
-// src/layouts/BlogPostLayout.astro
-import BlogPostLayout from '../layouts/BlogPostLayout.astro'
 const {content} = Astro.props;
 ---
-<BlogPostLayout>
+<html>
+  ...
   <h1>{content.title}</h1>
   <h2>Post author: {content.author}</h2>
   <slot />
-</BlogPostLayout>
+  ...
+</html>
 ```
 
 📚 Learn more about Astro’s Markdown support in our [Markdown guide](/en/guides/markdown-content/).
@@ -87,9 +94,10 @@ Layout components do not need to contain an entire page worth of HTML. You can b
 
 For example, a common layout for blog posts may display a title, date and author. A `BlogPostLayout.astro` layout component could add this UI to the page and also leverage a larger, site-wide layout to handle the rest of your page.
 
+**`src/layouts/BlogPostLayout.astro`**
+
 ```astro
 ---
-// src/layouts/BlogPostLayout.astro
 import BaseLayout from '../layouts/BaseLayout.astro'
 const {content} = Astro.props;
 ---


### PR DESCRIPTION
- New or updated content

 "See the example above for how to..." prompted me to reorder the layout examples (so that we don't need to do that!)

Now: 
- examples are more sequential and meaningful given the explanations by moving Nested Layout section to the end
- took out "Example" from all the code sample file names, because I don't think we do that elsewhere
- corrected some typos (e.g. `/layout/` vs `/layouts/` in some places)