### PR TITLE
Use fixed header navigation on all devices

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -69,7 +69,6 @@ body {
 	font-family: var(--font-body);
 	font-size: 16px;
 	line-height: 1.5;
-	max-width: 100vw;
 }
 
 nav ul {
@@ -547,26 +546,19 @@ h2.heading {
 
 /*
 	Add the correct amount of scroll padding to ensure that linked headings are always visible
-	and have enough distance to the viewport edge and potential sticky navigation bars.
+	and have enough distance to the viewport edge and potential fixed navigation bars.
 
 	Please note that this can't be done with `scroll-margin` on the scroll targets themselves
 	due to lack of iOS Safari browser support.
 */
 html {
-	/* Sticky navbar and sticky TOC are visible */
-	scroll-padding-top: calc(1rem + var(--theme-navbar-height) + var(--theme-sticky-toc-height));
-}
-
-@media (min-width: 50em) {
-	html {
-		/* Sticky TOC is visible */
-		scroll-padding-top: calc(1rem + var(--theme-sticky-toc-height));
-	}
+	/* Mobile TOC is displayed above page content */
+	scroll-padding-top: calc(1.5rem + var(--theme-navbar-height) + var(--theme-mobile-toc-height));
 }
 
 @media (min-width: 72em) {
 	html {
-		/* No sticky navigation bars */
-		scroll-padding-top: 1rem;
+		/* Regular TOC is displayed as a sidebar */
+		scroll-padding-top: calc(1.5rem + var(--theme-navbar-height));
 	}
 }

--- a/public/theme.css
+++ b/public/theme.css
@@ -3,7 +3,9 @@
 */
 :root {
 	--theme-navbar-height: 6rem;
-	--theme-sticky-toc-height: 4rem;
+	--theme-mobile-toc-height: 4rem;
+	--theme-left-sidebar-width: 20rem;
+	--theme-right-sidebar-width: 18rem;
 	/*
 		Minimum visual horizontal spacing from the edges of the viewport,
 		and between vertically arranged elements
@@ -120,7 +122,7 @@
 	--theme-selection-color: hsla(var(--color-purple), 1);
 	--theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
 
-	--theme-bg-gradient: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) calc(var(--theme-navbar-height) + var(--theme-sticky-toc-height)), var(--theme-bg-gradient-bottom));
+	--theme-bg-gradient: linear-gradient(180deg, var(--theme-bg-gradient-top), var(--theme-bg-gradient-top) calc(var(--theme-navbar-height) + var(--theme-mobile-toc-height)), var(--theme-bg-gradient-bottom));
 
 	--theme-glow-highlight: transparent;
 	--theme-glow-diffuse: hsla(var(--color-base-purple), 65%, 0.5);

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -68,16 +68,18 @@ const t = useTranslations(Astro);
 
 <style>
 	header {
-		z-index: 11;
+		position: fixed;
+		left: 0;
+		top: 0;
+		right: 0;
 		height: var(--theme-navbar-height);
+		z-index: 11;
 		padding: 2rem 0;
 		background-color: var(--theme-navbar-bg);
 		display: flex;
 		align-items: center;
 		justify-content: left;
 		overflow: hidden;
-		position: sticky;
-		top: 0;
 	}
 
 	.nav-wrapper {
@@ -175,8 +177,6 @@ const t = useTranslations(Astro);
 
 	@media (min-width: 50em) {
 		header {
-			position: static;
-			background-color: transparent;
 			padding: 2.5rem 0 1.5rem 0;
 		}
 		.astro {

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -61,11 +61,7 @@ for (const section of sidebarSections) {
 <script>
 	window.addEventListener('DOMContentLoaded', () => {
 		var target = document.querySelector('[data-current-parent="true"]');
-		// 120 is the rounded height of the header + learn/reference tab.
-		if (target && target.offsetTop > window.innerHeight - 120) {
-			// 50 is the rounded height of a menu item.
-			document.querySelector('.nav-groups').scrollTop = target.scrollTop + target.offsetTop - 50;
-		}
+		target?.scrollIntoView({ block: 'center' });
 	});
 </script>
 

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -72,13 +72,23 @@ for (const section of sidebarSections) {
 <style>
 	nav {
 		width: 100%;
+		height: 100%;
 		padding-top: 0rem;
 	}
 	.nav-groups {
-		height: 100%;
+		max-height: 100%;
 		overflow-x: visible;
 		overflow-y: auto;
-		max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height));
+	}
+
+	@media (min-width: 50em) {
+		.nav-groups {
+			position: fixed;
+			top: calc(var(--theme-navbar-height) + 3rem);
+			bottom: 0;
+			right: unset;
+			width: calc(var(--theme-left-sidebar-width) - var(--min-spacing-inline) * 1.6);
+		}
 	}
 
 	@media not screen and (min-width: 50em) {

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -19,11 +19,11 @@ const t = useTranslations(Astro);
 ---
 
 {
-	// For best cross-browser support of `position: sticky`, sticky elements must not be nested
+	// For best cross-browser support of sticky or fixed elements, they must not be nested
 	// inside elements that hide any overflow axis. The article content hides `overflow-x`,
-	// so we must place the sticky TOC here.
+	// so we must place the mobile TOC here.
 	headers && (
-		<nav class="sticky-toc">
+		<nav class="mobile-toc">
 			<TableOfContents
 				client:media="(max-width: 72em)"
 				headers={headers}
@@ -49,16 +49,14 @@ const t = useTranslations(Astro);
 </article>
 
 <style>
-	.sticky-toc, .content {
+	.content {
+		padding-top: calc(var(--theme-navbar-height) + var(--theme-mobile-toc-height) + var(--doc-padding-block));
+		padding-bottom: var(--doc-padding-block);
+		padding-inline: var(--min-spacing-inline);
 		width: 100%;
+		height: 100%;
 		max-width: 80ch;
 		margin-inline: auto;
-	}
-
-	.content {
-		padding-block: var(--doc-padding-block);
-		padding-inline: var(--min-spacing-inline);
-		height: 100%;
 		display: flex;
 		flex-direction: column;
 		overflow-x: hidden;
@@ -74,20 +72,25 @@ const t = useTranslations(Astro);
 		margin-bottom: 1.5rem;
 	}
 
-	.sticky-toc {
+	.mobile-toc {
 		display: block;
-		position: sticky;
-		z-index: 2;
+		position: fixed;
+		left: 0;
 		top: calc(var(--theme-navbar-height));
+		right: 0;
+		z-index: 2;
 	}
 	@media (min-width: 50em) {
-		.sticky-toc {
-			top: 0;
+		.mobile-toc {
+			left: var(--theme-left-sidebar-width);
 			margin-top: 0;
 		}
 	}
 	@media (min-width: 72em) {
-		.sticky-toc {
+		.content {
+			padding-top: calc(var(--theme-navbar-height) + var(--doc-padding-block));
+		}
+		.mobile-toc {
 			display: none;
 		}
 	}

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -10,30 +10,22 @@ const { content, githubEditUrl } = Astro.props;
 const headers = content.astro?.headers;
 ---
 
-<nav class="sidebar-nav" aria-label={t('rightSidebar.a11yTitle')}>
-	<div class="sidebar-nav-inner">
-		{headers && (
-			<TableOfContents
-				client:media="(min-width: 50em)"
-				headers={headers}
-				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
-				isMobile={false}
-			/>
-		)}
-		<ContributeMenu editHref={githubEditUrl} />
-		<CommunityMenu />
-	</div>
+<nav aria-label={t('rightSidebar.a11yTitle')}>
+	{headers && (
+		<TableOfContents
+			client:media="(min-width: 50em)"
+			headers={headers}
+			labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
+			isMobile={false}
+		/>
+	)}
+	<ContributeMenu editHref={githubEditUrl} />
+	<CommunityMenu />
 </nav>
 
 <style>
-	.sidebar-nav {
+	nav {
 		width: 100%;
-		position: sticky;
-		top: 0;
-	}
-
-	.sidebar-nav-inner {
-		height: 100%;
 		padding: var(--doc-padding-block) 0;
 		overflow: auto;
 	}

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -1,4 +1,4 @@
-/* The mobile container is a <details> element wrapping the sticky mobile TOC */
+/* The mobile container is a <details> element wrapping the mobile TOC */
 .toc-mobile-container > .toc-mobile-header::marker,
 .toc-mobile-container > .toc-mobile-header::-webkit-details-marker {
 	display: none;
@@ -26,7 +26,6 @@
 	to ensure that page content scrolling underneath is hidden.
 */
 .toc-mobile-header {
-	padding-inline: var(--min-spacing-inline);
 	display: block;
 	cursor: pointer;
 	white-space: nowrap;
@@ -39,8 +38,11 @@
 .toc-mobile-header-content {
 	display: flex;
 	align-items: center;
-	height: var(--theme-sticky-toc-height);
+	height: var(--theme-mobile-toc-height);
+	max-width: 80ch;
+	margin-inline: auto;
 	padding-bottom: var(--header-bottom-padding);
+	padding-inline: var(--min-spacing-inline);
 }
 
 .toc-toggle {
@@ -86,7 +88,7 @@
 
 .toc-mobile-container ul {
 	margin-inline: var(--min-spacing-inline);
-	max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-sticky-toc-height) - 1rem);
+	max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-mobile-toc-height) - 1rem);
 	overflow-y: auto;
 	border: 1px solid var(--theme-shade-subtle);
 	border-radius: 0.5rem;

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -29,87 +29,78 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 		<HeadSEO {content} {canonicalURL} />
 		<title set:html={formatTitle(content)} />
 		<style>
-			body {
-				width: 100%;
-				display: grid;
-				grid-template-rows: var(--theme-navbar-height) 1fr;
-			}
-			.layout {
-				display: grid;
-				grid-auto-flow: column;
-				grid-template-columns:
-					0
-					minmax(0, var(--max-width))
-					0;
-			}
-			.layout :global(> *) {
-				width: 100%;
-				height: 100%;
-			}
-			.grid-sidebar {
-				height: calc(var(--cur-viewport-height) - var(--theme-navbar-height));
-				position: sticky;
+			.sidebar {
+				position: fixed;
 				top: 0;
+				bottom: 0;
 				padding: 0;
 			}
-			#grid-left {
-				position: fixed;
+			#left-sidebar {
+				display: none;
 				background: var(--theme-bg-gradient);
 				z-index: 10;
-				display: none;
+				left: 0;
 			}
-			#grid-main {
-				grid-column: 2;
+			#right-sidebar {
+				display: none;
+				top: var(--theme-navbar-height);
+				right: 0;
+				width: var(--theme-right-sidebar-width);
+			}
+			#main-content {
 				display: flex;
 				flex-direction: column;
 				height: 100%;
 				min-width: 0;
 			}
-			#grid-right {
-				display: none;
-			}
 
 			/* Allow showing left sidebar as an overlay, but only while viewport stays narrow */
 			@media not screen and (min-width: 50em) {
+				/* Make the left sidebar visible and fill the entire viewport below the navbar */
+				:global(.mobile-sidebar-toggle #left-sidebar) {
+					display: block;
+					top: var(--theme-navbar-height);
+					right: 0;
+				}
+				/*
+					Try to prevent the rest of the page from scrolling,
+					and the main content from being visible below the overlay.
+
+					Unfortunately, iOS Safari doesn't currently play well with this
+					and will sometimes still scroll the page even though it shouldn't.
+
+					Once overscroll-behavior is properly supported, this should be fixed.
+				*/
 				:global(.mobile-sidebar-toggle) {
 					overflow: hidden;
 				}
-				:global(.mobile-sidebar-toggle #grid-left) {
-					display: block;
-					top: var(--theme-navbar-height);
-					bottom: 0;
-					height: initial;
+				:global(.mobile-sidebar-toggle #main-content) {
+					visibility: hidden;
+				}
+				:global(.mobile-sidebar-toggle #left-sidebar ul) {
+					overscroll-behavior: contain;
 				}
 			}
 
 			@media (min-width: 50em) {
-				.layout {
-					overflow: initial;
-					grid-template-columns:
-						20rem
-						minmax(0, var(--max-width));
+				#main-content {
+					margin-left: var(--theme-left-sidebar-width);
 				}
-				#grid-left {
+				#left-sidebar {
 					display: flex;
 					padding-inline-start: var(--min-spacing-inline);
 					padding-inline-end: 1rem;
-					position: sticky;
-					grid-column: 1;
+					top: var(--theme-navbar-height);
+					width: var(--theme-left-sidebar-width);
 					background: transparent;
 				}
 			}
 
 			@media (min-width: 72em) {
-				.layout {
-					grid-template-columns:
-						20rem
-						1fr
-						18rem;
-					padding-left: 0;
-					padding-right: 0;
+				#main-content {
+					margin-right: var(--theme-right-sidebar-width);
 				}
-				#grid-right {
-					grid-column: 3;
+				#right-sidebar {
 					display: flex;
 				}
 			}
@@ -137,13 +128,13 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 	<body>
 		<Header {currentPage} />
 		<main class="layout">
-			<aside id="grid-left" class="grid-sidebar">
+			<aside id="left-sidebar" class="sidebar">
 				<LeftSidebar {currentPage} />
 			</aside>
-			<aside id="grid-right" class="grid-sidebar">
+			<aside id="right-sidebar" class="sidebar">
 				{!hideRightSidebar && <RightSidebar content={content} githubEditUrl={githubEditUrl} />}
 			</aside>
-			<div id="grid-main" lang={isFallback && 'en'}>
+			<div id="main-content" lang={isFallback && 'en'}>
 				<PageContent {content} {githubEditUrl} {currentPage} {isFallback}>
 					<slot />
 				</PageContent>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Instead of having our header navigation disappear when scrolling on wide viewports, this PR changes all of our headers to a fixed position, effectively unifying our header behavior for all devices & viewport widths.
- As discussed on Discord, this allows the Search bar to be always easily accessible without having to scroll up.
- Unifying the header positioning also allowed to clean up our CSS code quite a bit, removing the now unnecessary grid layout and improving the browser's ability to keep the current scroll position when resizing the viewport. It's still possible for the content to jump a bit when any of the sidebars disappear, but it's a lot better than before.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
