### PR TITLE
Proper Rollup output configuration options

### DIFF
--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -115,9 +115,11 @@ export default defineConfig({
   vite: {
     build: {
       rollupOptions: {
-        entryFileNames: 'entry.[hash].js',
-        chunkFileNames: 'chunks/chunk.[hash].js',
-        assetFileNames: 'assets/asset.[hash][extname]',
+        output: {
+          entryFileNames: 'entry.[hash].js',
+          chunkFileNames: 'chunks/chunk.[hash].js',
+          assetFileNames: 'assets/asset.[hash][extname]',
+        },
       },
     },
   },


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

According to Rollup's documentation `entryFileNames`, `chunkFileNames`, and `assetFileNames` should be defined in an `output` object. For instance, note what's described for [emitted assets](https://rollupjs.org/guide/en/#outputassetfilenames). This change, that has been tested, fixes this minor omission.