### PR TITLE
Adding an "unmaintained content" aside

### DIFF
--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -9,12 +9,12 @@ Hello! You've found a page from an older version of our Docs site.
 
 This page is no longer linked to, and no longer maintained. Some pages are difficult to keep updated, lose their relevance over time, and grow stale more quickly than we can reasonably keep them current and helpful. This is probably one of those pages!
 
-Please explore the site using the navigation paths provided in the menus to view our current content, [visit our Docs home page](/en/getting-started) or read more [about why we think you'll love Astro](/en/concept/why-astro).
+Please explore the site using the navigation paths provided in the menus to view our current content, [visit our Docs home page](/en/getting-started/) or read more [about why we think you'll love Astro](/en/concepts/why-astro/).
 :::
 
 We often get asked the question, "How does Astro compare to my favorite project, **\_\_\_\_**?"  This guide was written to help answer that question for several popular site builders and Astro alternatives.
 
-Interested in a more general overview of Astro's benefits? Check out [Why Astro?](/en/concept/why-astro).
+Interested in a more general overview of Astro's benefits? Check out [Why Astro?](/en/concepts/why-astro/).
 
 Two key features make Astro different from most alternatives:
 

--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -2,12 +2,19 @@
 layout: ~/layouts/MainLayout.astro
 title: Astro vs. X
 description: Comparing Astro with other static site generators like Gatsby, Next.js, Nuxt, Hugo, Eleventy, and more.
-i18nReady: true
 ---
-<!-- TODO: UNcomment out the parts re: number of bytes of JS etc, once we decide which values/markers we'd like to use here. -->
-We often get asked the question, "How does Astro compare to my favorite project, **\_\_\_\_**?"
 
-This guide was written to help answer that question for several popular site builders and Astro alternatives.
+:::note[unmaintained content]
+Hello! You've found a page from an older version of our Docs site.
+
+This page is no longer linked to, and no longer maintained. Some pages are difficult to keep updated, lose their relevance over time, and grow stale more quickly than we can reasonably keep them current and helpful. This is probably one of those pages!
+
+Please explore the site using the navigation paths provided in the menus to view our current content, [visit our Docs home page](/en/getting-started) or read more [about why we think you'll love Astro](/en/concept/why-astro).
+:::
+
+We often get asked the question, "How does Astro compare to my favorite project, **\_\_\_\_**?"  This guide was written to help answer that question for several popular site builders and Astro alternatives.
+
+Interested in a more general overview of Astro's benefits? Check out [Why Astro?](/en/concept/why-astro).
 
 Two key features make Astro different from most alternatives:
 


### PR DESCRIPTION
- New or updated content

This adds an "unmaintained content" aside to the top of a page that exists in Docs but is not currently linked to, as it is still being discovered by search engines. Since we haven't yet decided what to do with this page, this notice informs readers that it is simply unmaintained, not hidden for any nefarious reasons!
![Screenshot 2022-08-11 09 13 40](https://user-images.githubusercontent.com/5098874/184130873-2164b21a-4305-4ce0-bea8-716264756b10.png)
