### PR TITLE
`getHeadings` clean up

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -282,7 +282,11 @@ If it's a page, URL of the page (e.g. `/en/guides/markdown-content`).
 
 #### `getHeadings()`
 
-An async function that returns the headers of the Markdown file. The response follows this type: `{ depth: number; slug: string; text: string }[]`.
+An async function that returns the headings in the Markdown file. The response follows this type:
+
+```ts
+{ depth: number; slug: string; text: string }[]
+```
 
 #### `rawContent()`
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -59,8 +59,8 @@ export interface MarkdownInstance<T extends Record<string, any>> {
 	url: string | undefined;
   /* Astro Component that renders the contents of this file */
 	Content: AstroComponent;
-  /* Function that returns array of h1...h6 element in this file */
-	getHeaders(): Promise<{ depth: number; slug: string; text: string }[]>;
+  /* Function that returns an array of the h1...h6 elements in this file */
+	getHeadings(): Promise<{ depth: number; slug: string; text: string }[]>;
 }
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Picks up the last few pieces from #1107 that weren’t done yet:

- API reference: `getHeaders()` -> `getHeadings()`
- Use “headings” over “headers” in Markdown guide
- Use a codeblock for the return type to avoid awkward linebreaks.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
