### PR TITLE
Patch to WIP-WHY-ASTRO branch: fix link: partial-hydration -> islands

### DIFF
--- a/src/pages/en/core-concepts/sharing-state.md
+++ b/src/pages/en/core-concepts/sharing-state.md
@@ -8,7 +8,7 @@ setup: |
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
 
-When building an Astro website with [islands architecture / partial hydration](/en/core-concepts/partial-hydration/), you may have run into this problem: **I want to share state between my components.**
+When building an Astro website with [islands architecture / partial hydration](/en/concepts/islands/), you may have run into this problem: **I want to share state between my components.**
 
 UI frameworks like React or Vue may encourage ["context" providers](https://reactjs.org/docs/context.html) for other components to consume. But when [partially hydrating components](/en/core-concepts/framework-components/#hydrating-interactive-components) within Astro or Markdown, you can't use these context wrappers.
 


### PR DESCRIPTION
@FredKSchott  Just a quick update to the one page that currently links to the page `en/core-concepts/partial-hydration`.

You may want to look at the link text to make sure that's still what you want it to say, but at least the link itself is correct.