### PR TITLE
Docs: Update deprecated usage of import.vite.globEager

### DIFF
--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -83,13 +83,13 @@ See [Vite's glob import documentation](https://vitejs.dev/guide/features.html#gl
 
 We recommend this option for `.md` files outside of the `pages` directory. This is common when generating routes [via `getStaticPaths`](/en/reference/api-reference/#getstaticpaths).
 
-For instance, say your `.md` posts are stored under a `src/posts/` directory. Each post has a `title`, `pubDate`, and `slug` in its frontmatter, where `slug` corresponds to the output URL on your site. We can generate an RSS feed using [Vite's `import.meta.globEager` helper](https://vitejs.dev/guide/features.html#glob-import) like so:
+For instance, say your `.md` posts are stored under a `src/posts/` directory. Each post has a `title`, `pubDate`, and `slug` in its frontmatter, where `slug` corresponds to the output URL on your site. We can generate an RSS feed using [Vite's `import.meta.glob` helper](https://vitejs.dev/guide/features.html#glob-import) like so:
 
 ```js
 // src/pages/rss.xml.js
 import rss from '@astrojs/rss';
 
-const postImportResult = import.meta.globEager('../posts/**/*.md');
+const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true });
 const posts = Object.values(postImportResult);
 
 export const get = () => rss({


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description

Vite's `globEager` is deprecated as per Vite's TypeScript docs. The suggested change as per TS & Vite's [Official Docs](https://vitejs.dev/guide/features.html#glob-import) is to use `import.meta.glob('....', { eager: true })` instead, having the exact same output.