### PR TITLE
i18n(zh-CN): Misalignment caused by grammatical errors for `editor-setup.md`

### DIFF
--- a/src/pages/zh-cn/editor-setup.md
+++ b/src/pages/zh-cn/editor-setup.md
@@ -58,7 +58,7 @@ Astro 可以和任意编辑器一同工作。不过我们推荐在 Astro 项目�
 
 要开始使用，首先要安装 Prettier 和该插件：
 
-``shell
+```shell
 npm install --save-dev prettier prettier-plugin-astro
 ```
 
@@ -73,7 +73,7 @@ prettier --write .
 :::caution[与 pnpm 一起使用]
 由于 Prettier 内部的上游问题，当使用 [pnpm](https://pnpm.io/) 时，无法自动检测到该插件。为了让它能找到这个插件，在运行 Prettier 时需要添加以下参数：
 
-``shell
+```shell
 prettier --write --plugin-search-dir=. .
 ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Translated content

#### Description

I fixed a formatting misalignment caused by a markdown syntax error.

This is what it looked like before the modification. This paragraph puzzled me for a long time until I realized that it was misaligned.

<img width="1552" alt="截屏2022-08-15 04 26 13" src="https://user-images.githubusercontent.com/26341224/184567275-7e16a292-fcb5-4bad-a914-cc2f91a21072.png">

And here is what the page looks like after I modified it.

<img width="1552" alt="截屏2022-08-15 04 28 09" src="https://user-images.githubusercontent.com/26341224/184567423-cb4fb35f-b8e9-4fe7-a50a-73317516ddd8.png">

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
