### PR TITLE
i18n(zh-cn): fix ghost word

### DIFF
--- a/src/pages/zh-cn/core-concepts/framework-components.md
+++ b/src/pages/zh-cn/core-concepts/framework-components.md
@@ -113,7 +113,7 @@ import MyVueComponent from '../components/MyVueComponent.vue';
 只有 **Astro** 组件（`.astro`）可以包括多个框架的组件
 :::
 
-## 向框架组件传递字组件
+## 向框架组件传递子组件
 
 在 Astro 组件中，你可以向框架组件传递子组件。每个框架都有自己的模式来引用这些子组件：React、Preact 和 Solid 均使用一个特殊的属性名 `children`，而 Svelte 和 Vue 则使用 `<slot />` 元素。
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- fix ghost word

#### Description

- change the word `字` to `子` in [`向框架组件传递字组件`](https://docs.astro.build/zh-cn/core-concepts/framework-components/#%E5%90%91%E6%A1%86%E6%9E%B6%E7%BB%84%E4%BB%B6%E4%BC%A0%E9%80%92%E5%AD%97%E7%BB%84%E4%BB%B6)
