### PR TITLE
Overhaul of vertical spacing

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -78,28 +78,39 @@ nav ul {
 }
 
 .content > section > * + *,
-.content > section > blockquote > * + * {
+.content > section > blockquote > * + *,
+.content > section > :is(ul, ol) > li > * + * {
 	margin-top: 1.25rem;
+	margin-bottom: 1.25rem;
 }
 
-.content > section > * + :is(ul, ol) {
-	margin-top: 0.3rem;
+.content > section > :is(ul, ol) > li,
+.content > section > :is(ul, ol) > li > * + *,
+.content > section > :is(ul, ol) > li > :is(ul, ol) > li,
+.content > section > :is(ul, ol) > li > :is(ul, ol) > li > * + * {
+	margin-top: 0.5rem;
 }
 
 .content > section > :first-child {
 	margin-top: 0;
 }
 
+.content > section > :is(ul, ol),
+.content > section > :is(ul, ol) :is(ul, ol) {
+	padding-inline-start: 1.5em;
+}
+
 /* Typography */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+:is(h1, h2, h3, h4, h5, h6),
+.content > section > .heading-wrapper {
 	margin-bottom: 1rem;
 	font-weight: bold;
 	line-height: 1.3;
+}
+
+:is(h1, h2, h3, h4, h5, h6) + *,
+.content > section > .heading-wrapper + * {
+	margin-top: 0;
 }
 
 h1,
@@ -107,12 +118,23 @@ h2 {
 	max-width: 40ch;
 }
 
-:is(h2, h3):not(:first-child) {
+:is(h2):not(:first-child),
+.heading-wrapper:not(:first-child):is(.level-h2) {
+	margin-top: 5rem;
+}
+
+:is(h3, h4):not(:first-child),
+.heading-wrapper:not(:first-child):is(.level-h3, .level-h4) {
 	margin-top: 3rem;
 }
 
-:is(h4, h5, h6):not(:first-child) {
+:is(h5, h6):not(:first-child),
+.heading-wrapper:not(:first-child):is(.level-h5, .level-h6) {
 	margin-top: 2rem;
+}
+
+:is(h1, h2, h3, h4, h5, h6, .heading-wrapper) + :is(h1, h2, h3, h4, h5, h6, .heading-wrapper):not(:first-child) {
+	margin-top: 0;
 }
 
 :is(h1, h2, h3, h4, h5) code {
@@ -157,13 +179,6 @@ h5 {
 
 .heading-wrapper:not(:first-child) {
 	margin-block: 0;
-}
-.heading-wrapper:not(:first-child):is(.level-h2, .level-h3) {
-	margin-top: 3rem;
-}
-
-.heading-wrapper:not(:first-child):is(.level-h4, .level-h5, .level-h6) {
-	margin-top: 2rem;
 }
 
 .heading-wrapper > * {
@@ -331,9 +346,9 @@ pre {
 
 .content kbd {
 	font-family: var(--font-body);
-	font-size: .9375rem;
-	border-radius: .25rem;
-	padding: .125rem .375rem;
+	font-size: 0.9375rem;
+	border-radius: 0.25rem;
+	padding: 0.125rem 0.375rem;
 	border: 1px solid var(--theme-shade-subtle);
 	box-shadow: 0 3px var(--theme-shade-subtle);
 	background-color: var(--theme-bg-offset);

--- a/public/index.css
+++ b/public/index.css
@@ -120,7 +120,7 @@ h2 {
 
 :is(h2):not(:first-child),
 .heading-wrapper:not(:first-child):is(.level-h2) {
-	margin-top: 5rem;
+	margin-top: 4rem;
 }
 
 :is(h3, h4):not(:first-child),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- This PR adds some “quick wins” in terms of vertical spacing in our main content styles, improving list spacing and spacing around headings.

Here’s one before/after example:

| before | after |
|---|---|
| <img width="810" alt="image" src="https://user-images.githubusercontent.com/357379/178007967-891d4899-25cf-485f-9811-d9339ba625be.png"> | <img width="794" alt="image" src="https://user-images.githubusercontent.com/357379/178007896-f77a89b7-a092-42e4-97a0-002d7c1f3ef0.png"> |


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
