### PR TITLE
Add retry logic to fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "htmlparser2": "^7.2.0",
     "kleur": "^4.1.5",
     "node-fetch": "^3.2.10",
+    "p-retry": "^5.1.1",
     "parse-numeric-range": "^1.3.0",
     "preact": "^10.10.1",
     "prettier": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ specifiers:
   kleur: ^4.1.5
   nanostores: ^0.5.13
   node-fetch: ^3.2.10
+  p-retry: ^5.1.1
   parse-numeric-range: ^1.3.0
   preact: ^10.10.1
   prettier: ^2.7.1
@@ -91,6 +92,7 @@ devDependencies:
   htmlparser2: 7.2.0
   kleur: 4.1.5
   node-fetch: 3.2.10
+  p-retry: 5.1.1
   parse-numeric-range: 1.3.0
   preact: 10.10.1
   prettier: 2.7.1
@@ -977,6 +979,10 @@ packages:
 
   /@types/resolve/1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  /@types/retry/0.12.1:
+    resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
+    dev: true
 
   /@types/sax/1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
@@ -3663,6 +3669,14 @@ packages:
       p-timeout: 3.2.0
     dev: true
 
+  /p-retry/5.1.1:
+    resolution: {integrity: sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      '@types/retry': 0.12.1
+      retry: 0.13.1
+    dev: true
+
   /p-timeout/3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
@@ -4061,6 +4075,11 @@ packages:
       retext-latin: 3.1.0
       retext-stringify: 3.1.0
       unified: 10.1.2
+
+  /retry/0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: true
 
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}

--- a/scripts/lib/github-get.mjs
+++ b/scripts/lib/github-get.mjs
@@ -1,28 +1,29 @@
 import fetch from 'node-fetch';
-
-const MAX_RETRIES = 5;
+import pRetry, { AbortError } from 'p-retry';
 
 /**
  * Fetch a URL from the GitHub API and resolve its JSON response.
- * @param {{ url: string; githubToken?: string; attempt?: number; }} options
+ * @param {{ url: string; githubToken?: string }} options
  * @returns {Promise<any>}
  */
-export async function githubGet({ url, githubToken = undefined, attempt = 0 }) {
-	const headers = {
-		Accept: 'application/vnd.github.v3+json',
-	};
-	if (githubToken) {
-		headers.Authorization = `token ${githubToken}`;
-	}
-	try {
-		const response = await fetch(url, { headers });
-		const json = await response.json();
-		if (!response.ok) {
-			throw new Error(`GitHub API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
-		}
-		return json;
-	} catch (error) {
-		if (attempt >= MAX_RETRIES) throw error;
-		return await githubGet({ url, githubToken, attempt: attempt + 1 });
-	}
+export async function githubGet({ url, githubToken = undefined }) {
+	return await pRetry(
+		async () => {
+			const headers = {
+				Accept: 'application/vnd.github.v3+json',
+			};
+			if (githubToken) {
+				headers.Authorization = `token ${githubToken}`;
+			}
+			const response = await fetch(url, { headers });
+			const json = await response.json();
+
+			if (!response.ok) {
+				throw new AbortError(`GitHub API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
+			}
+
+			return json;
+		},
+		{ retries: 5 }
+	);
 }

--- a/scripts/lib/github-get.mjs
+++ b/scripts/lib/github-get.mjs
@@ -1,25 +1,28 @@
 import fetch from 'node-fetch';
 
+const MAX_RETRIES = 5;
+
 /**
  * Fetch a URL from the GitHub API and resolve its JSON response.
- * @param {{ url: string; githubToken?: string }} options
+ * @param {{ url: string; githubToken?: string; attempt?: number; }} options
  * @returns {Promise<any>}
  */
-export async function githubGet({ url, githubToken = undefined }) {
+export async function githubGet({ url, githubToken = undefined, attempt = 0 }) {
 	const headers = {
 		Accept: 'application/vnd.github.v3+json',
 	};
 	if (githubToken) {
 		headers.Authorization = `token ${githubToken}`;
 	}
-	const response = await fetch(url, {
-		headers,
-	});
-	const json = await response.json();
-
-	if (!response.ok) {
-		throw new Error(`GitHub API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
+	try {
+		const response = await fetch(url, { headers });
+		const json = await response.json();
+		if (!response.ok) {
+			throw new Error(`GitHub API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`);
+		}
+		return json;
+	} catch (error) {
+		if (attempt >= MAX_RETRIES) throw error;
+		return await githubGet({ url, githubToken, attempt: attempt + 1 });
 	}
-
-	return json;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Adds retry logic to our `githubGet` helper to try and mitigate the regular CI failures we get for “Invalid response body” when generating integration pages. Here’s a recent example: <https://github.com/withastro/docs/runs/7837529942?check_suite_focus=true#step:4:18>

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
