### PR TITLE
Use docs integration guides instead of GitHub links

### DIFF
--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -18,11 +18,11 @@ Installing an adapter gives Astro access to the corresponding API, and allows As
 
 The following adapters are available today with more to come in the future:
 
-- [Cloudflare](https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare)
-- [Deno](https://github.com/withastro/astro/tree/main/packages/integrations/deno)
-- [Netlify](https://github.com/withastro/astro/tree/main/packages/integrations/netlify)
-- [Node.js](https://github.com/withastro/astro/tree/main/packages/integrations/node)
-- [Vercel](https://github.com/withastro/astro/tree/main/packages/integrations/vercel)
+- [Cloudflare](/en/guides/integrations-guide/cloudflare/)
+- [Deno](/en/guides/integrations-guide/deno)
+- [Netlify](/en/guides/integrations-guide/netlify)
+- [Node.js](/en/guides/integrations-guide/node)
+- [Vercel](/en/guides/integrations-guide/vercel)
 
 You can find instructions at the individual adapter links above to complete the following two steps (using `my-adapter` as an example placeholder) to enable SSR.
 1. Install the adapter to your project dependencies via npm or your package manager of choice

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -19,10 +19,10 @@ Installing an adapter gives Astro access to the corresponding API, and allows As
 The following adapters are available today with more to come in the future:
 
 - [Cloudflare](/en/guides/integrations-guide/cloudflare/)
-- [Deno](/en/guides/integrations-guide/deno)
-- [Netlify](/en/guides/integrations-guide/netlify)
-- [Node.js](/en/guides/integrations-guide/node)
-- [Vercel](/en/guides/integrations-guide/vercel)
+- [Deno](/en/guides/integrations-guide/deno/)
+- [Netlify](/en/guides/integrations-guide/netlify/)
+- [Node.js](/en/guides/integrations-guide/node/)
+- [Vercel](/en/guides/integrations-guide/vercel/)
 
 You can find instructions at the individual adapter links above to complete the following two steps (using `my-adapter` as an example placeholder) to enable SSR.
 1. Install the adapter to your project dependencies via npm or your package manager of choice


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Noticed we were still pointing to the adapter packages on GitHub from the SSR page. This updates those links to use the docs versions of those READMEs.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
