### PR TITLE
New GitHub action workflow for pages

### DIFF
--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -31,7 +31,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
       # Allows you to run this workflow manually from the Actions tab on GitHub.
       workflow_dispatch:
       
-      # Allow this job to push changes to your repository
+      # Allow this job to clone the repo and create a page deployment
     permissions:
       contents: read
       pages: write

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -80,10 +80,6 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
     This workflow uses the `npm ci` command by default. You must include a `package-lock.json` file in your repository for this to work. To generate one, run `npm i` in your terminal and commit the resulting lock file.
     :::
 
-    :::tip
-    See [the GitHub Pages Action documentation](https://github.com/marketplace/actions/github-pages-action) for different ways you can configure the final “Deploy to GitHub Pages” step.
-    :::
-
 3. Commit the new workflow file and push it to GitHub.
 4. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.
 5. Choose the `gh-pages` branch and the `"/" (root)` folder as the **Source** of your site and press **Save**.

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -25,6 +25,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
     name: Github Pages Astro CI
 
     on:
+     # Trigger the workflow every time you push to the `main` branch
       push:
         branches: [ main ]
       # Allows you to run this workflow manually from the Actions tab on GitHub.

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -41,15 +41,22 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
       build:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-node@v2
+        - name: Check out your repository using git
+          uses: actions/checkout@v2
+
+        - name: Use Node.js 16
+          uses: actions/setup-node@v2
           with:
             node-version: '16'
             cache: 'npm'
+
         # Not using npm? Change `npm ci` to `yarn install` or `pnpm i`
-        - run: npm ci
+        - name: Install dependencies
+          run: npm ci
+
         # Not using npm? Change `npm run build` to `yarn build` or `pnpm run build`
-        - run: npm run build --if-present
+        - name: Build Astro
+          run: npm run build --if-present
 
         - name: Archive build output
           # `./dist` is the default Astro build directory.

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -59,10 +59,10 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
         - name: Build Astro
           run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ./dist
+        - name: Upload artifact
+          uses: actions/upload-pages-artifact@v1
+          with:
+            path: ./dist
 
       deploy:
         environment:

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -22,51 +22,51 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 2. Create a new file in your project at `.github/workflows/deploy.yml` and paste in the YAML below.
 
     ```yaml
-  name: Build astro site
+    name: Build astro site
 
-  on:
-    push:
-      branches: [ main ]
-    pull_request:
-      branches: [ main ]
+    on:
+      push:
+        branches: [ main ]
+      pull_request:
+        branches: [ main ]
 
-  permissions:
-    contents: read
-    pages: write
-    id-token: write
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
-  jobs:
-    build:
+    jobs:
+      build:
 
-      runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-      steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run build --if-present
+        steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-node@v2
+          with:
+            node-version: '16'
+            cache: 'npm'
+        - run: npm ci
+        - run: npm run build --if-present
 
-      - name: Archive build output
-        run: "tar --dereference --directory dist/ -cvf artifact.tar ."
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
+        - name: Archive build output
+          run: "tar --dereference --directory dist/ -cvf artifact.tar ."
+        - name: Upload artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: github-pages
+            path: artifact.tar
+
+      deploy:
+        environment:
           name: github-pages
-          path: artifact.tar
-
-    deploy:
-      environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
-      runs-on: ubuntu-latest
-      needs: build
-      steps:
-        - name: Deploy to GitHub Pages
-          id: deployment
-          uses: paper-spa/deploy-pages@main
+          url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+          - name: Deploy to GitHub Pages
+            id: deployment
+            uses: paper-spa/deploy-pages@main
     ```
     
     :::caution

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -25,13 +25,14 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
     name: Github Pages Astro CI
 
     on:
-     # Trigger the workflow every time you push to the `main` branch
+      # Trigger the workflow every time you push to the `main` branch
+      # Using a different branch name? Replace `main` with your branch’s name
       push:
         branches: [ main ]
       # Allows you to run this workflow manually from the Actions tab on GitHub.
       workflow_dispatch:
       
-      # Allow this job to clone the repo and create a page deployment
+    # Allow this job to clone the repo and create a page deployment
     permissions:
       contents: read
       pages: write

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -62,6 +62,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
           # `./dist` is the default Astro build directory.
           # If you changed that, update it here too.
           run: "tar --dereference --directory dist/ -cvf artifact.tar ."
+
         - name: Upload artifact
           uses: actions/upload-artifact@v2
           with:

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -22,7 +22,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 2. Create a new file in your project at `.github/workflows/deploy.yml` and paste in the YAML below.
 
     ```yaml
-    name: Build astro site
+    name: Github Pages Astro CI
 
     on:
       push:
@@ -46,7 +46,9 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
           with:
             node-version: '16'
             cache: 'npm'
+        # Not using npm? Change `npm ci` to `yarn install` or `pnpm i`
         - run: npm ci
+        # Not using npm? Change `npm run build` to `yarn build` or `pnpm run build`
         - run: npm run build --if-present
 
         - name: Archive build output

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -58,16 +58,10 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
         - name: Build Astro
           run: npm run build --if-present
 
-        - name: Archive build output
-          # `./dist` is the default Astro build directory.
-          # If you changed that, update it here too.
-          run: "tar --dereference --directory dist/ -cvf artifact.tar ."
-
-        - name: Upload artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: github-pages
-            path: artifact.tar
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
 
       deploy:
         environment:

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -56,7 +56,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 
         # Not using npm? Change `npm run build` to `yarn build` or `pnpm run build`
         - name: Build Astro
-          run: npm run build --if-present
+          run: npm run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -27,9 +27,10 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
     on:
       push:
         branches: [ main ]
-      pull_request:
-        branches: [ main ]
-
+      # Allows you to run this workflow manually from the Actions tab on GitHub.
+      workflow_dispatch:
+      
+      # Allow this job to push changes to your repository
     permissions:
       contents: read
       pages: write
@@ -37,9 +38,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 
     jobs:
       build:
-
         runs-on: ubuntu-latest
-
         steps:
         - uses: actions/checkout@v2
         - uses: actions/setup-node@v2
@@ -52,6 +51,8 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
         - run: npm run build --if-present
 
         - name: Archive build output
+          # `./dist` is the default Astro build directory.
+          # If you changed that, update it here too.
           run: "tar --dereference --directory dist/ -cvf artifact.tar ."
         - name: Upload artifact
           uses: actions/upload-artifact@v2

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -78,7 +78,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
         steps:
           - name: Deploy to GitHub Pages
             id: deployment
-            uses: paper-spa/deploy-pages@main
+            uses: actions/deploy-pages@v1
     ```
     
     :::caution


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content 🎉 

#### Description

- Closes #1164
- What does this PR change?  I updated GitHub Action workflow to deploy Astro on GitHub Pages. GitHub officially supports deploying static websites written in any framework on GitHub Pages. There's a specific one that works well for Astro. 
- Did you change something visual? 
**BEFORE**
<img width="640" alt="Screen Shot 2022-08-02 at 5 08 27 PM" src="https://user-images.githubusercontent.com/22990146/182473763-cba4e713-1706-40cc-8f34-6c7b01efc5e1.png">

**AFTER**

![image](https://user-images.githubusercontent.com/22990146/182483621-19768c92-23a1-4948-8226-8fe1de60f964.png)



<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->


Working examples:
From engineer at GitHub on the Pages-Actions team: https://github.com/tcbyrd/astro-portfolio-demo/blob/main/.github/workflows/astro-build.yml
My own repo: https://github.com/blackgirlbytes/blackgyalbites-astro has a working example as well