### PR TITLE
fix: adds a link to the Markdown guide

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -436,7 +436,7 @@ Astro includes several built-in components for you to use in your projects. All 
 
 ### `<Markdown />`
 
-The Markdown component is no longer built into Astro.
+The Markdown component is no longer built into Astro. See [the Markdown guide](/en/guides/markdown-content/) to learn more.
 
 ### `<Code />`
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- What does this PR change? Give us a brief description.
This PR makes a small addition to the `<Markdown />` component section to reference the guide on how to use Markdown with Astro.  
It should make it easier for folks coming to the docs looking for information on that component to get context on the new way of doing things.