### PR TITLE
data-fetching-astro-glob

### DIFF
--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -18,7 +18,7 @@ const posts = await Astro.glob('../pages/posts/*.md');
 ---
   <ul>
     {posts.map((post) => (
-      <li><a href={post.frontmatter.url}>{post.frontmatter.title}</li></p>
+      <li><a href={post.frontmatter.url}>{post.frontmatter.title}</a></li>
     ))}
   </ul>
 ```

--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -5,7 +5,7 @@ description: Learn how to fetch remote data with Astro using the fetch API.
 i18nReady: true
 ---
 
-`.astro` files can fetch data from your local files, or remote data at build time to help generate your pages.
+`.astro` files can fetch local and remote data at build time to help generate your pages.
 
 ## Fetch data from your local files
 

--- a/src/pages/en/guides/data-fetching.md
+++ b/src/pages/en/guides/data-fetching.md
@@ -5,7 +5,24 @@ description: Learn how to fetch remote data with Astro using the fetch API.
 i18nReady: true
 ---
 
-`.astro` files can fetch remote data at build time to help generate your pages.
+`.astro` files can fetch data from your local files, or remote data at build time to help generate your pages.
+
+## Fetch data from your local files
+
+Get data from one or many local files in your project using Astro's top-level await and [`Astro.glob()`](/en/reference/api-reference/#astroglob). This function returns an array (even if you only query one file!) and gives your `.astro` file access to exported properties like Markdown/MDX frontmatter and more!
+
+```astro "Astro.glob('../pages/post/*.md')"
+---
+// src/components/blog-archive.astro
+const posts = await Astro.glob('../pages/posts/*.md');
+---
+  <ul>
+    {posts.map((post) => (
+      <li><a href={post.frontmatter.url}>{post.frontmatter.title}</li></p>
+    ))}
+  </ul>
+```
+
 
 ## `fetch()` in Astro
 


### PR DESCRIPTION
- New or updated content

A quick example of `Astro.glob()` on the data fetching page until we have a proper "Here's how to Content with Astro" full story. This is better exposure for an example of creating an index of blog posts, which currently only exists in Reference and is not as accessible.

Now, this page details:
- Fetching data from local files to use in a component (`Astro.glob`)
in addition to what was previously there:
- fetch from remote APIs, incl GraphQL, in both Astro and UI Framework components
- fetch from a headless CMS

