### PR TITLE
Use fredkbot over fredkschott

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: ci/docgen-integrations
-          token: ${{ secrets.NIGHTLY_PERSONAL_GITHUB_TOKEN }}
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           add-paths: src/pages/en/guides/integrations-guide/*.md
           commit-message: 'ci: update integration docs'
           title: 'ci: update integration docs'
@@ -54,7 +54,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: ci/docgen
-          token: ${{ secrets.NIGHTLY_PERSONAL_GITHUB_TOKEN }}
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           add-paths: src/pages/en/reference/*.md
           commit-message: 'ci: update reference docs'
           title: 'ci: update reference docs'


### PR DESCRIPTION
- Moves CI actions to use the new bot token
- This secret is an org secret, so once this is merged we can remove this `NIGHTLY` secret entirely from GH