### PR TITLE
Add instructions on how to use multiple frameworks at the same time in TypeScript

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -142,7 +142,11 @@ To see type errors in your editor, please make sure that you have the [Astro VS 
 
 ### Typing multiple JSX frameworks at the same time
 
-An issue arise when using multiple JSX frameworks in the same project, as every framework require different, conflicting settings inside `tsconfig.json`. To workaround this issue, TypeScript support [different pragma comments](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx) to set the JSX options on a per-file basis.
+An issue may arise when using multiple JSX frameworks in the same project, as each framework requires different, sometimes conflicting, settings inside `tsconfig.json`. 
+
+**Solution**: Set the [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImportSource) to `react` (default), `preact` or `solid-js` depending on your most-used framework. Then, use a [pragma comment](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx) inside any conflicting file from a different framework.
+
+For the default setting of 	`jsxImportSource: react`, you would use:
 
 The [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImportSource) being by default `react`, all your `.jsx` files will by default be typechecked using the React definitions if installed (`@types/react`). As such, your Preact and Solid files should contain pragma comments to set the setting to the proper value:
 

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -140,7 +140,7 @@ To see type errors in your editor, please make sure that you have the [Astro VS 
 
 ## Troubleshooting
 
-### Typing multiple JSX frameworks at the same time
+### Errors Typing multiple JSX frameworks at the same time
 
 An issue may arise when using multiple JSX frameworks in the same project, as each framework requires different, sometimes conflicting, settings inside `tsconfig.json`. 
 
@@ -148,7 +148,6 @@ An issue may arise when using multiple JSX frameworks in the same project, as ea
 
 For the default setting of 	`jsxImportSource: react`, you would use:
 
-The [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImportSource) being by default `react`, all your `.jsx` files will by default be typechecked using the React definitions if installed (`@types/react`). As such, your Preact and Solid files should contain pragma comments to set the setting to the proper value:
 
 ```jsx
 // For Preact
@@ -158,8 +157,12 @@ The [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImpor
 /** @jsxImportSource solid-js */
 ```
 
-Alternatively, if your project primarily use another framework, you may change the `jsxImportSource` setting to `preact` or `solid-js` and instead use a pragma comment inside your React files.
 
-### Typing Vue components when the `@types/react` package is installed
+### Vue components are mistakenly typed by the `@types/react` package when installed
 
-Due to being declared globally, the types definition from the `@types/react` package, if installed, will mistakenly be used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar). There's currently no reliable way to fix this, however a few solutions are discussed can be found in [this GitHub discussion](https://github.com/johnsoncodehk/volar/discussions/592)
+The types definition from the`@types/react` package is declared globally and therefore will be mistakenly used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar).
+
+**Status**:  Expected behavior.
+
+**Solution**: There's currently no reliable way to fix this, however a few solutions and more discussion can be found in [this GitHub discussion](https://github.com/johnsoncodehk/volar/discussions/592).
+

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -160,7 +160,7 @@ For the default setting of `jsxImportSource: react`, you would use:
 
 ### Vue components are mistakenly typed by the `@types/react` package when installed
 
-The types definition from the `@types/react` package are declared globally and therefore will be mistakenly used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar).
+The types definitions from the `@types/react` package are declared globally and therefore will be mistakenly used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar).
 
 **Status**: Expected behavior.
 

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -40,10 +40,6 @@ If your project uses a [UI framework](/en/core-concepts/framework-components/), 
 
 ## Type Imports
 
-
-
-## Type Imports
-
 Use explicit type imports and exports whenever possible. 
 
 ```diff

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -47,6 +47,8 @@ Use type imports & exports whenever possible. This will help you avoid edge-case
 + import type { SomeType } from './script';
 ```
 
+The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error` to have TypeScript report an error when a value import is only used as a type and should instead use `import type`
+
 ## Import Aliases
 
 Astro supports [import aliases](/en/guides/aliases/) that you define in your `tsconfig.json` & `jsconfig.json` `paths` configuration. [Read our guide](/en/guides/aliases/) to learn more.
@@ -135,19 +137,18 @@ To see type errors in your editor, please make sure that you have the [Astro VS 
 `astro check` only checks types within `.astro` files, and `tsc --noEmit` only checks types within `.ts` and `.tsx` files. To check types within Svelte and Vue files, you can use the [`svelte-check`](https://www.npmjs.com/package/svelte-check) and the [`vue-tsc`](https://www.npmjs.com/package/vue-tsc) packages respectively.
 :::
 
-📚 Read more about [`.ts` file imports](/en/guides/imports/#typescript) in Astro.  
+📚 Read more about [`.ts` file imports](/en/guides/imports/#typescript) in Astro.
 📚 Read more about [TypeScript Configuration](https://www.typescriptlang.org/tsconfig/).
 
 ## Troubleshooting
 
 ### Errors Typing multiple JSX frameworks at the same time
 
-An issue may arise when using multiple JSX frameworks in the same project, as each framework requires different, sometimes conflicting, settings inside `tsconfig.json`. 
+An issue may arise when using multiple JSX frameworks in the same project, as each framework requires different, sometimes conflicting, settings inside `tsconfig.json`.
 
 **Solution**: Set the [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImportSource) to `react` (default), `preact` or `solid-js` depending on your most-used framework. Then, use a [pragma comment](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx) inside any conflicting file from a different framework.
 
-For the default setting of 	`jsxImportSource: react`, you would use:
-
+For the default setting of `jsxImportSource: react`, you would use:
 
 ```jsx
 // For Preact
@@ -157,12 +158,10 @@ For the default setting of 	`jsxImportSource: react`, you would use:
 /** @jsxImportSource solid-js */
 ```
 
-
 ### Vue components are mistakenly typed by the `@types/react` package when installed
 
-The types definition from the`@types/react` package is declared globally and therefore will be mistakenly used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar).
+The types definition from the `@types/react` package are declared globally and therefore will be mistakenly used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar).
 
-**Status**:  Expected behavior.
+**Status**: Expected behavior.
 
 **Solution**: There's currently no reliable way to fix this, however a few solutions and more discussion can be found in [this GitHub discussion](https://github.com/johnsoncodehk/volar/discussions/592).
-

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -40,14 +40,25 @@ If your project uses a [UI framework](/en/core-concepts/framework-components/), 
 
 ## Type Imports
 
-Use type imports & exports whenever possible. This will help you avoid edge-cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
+
+
+## Type Imports
+
+Use explicit type imports and exports whenever possible. 
 
 ```diff
 - import { SomeType } from './script';
 + import type { SomeType } from './script';
 ```
+This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
-The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error` to have TypeScript report an error when a value import is only used as a type and should instead use `import type`
+In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error`. Then, TypeScript will check your imports and tell you when  `import type` should be used.
+
+```json
+{
+  "compilerOptions": {
+    "importsNotUsedAsValues": "error",
+```
 
 ## Import Aliases
 

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -36,7 +36,7 @@ Some TypeScript configuration options require special attention in Astro. Below 
 }
 ```
 
-If your project uses a framework, additional settings depending on the framework might be needed, see your framework's documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://reactjs.org/docs/static-type-checking.html), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))
+If your project uses a [UI framework](/en/core-concepts/framework-components/), additional settings depending on the framework might be needed. Please see your framework's TypeScript documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://reactjs.org/docs/static-type-checking.html), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))
 
 ## Type Imports
 

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -36,6 +36,8 @@ Some TypeScript configuration options require special attention in Astro. Below 
 }
 ```
 
+If your project uses a framework, additional settings depending on the framework might be needed, see your framework's documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://reactjs.org/docs/static-type-checking.html), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))
+
 ## Type Imports
 
 Use type imports & exports whenever possible. This will help you avoid edge-cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
@@ -135,3 +137,25 @@ To see type errors in your editor, please make sure that you have the [Astro VS 
 
 📚 Read more about [`.ts` file imports](/en/guides/imports/#typescript) in Astro.  
 📚 Read more about [TypeScript Configuration](https://www.typescriptlang.org/tsconfig/).
+
+## Troubleshooting
+
+### Typing multiple JSX frameworks at the same time
+
+An issue arise when using multiple JSX frameworks in the same project, as every framework require different, conflicting settings inside `tsconfig.json`. To workaround this issue, TypeScript support [different pragma comments](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx) to set the JSX options on a per-file basis.
+
+The [`jsxImportSource` setting](https://www.typescriptlang.org/tsconfig#jsxImportSource) being by default `react`, all your `.jsx` files will by default be typechecked using the React definitions if installed (`@types/react`). As such, your Preact and Solid files should contain pragma comments to set the setting to the proper value:
+
+```jsx
+// For Preact
+/** @jsxImportSource preact */
+
+// For Solid
+/** @jsxImportSource solid-js */
+```
+
+Alternatively, if your project primarily use another framework, you may change the `jsxImportSource` setting to `preact` or `solid-js` and instead use a pragma comment inside your React files.
+
+### Typing Vue components when the `@types/react` package is installed
+
+Due to being declared globally, the types definition from the `@types/react` package, if installed, will mistakenly be used to typecheck `.vue` files when using [Volar](https://github.com/johnsoncodehk/volar). There's currently no reliable way to fix this, however a few solutions are discussed can be found in [this GitHub discussion](https://github.com/johnsoncodehk/volar/discussions/592)

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -55,8 +55,8 @@ In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`i
 {
   "compilerOptions": {
     "importsNotUsedAsValues": "error",
-    }
   }
+}
 ```
 
 ## Import Aliases

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -55,9 +55,12 @@ This way, you avoid edge cases where Astro's bundler may try to incorrectly bund
 In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error`. Then, TypeScript will check your imports and tell you when  `import type` should be used.
 
 ```json
+// tsconfig.json
 {
   "compilerOptions": {
     "importsNotUsedAsValues": "error",
+    }
+  }
 ```
 
 ## Import Aliases


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Added instructions on how to use multiple JSX frameworks at the same time with full TS support. Also added some info about `@types/react` mistakenly typing `.vue` files when installed

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
