### PR TITLE
Note baseUrl is required for aliases

### DIFF
--- a/src/pages/en/guides/aliases.md
+++ b/src/pages/en/guides/aliases.md
@@ -32,6 +32,10 @@ You can add import aliases from either `tsconfig.json` or `jsconfig.json`.
 }
 ```
 
+:::note
+Make sure `compilerOptions.baseUrl` is set so the aliased paths can be resolved.
+:::
+
 With this change, you can now import using the aliases anywhere in your project:
 
 ```astro title="src/pages/about/company.astro" ins="@components" ins="@assets"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Closes https://github.com/withastro/astro/issues/3729

Added a note block to show `baseUrl` is required to be set for import aliases to work. Astro would skip aliases if not set based on https://github.com/withastro/astro/blob/e918b3883e156a0de2148517b619a2cf451917d2/packages/astro/src/vite-plugin-config-alias/index.ts#L39.