### PR TITLE
i18n(ja): Update Japanese `astro-pages.md`

### DIFF
--- a/src/pages/ja/core-concepts/astro-pages.md
+++ b/src/pages/ja/core-concepts/astro-pages.md
@@ -37,7 +37,7 @@ Astroページは、`<head>` と `<body>` を含む完全な `<html>...</html>` 
 
 すべてのページで同じHTML要素を繰り返すことを避けるために、共通の `<head>` と `<body>` 要素を独自の[レイアウトコンポーネント](/ja/core-concepts/layouts/)に移動できます。レイアウトコンポーネントはいくつでも使えます。
 
-```astro
+```astro {3} /</?MySiteLayout>/
 ---
 // 例: src/pages/index.astro
 import MySiteLayout from '../layouts/MySiteLayout.astro';
@@ -57,7 +57,7 @@ Astroは `/src/pages/` にあるMarkdown (`.md`) ファイルも、最終的なW
 ページレイアウトは[Markdownファイル](#markdownページ)に対して特に有効です。Markdownファイルは特別な `layout`というfront-matterプロパティを使用して、Markdownコンテンツを `<html>...</html>` ページドキュメントにラップする [レイアウトコンポーネント](/ja/core-concepts/layouts/)を指定できます。
 
 
-```md
+```md {3}
 ---
 # 例: src/pages/page.md
 layout: '../layouts/MySiteLayout.astro'

--- a/src/pages/ja/core-concepts/astro-pages.md
+++ b/src/pages/ja/core-concepts/astro-pages.md
@@ -99,8 +99,7 @@ export async function get() {
 
 APIルートは、[params](/ja/reference/api-reference/#params)と[Request](https://developer.mozilla.org/ja/docs/Web/API/Request) を含む `APIContext` オブジェクトを受け取ります。
 
-
-```ts
+```ts title="src/pages/request-path.json.ts"
 import type { APIContext } from 'astro';
 
 export async function get({ params, request }: APIContext) {
@@ -114,7 +113,7 @@ export async function get({ params, request }: APIContext) {
 
 APIルートの関数は `APIRoute` 型を使って書くこともできます。これにより、APIルートが間違った型を返した場合に、より適切なエラーメッセージを表示できます。
 
-```ts
+```ts title="src/pages/request-path.json.ts"
 import type { APIRoute } from 'astro';
 
 export const get: APIRoute = ({ params, request }) => {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

- Updated Japanese astro-pages.md to match the English update
    - https://github.com/withastro/docs/commit/c09a2f5c083cd5d80c96098c936022f90d488bdf
    - https://github.com/withastro/docs/commit/55b0e331d59961b976fdcef64d1b0d1da4bcdf1f
