### PR TITLE
Add mention of new `env.d.ts` file to TypeScript page

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -34,13 +34,12 @@ Some TypeScript configuration options require special attention in Astro. Below 
 }
 ```
 
-Additionally, our templates include `env.d.ts` file inside the `src` folder that contains the following:
+Additionally, our templates include an `env.d.ts` file inside the `src` folder to provide [Vite's client types](https://vitejs.dev/guide/features.html#client-types) to your project:
 
 ```typescript title="env.d.ts"
 /// <reference types="astro/client" />
 ```
-
-This will includes [Vite's client types](https://vitejs.dev/guide/features.html#client-types) inside your project. Alternatively, if you prefer not having this file in your project, you can delete it and use the [`types` setting](https://www.typescriptlang.org/tsconfig#types) inside your `tsconfig.json` to add them:
+Optionally, you can delete this file and instead add the [`types` setting](https://www.typescriptlang.org/tsconfig#types) to your `tsconfig.json`:
 
 ```json title="tsconfig.json"
 {

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -28,13 +28,29 @@ Some TypeScript configuration options require special attention in Astro. Below 
     "resolveJsonModule": true,
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Astro runtime.
-    "types": ["astro/client"],
-    // Tell TypeScript where your build output is
-    "outDir": "./dist"
+    // Astro will directly run your TypeScript code, no transpilation needed.
+    "noEmit": true
   }
 }
 ```
+
+Additionally, our templates include `env.d.ts` file inside the `src` folder that contains the following:
+
+```typescript title="env.d.ts"
+/// <reference types="astro/client" />
+```
+
+This will includes [Vite's client types](https://vitejs.dev/guide/features.html#client-types) inside your project. Alternatively, if you prefer not having this file in your project, you can delete it and use the [`types` setting](https://www.typescriptlang.org/tsconfig#types) inside your `tsconfig.json` to add them:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["astro/client"]
+  }
+}
+```
+
+### UI Frameworks
 
 If your project uses a [UI framework](/en/core-concepts/framework-components/), additional settings depending on the framework might be needed. Please see your framework's TypeScript documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://reactjs.org/docs/static-type-checking.html), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

In https://github.com/withastro/astro/pull/4171, we're including a new `.d.ts` file inside people's projects that will replace the usage of the `types` field inside `tsconfig.json`. The reasons for this change are outlined in the PR. So this is the docs part of that effort 😄

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
