### PR TITLE
Clarify linking between pages

### DIFF
--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -11,6 +11,9 @@ i18nReady: true
 
 Astro leverages a routing strategy called **file-based routing.** Every `.astro` file in your `src/pages` directory becomes a page or an endpoint on your site based on its file path.
 
+Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your component template to link between pages.
+
+
 📚 Read more about [Routing in Astro](/en/core-concepts/routing/).
 
 ### Page HTML

--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -24,6 +24,14 @@ src/pages/posts/1.md         -> mysite.com/posts/1
 There is no separate "routing config" to maintain in an Astro project! When you add a file to the `/src/pages` directory, a new route is automatically created for you. In static builds, you can customize the file output format using the [`build.format`](/en/reference/configuration-reference/#buildformat) configuration option.
 :::
 
+## Navigating between pages
+
+Astro uses standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) to navigate between routes. There is no framework-specific `<Link>` component provided.
+
+```astro
+<p>Read more <a href="/about/">about</a> Astro!</p>
+```
+
 ## Dynamic routes
 
 A single Astro Page component can also specify dynamic route parameters in its filename to generate multiple routes that match a given criteria. You can create several related pages at once, such as author pages, or a page for each blog tag. Named parameters allow you to specify values for "named" levels of these route paths, and rest parameters allow for more flexible "catch-all" routes.


### PR DESCRIPTION
- New or updated content

Explicitly mentions using a standard HTML `<a>` tag for linking to other pages on your site. There is no provided `<Link>` component.

To close #992 

