### PR TITLE
Fix import in translation status script

### DIFF
--- a/scripts/lib/github-issues.mjs
+++ b/scripts/lib/github-issues.mjs
@@ -7,7 +7,7 @@
  */
 
 import fetch from 'node-fetch';
-import { githubGet } from './github-get';
+import { githubGet } from './github-get.mjs';
 import output from './output.mjs';
 
 /**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

In #954 I extracted a function from the translation status checker to a separate module so I could re-use it in the page generator. I messed up the updated import inside the translation status script, leaving out the `.mjs` extension which is required.

This PR fixes that.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
