### PR TITLE
Fix wrong Node.js version numbers

### DIFF
--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -9,7 +9,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Prerequisites
 
-- **Node.js** - `14.15.0`, `v16.0.0`, or higher.
+- **Node.js** - `14.18.0`, `v16.12.0`, or higher.
 - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro is accessed through its command-line interface (CLI).
 

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -9,7 +9,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Prerequisites
 
-- **Node.js** - `14.15.0`, `v16.0.0`, or higher.
+- **Node.js** - `14.18.0`, `v16.12.0`, or higher.
 - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro is accessed through its command-line interface (CLI).
 


### PR DESCRIPTION
Installing Astro with Node.js version 16.5.0 fails:

> error @astrojs/telemetry@0.4.1: The engine "node" is incompatible with this
> module. Expected version "^14.18.0 || >=16.12.0". Got "16.5.0"

Update the docs to reflect the minimum required Node.js versions.

#### What kind of changes does this PR include?

- New or updated content

#### Description

Update the docs to reflect the minimum required Node.js versions.