### PR TITLE
Remove RC when talking about Astro v1

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -198,7 +198,7 @@ You can also pass the `--drafts` flag when running `astro build` to build draft 
 ### Variables and Components
 
 :::caution[Deprecated]
-Astro v1.0 Release Candidate (RC) **only supports standard Markdown in `.md` files**. The ability to use [components or JSX in Markdown pages is no longer enabled by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and support will eventually be removed entirely. 
+Astro v1.0 **only supports standard Markdown in `.md` files**. The ability to use [components or JSX in Markdown pages is no longer enabled by default](/en/migrate/#deprecated-components-and-jsx-in-markdown) and support will eventually be removed entirely. 
 
 Astro config supports a [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) that will re-enable these features in Markdown pages until you are able to migrate to MDX in Astro. The Astro MDX integration is the recommended path forward if you need more features than standard Markdown provides.
 :::

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -15,7 +15,7 @@ The Astro v1.0 (and all the Release Candidates for it) introduces some changes t
 
 ### Updated: Vite 3
 
-Astro v1.0 RC has upgraded from Vite 2 to [Vite 3](https://vitejs.dev/). We've handled most of the upgrade for you inside of Astro; however, some subtle Vite behaviors may still change between versions. Refer to the official [Vite Migration Guide](https://vitejs.dev/guide/migration.html#general-changes) if you run into trouble.
+Astro v1.0 has upgraded from Vite 2 to [Vite 3](https://vitejs.dev/). We've handled most of the upgrade for you inside of Astro; however, some subtle Vite behaviors may still change between versions. Refer to the official [Vite Migration Guide](https://vitejs.dev/guide/migration.html#general-changes) if you run into trouble.
 
 ### Deprecated: `Astro.canonicalURL`
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -9,9 +9,9 @@ This guide will help you migrate from older versions of Astro to the latest vers
 
 Read the guide below for major highlights and instructions on how to handle breaking changes.
 
-## Astro 1.0 Release Candidate
+## Astro 1.0
 
-The Astro v1.0 Release Candidate (RC) introduces some changes that you should be aware of when migrating from beta or earlier releases. See below for more details.
+The Astro v1.0 (and all the Release Candidates for it) introduces some changes that you should be aware of when migrating from beta or earlier releases. See below for more details.
 
 ### Updated: Vite 3
 

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -11,7 +11,7 @@ Read the guide below for major highlights and instructions on how to handle brea
 
 ## Astro 1.0
 
-The Astro v1.0 (and all the Release Candidates for it) introduces some changes that you should be aware of when migrating from beta or earlier releases. See below for more details.
+Astro v1.0 introduces some changes that you should be aware of when migrating from v0.x and v1.0-beta releases. See below for more details.
 
 ### Updated: Vite 3
 

--- a/src/pages/es/guides/markdown-content.md
+++ b/src/pages/es/guides/markdown-content.md
@@ -174,7 +174,7 @@ export default defineConfig({
 ## Markdown de Astro
 
 :::caution[Deprecated]
-Astro v1.0 Release Candidate (RC) [ya no admite componentes o JSX en las páginas de Markdown de forma predeterminada](/es/migrate/#deprecated-components-and-jsx-in-markdown) y es posible que se elimine en una versión futura. 
+Astro v1.0 [ya no admite componentes o JSX en las páginas de Markdown de forma predeterminada](/es/migrate/#deprecated-components-and-jsx-in-markdown) y es posible que se elimine en una versión futura. 
 
 Mientras tanto, la configuración de Astro admite una [legacy flag](/es/reference/configuration-reference/#legacyastroflavoredmarkdown) que reactivará estas funcionalidades en páginas de Markdown hasta que pueda migrar a [`@astrojs/mdx`](/es/guides/integrations-guide/mdx/).
 :::


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description
I did remove the text with the Release Candidate. However I still added:
> The Astro v1.0 *(and all the Release Candidates for it)* introduces some changes [...]

However maybe we could even remove that little notice as normally you don't install a RC when there's the actual release already.