### PR TITLE
[migration guide] Moving to MDX does NOT require changing layout

### DIFF
--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -40,33 +40,28 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
 
 1. Install the [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration.
 
-1. Change your existing `.md` file extensions to `.mdx`
+2. Change your existing `.md` file extensions to `.mdx`
 
-1. Remove any `layout:` and `setup:` properties from your frontmatter, replacing them with ESM import statements below the frontmatter.
-
-1. Wrap your MDX content in a `<Layout>` component, and pass all your frontmatter values as props so you can continue to access them in your layout.
+3. Remove the `setup:` property from your frontmatter, and write its ESM import statements below the frontmatter.
 
 ```mdx
 // src/pages/posts/my-post.mdx
 ---
-title: md to mdx
+layout: '../../layouts/BaseLayout.astro'
+title: 'Migrating to MDX'
 date: 2022-07-26
 tags: ["markdown", "mdx", "astro"]
 ---
 import ReactCounter from '../../components/ReactCounter.jsx'
-import BaseLayout from '../../layouts/BaseLayout.astro'
 
-<BaseLayout content={frontmatter}>
-    # {frontmatter.title}
-    
-    Here is my counter component, working in MDX:
-    
-    <ReactCounter client:load />
-</BaseLayout>
+# {frontmatter.title}
+
+Here is my counter component, working in MDX:
+
+<ReactCounter client:load />
 ```
 
-
-5. Update any `Astro.glob()` statements that currently return `.md` files so that they will now return your `.mdx` files.
+4. Update any `Astro.glob()` statements that currently return `.md` files so that they will now return your `.mdx` files.
 
 :::caution
 The object returned when importing `.mdx` files (including using Astro.glob) differs from the object returned when importing `.md` files. However, `frontmatter`, `file`, and `url` work identically.

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -44,28 +44,28 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
 
 3. Remove the `setup:` property from your frontmatter, and write its ESM import statements below the frontmatter.
 
-```mdx
-// src/pages/posts/my-post.mdx
----
-layout: '../../layouts/BaseLayout.astro'
-title: 'Migrating to MDX'
-date: 2022-07-26
-tags: ["markdown", "mdx", "astro"]
----
-import ReactCounter from '../../components/ReactCounter.jsx'
+    ```mdx
+    // src/pages/posts/my-post.mdx
+    ---
+    layout: '../../layouts/BaseLayout.astro'
+    title: 'Migrating to MDX'
+    date: 2022-07-26
+    tags: ["markdown", "mdx", "astro"]
+    ---
+    import ReactCounter from '../../components/ReactCounter.jsx'
 
-# {frontmatter.title}
+    # {frontmatter.title}
 
-Here is my counter component, working in MDX:
+    Here is my counter component, working in MDX:
 
-<ReactCounter client:load />
-```
+    <ReactCounter client:load />
+    ```
 
 4. Update any `Astro.glob()` statements that currently return `.md` files so that they will now return your `.mdx` files.
 
-:::caution
-The object returned when importing `.mdx` files (including using Astro.glob) differs from the object returned when importing `.md` files. However, `frontmatter`, `file`, and `url` work identically.
-:::
+    :::caution
+    The object returned when importing `.mdx` files (including using Astro.glob) differs from the object returned when importing `.md` files. However, `frontmatter`, `file`, and `url` work identically.
+    :::
 
 Additionally, after importing `.mdx`, you can use the default export as a component:
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -69,11 +69,10 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
 
 Additionally, after importing `.mdx`, you can use the default export as a component:
 
-```astro
+```astro title="example.astro"
 ---
 const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
 ---
-...
 
 {mdxPosts.map(Post => <Post/>)}
 ```

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -82,9 +82,11 @@ const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
 While you are transitioning to MDX, you may wish to [enable the legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
 
 ```astro
+---
 const mdPosts = await Astro.glob('../pages/posts/*.md');
 const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
 const allPosts = [...mdxPosts, ...mdPosts];
+---
 ```
 :::
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -67,15 +67,25 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
     The object returned when importing `.mdx` files (including using Astro.glob) differs from the object returned when importing `.md` files. However, `frontmatter`, `file`, and `url` work identically.
     :::
 
-Additionally, after importing `.mdx`, you can use the default export as a component:
+5. Update any use of the `<Content />` component to use the default export when importing MDX:
 
-```astro title="example.astro"
----
-const mdxPosts = await Astro.glob('../pages/posts/*.mdx');
----
+    ```astro title="src/pages/index.astro"
+    ---
+    // Multiple imports with Astro.glob
+    const mdxPosts = await Astro.glob('./posts/*.mdx');
+    ---
 
-{mdxPosts.map(Post => <Post/>)}
-```
+    {mdxPosts.map(Post => <Post.default />)}
+    ```
+    
+    ```astro title="src/pages/index.astro"
+    ---
+    // Import a single page
+    import { default as About } from './about.mdx';
+    ---
+
+    <About />    
+    ```
 
 :::tip
 While you are transitioning to MDX, you may wish to [enable the legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:


### PR DESCRIPTION
- New or updated content

relies on https://github.com/withastro/astro/pull/4088

Since @bholmesdev gave us `layout:` in MDX, we no longer have to tell people to use a Layout component when converting their `.md` files to `.mdx`

This removes that step, and updates the MDX code sample to show no `<Layout>` component being used, in favour of `layout:` in the frontmatter (which should be what they had before).

NOTE: While there is more exciting MDX layout stuff possible now, for the purposes of just explicitly explaining how to convert an *existing* Astro `.md` file to a working `.mdx` file, we don't need to mention that.