### PR TITLE
[AlpineJS] Add comment and link to AlpineJS installation

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -11,7 +11,7 @@ Astro supports a variety of popular frameworks including [React](https://reactjs
 
 ## Installing Integrations
 
-Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
+Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS and Lit. One or several of these Astro integrations can be installed and configured in your project. (No Astro integration is necessary for AlpineJS, which is [installed from a `<script>` tag](https://alpinejs.dev/essentials/installation#from-a-script-tag).)
 
 To configure Astro to use these frameworks, first, install its integration and any associated peer dependencies:
 


### PR DESCRIPTION
- New or updated content

Added a line with a link to AlpineJS installation instructions (adding a `<script>` to head) because not having an official Astro integration to install led to questions and confusion.