### PR TITLE
Change `<IntegrationsNav>` links to the current page language

### DIFF
--- a/src/components/IntegrationsNav.astro
+++ b/src/components/IntegrationsNav.astro
@@ -17,9 +17,10 @@ function categoryLinksFromPages(pages: MarkdownInstance<Frontmatter>[], category
 		.filter(page => page.frontmatter.category === category)
 		.map((page) => {
 			const [scope, name] = page.frontmatter.title.split(' ').shift()!.split('/');
+			const pageUrl = page.url.replace('/en/', `/${lang}/`) + '/';
 			return {
 				title: '<span class="scope">' + scope + '/&#8203;</span>' + name,
-				href: page.url.replace('/en/', `/${lang}/`) + '/',
+				href: pageUrl,
 				logo: name as any,
 			};
 		});

--- a/src/components/IntegrationsNav.astro
+++ b/src/components/IntegrationsNav.astro
@@ -1,5 +1,6 @@
 ---
 import type { MarkdownInstance } from "astro";
+import { getLanguageFromURL } from '../util';
 import { useTranslations } from "../i18n/util";
 import CardsNav from "./NavGrid/CardsNav.astro";
 
@@ -8,6 +9,9 @@ interface Frontmatter {
 	category: 'renderer' | 'adapter' | 'other';
 }
 
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+
 function categoryLinksFromPages(pages: MarkdownInstance<Frontmatter>[], category: string) {
 	return pages
 		.filter(page => page.frontmatter.category === category)
@@ -15,7 +19,7 @@ function categoryLinksFromPages(pages: MarkdownInstance<Frontmatter>[], category
 			const [scope, name] = page.frontmatter.title.split(' ').shift()!.split('/');
 			return {
 				title: '<span class="scope">' + scope + '/&#8203;</span>' + name,
-				href: page.url + '/',
+				href: page.url.replace('/en/', `/${lang}/`) + '/',
 				logo: name as any,
 			};
 		});


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR changes the card's links to your current page language so that we can use fallback pages for languages where the individual integrations pages aren't translated yet without breaking the link checker.

![sSrNXwm](https://user-images.githubusercontent.com/61414485/179732753-9e661411-ed03-46f7-aafe-951b449f4305.gif)

