### PR TITLE
Add link from routing to `build.format` reference

### DIFF
--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -21,7 +21,7 @@ src/pages/posts/1.md         -> mysite.com/posts/1
 ```
 
 :::tip
-There is no separate "routing config" to maintain in an Astro project. Static pages are created by placing files in the `/src/pages/` directory.
+There is no separate "routing config" to maintain in an Astro project! When you add a file to the `/src/pages` directory, a new route is automatically created for you. In static builds, you can customize the file output format using the [`build.format`](/en/reference/configuration-reference/#buildformat) configuration option.
 :::
 
 ## Dynamic routes


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #1007
- Adds a link to the configuration reference entry for `build.format` from the routing page to help discoverability of that option.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
