### PR TITLE
Moving astro vs jsx comparison (formerly chart) and resulting fallout

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -213,6 +213,31 @@ const htmlString = '<p>Raw HTML content</p>';
 <Fragment set:html={htmlString} />
 ```
 
+### Differences between Astro and JSX
+
+Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience, but there a couple of key differences between `.astro` files and JSX.
+
+#### Attributes
+
+In Astro, you use the standard `kebab-case` format for all HTML attributes instead of the `camelCase` used in JSX. This even works for `class`, which is not supported by React.
+
+```jsx del={1} ins={2} title="example.astro"
+<div className="box" dataValue="3" />
+<div class="box" data-value="3" />
+```
+
+#### Modifying `<head>`
+
+In JSX, you may see special libraries used to help you manage a page’s `<head>` tag. This is not necessary in Astro. Write `<head>` and its contents in your top-level layout.
+
+#### Comments
+
+In Astro, you can use standard HTML comments where JSX would use JavaScript style comments.
+
+```html title="example.astro"
+<!-- HTML comment syntax is valid in .astro files -->
+```
+
 ## Component Props
 
 An Astro component can define and accept props. These props then become available to the component template for rendering HTML. Props are available on the `Astro.props` global in your frontmatter script.

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -194,14 +194,6 @@ const htmlString = '<p>Raw HTML content</p>';
 
 Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience, but there a couple of key differences between `.astro` files and JSX.
 
-| Feature                      | Astro | JSX  |
-| ---------------------------- | ----- | --------- |
-| Multiple frameworks per-file | Yes | No |
-| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
-| Attributes                   | `dash-case` | `camelCase`|
-| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
-| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
-
 #### Attributes
 
 In Astro, you use the standard `kebab-case` format for all HTML attributes instead of the `camelCase` used in JSX. This even works for `class`, which is not supported by React.

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -9,7 +9,7 @@ i18nReady: true
 
 **If you know HTML, you already know enough to write your first Astro component.**
 
-Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
+Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](#differences-between-astro-and-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
 Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -194,6 +194,14 @@ const htmlString = '<p>Raw HTML content</p>';
 
 Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience, but there a couple of key differences between `.astro` files and JSX.
 
+| Feature                      | Astro | JSX  |
+| ---------------------------- | ----- | --------- |
+| Multiple frameworks per-file | Yes | No |
+| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
+| Attributes                   | `dash-case` | `camelCase`|
+| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
+| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
+
 #### Attributes
 
 In Astro, you use the standard `kebab-case` format for all HTML attributes instead of the `camelCase` used in JSX. This even works for `class`, which is not supported by React.
@@ -214,16 +222,6 @@ In Astro, you can use standard HTML comments where JSX would use JavaScript styl
 ```html title="example.astro"
 <!-- HTML comment syntax is valid in .astro files -->
 ```
-
-### `.astro` vs `.jsx` files
-
-| Feature                      | Astro | JSX  |
-| ---------------------------- | ----- | --------- |
-| Multiple frameworks per-file | Yes | No |
-| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
-| Attributes                   | `dash-case` | `camelCase`|
-| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
-| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
 
 ## Component Props
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -7,14 +7,14 @@ i18nReady: true
 
 **Astro components** are the basic building blocks of any Astro project. They are HTML-only templating components with no client-side runtime.
 
-Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](/en/comparing-astro-vs-other-tools/#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
+Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
 Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
 
 The most important thing to know about Astro components is that they **render to HTML during your build.** Even if you run JavaScript code inside of your components, it will all run ahead-of-time, stripped from the final page that you send to your users. The result is a faster site, with zero JavaScript footprint added by default.
 
 
-## Component Overview
+## Component Structure
 
 An Astro component is made up of two main parts: the **Component Script** and the **Component Template**. Each part performs a different job, but together they aim to provide a framework that is both easy to use and expressive enough to handle whatever you might want to build.
 
@@ -105,11 +105,36 @@ const myFavoritePokemon = [/* ... */];
 <p class:list={["add", "dynamic", {classNames: true}]} />
 ```
 
-### JSX Expressions
+## JSX-like Expressions
 
-You can can define local JavaScript variables inside of the frontmatter component script within an Astro component. You can then inject these variables into the component's HTML template using JSX expressions!
+You can can define local JavaScript variables inside of the frontmatter component script within an Astro component. You can then inject these variables into the component's HTML template using JSX-like expressions!
 
-#### Variables
+### `.astro` vs `.jsx`
+
+Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience.
+
+**If you know HTML, you already know enough to write your first Astro component.**
+
+| Feature                      | Astro | JSX  |
+| ---------------------------- | ----- | --------- |
+| File extension               | `.astro` | `.jsx` or `.tsx` |
+| User-Defined Components      | `<Capitalized>` | `<Capitalized>`  |
+| Expression Syntax            | `{}` | `{}` |
+| Spread Attributes            | `{...props}` | `{...props}` |
+| Boolean Attributes           | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}` |
+| Inline Functions             | `{items.map(item => <li>{item}</li>)}`  | `{items.map(item => <li>{item}</li>)}` |
+| Conditional Rendering             | `{condition &&  <p>text<p>}`  | `{condition &&  <p>text<p>}` |
+| IDE Support                  | [VS Code (incl. Open VSX), Nova](/en/editor-setup/) | Phenomenal |
+| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
+| Fragments                    | Automatic top-level, `<Fragment>` or `<>` inside functions | Wrap with `<Fragment>` or `<>` |
+| Multiple frameworks per-file | Yes | No |
+| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
+| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
+| Special Characters           | `&nbsp;`  | `&nbsp;`  |
+| Attributes                   | `dash-case` | `camelCase`|
+
+
+### Variables
 
 Local variables can be added into the HTML using the curly braces syntax:
 
@@ -122,7 +147,7 @@ const name = "Astro";
 </div>
 ```
 
-#### Dynamic Attributes
+### Dynamic Attributes
 
 Local variables can be used in curly braces to pass attribute values to both HTML elements and components:
 
@@ -135,7 +160,7 @@ const name = "Astro";
 <MyComponent templateLiteralNameAttribute={`MyNameIs${name}`} />
 ```
 
-#### Dynamic HTML
+### Dynamic HTML
 
 Local variables can be used in JSX-like functions to produce dynamically-generated HTML elements:
 
@@ -150,7 +175,7 @@ const items = ["Dog", "Cat", "Platypus"];
 </ul>
 ```
 
-#### Fragments & Multiple Elements
+### Fragments & Multiple Elements
 
 An Astro component template can render multiple elements with no need to wrap everything in a single `<div>` or `<>`, unlike JavaScript or JSX.
 
@@ -188,7 +213,7 @@ const htmlString = '<p>Raw HTML content</p>';
 <Fragment set:html={htmlString} />
 ```
 
-### Component Props
+## Component Props
 
 An Astro component can define and accept props. These props then become available to the component template for rendering HTML. Props are available on the `Astro.props` global in your frontmatter script.
 
@@ -231,7 +256,7 @@ const name = "Astro"
 <p>I hope you have a wonderful day!</p>
 ```
 
-### Slots
+## Slots
 
 The `<slot />` element is a placeholder for external HTML content, allowing you to inject (or "slot") child elements from other files into your component template.
 
@@ -274,7 +299,7 @@ This pattern is the basis of an Astro layout component: an entire page of HTML c
 
 
 
-#### Named Slots
+### Named Slots
 
 An Astro component can also have named slots. This allows you to pass only HTML elements with the corresponding slot name into a slot's location.
 
@@ -319,7 +344,7 @@ Named slots can also be passed to [UI framework components](/en/core-concepts/fr
 :::
 
 
-#### Fallback Content for Slots
+### Fallback Content for Slots
 Slots can also render **fallback content**. When there are no matching children passed to a slot, a `<slot />` element will render its own placeholder children.
 
 ```astro
@@ -342,7 +367,7 @@ const { title } = Astro.props
 </div>
 ```
 
-### CSS Styles
+## CSS Styles
 
 CSS `<style>` tags are also supported inside of the component template.
 
@@ -366,7 +391,7 @@ The styles defined here apply only to content written directly in the component'
 
 📚 See our [Styling Guide](/en/guides/styling/) for more information on applying styles.
 
-### Client-Side Scripts
+## Client-Side Scripts
 
 To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
 
@@ -400,7 +425,7 @@ Adding `type="module"` or any other attribute to a `<script>` tag will disable A
 
 📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.
 
-#### Loading External Scripts
+### Loading External Scripts
 
 **When to use this:** If your JavaScript file lives inside of `public/`.
 
@@ -410,7 +435,7 @@ Note that this approach skips the JavaScript processing, bundling and optimizati
 // absolute URL path
 <script is:inline src="/some-external-script.js"></script>
 ```
-#### Using Hoisted Scripts
+### Using Hoisted Scripts
 
 **When to use this:** If your external script lives inside of `src/` _and_ it supports the ESM module type.
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -7,6 +7,8 @@ i18nReady: true
 
 **Astro components** are the basic building blocks of any Astro project. They are HTML-only templating components with no client-side runtime.
 
+**If you know HTML, you already know enough to write your first Astro component.**
+
 Astro component syntax is a superset of HTML. The syntax was [designed to feel familiar to anyone with experience writing HTML or JSX](#astro-vs-jsx), and adds support for including components and JavaScript expressions. You can spot an Astro component by its file extension: `.astro`.
 
 Astro components are extremely flexible. Often, an Astro component will contain some **reusable UI on the page**, like a header or a profile card. At other times, an Astro component may contain a smaller snippet of HTML, like a collection of common `<meta>` tags that make SEO easy to work with. Astro components can even contain an entire page layout.
@@ -108,31 +110,6 @@ const myFavoritePokemon = [/* ... */];
 ## JSX-like Expressions
 
 You can can define local JavaScript variables inside of the frontmatter component script within an Astro component. You can then inject these variables into the component's HTML template using JSX-like expressions!
-
-### `.astro` vs `.jsx`
-
-Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience.
-
-**If you know HTML, you already know enough to write your first Astro component.**
-
-| Feature                      | Astro | JSX  |
-| ---------------------------- | ----- | --------- |
-| File extension               | `.astro` | `.jsx` or `.tsx` |
-| User-Defined Components      | `<Capitalized>` | `<Capitalized>`  |
-| Expression Syntax            | `{}` | `{}` |
-| Spread Attributes            | `{...props}` | `{...props}` |
-| Boolean Attributes           | `autocomplete` === `autocomplete={true}` | `autocomplete` === `autocomplete={true}` |
-| Inline Functions             | `{items.map(item => <li>{item}</li>)}`  | `{items.map(item => <li>{item}</li>)}` |
-| Conditional Rendering             | `{condition &&  <p>text<p>}`  | `{condition &&  <p>text<p>}` |
-| IDE Support                  | [VS Code (incl. Open VSX), Nova](/en/editor-setup/) | Phenomenal |
-| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
-| Fragments                    | Automatic top-level, `<Fragment>` or `<>` inside functions | Wrap with `<Fragment>` or `<>` |
-| Multiple frameworks per-file | Yes | No |
-| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
-| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
-| Special Characters           | `&nbsp;`  | `&nbsp;`  |
-| Attributes                   | `dash-case` | `camelCase`|
-
 
 ### Variables
 
@@ -237,6 +214,16 @@ In Astro, you can use standard HTML comments where JSX would use JavaScript styl
 ```html title="example.astro"
 <!-- HTML comment syntax is valid in .astro files -->
 ```
+
+### `.astro` vs `.jsx` files
+
+| Feature                      | Astro | JSX  |
+| ---------------------------- | ----- | --------- |
+| Multiple frameworks per-file | Yes | No |
+| Requires JS import           | No    | Yes, `jsxPragma` (`React` or `h`) must be in scope |
+| Attributes                   | `dash-case` | `camelCase`|
+| Modifying `<head>`           | Just use `<head>` in top-level pages | Per-framework (`<Head>`, `<svelte:head>`, etc) |
+| Comment Style                | `<!-- HTML -->` | `{/* JavaScript */}`  |
 
 ## Component Props
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -195,7 +195,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 :::caution[Deprecated]
 Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
-In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [MDX in Astro](#astro-mdx).
+In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to MDX in Astro.
 :::
 
 ### Using Variables in Markdown

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -195,7 +195,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 :::caution[Deprecated]
 Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
-In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/).
+In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [MDX in Astro`](#astro-mdx).
 :::
 
 ### Using Variables in Markdown
@@ -206,9 +206,30 @@ See the migration guide for help [converting your existing Astro `.md` files to 
 
 ### Using Components in Markdown
 
-Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use Astro components or [UI framework components in MDX (`.mdx`) files](/en/core-concepts/framework-components/#using-framework-components).
+Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use [Astro components](/en/guides/core-concepts/astro-components/) or [UI framework components](en/guides/core-concepts/framework-components/) in MDX (`.mdx`) files.
 
 See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
+
+
+## MDX
+
+Astro includes full support for MDX with the [official `@astrojs/mdx` integration](/en/guides/integration-guides/mdx/). 
+
+Any `.mdx` page located in your project within `src/pages` will automatically generate a page route. 
+
+📚 Read more about using MDX in Astro in our [MDX integration guide](/en/guides/integration-guides/mdx).
+
+### Using Variables in MDX
+
+With the `@astrojs/mdx` integration, you can use [variables and JSX expressions in MDX (`.mdx`) files](/en/guides/integrations-guide/mdx/#variables).
+
+
+### Using Components in MDX
+
+With the `@astrojs/mdx` integration, you can use [Astro components](/en/guides/core-concepts/astro-components/) or [UI framework components](en/guides/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
+
+Don't forget to include a `client:directive` if necessary!
+
 
 ## Importing Markdown
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -195,7 +195,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 :::caution[Deprecated]
 Astro v1.0 Release Candidate (RC) [no longer supports components or JSX in Markdown pages by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and may be removed in a future release. 
 
-In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [MDX in Astro`](#astro-mdx).
+In the meantime, Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to [MDX in Astro](#astro-mdx).
 :::
 
 ### Using Variables in Markdown

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -213,7 +213,7 @@ See the migration guide for help [converting your existing Astro `.md` files to 
 
 ## MDX
 
-Astro includes full support for MDX with the [official `@astrojs/mdx` integration](/en/guides/integration-guides/mdx/). 
+Astro includes full support for MDX with the [official `@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/). 
 
 Any `.mdx` page located in your project within `src/pages` will automatically generate a page route. 
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -206,7 +206,7 @@ See the migration guide for help [converting your existing Astro `.md` files to 
 
 ### Using Components in Markdown
 
-Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use [Astro components](/en/guides/core-concepts/astro-components/) or [UI framework components](en/guides/core-concepts/framework-components/) in MDX (`.mdx`) files.
+Please install the official [`@astrojs/mdx`](/en/integrations-guide/mdx/) integration to continue to use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](en/core-concepts/framework-components/) in MDX (`.mdx`) files.
 
 See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -226,7 +226,7 @@ With the `@astrojs/mdx` integration, you can use [variables and JSX expressions 
 
 ### Using Components in MDX
 
-With the `@astrojs/mdx` integration, you can use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](/en/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
+With the `@astrojs/mdx` integration, you can use Astro or UI framework components in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
 
 Don't forget to include a `client:directive` if necessary!
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -217,7 +217,7 @@ Astro includes full support for MDX with the [official `@astrojs/mdx` integratio
 
 Any `.mdx` page located in your project within `src/pages` will automatically generate a page route. 
 
-📚 Read more about using MDX in Astro in our [MDX integration guide](/en/guides/integration-guides/mdx).
+📚 Read more about using MDX in Astro in our [MDX integration guide](/en/guides/integration-guides/mdx/).
 
 ### Using Variables in MDX
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -226,7 +226,7 @@ With the `@astrojs/mdx` integration, you can use [variables and JSX expressions 
 
 ### Using Components in MDX
 
-With the `@astrojs/mdx` integration, you can use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](en/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
+With the `@astrojs/mdx` integration, you can use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](/en/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
 
 Don't forget to include a `client:directive` if necessary!
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -217,7 +217,7 @@ Astro includes full support for MDX with the [official `@astrojs/mdx` integratio
 
 Any `.mdx` page located in your project within `src/pages` will automatically generate a page route. 
 
-📚 Read more about using MDX in Astro in our [MDX integration guide](/en/guides/integration-guides/mdx/).
+📚 Read more about using MDX in Astro in our [MDX integration guide](/en/guides/integrations-guide/mdx/).
 
 ### Using Variables in MDX
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -206,7 +206,7 @@ See the migration guide for help [converting your existing Astro `.md` files to 
 
 ### Using Components in Markdown
 
-Please install the official [`@astrojs/mdx`](/en/integrations-guide/mdx/) integration to continue to use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](en/core-concepts/framework-components/) in MDX (`.mdx`) files.
+Please install the official [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration to continue to use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](/en/core-concepts/framework-components/) in MDX (`.mdx`) files.
 
 See the migration guide for help [converting your existing Astro `.md` files to `.mdx`](/en/migrate/#converting-existing-md-files-to-mdx).
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -226,7 +226,7 @@ With the `@astrojs/mdx` integration, you can use [variables and JSX expressions 
 
 ### Using Components in MDX
 
-With the `@astrojs/mdx` integration, you can use [Astro components](/en/guides/core-concepts/astro-components/) or [UI framework components](en/guides/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
+With the `@astrojs/mdx` integration, you can use [Astro components](/en/core-concepts/astro-components/) or [UI framework components](en/core-concepts/framework-components/) in MDX (`.mdx`) files just as you would [use them in any other Astro component](/en/core-concepts/framework-components/#using-framework-components).
 
 Don't forget to include a `client:directive` if necessary!
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -60,7 +60,7 @@ Then check your import statement:
 
 - Is your import linking to the wrong place? (Check your import path.)
 
-- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/astro-components/#astro-vs-jsx).)
+- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/astro-components/#differences-between-astro-and-jsx).)
 
 - Have you included the extension in the import? (Check that your imported file contains an extension. e.g. `.astro`, `.md`, `.vue`, `.svelte`. Note: File extensions are **not** required for `.js(x)` and `.ts(x)` files only.)
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -54,7 +54,7 @@ This error can be thrown when trying to import or render an invalid component, o
 
 ### My component is not rendering
 
-First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.mxd`](/en/guides/markdown-content/#using-components-in-mdx) file.
+First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.mdx`](/en/guides/markdown-content/#using-components-in-mdx) file.
 
 Then check your import statement:
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -60,7 +60,7 @@ Then check your import statement:
 
 - Is your import linking to the wrong place? (Check your import path.)
 
-- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/components/#astro-vs-jsx).)
+- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/astro-components/#astro-vs-jsx).)
 
 - Have you included the extension in the import? (Check that your imported file contains an extension. e.g. `.astro`, `.md`, `.vue`, `.svelte`. Note: File extensions are **not** required for `.js(x)` and `.ts(x)` files only.)
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -54,13 +54,13 @@ This error can be thrown when trying to import or render an invalid component, o
 
 ### My component is not rendering
 
-First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.md` frontmatter](/en/guides/markdown-content/#using-components-in-markdown).
+First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.mxd`](/en/guides/markdown-content/#using-components-in-mdx) file.
 
 Then check your import statement:
 
 - Is your import linking to the wrong place? (Check your import path.)
 
-- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/comparing-astro-vs-other-tools/#astro-vs-jsx).)
+- Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/components/#astro-vs-jsx).)
 
 - Have you included the extension in the import? (Check that your imported file contains an extension. e.g. `.astro`, `.md`, `.vue`, `.svelte`. Note: File extensions are **not** required for `.js(x)` and `.ts(x)` files only.)
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -54,7 +54,7 @@ This error can be thrown when trying to import or render an invalid component, o
 
 ### My component is not rendering
 
-First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.mdx`](/en/guides/markdown-content/#using-components-in-mdx) file.
+First, check to see that you have **imported the component** in your [`.astro` component script](/en/core-concepts/astro-components/#the-component-script) or [`.mdx` file](/en/guides/markdown-content/#using-components-in-mdx).
 
 Then check your import statement:
 


### PR DESCRIPTION
- New or updated content

Apologize that this took a bit of a turn...

MAIN CHANGE: Brings the `astro vs jsx` chart into `astro-components`, since it currently lives on a page that is no longer linked to on our site. Location of the chart on this page is my proposal, but open to feedback.

FALLOUT:
- `astro-components`: reorganizes headings to address everything falling under "Component Overview". Mostly brings every heading level up one, makes for a nicer right sidebar TOC.

- `troubleshooting`: updates link to this chart and while right there, I noticed reference to old components in Markdown to fix, which should now refer to using components in MDX. (The tip is still appropriate, only to MDX instead of Markdown.)

- `markdown-content`: Adds a new `MDX` section, with analogous "using variables in..." and "using components in..." to provide a better place to link to this content from troubleshooting. The content in this section is basic, with links to the actual MDX integration guide, but does give prominence to MDX from the Markdown page.