### PR TITLE
With remarkReadingTime, extend remarkPlugins (not remove defaults)

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -459,7 +459,7 @@ import { remarkReadingTime } from './remark-reading-time.mjs';
 
 export default {
   markdown: {
-    remarkPlugins: [remarkReadingTime],
+    remarkPlugins: { extends: [remarkReadingTime] },
   },
 };
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

Very minor fix. This simply makes it so the documentation will instruct the reader to *extend* their remark plugins, rather than overwrite the defaults.

Before:
```
import { remarkReadingTime } from './remark-reading-time.mjs';

export default {
  markdown: {
    remarkPlugins: [remarkReadingTime],
  },
};
```

After:
```
import { remarkReadingTime } from './remark-reading-time.mjs';

export default {
  markdown: {
    remarkPlugins: { extends: [remarkReadingTime] },
  },
};
```

#### Description

I ran into an issue with my tables not rendering, did some research, found that markdown doesn't include tables by default, but people tend to use GitHub-flavored markdown in order to add some extra features -- and my config didn't enable that, since I had directly followed the documentation on adding reading time. It just says to "apply this plugin to your config," with the code. If it'd be better to expand on that by describing extending/replacing, feel free to add that to this PR :) 

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
