### PR TITLE
Fixed article usage

### DIFF
--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -69,13 +69,13 @@ This is a common convention in Astro projects, but it is not required. Feel free
 
 ### `src/layouts`
 
-[Layouts](/en/core-concepts/layouts/) are special kind of component that wrap some content in a larger page layout. These are most often used by [Astro pages](/en/core-concepts/astro-pages/) and [Markdown pages](/en/guides/markdown-content/) to define the layout of the page.
+[Layouts](/en/core-concepts/layouts/) are a special kind of component that wrap some content in a larger page layout. These are most often used by [Astro pages](/en/core-concepts/astro-pages/) and [Markdown pages](/en/guides/markdown-content/) to define the layout of the page.
 
 Just like `src/components`, this directory is a common convention but not required.
 
 ### `src/pages`
 
-[Pages](/en/core-concepts/astro-pages/) are special kind of component used to create new pages on your site. A page can be an Astro component, or a Markdown file that represents some page of content for your site.
+[Pages](/en/core-concepts/astro-pages/) are a special kind of component used to create new pages on your site. A page can be an Astro component, or a Markdown file that represents some page of content for your site.
 
 :::caution
 `src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Fixed grammar related to article usage
- An article like "a/an" or "the" should be used before a singular countable noun to establish what the noun refers to. Hence added "a" before the nouns.