### PR TITLE
Remove translate link in non-`i18nReady`, fallback and translated pages

### DIFF
--- a/src/components/RightSidebar/ContributeMenu.astro
+++ b/src/components/RightSidebar/ContributeMenu.astro
@@ -2,7 +2,12 @@
 import UIString from '../UIString.astro';
 import { getLanguageFromURL } from '../../util';
 
-const { i18nReady, editHref } = Astro.props;
+export interface Props {
+  i18nReady: boolean | undefined;
+  editHref: string;
+}
+
+const { i18nReady, editHref } = Astro.props as Props;
 
 const currentPage = new URL(Astro.request.url).pathname;
 const lang = getLanguageFromURL(currentPage);

--- a/src/components/RightSidebar/ContributeMenu.astro
+++ b/src/components/RightSidebar/ContributeMenu.astro
@@ -1,7 +1,13 @@
 ---
 import UIString from '../UIString.astro';
+import { getLanguageFromURL } from '../../util';
 
-const { editHref } = Astro.props;
+const { i18nReady, editHref } = Astro.props;
+
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+const isFallback = !!Astro.params.fallback;
+const isTranslatable =  (lang === 'en' || isFallback) && i18nReady;
 ---
 
 <h2 class="heading"><UIString key="rightSidebar.contribute" /></h2>
@@ -28,18 +34,20 @@ const { editHref } = Astro.props;
 			<span><UIString key="rightSidebar.editPage" /></span>
 		</a>
 	</li>
-	<li class={`header-link depth-2`}>
-		<a href="https://github.com/withastro/docs/blob/main/src/i18n#readme" target="_blank">
-			<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.6 77.3" height="1.24em" width="1.24em" style="margin: -2px;">
-				<path fill="currentColor" d="M61,24.6h7.9l18.7,51.6h-7.7l-5.4-15.5H54.3l-5.6,15.5h-7.2L61,24.6z M72.6,55l-8-22.8L56.3,55H72.6z"></path>
-				<path
-					fill="currentColor"
-					d="M53.6,60.6c-10-4-16-9-22-14c0,0,1.3,1.3,0,0c-6,5-20,13-20,13l-4-6c8-5,10-6,19-13c-2.1-1.9-12-13-13-19h8          c4,9,10,14,10,14c10-8,10-19,10-19h8c0,0-1,13-12,24l0,0c5,5,10,9,19,13L53.6,60.6z M1.6,16.6h56v-8h-23v-7h-9v7h-24V16.6z"
-				></path>
-			</svg>
-			<span><UIString key="rightSidebar.translatePage" /></span>
-		</a>
-	</li>
+	{isTranslatable &&
+		<li class={`header-link depth-2`}>
+			<a href="https://github.com/withastro/docs/blob/main/src/i18n#readme" target="_blank">
+				<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.6 77.3" height="1.24em" width="1.24em" style="margin: -2px;">
+					<path fill="currentColor" d="M61,24.6h7.9l18.7,51.6h-7.7l-5.4-15.5H54.3l-5.6,15.5h-7.2L61,24.6z M72.6,55l-8-22.8L56.3,55H72.6z"></path>
+					<path
+						fill="currentColor"
+						d="M53.6,60.6c-10-4-16-9-22-14c0,0,1.3,1.3,0,0c-6,5-20,13-20,13l-4-6c8-5,10-6,19-13c-2.1-1.9-12-13-13-19h8          c4,9,10,14,10,14c10-8,10-19,10-19h8c0,0-1,13-12,24l0,0c5,5,10,9,19,13L53.6,60.6z M1.6,16.6h56v-8h-23v-7h-9v7h-24V16.6z"
+					></path>
+				</svg>
+				<span><UIString key="rightSidebar.translatePage" /></span>
+			</a>
+		</li>
+	}
 </ul>
 
 <style>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -19,7 +19,7 @@ const headers = content.astro?.headers;
 			isMobile={false}
 		/>
 	)}
-	<ContributeMenu editHref={githubEditUrl} />
+	<ContributeMenu i18nReady={content.i18nReady} editHref={githubEditUrl} />
 	<CommunityMenu />
 </nav>
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR removes the "translate this page" link on the `<ContributeMenu>` component for translated, non-i18nReady, and fallback pages (if they aren't `i18nReady`).

| `i18nReady: false`  |  Fallback  |  Translated  |
| ------------------- | ------------------- | ------------------- |
|  ![image](https://user-images.githubusercontent.com/61414485/180251304-3bfffd35-9f95-4e66-8f6f-144f5b343181.png) |  ![image](https://user-images.githubusercontent.com/61414485/180251886-1be01842-2b17-490a-bafc-566d8a090866.png) | ![image](https://user-images.githubusercontent.com/61414485/180252305-bb744b8f-b9f3-45ca-9e4a-fc8f10b01434.png) |