### PR TITLE
[i18n README]: Adds extra warning re: do not translate

### DIFF
--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -11,7 +11,8 @@ Translations all live in this GitHub repository. You can add and update them by 
 See our automated [Translation Status Overview issue](https://github.com/withastro/docs/issues/438) for a quick list of which pages are missing or need updating.
 
 
-> **Please do not translate any pages without first checking the status on our Tracker**! 
+> **Warning**
+> Please do not translate any pages without first checking their status in our [Overview Issue](https://github.com/withastro/docs/issues/438)! 
  
 Not every page is marked as "ready to translate." So, even if you find a page that is not yet translated on the Docs site, you must confirm that it is on the list of available pages to translate. If the `.md` files does not contain `i18nReady: true` in its YAML frontmatter, do not translate the document.
 

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -10,6 +10,13 @@ Translations all live in this GitHub repository. You can add and update them by 
 ### How can I find out what needs translating?
 See our automated [Translation Status Overview issue](https://github.com/withastro/docs/issues/438) for a quick list of which pages are missing or need updating.
 
+
+> **Please do not translate any pages without first checking the status on our Tracker**! 
+ 
+Not every page is marked as "ready to translate." So, even if you find a page that is not yet translated on the Docs site, you must confirm that it is on the list of available pages to translate. If the `.md` files does not contain `i18nReady: true` in its YAML frontmatter, do not translate the document.
+
+You can read more about how pages are marked "ready for (initial) translating" and "needs updating" in [CONTRIBUTING.md](https://github.com/withastro/docs/blob/main/CONTRIBUTING.md).
+
 ### How can I participate in the conversation and decisions?
 Discussion around translation currently takes place in [the Astro Discord](https://astro.build/chat). Everyone is welcome to participate! If you are interested in getting involved, please reach out to us in the `#docs-i18n` channel.
 


### PR DESCRIPTION
- New or updated content

Starts to address issues of i18n guidance for translators.

- Adds more explicit warning re: when NOT translate
- Inclues link to CONTRIBUTING to see more about when things are/aren't marked for translation (TODO: which will include description of using phrases like "minor" and "typo" there, since it's really the English contributors who need to know about this).
- TODO: move this file, probably just to `src` like the other READMES until we decide on a better location for all the README guides?
