### PR TITLE
Add react to optional peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,16 @@
     "node": "^14.15.0 || >=16.0.0",
     "pnpm": ">=7.0.0"
   },
-  "packageManager": "pnpm@7.0.0"
+  "packageManager": "pnpm@7.0.0",
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- [X] Something else!

#### Description

Adds `react`, `react-dom`, and `@types/react` to optional peer deps. This should fix install errors after the react -> preact compat refactor!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
