### PR TITLE
Fix hydration by moving code into server-side file

### DIFF
--- a/src/components/ContributorList.astro
+++ b/src/components/ContributorList.astro
@@ -1,5 +1,5 @@
 ---
-import { cachedFetch } from '../util';
+import { cachedFetch } from '../util-server';
 import UIString from './UIString.astro';
 
 export interface Props {

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -1,7 +1,7 @@
 ---
 import UIString from './UIString.astro';
 import Badge from './Badge.astro';
-import { cachedFetch } from '../util';
+import { cachedFetch } from '../util-server';
 
 export interface Props {
   v: string;

--- a/src/components/Version.astro
+++ b/src/components/Version.astro
@@ -1,5 +1,5 @@
 ---
-import { cachedFetch } from "../util";
+import { cachedFetch } from '../util-server';
 
 export interface Props {
 	pkgName: string;

--- a/src/util-server.ts
+++ b/src/util-server.ts
@@ -1,0 +1,44 @@
+/*
+	This file contains server-side utilities using features that don't work in a browser.
+	Do not import this file from a hydrated client-side component.
+*/
+
+import EleventyFetch from '@11ty/eleventy-fetch';
+
+export type CachedFetchOptions = {
+	duration?: string;
+	verbose?: boolean;
+};
+
+export async function cachedFetch(
+	url: string,
+	fetchOptions = {},
+	{ duration = '5m', verbose = false }: CachedFetchOptions = {}
+) {
+	let status = 200;
+	let statusText = 'OK';
+	let buffer: Buffer | undefined;
+
+	try {
+		buffer = await EleventyFetch(url, {
+			duration,
+			verbose,
+			type: 'buffer',
+			fetchOptions,
+		});
+	} catch (error) {
+		const msg: string = error?.message || error.toString();
+		const matches = msg.match(/^Bad response for (.*) \(.*?\): (.*)$/);
+		status = parseInt(matches?.[2] || '') || 404;
+		statusText = matches?.[3] || msg;
+	}
+
+	return {
+		ok: status >= 200 && status <= 299,
+		status,
+		statusText,
+		body: buffer,
+		json: () => buffer && JSON.parse(buffer.toString()),
+		text: () => buffer?.toString(),
+	};
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,3 @@
-import EleventyFetch from '@11ty/eleventy-fetch';
-
 export function getLanguageFromURL(pathname: string) {
 	const langCodeMatch = pathname.match(/\/([a-z]{2}-?[a-z]{0,2})\//);
 	return langCodeMatch ? langCodeMatch[1] : 'en';
@@ -41,42 +39,4 @@ export function unescapeHtml(escapedString: string) {
 			.replace(/&gt;/g, ">")
 			.replace(/&quot;/g, "\"")
 			.replace(/&#039;/g, "'");
-}
-
-export type CachedFetchOptions = {
-	duration?: string;
-	verbose?: boolean;
-};
-
-export async function cachedFetch(
-	url: string,
-	fetchOptions = {},
-	{ duration = '5m', verbose = false }: CachedFetchOptions = {}
-) {
-	let status = 200;
-	let statusText = 'OK';
-	let buffer: Buffer | undefined;
-
-	try {
-		buffer = await EleventyFetch(url, {
-			duration,
-			verbose,
-			type: 'buffer',
-			fetchOptions,
-		});
-	} catch (error) {
-		const msg: string = error?.message || error.toString();
-		const matches = msg.match(/^Bad response for (.*) \(.*?\): (.*)$/);
-		status = parseInt(matches?.[2] || '') || 404;
-		statusText = matches?.[3] || msg;
-	}
-
-	return {
-		ok: status >= 200 && status <= 299,
-		status,
-		statusText,
-		body: buffer,
-		json: () => buffer && JSON.parse(buffer.toString()),
-		text: () => buffer?.toString(),
-	};
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fixes a hydration issue preventing the TOC from updating.
- In PR #1120, I added an import from `@11ty/eleventy-fetch` to `util.ts`, which is both being used in the frontmatter scripts of `.astro` files, but also in our TOC preact component. Apparently tree-shaking isn't being applied properly in this case, so hydration of the TOC component failed.
- I fixed the issue by moving the import and the code using it into a new `util-server.ts` file that is only referenced by server-side code.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
