### PR TITLE
Fix typo in images guide

### DIFF
--- a/src/pages/en/guides/images.md
+++ b/src/pages/en/guides/images.md
@@ -207,7 +207,7 @@ In `.mdx` files, `<Image />` and `<Picture />` can receive your image `src` thro
 ```mdx
 // src/pages/index.mdx
 
-import { Image, Picture } from '@astrojs/image/component';
+import { Image, Picture } from '@astrojs/image/components';
 import rocket from '../assets/rocket.png';
 export const galaxy = 'https://astro.build/assets/galaxy.jpg';
 


### PR DESCRIPTION
#### What kind of changes does this PR include?


- Minor content fixes (broken links, typos, etc.)

#### Description

Fix one typo in the images page on the mdx integration. Uses `@astrojs/image/component` instead of `@astrojs/image/components` for importing `<Image />`.