### PR TITLE
Add `cachedFetch()` function to speed up builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ sandbox.config.json
 
 # Local Netlify folder
 .netlify
+
+# Cached requests
+.cache

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "github:translation-status": "node ./scripts/github-translation-status.mjs"
   },
   "devDependencies": {
+    "@11ty/eleventy-fetch": "^3.0.0",
     "@actions/core": "^1.9.0",
     "@algolia/client-search": "^4.13.1",
     "@astrojs/preact": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@11ty/eleventy-fetch': ^3.0.0
   '@actions/core': ^1.9.0
   '@algolia/client-search': ^4.13.1
   '@astrojs/preact': ^0.3.1
@@ -58,6 +59,7 @@ dependencies:
   sass: 1.53.0
 
 devDependencies:
+  '@11ty/eleventy-fetch': 3.0.0
   '@actions/core': 1.9.0
   '@algolia/client-search': 4.13.1
   '@astrojs/preact': 0.3.1_zovicw5hrcrgb3nz2xoc225r6q
@@ -93,6 +95,19 @@ devDependencies:
   unist-util-visit: 4.1.0
 
 packages:
+
+  /@11ty/eleventy-fetch/3.0.0:
+    resolution: {integrity: sha512-qJvfb331rYQAmlCS71Ygg0/XHUdB4/qXBOLsG0DJ1m61WL5JNha52OtKVeQq34u2J2Nfzim+X4TIL/+QyesB7Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      debug: 4.3.4
+      flat-cache: 3.0.4
+      node-fetch: 2.6.7
+      p-queue: 6.6.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
 
   /@actions/core/1.9.0:
     resolution: {integrity: sha512-5pbM693Ih59ZdUhgk+fts+bUWTnIdHV3kwOSr+QIoFHMLg7Gzhwm0cifDY/AG68ekEJAkHnQVpcy4f6GjmzBCA==}
@@ -2260,6 +2275,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /eventemitter3/4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: true
+
   /execa/6.1.0:
     resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2329,7 +2348,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       array-back: 5.0.0
-      glob: 7.2.0
+      glob: 7.2.3
     dev: false
 
   /fill-range/7.0.1:
@@ -2478,17 +2497,6 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob/7.2.0:
-    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-
   /glob/7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
@@ -2498,7 +2506,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3656,6 +3663,18 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
 
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
   /node-fetch/3.2.6:
     resolution: {integrity: sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3710,7 +3729,7 @@ packages:
       object-keys: 1.1.1
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
 
@@ -3761,6 +3780,11 @@ packages:
       strip-ansi: 7.0.1
       wcwidth: 1.0.1
 
+  /p-finally/1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+    dev: true
+
   /p-limit/2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3791,6 +3815,21 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
+
+  /p-queue/6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+    dev: true
+
+  /p-timeout/3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-finally: 1.0.0
+    dev: true
 
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3860,7 +3899,7 @@ packages:
     engines: {node: '>=8'}
 
   /path-is-absolute/1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
 
   /path-key/3.1.1:
@@ -4552,6 +4591,10 @@ packages:
     resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
     engines: {node: '>=6'}
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
 
@@ -4919,6 +4962,17 @@ packages:
     resolution: {integrity: sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==}
     engines: {node: '>= 8'}
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
+
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
@@ -4973,7 +5027,7 @@ packages:
       strip-ansi: 7.0.1
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /xmlcreate/2.0.4:
     resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}

--- a/src/components/ContributorList.astro
+++ b/src/components/ContributorList.astro
@@ -1,4 +1,5 @@
 ---
+import { cachedFetch } from '../util';
 import UIString from './UIString.astro';
 
 export interface Props {
@@ -17,24 +18,21 @@ async function getContributors(repo, page = 1) {
 		const url = `https://api.github.com/repos/${repo}/contributors?per_page=${pageSize}&page=${page}`;
 		
 		const token = import.meta.env.PUBLIC_GITHUB_TOKEN;
-		if (!token) {
-			printError('Cannot find environment variable "PUBLIC_GITHUB_TOKEN" used for escaping rate-limiting.');
-		}
 		
-		const res = await fetch(url, {
+		const res = await cachedFetch(url, {
 			method: 'GET',
 			headers: {
 				Authorization: token && `Basic ${Buffer.from(token, 'binary').toString('base64')}`,
 				'User-Agent': 'astro-docs/1.0',
 			},
-		});
+		}, { duration: '15m' });
 		
 		const data = await res.json();
 		
 		if (!res.ok) {
 			throw new Error(
 				`Request to fetch contributors failed. Reason: ${res.statusText}
-         Message: ${data.message}`
+         Message: ${data?.message}`
 			);
 		}
 		

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -1,6 +1,7 @@
 ---
 import UIString from './UIString.astro';
 import Badge from './Badge.astro';
+import { cachedFetch } from '../util';
 
 export interface Props {
   v: string;
@@ -21,7 +22,7 @@ const parseSemVer = (semver: string) => semver
  */
 const isFeatureNew = async (sinceVersion: string) => {
   const astroInfo =
-    await fetch('https://registry.npmjs.org/astro/latest').then(res => res.json());
+    await cachedFetch('https://registry.npmjs.org/astro/latest').then(res => res.json());
   const latestAstroVersion = astroInfo.version;
   const [sinceMajor, sinceMinor] = parseSemVer(sinceVersion);
   const [latestMajor, latestMinor] = parseSemVer(latestAstroVersion);

--- a/src/components/Version.astro
+++ b/src/components/Version.astro
@@ -1,11 +1,13 @@
 ---
+import { cachedFetch } from "../util";
+
 export interface Props {
 	pkgName: string;
 }
 
 const { pkgName } = Astro.props as Props
 
-const packageInfo = await fetch(`https://registry.npmjs.org/${pkgName}/latest`).then(res => res.json());
+const packageInfo = await cachedFetch(`https://registry.npmjs.org/${pkgName}/latest`).then(res => res.json());
 const { version } = packageInfo;
 ---
 <span>v{version}</span>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Adds a `cachedFetch()` function to `utils.ts` which uses `@11ty/eleventy-fetch` to cache `fetch()` calls.
- Mimics the `Response` object returned by the `fetch()` API.
- Hopefully makes Astro Docs builds and Netlify deploys more resilient.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
