### PR TITLE
Remove "imports on top" warning

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -55,7 +55,6 @@ You can use the component script to write any JavaScript code that you need to r
 
 ```astro
 ---
-// Note: Imports must live at the top of your file.
 import SomeAstroComponent from '../components/SomeAstroComponent.astro';
 import SomeReactComponent from '../components/SomeReactComponent.jsx';
 import someData from '../data/pokemon.json';

--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -58,10 +58,6 @@ import MyReactComponent from '../components/MyReactComponent.jsx';
 </html>
 ```
 
-:::tip
-Remember: all imports must live at the **top** of your Astro component script!
-:::
-
 By default, your framework components will render as static HTML. This is useful for templating components that are not interactive and avoids sending any unnecessary JavaScript to the client.
 
 ## Hydrating Interactive Components

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -13,7 +13,7 @@ Here are some common error messages you might see in the terminal, what they mig
 
 ### Transform failed with "Unexpected `export`"
 
-A current limitation in Astro is that `export` statements (other than `getStaticPaths`) are not supported in `.astro` files.
+A current limitation in Astro is that `export` statements (other than `getStaticPaths()`) are not supported in `.astro` files.
 
 
 **Solution**: Move any `export` statements to a `.js` or `.ts` file.

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -11,18 +11,6 @@ Astro provides several different tools to help you troubleshoot and debug your c
 
 Here are some common error messages you might see in the terminal, what they might mean, and what to do about them.
 
-### Transform failed with "Unexpected `export`"
-
-A current limitation in Astro is that `export` statements (other than `getStaticPaths()`) are not supported in `.astro` files.
-
-
-**Solution**: Move any `export` statements to a `.js` or `.ts` file.
-
-**Status**: Current limitation; a fix may be explored in the future.
-
-**Not sure that this is your problem?**  
-Check to see if anyone else has reported [this issue](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Unexpected+export)!
-
 ### Cannot use import statement outside a module
 
 In Astro components, `<script>` tags are hoisted and loaded as [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) by default. If you have included the [`is:inline` directive](/en/reference/directives-reference/#isinline) or any other attribute in your tag, this default behavior is removed.

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -11,16 +11,17 @@ Astro provides several different tools to help you troubleshoot and debug your c
 
 Here are some common error messages you might see in the terminal, what they might mean, and what to do about them.
 
-### Transform failed with X error
+### Transform failed with "Unexpected `export`"
 
-This message often appears due to a current limitation in Astro requiring your import and export statements to be at the top of your `.astro` file.
+A current limitation in Astro is that `export` statements (other than `getStaticPaths`) are not supported in `.astro` files.
 
-**Solution**: Write your imports and exports at the top of your component script.
 
-**Status**: Current limitation; fix is being worked on.
+**Solution**: Move any `export` statements to a `.js` or `.ts` file.
+
+**Status**: Current limitation; a fix may be explored in the future.
 
 **Not sure that this is your problem?**  
-Check to see if anyone else has reported [this issue](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Transform+failed+with+*+error)!
+Check to see if anyone else has reported [this issue](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Unexpected+export)!
 
 ### Cannot use import statement outside a module
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Removes tips/warnings that import statements must go on top of your `.astro` files!
- Replaces old debugging tip with new "unexpected export" tip
- Blocked by https://github.com/withastro/compiler/pull/463

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
