### PR TITLE
Updated markdown draft explanation with example

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -142,7 +142,7 @@ To build and publish this post:
 ```
 
 :::caution[Drafts and Astro.glob()]
-Although `draft: true` will prevent a page from being built on your site at that page route, [`Astro.glob()`](https://docs.astro.build/en/reference/api-reference/#astroglob) currently returns **all your Markdown files**.
+Although `draft: true` will prevent a page from being built on your site at that page route, [`Astro.glob()`](/en/reference/api-reference/#astroglob) currently returns **all your Markdown files**.
 :::
 
 To exclude draft posts from being included in a post archive, or list of most recent posts, you can filter the results returned by your `Astro.glob()`.

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -147,8 +147,9 @@ Although `draft: true` will prevent a page from being built on your site at that
 
 To exclude draft posts from being included in a post archive, or list of most recent posts, you can filter the results returned by your `Astro.glob()`.
 
-```
-const posts = await Astro.glob('../pages/post/*.md').filter((post) => !post.frontmatter.draft);
+```js
+const posts = await Astro.glob('../pages/post/*.md')
+  .filter((post) => !post.frontmatter.draft);
 ```
 
 ⚙️ To enable building draft pages:

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -142,10 +142,14 @@ To build and publish this post:
 ```
 
 :::caution[Drafts and Astro.glob()]
-Although `draft: true` will prevent a page from being built on your site at that page route, `Astro.glob()` currently returns **all your Markdown files**.
+Although `draft: true` will prevent a page from being built on your site at that page route, [`Astro.glob()`](https://docs.astro.build/en/reference/api-reference/#astroglob) currently returns **all your Markdown files**.
 :::
 
-To exclude the data (e.g. title, link, description) from a draft post from being included in your post archive, or list of most recent posts, be sure that your `Astro.glob()` function also **filters to exclude any draft posts**.
+To exclude draft posts from being included in a post archive, or list of most recent posts, you can filter the results returned by your `Astro.glob()`.
+
+```
+const posts = await Astro.glob('../pages/post/*.md').filter((post) => !post.frontmatter.draft);
+```
 
 ⚙️ To enable building draft pages:
 


### PR DESCRIPTION
- New or updated content
- Closes #910 

Simplifies wording for Markdown drafts, and provides a short example of filtering as well as a link back to `Astro.glob()` 