### PR TITLE
Improve sticky TOC on mobile devices and medium viewports

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -21,8 +21,7 @@
 }
 body::-webkit-scrollbar,
 body::-webkit-scrollbar-track {
-	/* same as --theme-bg-gradient but without 'fixed' */
-	background: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) var(--theme-navbar-height), var(--theme-bg-gradient-bottom));
+	background: var(--theme-bg-gradient);
 }
 
 ::-webkit-scrollbar-thumb {
@@ -32,23 +31,38 @@ body::-webkit-scrollbar-track {
 	border-radius: 10px;
 }
 
-:root {
-	--max-width: calc(100% - 1rem);
-}
-
-@media (min-width: 50em) {
-	:root {
-		--max-width: 46em;
-	}
-}
-
 @media (prefers-reduced-motion: no-preference) {
 	:root {
 		scroll-behavior: smooth;
 	}
 }
 
+/*
+	Ensure that the auto-hiding/showing address bar on iOS Safari
+	always has a background color matching our theme.
+*/
+html {
+	background: var(--theme-bg-gradient-bottom);
+}
+
+/*
+	Use a pseudo-element to add a gradient background that covers the entire viewport.
+	Using a regular fixed background does not work properly on mobile browsers like iOS Safari.
+*/
+body::before {
+	content: '';
+	display: block;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: -999;
+	background: var(--theme-bg-gradient);
+}
+
 body {
+	color: var(--theme-text);
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
@@ -56,14 +70,6 @@ body {
 	font-size: 16px;
 	line-height: 1.5;
 	max-width: 100vw;
-	--gutter: 0.5rem;
-	--doc-padding: 0.5rem;
-}
-
-@media (min-width: 50em) {
-	body {
-		--doc-padding: 2rem;
-	}
 }
 
 nav ul {
@@ -163,10 +169,6 @@ h5 {
 .heading-wrapper > * {
 	display: inline;
 	margin-bottom: 0;
-}
-
-.heading-wrapper [id] {
-	scroll-margin: 4rem;
 }
 
 .heading-wrapper > .anchor-link {
@@ -532,4 +534,30 @@ h2.heading {
 	overflow: visible;
 	clip: auto;
 	white-space: normal;
+}
+
+/*
+	Add the correct amount of scroll padding to ensure that linked headings are always visible
+	and have enough distance to the viewport edge and potential sticky navigation bars.
+
+	Please note that this can't be done with `scroll-margin` on the scroll targets themselves
+	due to lack of iOS Safari browser support.
+*/
+html {
+	/* Sticky navbar and sticky TOC are visible */
+	scroll-padding-top: calc(1rem + var(--theme-navbar-height) + var(--theme-sticky-toc-height));
+}
+
+@media (min-width: 50em) {
+	html {
+		/* Sticky TOC is visible */
+		scroll-padding-top: calc(1rem + var(--theme-sticky-toc-height));
+	}
+}
+
+@media (min-width: 72em) {
+	html {
+		/* No sticky navigation bars */
+		scroll-padding-top: 1rem;
+	}
 }

--- a/public/theme.css
+++ b/public/theme.css
@@ -11,7 +11,7 @@
 	--min-spacing-inline: 1rem;
 	/* Vertical spacing around the article content and the right sidebar */
 	--doc-padding-block: 0.5rem;
-	--max-width: calc(100%);
+	--max-width: 100%;
 	--cur-viewport-height: 100vh;
 }
 

--- a/public/theme.css
+++ b/public/theme.css
@@ -1,3 +1,44 @@
+/*
+	Define common sizes and spacings
+*/
+:root {
+	--theme-navbar-height: 6rem;
+	--theme-sticky-toc-height: 4rem;
+	/*
+		Minimum visual horizontal spacing from the edges of the viewport,
+		and between vertically arranged elements
+	*/
+	--min-spacing-inline: 1rem;
+	/* Vertical spacing around the article content and the right sidebar */
+	--doc-padding-block: 0.5rem;
+	--max-width: calc(100%);
+	--cur-viewport-height: 100vh;
+}
+
+@media (min-width: 50em) {
+	:root {
+		--min-spacing-inline: 1.5rem;
+		--doc-padding-block: 1rem;
+		--max-width: 46em;
+	}
+}
+
+@media (min-width: 72em) {
+	:root {
+		--doc-padding-block: 2rem;
+	}
+}
+
+/* Use dynamic viewport height if the unit is supported by the browser */
+@supports (height: 100dvh) {
+	:root {
+		--cur-viewport-height: 100dvh;
+	}
+}
+
+/*
+	Define common fonts and colors
+*/
 :root {
 	--font-fallback: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 	--font-body: system-ui, var(--font-fallback);
@@ -5,15 +46,13 @@
 		'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
 
 	/*
-   * Variables with --color-base prefix define
-   * the hue, and saturation values to be used for
-   * hsla colors.
-   *
-   * ex:
-   *
-   * --color-base-{color}: {hue}, {saturation};
-   *
-   */
+		Variables with --color-base prefix define
+		the hue, and saturation values to be used for
+		hsla colors.
+
+		Example:
+		--color-base-{color}: {hue}, {saturation};
+	*/
 
 	--color-base-white: 0, 0%;
 	--color-base-black: 240, 100%;
@@ -28,11 +67,10 @@
 	--color-base-yellow: 41, 100%;
 
 	/*
-   * Color palettes are made using --color-base 
-   * variables, along with a lightness value to
-   * define different variants.
-   *
-   */
+		Color palettes are made using --color-base 
+		variables, along with a lightness value to
+		define different variants.
+	*/
 
 	--color-gray-5: var(--color-base-gray), 5%;
 	--color-gray-10: var(--color-base-gray), 10%;
@@ -79,21 +117,14 @@
 	--theme-code-bg: hsla(257, 31%, 22%, 1);
 	--theme-code-text: hsla(var(--color-gray-95), 1);
 	--theme-navbar-bg: var(--theme-bg);
-	--theme-navbar-height: 6rem;
 	--theme-selection-color: hsla(var(--color-purple), 1);
 	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
 
-	--theme-bg-gradient: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) calc(3 * var(--theme-navbar-height)), var(--theme-bg-gradient-bottom));
-	--theme-bg-gradient: fixed linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) calc(3 * var(--theme-navbar-height)), var(--theme-bg-gradient-bottom)) no-repeat, var(--theme-bg-gradient-bottom);
+	--theme-bg-gradient: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) calc(var(--theme-navbar-height) + var(--theme-sticky-toc-height)), var(--theme-bg-gradient-bottom));
 
 	--theme-glow-highlight: transparent;
 	--theme-glow-diffuse: hsla(var(--color-base-purple), 65%, 0.5);
 	--theme-glow-blur: 10px;
-}
-
-body {
-	background: var(--theme-bg-gradient);
-	color: var(--theme-text);
 }
 
 :root.theme-dark {

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -85,8 +85,7 @@ const t = useTranslations(Astro);
 		justify-content: center;
 		gap: 0.75rem;
 		width: 100%;
-		padding-left: 1rem;
-		padding-right: 1rem;
+		padding-inline: var(--min-spacing-inline);
 	}
 
 	/* If the device is likely to show a scrollbar gutter, reserve space for it */
@@ -178,10 +177,6 @@ const t = useTranslations(Astro);
 			position: static;
 			background-color: transparent;
 			padding: 2.5rem 0 1.5rem 0;
-		}
-		.nav-wrapper {
-			padding-left: 1.5rem;
-			padding-right: 1.5rem;
 		}
 		.astro {
 			width: auto;

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -72,14 +72,13 @@ for (const section of sidebarSections) {
 <style>
 	nav {
 		width: 100%;
-		margin-inline-end: 1rem;
 		padding-top: 0rem;
 	}
 	.nav-groups {
 		height: 100%;
 		overflow-x: visible;
 		overflow-y: auto;
-		max-height: calc(100vh - var(--theme-navbar-height));
+		max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height));
 	}
 
 	@media not screen and (min-width: 50em) {

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -18,20 +18,26 @@ if (index !== -1 && index < links.length - 1) next = makeLinkItem(links[index + 
 const t = useTranslations(Astro);
 ---
 
+{
+	// For best cross-browser support of `position: sticky`, sticky elements must not be nested
+	// inside elements that hide any overflow axis. The article content hides `overflow-x`,
+	// so we must place the sticky TOC here.
+	headers && (
+		<nav class="sticky-toc">
+			<TableOfContents
+				client:media="(max-width: 72em)"
+				headers={headers}
+				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
+				isMobile={true}
+			/>
+		</nav>
+	)
+}
+
 <article id="article" class="content">
 	<section class="main-section">
 		<h1 class="content-title" id="overview" set:html={title} />
 		{isFallback && <FallbackNotice />}
-		{headers && (
-			<nav class="sticky-nav block lg-hidden">
-				<TableOfContents
-					client:media="(max-width: 72em)"
-					headers={headers}
-					labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
-					isMobile={true}
-				/>
-			</nav>
-		)}
 		<slot />
 	</section>
 	{(previous || next) && (
@@ -43,26 +49,22 @@ const t = useTranslations(Astro);
 </article>
 
 <style>
-	.content {
-		padding: 0;
-		max-width: 75ch;
+	.sticky-toc, .content {
 		width: 100%;
+		max-width: 80ch;
+		margin-inline: auto;
+	}
+
+	.content {
+		padding-block: var(--doc-padding-block);
+		padding-inline: var(--min-spacing-inline);
 		height: 100%;
 		display: flex;
 		flex-direction: column;
-		margin: auto;
+		overflow-x: hidden;
 	}
 	.content > section {
 		margin-bottom: 4rem;
-	}
-	.block {
-		display: block;
-	}
-	.sticky-nav {
-		width: 100%;
-		position: sticky;
-		z-index: 2;
-		top: 0;
 	}
 	.next-previous-nav {
 		display: flex;
@@ -72,8 +74,20 @@ const t = useTranslations(Astro);
 		margin-bottom: 1.5rem;
 	}
 
+	.sticky-toc {
+		display: block;
+		position: sticky;
+		z-index: 2;
+		top: calc(var(--theme-navbar-height));
+	}
+	@media (min-width: 50em) {
+		.sticky-toc {
+			top: 0;
+			margin-top: 0;
+		}
+	}
 	@media (min-width: 72em) {
-		.lg-hidden {
+		.sticky-toc {
 			display: none;
 		}
 	}

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -34,7 +34,7 @@ const headers = content.astro?.headers;
 
 	.sidebar-nav-inner {
 		height: 100%;
-		padding: var(--doc-padding) 0;
+		padding: var(--doc-padding-block) 0;
 		overflow: auto;
 	}
 

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -1,19 +1,4 @@
-.toc-mobile-container {
-	--toc-overlap-inline-start: 1rem;
-	--toc-overlap-inline-end: 1rem;
-	width: calc(100% + var(--toc-overlap-inline-start) + var(--toc-overlap-inline-end));
-	margin-top: 1.75rem;
-	margin-inline: calc(-1 * var(--toc-overlap-inline-start)) calc(-1 * var(--toc-overlap-inline-end));
-	transform: translateY(-1px);
-}
-
-@media (min-width: 50em) {
-	.toc-mobile-container {
-		--toc-overlap-inline-start: 2rem;
-		--toc-overlap-inline-end: 0.5rem;
-	}
-}
-
+/* The mobile container is a <details> element wrapping the sticky mobile TOC */
 .toc-mobile-container > .toc-mobile-header::marker,
 .toc-mobile-container > .toc-mobile-header::-webkit-details-marker {
 	display: none;
@@ -23,17 +8,39 @@
 	transform: rotate(90deg);
 }
 
+.toc-mobile-container {
+	--header-bottom-padding: 1.5rem;
+}
+
+@media (min-width: 50em) {
+	/* Improve toggle & title alignment with left sidebar */
+	.toc-mobile-container {
+		--header-bottom-padding: 0.5rem;
+	}
+}
+
+/*
+	The mobile header is the clickable <summary> heading.
+
+	It has a opaque background and covers the entire viewport width
+	to ensure that page content scrolling underneath is hidden.
+*/
 .toc-mobile-header {
-	display: flex;
-	align-items: baseline;
+	padding-inline: var(--min-spacing-inline);
+	display: block;
 	cursor: pointer;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	padding-top: 0.75rem;
-	padding-inline: var(--toc-overlap-inline-start) var(--toc-overlap-inline-end);
-	padding-bottom: 1.25rem;
-	background: var(--theme-bg-gradient);
+	background: var(--theme-bg-gradient-top);
+	-webkit-tap-highlight-color: transparent;
+}
+
+.toc-mobile-header-content {
+	display: flex;
+	align-items: center;
+	height: var(--theme-sticky-toc-height);
+	padding-bottom: var(--header-bottom-padding);
 }
 
 .toc-toggle {
@@ -71,16 +78,21 @@
 }
 
 .toc-mobile-container ul {
-	max-height: calc(100vh - 22rem);
+	margin-inline: var(--min-spacing-inline);
+	max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-sticky-toc-height) - 1rem);
 	overflow-y: auto;
-	margin-inline: var(--toc-overlap-inline-start) var(--toc-overlap-inline-end);
 	border: 1px solid var(--theme-shade-subtle);
 	border-radius: 0.5rem;
 	padding: 0.5rem 0;
 	background: linear-gradient(var(--theme-bg-offset), var(--theme-bg-offset)), var(--theme-bg-gradient);
-	transform: translateY(-0.5rem);
+	transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
 }
 
 .toc-mobile-container .header-link {
 	border: 0;
+}
+
+.toc-mobile-container .header-link a {
+	/* Add block padding to mobile header links to increase tap zones */
+	padding-block: 0.125rem;
 }

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -33,13 +33,15 @@ const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels, isM
 		const currentHeading = headers.find(({ slug }) => slug === currentID);
 		return isMobile ? (
 			<summary class="toc-mobile-header">
-				<div className="toc-toggle">
-					{children}
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 1 16 16" width="16" height="16" aria-hidden="true">
-						<path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path>
-					</svg>
+				<div class="toc-mobile-header-content">
+					<div className="toc-toggle">
+						{children}
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 1 16 16" width="16" height="16" aria-hidden="true">
+							<path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path>
+						</svg>
+					</div>
+					{!open && currentHeading?.slug !== 'overview' && <span class="toc-current-heading">{unescapeHtml(currentHeading?.text || '')}</span>}
 				</div>
-				{!open && currentHeading?.slug !== 'overview' && <span class="toc-current-heading">{unescapeHtml(currentHeading?.text || '')}</span>}
 			</summary>
 		) : (
 			children

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -31,28 +31,23 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 		<style>
 			body {
 				width: 100%;
-				height: 100vh;
 				display: grid;
 				grid-template-rows: var(--theme-navbar-height) 1fr;
-			}
-			@supports (height: 100dvh) {
-				body { height: 100dvh; }
 			}
 			.layout {
 				display: grid;
 				grid-auto-flow: column;
 				grid-template-columns:
-					minmax(var(--gutter), 1fr)
+					0
 					minmax(0, var(--max-width))
-					minmax(var(--gutter), 1fr);
-				overflow-x: hidden;
+					0;
 			}
 			.layout :global(> *) {
 				width: 100%;
 				height: 100%;
 			}
 			.grid-sidebar {
-				height: 100vh;
+				height: calc(var(--cur-viewport-height) - var(--theme-navbar-height));
 				position: sticky;
 				top: 0;
 				padding: 0;
@@ -64,7 +59,6 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				display: none;
 			}
 			#grid-main {
-				padding: var(--doc-padding) var(--gutter);
 				grid-column: 2;
 				display: flex;
 				flex-direction: column;
@@ -94,11 +88,11 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 					grid-template-columns:
 						20rem
 						minmax(0, var(--max-width));
-					gap: 1em;
 				}
 				#grid-left {
 					display: flex;
-					padding-inline-start: 1.5rem;
+					padding-inline-start: var(--min-spacing-inline);
+					padding-inline-end: 1rem;
 					position: sticky;
 					grid-column: 1;
 					background: transparent;

--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -25,17 +25,20 @@ const t = useTranslations(Astro);
 				display: grid;
 				grid-auto-flow: column;
 				grid-template-columns:
-					minmax(var(--gutter), 1fr)
+					minmax(var(--doc-padding-inline), 1fr)
 					minmax(0, var(--max-width))
-					minmax(var(--gutter), 1fr);
+					minmax(var(--doc-padding-inline), 1fr);
 				overflow-x: hidden;
 			}
 			article {
-				padding: var(--doc-padding) var(--gutter);
+				padding: var(--doc-padding-block) var(--doc-padding-inline);
 				grid-column: 2;
 				display: flex;
 				flex-direction: column;
 				height: 100%;
+			}
+			:global(#menu-toggle) {
+				display: none;
 			}
 		</style>
 	</head>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Improves the sticky TOC on mobile devices like iOS Safari:
  - The TOC was not sticky on iOS Safari before, now it is
  - Scroll anchors are no longer obscured by sticky elements
  - You can now tap on top of the screen to go to the beginning of the page again
  - The dynamically resizing Safari tab bar now works again instead of being stuck in the expanded state

- Improves the sticky TOC on all devices with medium viewports:
  - Instead of the TOC being below the article heading and scrolling/stopping out of sync with the left sidebar, it is now always at the top of the main column (as discussed on Discord) and scrolls in sync with the left sidebar.

- Cleanup: Reduced magic numbers across the CSS code by moving them to clearly named variables in `public/theme.css`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
