### PR TITLE
Remove `ENABLE_VC_BUILD` from vercel deployment guide

### DIFF
--- a/src/pages/en/guides/deploy/vercel.md
+++ b/src/pages/en/guides/deploy/vercel.md
@@ -40,20 +40,6 @@ To enable SSR in your Astro project and deploy on Vercel:
     });
     ```
 
-1. Enable Vercel’s [Build Output API](https://vercel.com/docs/build-output-api/v3) by setting the `ENABLE_VC_BUILD` environment variable in `vercel.json`.
-
-    ```js
-    {
-      "build": {
-        "env": {
-          "ENABLE_VC_BUILD": "1"
-        }
-      }
-    }
-    ```
-
-    📚 Learn more about [setting enviroment variables in Vercel](https://vercel.com/docs/concepts/projects/environment-variables)
-
 ## How to deploy
 
 You can deploy to Vercel through the website UI or using Vercel’s CLI (command line interface). The process is the same for both static and SSR Astro sites.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Removed the bullet point because the environment variable is not needed anymore. See https://github.com/withastro/astro/pull/4020
