### PR TITLE
Fixed article usage problem

### DIFF
--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -10,7 +10,7 @@ i18nReady: true
 Static Site Generator  🚀  Bring your own Framework  🚀  Ship Less JavaScript
 
 :::tip
-Have an older project? Follow the [migration guide](/en/migrate/) to upgrade to v1.0 beta!
+Have an older project? Follow the [migration guide](/en/migrate/) to upgrade to the v1.0 beta!
 :::
 
 ## Try Astro


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Fixed article usage problem in docs.
- An article like "a/an" or "the" should be used before a singular countable noun to establish the reference to the noun. Hence added "the" before the noun.
