### PR TITLE
Fix Shiki tokens with styles other than `color`

### DIFF
--- a/src/components/CodeSnippet/shiki-line.ts
+++ b/src/components/CodeSnippet/shiki-line.ts
@@ -24,16 +24,17 @@ export class ShikiLine {
 		this.afterTokens = lineMatches[5];
 
 		// Split line into inline tokens
-		const tokenRegExp = /<span style="color: (#[0-9A-Fa-f]+)">(.*?)<\/span>/g;
+		const tokenRegExp = /<span style="color: (#[0-9A-Fa-f]+)([^"]*)">(.*?)<\/span>/g;
 		const tokenMatches = tokensHtml.matchAll(tokenRegExp);
 		this.tokens = [];
 		this.textLine = '';
 		for (const tokenMatch of tokenMatches) {
-			const [, color, innerHtml] = tokenMatch;
+			const [, color, otherStyles, innerHtml] = tokenMatch;
 			const text = unescape(innerHtml);
 			this.tokens.push({
 				tokenType: 'syntax',
 				color,
+				otherStyles,
 				innerHtml,
 				text,
 				textStart: this.textLine.length,
@@ -105,7 +106,7 @@ export class ShikiLine {
 		let innerHtml = this.tokens
 			.map((token) => {
 				if (token.tokenType === 'marker') return `<${token.closing ? '/' : ''}${token.markerType}>`;
-				return `<span style="color:${token.color}">${token.innerHtml}</span>`;
+				return `<span style="color:${token.color}${token.otherStyles}">${token.innerHtml}</span>`;
 			})
 			.join('');
 		

--- a/src/components/CodeSnippet/types.ts
+++ b/src/components/CodeSnippet/types.ts
@@ -23,6 +23,7 @@ export type MarkedRange = {
 export type SyntaxToken = {
 	tokenType: 'syntax';
 	color: string;
+	otherStyles: string;
 	innerHtml: string;
 	text: string;
 	textStart: number;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fixes cases where Shiki tokens contain additional styles like bold or italics. Before this fix, such tokens were not recognized and removed from the output in the code snippet marking phase.
  - Before:
![image](https://user-images.githubusercontent.com/6137925/182589361-30dd8c2c-c310-459d-a6bd-8318d1a7cba8.png)

  - After:
![image](https://user-images.githubusercontent.com/6137925/182589277-f51f9b95-b26d-4e90-9233-bc6d6d54df48.png)


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
