### PR TITLE
Deprecating the "Authoring markdown" section and adding config docs for the new legacy flag

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -173,7 +173,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 ## Authoring Markdown
 
 :::caution[Deprecated]
-Astro no longer supports components or JSX in markdown pages by default and may be removed in a future release. In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will enable these features in markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx).
+Astro no longer supports components or JSX in markdown pages by default and may be removed in a future release. In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will enable these features in markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/).
 :::
 
 In addition to supporting standard Markdown syntax, Astro also extends Markdown to make your content even more expressive. Below are some Markdown features that only exist in Astro.

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -172,6 +172,10 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 
 ## Authoring Markdown
 
+:::caution[Deprecated]
+Astro no longer supports components or JSX in markdown pages by default and may be removed in a future release. In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will enable these features in markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx).
+:::
+
 In addition to supporting standard Markdown syntax, Astro also extends Markdown to make your content even more expressive. Below are some Markdown features that only exist in Astro.
 
 ### Using Variables in Markdown

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -38,7 +38,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 ### Deprecated: Components and JSX in Markdown
 
-Astro no longer supports components or JSX expressions in Markdown pages by default. For long term support you should migrate to the [`@astrojs/mdx`]() integration.
+Astro no longer supports components or JSX expressions in Markdown pages by default. For long-term support you should migrate to the [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration.
 
 To make migrating easier, a new [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) can be used to re-enable previous Markdown features.
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -36,19 +36,17 @@ const canonicalURL = Astro.canonicalURL;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ```
 
-## Astro 1.0 Beta
+## Migrate to v1.0.0-beta
 
 On April 4, 2022 we released the Astro 1.0 Beta! 🎉
 
-**We do not plan to make any more breaking changes during this beta period, leading up to the official v1.0.0 release (planned for [late July, 2022](https://astro.build/blog/astro-1-release-update/)).**
-
-If any breaking changes must be made, we will call them out in this section.
-
-## Migrate to v1.0.0-beta.0
-
-The `v1.0.0-beta.0` release of Astro contained no breaking changes.
-
 If you are coming from v0.25 or earlier, make sure you have read and followed the [v0.26 Migration Guide](#migrate-to-v026) below, which contained several major breaking changes.
+
+The `v1.0.0-beta.0` release of Astro contained no breaking changes. Below are small changes that were introduced during the beta period.
+
+### Changed: RSS Feeds
+
+RSS feeds should now be generated using the `@astrojs/rss` package, as described in our [RSS guide](/en/guides/rss/).
 
 ## Migrate to v0.26
 ### New Configuration API

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -27,7 +27,7 @@ Astro v1.0 RC has upgraded from Vite 2 to [Vite 3](https://vitejs.dev/). We've h
 
 ### Deprecated: `Astro.canonicalURL`
 
-You can now use the new [`Astro.url`](/en/reference/api-reference/#astrourl) helper to construct your own canonical URL from the current page/request URL.
+You can now use the new [`Astro.url`](/en/reference/api-reference/#astrourl) helper to construct your own canonical URL from the current page/request URL. 
 
 ```js
 // Before:
@@ -35,6 +35,12 @@ const canonicalURL = Astro.canonicalURL;
 // After:
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ```
+
+### Deprecated: Components and JSX in Markdown
+
+Astro no longer supports components or JSX expressions in Markdown pages by default. For long term support you should migrate to the [`@astrojs/mdx`]() integration.
+
+To make migrating easier, a new [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) can be used to re-enable previous Markdown features.
 
 ## Migrate to v1.0.0-beta
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -263,28 +263,6 @@ A Markdown page is considered a draft if it includes `draft: true` in its frontm
 ```
 
 
-### markdown.mode
-
-<p>
-
-**Type:** `'md' | 'mdx'`<br>
-**Default:** `mdx`
-</p>
-
-Control whether Markdown processing is done using MDX or not.
-
-MDX processing enables you to use JSX inside your Markdown files. However, there may be instances where you don't want this behavior, and would rather use a "vanilla" Markdown processor. This field allows you to control that behavior.
-
-```js
-{
-  markdown: {
-    // Example: Use non-MDX processor for Markdown files
-    mode: 'md',
-  }
-}
-```
-
-
 ### markdown.shikiConfig
 
 <p>
@@ -357,6 +335,29 @@ Pass a custom [Rehype](https://github.com/remarkjs/remark-rehype) plugin to cust
     rehypePlugins: [],
   },
 };
+```
+
+## Legacy Options
+
+### legacy.astroFlavoredMarkdown
+
+<p>
+
+**Type:** `boolean`<br>
+**Default:** `false`
+</p>
+
+Control whether Astro supports using components and JSX expressions in markdown pages.
+
+Support for these markdown features has been deprecated in favor of the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx). Use this flag if you need to re-enable support for components and JSX expression in markdown until you are able to migrate over to MDX.
+
+```js
+{
+  legacy: {
+    // Example: Re-enable support for components and JSX in `.md` pages
+    astroFlavoredMarkdown: true,
+  }
+}
 ```
 
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -337,29 +337,6 @@ Pass a custom [Rehype](https://github.com/remarkjs/remark-rehype) plugin to cust
 };
 ```
 
-## Legacy Options
-
-### legacy.astroFlavoredMarkdown
-
-<p>
-
-**Type:** `boolean`<br>
-**Default:** `false`
-</p>
-
-Control whether Astro supports using components and JSX expressions in markdown pages.
-
-Support for these markdown features has been deprecated in favor of the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/). Use this flag if you need to re-enable support for components and JSX expression in markdown until you are able to migrate over to MDX.
-
-```js
-{
-  legacy: {
-    // Example: Re-enable support for components and JSX in `.md` pages
-    astroFlavoredMarkdown: true,
-  }
-}
-```
-
 
 ## Adapter
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -349,7 +349,7 @@ Pass a custom [Rehype](https://github.com/remarkjs/remark-rehype) plugin to cust
 
 Control whether Astro supports using components and JSX expressions in markdown pages.
 
-Support for these markdown features has been deprecated in favor of the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx). Use this flag if you need to re-enable support for components and JSX expression in markdown until you are able to migrate over to MDX.
+Support for these markdown features has been deprecated in favor of the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/). Use this flag if you need to re-enable support for components and JSX expression in markdown until you are able to migrate over to MDX.
 
 ```js
 {

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -263,6 +263,28 @@ A Markdown page is considered a draft if it includes `draft: true` in its frontm
 ```
 
 
+### markdown.mode
+
+<p>
+
+**Type:** `'md' | 'mdx'`<br>
+**Default:** `mdx`
+</p>
+
+Control whether Markdown processing is done using MDX or not.
+
+MDX processing enables you to use JSX inside your Markdown files. However, there may be instances where you don't want this behavior, and would rather use a "vanilla" Markdown processor. This field allows you to control that behavior.
+
+```js
+{
+  markdown: {
+    // Example: Use non-MDX processor for Markdown files
+    mode: 'md',
+  }
+}
+```
+
+
 ### markdown.shikiConfig
 
 <p>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

Updating the docs to reflect the new "legacy" mode for Astro-flavored markdown in [PR #4016](https://github.com/withastro/astro/pull/4016)

#### Description

- Deprecates the "Authoring markdown" section with a note on how to re-enable the features until they are removed in a future Astro release (no timeline on that, I'd guess 2.0?)
- Adds configuration docs for the new `legacy.astroFlavoredMarkdown` flag

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
