### PR TITLE
High Contrast and Reduced Motion improvements

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -579,3 +579,10 @@ html {
 		scroll-padding-top: calc(1.5rem + var(--theme-navbar-height));
 	}
 }
+
+@media (prefers-reduced-motion: reduce) {
+	details svg {
+		/* Removes the collapsible sidebar svg animation */
+		transition: none !important;
+	}
+}

--- a/public/index.css
+++ b/public/index.css
@@ -418,6 +418,8 @@ blockquote {
 	background-color: var(--theme-bg-offset);
 	border-radius: 0 0.25rem 0.25rem 0;
 	line-height: 1.7;
+	/* Indicates the blockquote boundaries for forced colors users, transparent is changed to a solid color */
+	outline: 1px solid transparent;
 }
 
 img {

--- a/src/components/TabGroup/TabGroup.css
+++ b/src/components/TabGroup/TabGroup.css
@@ -31,7 +31,7 @@
 
   .TabGroup .active {
 		color: ButtonText;
-    border-bottom-color: Highlight;
+		border-bottom-color: ButtonText;
   }
 
 	.TabGroup a, .TabGroup button {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description

- Added outline for blockquote elements in high contrast mode:
![image](https://user-images.githubusercontent.com/61414485/178160702-9b1dc21b-947b-411b-9613-04bfb877010b.png)
- Changed TabGroup `border-bottom-color` for a more semantic color (Highlight -> ButtonText), now all the tabs in the docs have the same semantic styling.
 - Removed details svg animation in reduced motion mode:
![image](https://i.imgur.com/RB2RgeQ.gif)
