### PR TITLE
Fix invisible 404 page

### DIFF
--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -16,26 +16,13 @@ const t = useTranslations(Astro);
 		<HeadCommon />
 		<title>{`${title} 🚀 ${t('site.title')}`}</title>
 		<style>
-			body {
-				width: 100%;
-				display: grid;
-				grid-template-rows: var(--theme-navbar-height) 1fr;
-			}
-			.layout {
-				display: grid;
-				grid-auto-flow: column;
-				grid-template-columns:
-					minmax(var(--doc-padding-inline), 1fr)
-					minmax(0, var(--max-width))
-					minmax(var(--doc-padding-inline), 1fr);
-				overflow-x: hidden;
-			}
-			article {
-				padding: var(--doc-padding-block) var(--doc-padding-inline);
-				grid-column: 2;
-				display: flex;
-				flex-direction: column;
+			html, body, main {
 				height: 100%;
+			}
+			main {
+				display: grid;
+				place-items: center;
+				padding-inline: var(--min-spacing-inline);
 			}
 			:global(#menu-toggle) {
 				display: none;


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- Closes #1050 

The 404 page content was being hidden because of CSS conflicts, this PR simplifies the SplashLayout code so that the 404 page is visible again. We can discuss if we want the 404 page content aligned to the middle or left, I just went with what was more similar to what we already had.

| docs.astro.build  |  Deploy Preview  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/180206364-1d2f5192-d012-4432-b6ba-0b6174314451.png) |  ![image](https://user-images.githubusercontent.com/61414485/180206410-e2684dab-3679-4579-b26a-5fe2e0ea435d.png) |