### PR TITLE
Add type assertion to Astro.props

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -78,7 +78,7 @@ export interface Props {
   name: string;
   greeting?: string;
 }
-const { greeting = 'Hello', name } = Astro.props
+const { greeting = 'Hello', name } = Astro.props as Props
 ---
 <h2>{greeting}, {name}!</h2>
 ```


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

This type assertion was missing from the "TypeScript" page, while it's present
at other places. The assertion is necessary to have proper type info in the component itself.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
