### PR TITLE
Remove deprecated Astro.canonicalURL

### DIFF
--- a/src/components/LeftSidebar/SidebarContent.astro
+++ b/src/components/LeftSidebar/SidebarContent.astro
@@ -1,5 +1,5 @@
 ---
-import { getLanguageFromURL, removeSubpageSegment } from '../../util';
+import { getLanguageFromURL, removeSubpageSegment, getCanonicalURL } from '../../util';
 import UIString from '../UIString.astro';
 
 export interface Props {
@@ -14,7 +14,7 @@ export interface Props {
 }
 
 const { type, defaultActiveTab, sidebarSections, currentPageMatch } = Astro.props as Props;
-const lang = getLanguageFromURL(Astro.canonicalURL.pathname);
+const lang = getLanguageFromURL(getCanonicalURL(Astro).pathname);
 ---
 
 {sidebarSections.length === 0 && (

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -2,13 +2,13 @@
 import ArticleNavigationButton from './ArticleNavigationButton.astro';
 import TableOfContents from '../RightSidebar/TableOfContents';
 import { getNav, useTranslations } from "../../i18n/util";
-import { getLanguageFromURL } from '../../util';
+import { getLanguageFromURL, getCanonicalURL } from '../../util';
 
 const { content, currentPage } = Astro.props;
 // We wrap `@astrojs/` in a span to style it separately on integration pages.
 const title = content.title.replace('@astrojs/', '<span class="scope">@astrojs/</span>');
 const headers = content.astro?.headers;
-const lang = getLanguageFromURL(Astro.canonicalURL.pathname);
+const lang = getLanguageFromURL(getCanonicalURL(Astro).pathname);
 const links = (await getNav(Astro)).filter((x) => !('header' in x) && x.slug) as { text: string; slug: string; }[];
 const index = links.findIndex((x) => currentPage.includes(x.slug));
 const makeLinkItem = ({ text, slug }) => ({ text, link: `/${lang}/${slug}/` });

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -1,7 +1,7 @@
 import type { AstroGlobal } from 'astro';
 import { readdir } from 'node:fs/promises';
 import { DocSearchTranslation, UIDict, UIDictionaryKeys, NavDict } from './translation-checkers';
-import { getLanguageFromURL } from '../util';
+import { getLanguageFromURL, getCanonicalURL } from '../util';
 
 /**
  * Convert the map of modules returned by `import.meta.globEager` to an object
@@ -62,14 +62,14 @@ const fallbackLang = 'en';
 
 /** Returns a dictionary of strings for use with DocSearch. */
 export function getDocSearchStrings(Astro: AstroGlobal): DocSearchTranslation {
-	const lang = getLanguageFromURL(Astro.canonicalURL.pathname) || fallbackLang;
+	const lang = getLanguageFromURL(getCanonicalURL(Astro).pathname) || fallbackLang;
 	// A shallow merge is sufficient here as most of the actual fallbacks are provided by DocSearch.
 	return { ...docsearchTranslations[fallbackLang], ...docsearchTranslations[lang] };
 }
 
 /** Get the navigation sidebar content for the current language. */
 export async function getNav(Astro: AstroGlobal): Promise<NavDict> {
-	const lang = getLanguageFromURL(Astro.canonicalURL.pathname) || fallbackLang;
+	const lang = getLanguageFromURL(getCanonicalURL(Astro).pathname) || fallbackLang;
 	return await markFallbackNavEntries(lang, navTranslations[lang]);
 }
 
@@ -90,7 +90,7 @@ export async function getNav(Astro: AstroGlobal): Promise<NavDict> {
  * <FrameworkComponent label={t('articleNav.nextPage')} />
  */
 export function useTranslations(Astro: Readonly<AstroGlobal>): (key: UIDictionaryKeys) => string | undefined {
-	const lang = getLanguageFromURL(Astro.canonicalURL.pathname) || 'en';
+	const lang = getLanguageFromURL(getCanonicalURL(Astro).pathname) || 'en';
 	return function getTranslation(key: UIDictionaryKeys) {
 		const str = translations[lang]?.[key] || translations[fallbackLang][key];
 		if (str === undefined) console.error(`Missing translation for “${key}” in “${lang}”.`);

--- a/src/layouts/DeployGuideLayout.astro
+++ b/src/layouts/DeployGuideLayout.astro
@@ -2,8 +2,10 @@
 import MainLayout from "./MainLayout.astro";
 import DeployGuidesNav from "../components/DeployGuidesNav.astro";
 import BrandLogo from "~/components/BrandLogo.astro";
+import { getCanonicalURL } from '../util';
 
-const brand = Astro.canonicalURL.pathname.replace(/\/$/, '').split('/').pop();
+const canonicalURL = getCanonicalURL(Astro);
+const brand = canonicalURL.pathname.replace(/\/$/, '').split('/').pop();
 ---
 
 <MainLayout {...Astro.props}>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -6,7 +6,7 @@ import Header from '../components/Header/Header.astro';
 import PageContent from '../components/PageContent/PageContent.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
-import { getLanguageFromURL } from '../util';
+import { getLanguageFromURL, getCanonicalURL } from '../util';
 import { normalizeLangTag } from '../i18n/bcp-normalize';
 import { useTranslations } from '../i18n/util';
 
@@ -20,7 +20,7 @@ const t = useTranslations(Astro);
 const formatTitle = (content) => (content.title ? `${content.title} 🚀 ${t('site.title')}` : t('site.title'));
 const lang = getLanguageFromURL(url.pathname);
 const bcpLang = normalizeLangTag(lang);
-const canonicalURL = new URL(Astro.canonicalURL);
+const canonicalURL = getCanonicalURL(Astro);
 if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/`, '/en/');
 ---
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -121,20 +121,6 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 ---
 ```
 
-### `Astro.canonicalURL`
-
-The [canonical URL][canonical] of the current page. If the `site` option is set, the site's origin will be the origin of this URL.
-
-You can also use the `canonicalURL` to grab the current page's `pathname`.
-
-```astro
----
-const path = Astro.canonicalURL.pathname;
----
-
-<h1>Welcome to {path}</h1>
-```
-
 ### `Astro.site`
 
 `Astro.site` returns a `URL` made from `.site` in your Astro config. If undefined, this will return a URL generated from `localhost`.
@@ -531,5 +517,3 @@ const serverObject = {
 
 This component provides a way to inspect values on the client-side, without any JavaScript.
 
-
-[canonical]: https://en.wikipedia.org/wiki/Canonical_link_element

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import type { AstroGlobal } from 'astro';
+
 export function getLanguageFromURL(pathname: string) {
 	const langCodeMatch = pathname.match(/\/([a-z]{2}-?[a-z]{0,2})\//);
 	return langCodeMatch ? langCodeMatch[1] : 'en';
@@ -20,6 +22,10 @@ export function removeSubpageSegment(path:string) {
 		return path.slice(0, path.lastIndexOf('/'));
 	}
 	return path;
+}
+
+export function getCanonicalURL(Astro: AstroGlobal): URL {
+	return new URL(new URL(Astro.request.url).pathname, Astro.site);
 }
 
 export function escapeHtml(unescapedString: string) {


### PR DESCRIPTION

#### What kind of changes does this PR include?
- New or updated content
- Changes to the docs site code

#### Description

- Removes the deprecated `Astro.canonicalURL` and all references to it.
- This is pending https://github.com/withastro/astro/pull/3904
  - This will go out with the RC


