### PR TITLE
[migration guide] added md to mdx checklist section

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -173,7 +173,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 ## Astro Markdown
 
 :::caution[Deprecated]
-Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
+Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
 In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/).
 :::

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -173,7 +173,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 ## Astro Markdown
 
 :::caution[Deprecated]
-Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](en/migrate//#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
+Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
 In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/).
 :::

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -170,21 +170,25 @@ export default defineConfig({
 You can also pass the `--drafts` flag when running `astro build` to build draft pages!
 :::
 
-## Authoring Markdown
+## Astro Markdown
 
 :::caution[Deprecated]
-Astro no longer supports components or JSX in Markdown pages by default and may be removed in a future release. 
+Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](en/migrate//#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
 In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/).
 :::
 
 ### Using Variables in Markdown
 
-Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) package to use variables and JSX expressions in MDX (`.mdx`) files.
+Please install the official [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/) to use [variables and JSX expressions in MDX (`.mdx`) files](/en/guides/integrations-guide/mdx/#variables).
+
+See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 
 ### Using Components in Markdown
 
-Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) package to use components in MDX (`.mdx`) files.
+Please install the official [`@astrojs/mdx`) integration](/en/guides/integrations-guide/mdx/) to use Astro components or [UI framework components in MDX (`.mdx`) files](/en/core-concepts/framework-components/#using-framework-components).
+
+See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 
 ## Importing Markdown
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -186,7 +186,7 @@ See the migration guide for help [converting your existing Astro `.md` files to 
 
 ### Using Components in Markdown
 
-Please install the official [`@astrojs/mdx`) integration](/en/guides/integrations-guide/mdx/) to use Astro components or [UI framework components in MDX (`.mdx`) files](/en/core-concepts/framework-components/#using-framework-components).
+Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use Astro components or [UI framework components in MDX (`.mdx`) files](/en/core-concepts/framework-components/#using-framework-components).
 
 See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -180,7 +180,7 @@ In the meantime, Astro config supports a [legacy flag](/en/reference/configurati
 
 ### Using Variables in Markdown
 
-Please install the official [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/) to use [variables and JSX expressions in MDX (`.mdx`) files](/en/guides/integrations-guide/mdx/#variables).
+Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use [variables and JSX expressions in MDX (`.mdx`) files](/en/guides/integrations-guide/mdx/#variables).
 
 See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -69,7 +69,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 5. Update any `Astro.glob()` statements that currently return `.md` files so that they will now return your `.mdx` files.
 
 :::caution
-The object returned when importing a .mdx file (including using Astro.glob) differs from the object returned when importing .md. frontmatter, file, and url work identically.
+The object returned when importing `.mdx` files (including using Astro.glob) differs from the object returned when importing `.md` files. However, `frontmatter`, `file`, and `url` work identically.
 :::
 
 Additionally, after importing `.mdx`, you can use the default export as a component:

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -66,7 +66,22 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 ```
 
 
-6. Update any `Astro.glob()` statement that currently retrieve `.md` files so that they will now return your `.mdx` files.
+5. Update any `Astro.glob()` statements that currently return `.md` files so that they will now return your `.mdx` files.
+
+:::caution
+The object returned when importing a .mdx file (including using Astro.glob) differs from the object returned when importing .md. frontmatter, file, and url work identically.
+:::
+
+Additionally, after importing `.mdx`, you can use the default export as a component:
+
+```astro
+---
+const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
+---
+...
+
+{mdxPosts.map(Post => <Post/>)}
+```
 
 :::tip
 While you are transitioning to MDX, you may wish to [enable the legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -65,23 +65,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 </BaseLayout>
 ```
 
-5. Update your layout component to no longer receive the Markdown content object as props, and update your template variables accordingly:
-
-```diff
----
-// src/layouts/BaseLayout.astro
-
-- const { content } = Astro.props
-+ const { title, date, tags } = Astro.props.content
----
-
-- <h1>{content.title}</h1>
-+ <h1>{title}</h1>
-
-<slot />
-
-
-```
 
 6. Update any `Astro.glob()` statement that currently retrieve `.md` files so that they will now return your `.mdx` files.
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -44,7 +44,7 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
 
 1. Remove any `layout:` and `setup:` properties from your frontmatter, replacing them with ESM import statements below the frontmatter.
 
-1. Wrap your MDX content in a `<Layout>` component, and pass all your frontmatter values as props.
+1. Wrap your MDX content in a `<Layout>` component, and pass all your frontmatter values as props so you can continue to access them in your layout.
 
 ```mdx
 // src/pages/posts/my-post.mdx

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -72,7 +72,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 // src/layouts/BaseLayout.astro
 
 - const { content } = Astro.props
-+ const { title, date, tags } = Astro.props
++ const { title, date, tags } = Astro.props.content
 ---
 
 - <h1>{content.title}</h1>

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -65,19 +65,21 @@ import BaseLayout from '../../layouts/BaseLayout.astro'
 </BaseLayout>
 ```
 
-5. Update your layout component to no longer receive the Markdown content object, and update your template accordingly:
+5. Update your layout component to no longer receive the Markdown content object as props, and update your template variables accordingly:
 
-```astro
+```diff
 ---
 // src/layouts/BaseLayout.astro
 
-const { title, date, tags } = Astro.props
+- const { content } = Astro.props
++ const { title, date, tags } = Astro.props
 ---
 
 - <h1>{content.title}</h1>
 + <h1>{title}</h1>
 
 <slot />
+
 
 ```
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -47,6 +47,7 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
 1. Wrap your MDX content in a `<Layout>` component, and pass all your frontmatter values as props.
 
 ```mdx
+// src/pages/posts/my-post.mdx
 ---
 title: md to mdx
 date: 2022-07-26

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -56,7 +56,7 @@ tags: ["markdown", "mdx", "astro"]
 import ReactCounter from '../../components/ReactCounter.jsx'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 
-<BaseLayout { ...frontmatter}>
+<BaseLayout content={frontmatter}>
     # {frontmatter.title}
     
     Here is my counter component, working in MDX:

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -84,7 +84,7 @@ const { title, date, tags } = Astro.props
 6. Update any `Astro.glob()` statement that currently retrieve `.md` files so that they will now return your `.mdx` files.
 
 :::tip
-While you are transitioning to MDX, you may wish to include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
+While you are transitioning to MDX, you may wish to [enable the legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
 
 ```astro
 const mdPosts = await Astro.glob('../pages/posts/*.md');

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -34,6 +34,64 @@ Astro no longer supports components or JSX expressions in Markdown pages by defa
 
 To make migrating easier, a new [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) can be used to re-enable previous Markdown features.
 
+### Checklist for converting your site from `.md` files to `.mdx`
+
+If you're not familiar with MDX, here are some steps you can follow to quickly convert an existing "Astro Flavored Markdown" file to MDX. As you learn more about MDX, feel free to explore other ways of writing your pages!
+
+1. Install the [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration.
+
+1. Change your existing `.md` file extensions to `.mdx`
+
+1. Remove any `layout:` and `setup:` properties from your frontmatter, replacing them with ESM import statements below the frontmatter.
+
+1. Wrap your MDX content in a `<Layout>` component, and pass all your frontmatter values as props.
+
+```mdx
+---
+title: md to mdx
+date: 2022-07-26
+tags: ["markdown", "mdx", "astro"]
+---
+import ReactCounter from '../../components/ReactCounter.jsx'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+
+<BaseLayout { ...frontmatter}>
+    # {frontmatter.title}
+    
+    Here is my counter component, working in MDX:
+    
+    <ReactCounter client:load />
+</BaseLayout>
+```
+
+5. Update your layout component to no longer receive the Markdown content object, and update your template accordingly:
+
+```astro
+---
+// src/layouts/BaseLayout.astro
+
+const { title, date, tags } = Astro.props
+---
+
+- <h1>{content.title}</h1>
++ <h1>{title}</h1>
+
+<slot />
+
+```
+
+6. Update any `Astro.glob()` statement that currently retrieve `.md` files so that they will now return your `.mdx` files.
+
+:::tip
+While you are transitioning to MDX, you may wish to include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
+
+```astro
+const mdPosts = await Astro.glob('../pages/posts/*.md');
+const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
+const allPosts = [...mdxPosts, ...mdPosts];
+```
+:::
+
 ### `<Markdown />` Component Removed
 
 Astro's built-in `<Markdown />` component has been moved to a separate package. To continue using this component, you will now need to install `@astrojs/markdown` and update your imports accordingly. For more details, see [the `@astrojs/markdown` README](https://github.com/withastro/astro/tree/main/packages/markdown/component).

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -34,7 +34,7 @@ Astro no longer supports components or JSX expressions in Markdown pages by defa
 
 To make migrating easier, a new [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) can be used to re-enable previous Markdown features.
 
-### Checklist for converting your site from `.md` files to `.mdx`
+### Converting existing `.md` files to `.mdx`
 
 If you're not familiar with MDX, here are some steps you can follow to quickly convert an existing "Astro Flavored Markdown" file to MDX. As you learn more about MDX, feel free to explore other ways of writing your pages!
 


### PR DESCRIPTION
- New or updated content

Adds a section to the migration guide re: converting an existing `.md` file to `.mdx`
- includes reminder to update any `Astro.glob()` statments.

This looks long, and I don't like that. We could hide it in a `<details>`?  😅  But, I think this is helpful to people with existing "Astro Flavored Markdown" files who now want to convert to `.mdx`.  Even some of our more experiences users were not sure what to do.

And of course, once we reintroduce `layout:`, this whole matter is much simpler, and much of this can be removed/streamlined. I'm only thinking of helping people immediately. And, I think this at least does that.