### PR TITLE
Markdown `content` prop -> `frontmatter` prop

### DIFF
--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -68,19 +68,19 @@ description: My first blog post!
 This is a post written in Markdown.
 ```
 
-When a Markdown file includes a layout, it passes a `content` property to the `.astro` component which includes the frontmatter properties and the final HTML output of the page.
+When a Markdown file includes a layout, it passes a `frontmatter` property to the `.astro` component which includes the frontmatter properties and the final HTML output of the page.
 
 
 **`src/layouts/BlogPostLayout.astro`**
 
-```astro /content(?:.\w+)?/
+```astro /frontmatter(?:.\w+)?/
 ---
-const {content} = Astro.props;
+const {frontmatter} = Astro.props;
 ---
 <html>
    <!-- ... -->
-  <h1>{content.title}</h1>
-  <h2>Post author: {content.author}</h2>
+  <h1>{frontmatter.title}</h1>
+  <h2>Post author: {frontmatter.author}</h2>
   <slot />
    <!-- ... -->
 </html>
@@ -99,11 +99,11 @@ For example, a common layout for blog posts may display a title, date and author
 ```astro {2} /</?BaseLayout>/
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
-const {content} = Astro.props;
+const {frontmatter} = Astro.props;
 ---
 <BaseLayout>
-  <h1>{content.title}</h1>
-  <h2>Post author: {content.author}</h2>
+  <h1>{frontmatter.title}</h1>
+  <h2>Post author: {frontmatter.author}</h2>
   <slot />
 </BaseLayout>
 ```

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -78,11 +78,9 @@ Markdown and MDX files do not return identical `Astro.props` objects. See the MD
 
 A Markdown layout will have access to the following information via `Astro.props`:
 
-- **`file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
-- **`url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - all frontmatter from the Markdown or MDX document.
-  - **`frontmatter.file`** - Same as the top-level `file` property. Present for legacy purposes!
-  - **`frontmatter.url`** - Same as the top-level `url` property. Present for legacy purposes!
+  - **`frontmatter.file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
+  - **`frontmatter.url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
 - **`headings`** - A list of headings (`h1 -> h6`) in the Markdown document with associated metadata. This list follows the type: `{ depth: number; slug: string; text: string }[]`.
 - **`rawContent()`** - A function that returns the raw Markdown document as a string.
 - **`compiledContent()`** - A function that returns the Markdown document compiled to an HTML string.
@@ -91,8 +89,6 @@ An example blog post may pass the following `Astro.props` object to its layout:
 
 ```js
 Astro.props = {
-  file: "/home/user/projects/.../file.md",
-  url: "/en/guides/markdown-content/",
   frontmatter: {
     /** Frontmatter from a blog post */
     title: "Astro 0.18 Release",

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -78,9 +78,11 @@ Markdown and MDX files do not return identical `Astro.props` objects. See the MD
 
 A Markdown layout will have access to the following information via `Astro.props`:
 
-- **`content`** - all frontmatter from the Markdown or MDX document.
-  - **`content.file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
-  - **`content.url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
+- **`file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
+- **`url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
+- **`frontmatter`** - all frontmatter from the Markdown or MDX document.
+  - **`frontmatter.file`** - Same as the top-level `file` property. Present for legacy purposes!
+  - **`frontmatter.url`** - Same as the top-level `url` property. Present for legacy purposes!
 - **`headings`** - A list of headings (`h1 -> h6`) in the Markdown document with associated metadata. This list follows the type: `{ depth: number; slug: string; text: string }[]`.
 - **`rawContent()`** - A function that returns the raw Markdown document as a string.
 - **`compiledContent()`** - A function that returns the Markdown document compiled to an HTML string.
@@ -89,7 +91,9 @@ An example blog post may pass the following `Astro.props` object to its layout:
 
 ```js
 Astro.props = {
-  content: {
+  file: "/home/user/projects/.../file.md",
+  url: "/en/guides/markdown-content/",
+  frontmatter: {
     /** Frontmatter from a blog post */
     title: "Astro 0.18 Release",
     date: "Tuesday, July 27 2021",

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -46,26 +46,26 @@ layout: ../layouts/BaseLayout.astro
 
 A typical layout for Markdown pages includes:
 
-1. The `content` prop to access the Markdown or MDX page's frontmatter and other data. See [Markdown Layout Props](#markdown-layout-props) for a complete list of props available.
+1. The `frontmatter` prop to access the Markdown or MDX page's frontmatter and other data. See [Markdown Layout Props](#markdown-layout-props) for a complete list of props available.
 2. A default [`<slot />`](/en/core-concepts/astro-components/#slots) to indicate where the page's Markdown content should be rendered.
 
-```astro /(?<!//.*){?content(?:\\.\w+)?}?/ "<slot />"
+```astro /(?<!//.*){?frontmatter(?:\\.\w+)?}?/ "<slot />"
 ---
 // src/layouts/BaseLayout.astro
-// 1. The content prop gives access to frontmatter and other data
-const { content } = Astro.props;
+// 1. The frontmatter prop gives access to frontmatter and other data
+const { frontmatter } = Astro.props;
 ---
 <html>
   <head>
     <!-- Add other Head elements here, like styles and meta tags. -->
-    <title>{content.title}</title>
+    <title>{frontmatter.title}</title>
   </head>
   <body>
     <!-- Add other UI components here, like common headers and footers. -->
-    <h1>{content.title} by {content.author}</h1>
+    <h1>{frontmatter.title} by {frontmatter.author}</h1>
     <!-- 2. Rendered HTML will be passed into the default slot. -->
     <slot />
-    <p>Written on: {content.date}</p>
+    <p>Written on: {frontmatter.date}</p>
   </body>
 </html>
 ```
@@ -119,14 +119,14 @@ Astro.props = {
 
 #### Example: Using one Layout that works for `.md`, `.mdx`, and `.astro` files
 
-A single Astro layout can be written to receive the content object from `.md` and `.mdx` files, as well as any named props passed from `.astro` files.
+A single Astro layout can be written to receive the `frontmatter` object from `.md` and `.mdx` files, as well as any named props passed from `.astro` files.
 
 In the example below, the layout will display the page title either from an Astro component passing a `title` attribute or from a frontmatter YAML `title` property:
 
 ```astro /{?title}?/ /Astro.props[.a-z]*/
 ---
 // src/components/MyLayout.astro
-const { title } = Astro.props.content || Astro.props;
+const { title } = Astro.props.frontmatter || Astro.props;
 ---
 <html>
   <head></head>
@@ -467,9 +467,9 @@ export default {
 
 ...all Markdown documents will have a calculated `minutesRead`. You can use this to include an "X min read" banner in a [markdown layout](#markdown-and-mdx-pages), for instance:
 
-```astro title="src/layouts/BlogLayout.astro" "const { minutesRead } = Astro.props.content;" "<p>{minutesRead}</p>"
+```astro title="src/layouts/BlogLayout.astro" "const { minutesRead } = Astro.props.frontmatter;" "<p>{minutesRead}</p>"
 ---
-const { minutesRead } = Astro.props.content;
+const { minutesRead } = Astro.props.frontmatter;
 ---
 
 <html>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Change all references to the Markdown layout `Astro.props.content` property to `Astro.props.frontmatter`. Both will continue to work, but `frontmatter` should be the new recommendation. Seemed a _bit_ much to add deprecation notices everywhere, so I'm voting for a clean sweep for 1.0 stable here!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
