### PR TITLE
Fix typos on `astro-components.md` and `manual.md`

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -113,7 +113,7 @@ You can can define local JavaScript variables inside of the frontmatter componen
 
 #### Variables
 
-Local variables can be added into the HTML using the using curly braces syntax:
+Local variables can be added into the HTML using the curly braces syntax:
 
 ```astro
 ---

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -115,7 +115,7 @@ If you want to include [UI framework components](/en/core-concepts/framework-com
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 
-## 6. Next steps
+## 6. Next Steps
 
 If you have followed the steps above, your project directory should now look like this:
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Changes:
`astro-components.md`: `using the using (...)` -> `using the (...)`
`manual.md`: `Next steps` -> `Next Steps`