### PR TITLE
Remove pre-rc upgrade command

### DIFF
--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -13,14 +13,6 @@ Read the guide below for major highlights and instructions on how to handle brea
 
 The Astro v1.0 Release Candidate (RC) introduces some changes that you should be aware of when migrating from beta or earlier releases. See below for more details.
 
-:::note
-The Release Candidate is not yet installed by default for most users, but you can try it today by running this command:
-
-```sh
-npm install astro@next--rc
-```
-:::
-
 ### Updated: Vite 3
 
 Astro v1.0 RC has upgraded from Vite 2 to [Vite 3](https://vitejs.dev/). We've handled most of the upgrade for you inside of Astro, however some subtle Vite behaviors may still change between versions. Refer to the official [Vite Migration Guide](https://vitejs.dev/guide/migration.html#general-changes) if you run into trouble.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Changes to the docs site code

#### Description
Removes the `pnpm i -D astro@next--rc` command from migration as it is no longer needed

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
