### PR TITLE
Fixed unnecessary comma usage

### DIFF
--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -59,7 +59,7 @@ The `src/` folder is where most of your project source code lives. This includes
 
 Astro processes, optimizes, and bundles your `src/` files to create the final website that is shipped to the browser.  Unlike the static `public/` directory, your `src/` files are built and handled for you by Astro.
 
-Some files (like Astro components) are not even sent to the browser as written, but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
+Some files (like Astro components) are not even sent to the browser as written but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
 
 ### `src/components`
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Fixed a typo.
- A compound predicate with only two verb phrases requires no punctuation to separate them. Hence removed the unnecessary comma.
