### PR TITLE
Make the tabs fancy

### DIFF
--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -7,19 +7,43 @@
 	margin-inline-start: -1rem;
 	overflow-x: scroll;
 	/* Hide scrollbar on firefox */
-	scrollbar-width: none; 
+	scrollbar-width: none;
 }
 
 .tab-scroll-overflow::-webkit-scrollbar {
 	/* Hide scrollbar on chrome / safari */
-  display: none;
+	display: none;
 }
 
-.tab:focus {
+.tab,
+.tab:focus,
+.tab:active {
+	border-bottom: 0 !important;
+}
+
+.tab:focus-visible {
 	outline: 2px solid var(--theme-accent);
 	outline-offset: -2px;
 }
 
 .tabpanel {
 	padding-block-start: 1rem;
+}
+
+.tablist {
+	position: relative;
+}
+
+.selectedIndicator {
+	position: absolute;
+	bottom: -2px;
+	height: 4px;
+	background-color: var(--theme-accent);
+	transition-duration: 200ms;
+}
+
+@media (prefers-reduced-motion) {
+	.selectedIndicator {
+		transition-duration: 0;
+	}
 }

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -42,6 +42,12 @@
 	transition-duration: 200ms;
 }
 
+@media (forced-colors: active) {
+	.selectedIndicator {
+		background-color: ButtonText;
+	}
+}
+
 @media (prefers-reduced-motion) {
 	.selectedIndicator {
 		transition-duration: 0;

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -15,15 +15,13 @@
 	display: none;
 }
 
-.tab,
-.tab:focus,
-.tab:active {
-	border-bottom: 0 !important;
-}
-
-.tab:focus-visible {
+.tab:focus {
 	outline: 2px solid var(--theme-accent);
 	outline-offset: -2px;
+}
+
+.tab:not(:focus-visible) {
+  outline: 0;
 }
 
 .tabpanel {

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -47,8 +47,8 @@
 	}
 }
 
-@media (prefers-reduced-motion) {
+@media (prefers-reduced-motion: no-preference) {
 	.selectedIndicator {
-		transition-duration: 0;
+		transition-duration: 200ms;
 	}
 }

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -34,6 +34,8 @@
 
 .selectedIndicator {
 	position: absolute;
+	transform-origin: left;
+	left: 0;
 	bottom: -4px;
 	height: 4px;
 	background-color: var(--theme-accent);

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -36,7 +36,7 @@
 
 .selectedIndicator {
 	position: absolute;
-	bottom: -2px;
+	bottom: -4px;
 	height: 4px;
 	background-color: var(--theme-accent);
 	transition-duration: 200ms;

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -39,7 +39,6 @@
 	bottom: -4px;
 	height: 4px;
 	background-color: var(--theme-accent);
-	transition-duration: 200ms;
 }
 
 @media (forced-colors: active) {

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -113,7 +113,7 @@ export default function Tabs({ sharedStore, ...slots }: Props) {
 							{content}
 						</button>
 					))}
-					<span ref={activeTabIndicatorRef} className={styles.selectedIndicator} />
+					<span ref={activeTabIndicatorRef} className={styles.selectedIndicator} aria-hidden="true" />
 				</div>
 			</div>
 			{panels.map(([key, content]) => (

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -67,7 +67,6 @@ export default function Tabs({ sharedStore, ...slots }: Props) {
 		// Fancy indicator animation
 		const activeTab = tabButtonRefs?.current[`tab.${curr}`];
 		if (activeTabIndicatorRef.current && tabButtonContainerRef.current && activeTab) {
-			console.log('A');
 			const tabBoundingRect = activeTab.getBoundingClientRect();
 			const containerBoundingRect = tabButtonContainerRef.current.getBoundingClientRect();
 			activeTabIndicatorRef.current.style.width = tabBoundingRect.width + 'px';

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -69,8 +69,8 @@ export default function Tabs({ sharedStore, ...slots }: Props) {
 		if (activeTabIndicatorRef.current && tabButtonContainerRef.current && activeTab) {
 			const tabBoundingRect = activeTab.getBoundingClientRect();
 			const containerBoundingRect = tabButtonContainerRef.current.getBoundingClientRect();
-			activeTabIndicatorRef.current.style.width = tabBoundingRect.width + 'px';
-			activeTabIndicatorRef.current.style.left = tabBoundingRect.left - containerBoundingRect.left + 'px';
+			if (!activeTabIndicatorRef.current.style.width) activeTabIndicatorRef.current.style.width = '1px';
+			activeTabIndicatorRef.current.style.transform = `translateX(${tabBoundingRect.left - containerBoundingRect.left}px) scaleX(${tabBoundingRect.width})`;
 		}
 	}, [curr]);
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Updated `Tabs` component, adding a fancy animation when the user switches tabs.

#### Description

- Adds fancy tab switching animation to... one of the many different tabs components. This one seemed the most general, so it was the one I modified.

Before:
https://user-images.githubusercontent.com/74938858/183867083-b67d32b2-2864-4c15-ba9d-ba9000c71a60.mov

After:
https://user-images.githubusercontent.com/74938858/183866697-3f469246-7f1a-4b7c-bde0-bfe4b030afb8.mov

Some of the CSS I had to change seemed kinda sketchy, so LMK if something's broken. I also changed the focus styles from applying on `:focus` to on `:focus-visible` (which has slightly lower browser support - [around 89% according to caniuse](https://caniuse.com/css-focus-visible) because it was running the effect).

Fun fact: this was the first time I've ever used `useLayoutEffect`!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
