### PR TITLE
Fixed typo in differences between astro and jsx

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -204,7 +204,7 @@ const htmlString = '<p>Raw HTML content</p>';
 
 ### Differences between Astro and JSX
 
-Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience, but there a couple of key differences between `.astro` files and JSX.
+Astro component syntax is a superset of HTML. It was designed to feel familiar to anyone with HTML or JSX experience, but there are a couple of key differences between `.astro` files and JSX.
 
 #### Attributes
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Changes to the docs site code

#### Description

- ~~Closes #~~ Closes no open issues
- What does this PR change? Give us a brief description.
In [this section](https://docs.astro.build/en/core-concepts/astro-components/#differences-between-astro-and-jsx) the phrase reads "...but there a couple of key differences between .astro files and JSX." I added the word "are" so that it then reads as "...but there are a couple of key differences between .astro files and JSX."


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
