### PR TITLE
fix: Reformat code samples on UI frameworks page

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -125,8 +125,8 @@ Inside of an Astro component, you **can** pass children to framework components.
 
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 ---
 <MyReactSidebar>
@@ -139,8 +139,8 @@ Additionally, you can use [Named Slots](/en/core-concepts/astro-components/#name
 For React, Preact, and Solid these slots will be converted to a top-level prop. Slot names using `kebab-case` will be converted to `camelCase`.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MySidebar from '../components/MySidebar.jsx';
 ---
 <MySidebar>
@@ -182,8 +182,8 @@ For Svelte and Vue these slots can be referenced using a `<slot>` element with t
 Inside of an Astro file, framework component children can also be hydrated components. This means that you can recursively nest components from any of these frameworks.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 import MyReactButton from '../components/MyReactButton.jsx';
 import MySvelteButton from '../components/MySvelteButton.svelte';

--- a/src/pages/es/core-concepts/framework-components.md
+++ b/src/pages/es/core-concepts/framework-components.md
@@ -124,8 +124,8 @@ Solo los componentes de **Astro** (`.astro`) pueden contener componentes de múl
 Dentro de un componente de Astro, **puedes** pasar elementos secundarios a los componentes del framework. Cada framework tiene sus propios patrones sobre cómo hacer referencia a estos elementos secundarios: React, Preact y Solid usan una prop especial llamada `children`, mientras que Svelte y Vue usan el elemento `<slot />`.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 ---
 <MyReactSidebar>
@@ -138,8 +138,8 @@ Además, puedes usar [slots con nombre](/es/core-concepts/astro-components/#slot
 Para React, Preact y Solid, estos slots se convertirán en una prop de nivel superior. Los slots con nombres que usen `kebab-case` se convertirán a `camelCase`.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MySidebar from '../components/MySidebar.jsx';
 ---
 <MySidebar>
@@ -181,8 +181,8 @@ Para Svelte y Vue, se pueden hacer referencia a estos slots mediante un elemento
 Dentro de un archivo Astro, los hijos de los componentes del framework también pueden ser componentes hidratados. Esto significa que puedes anidar recursivamente componentes de cualquiera de estos frameworks.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 import MyReactButton from '../components/MyReactButton.jsx';
 import MySvelteButton from '../components/MySvelteButton.svelte';

--- a/src/pages/fr/core-concepts/framework-components.md
+++ b/src/pages/fr/core-concepts/framework-components.md
@@ -124,8 +124,8 @@ Dans un composant Astro, vous pouvez passer des enfants à des composants de Fra
 
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 ---
 <MyReactSidebar>
@@ -138,8 +138,8 @@ De plus, vous pouvez utiliser les ["Slots" Nommés](/fr/core-concepts/astro-comp
 Dans React, Preact et Solid, ces "Slots" seront convertis en propriété de niveau supérieur. Les noms de slots utilisant le format `kebab-case` seront convertis en `camelCase`.
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MySidebar from '../components/MySidebar.jsx';
 ---
 <MySidebar>

--- a/src/pages/pt-br/core-concepts/framework-components.md
+++ b/src/pages/pt-br/core-concepts/framework-components.md
@@ -124,8 +124,8 @@ Apenas componentes **Astro** (`.astro`) podem conter componentes de múltiplos f
 Dentro de um componente Astro, você **pode** passar filhos para componentes de frameworks. Cada framework tem seus próprios padrões para como se referenciar a esses filhos: React, Preact, e Solid usam todos uma prop especial chamada `children`, enquanto Svelte e Vue usam o elemento `<slot />`.
 
 ```astro
-// src/pages/MinhaPaginaAstro.astro
 ---
+// src/pages/MinhaPaginaAstro.astro
 import MinhaBarraLateralReact from '../components/MinhaBarraLateralReact.jsx';
 ---
 <MinhaBarraLateralReact>
@@ -138,8 +138,8 @@ Adicionalmente, você pode usar [Slots Nomeados](/pt-br/core-concepts/astro-comp
 Para React, Preact, e Solid esses slots serão convertidos em uma prop top-level. Nomes de slots usando`kebab-case` serão convertidos para `camelCase`.
 
 ```astro
-// src/pages/MinhaPaginaAstro.astro
 ---
+// src/pages/MinhaPaginaAstro.astro
 import MinhaBarraLateral from '../components/MinhaBarraLateral.jsx';
 ---
 <MinhaBarraLateral>

--- a/src/pages/zh-cn/core-concepts/framework-components.md
+++ b/src/pages/zh-cn/core-concepts/framework-components.md
@@ -126,8 +126,8 @@ import MyVueComponent from '../components/MyVueComponent.vue';
 
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 ---
 <MyReactSidebar>
@@ -141,8 +141,8 @@ import MyReactSidebar from '../components/MyReactSidebar.jsx';
 
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MySidebar from '../components/MySidebar.jsx';
 ---
 <MySidebar>
@@ -184,8 +184,8 @@ export default function MySidebar(props) {
 在 Astro 文件中，框架组件子项也是激活组件。这意味着你可以嵌套地使用这些框架组件。
 
 ```astro
-// src/pages/MyAstroPage.astro
 ---
+// src/pages/MyAstroPage.astro
 import MyReactSidebar from '../components/MyReactSidebar.jsx';
 import MyReactButton from '../components/MyReactButton.jsx';
 import MySvelteButton from '../components/MySvelteButton.svelte';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Closes #1025
- Reformat codeblocks in `core-concepts/framework-components.md` for every available language

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
