### PR TITLE
i18n(zh-cn): reverse the unnecessary translation

### DIFF
--- a/src/pages/zh-cn/core-concepts/framework-components.md
+++ b/src/pages/zh-cn/core-concepts/framework-components.md
@@ -113,7 +113,7 @@ import MyVueComponent from '../components/MyVueComponent.vue';
 只有 **Astro** 组件（`.astro`）可以包括多个框架的组件
 :::
 
-## 向框架组件传递字组件
+## 向框架组件传递子组件
 
 在 Astro 组件中，你可以向框架组件传递子组件。每个框架都有自己的模式来引用这些子组件：React、Preact 和 Solid 均使用一个特殊的属性名 `children`，而 Svelte 和 Vue 则使用 `<slot />` 元素。
 

--- a/src/pages/zh-cn/guides/markdown-content.md
+++ b/src/pages/zh-cn/guides/markdown-content.md
@@ -220,7 +220,7 @@ Great post: <a href={greatPost.url}>{greatPost.frontmatter.title}</a>
 - `frontmatter`：此文件的 YAML frontmatter 中指定的任何数据。
 - `file`：此文件的绝对路径（例如 `/home/user/projects/.../file.md`）。
 - `url`：如果是页面，则为页面的 URL（例如 `/en/guides/markdown-content`）。
-- `getHeaders()`：返回 Markdown 文件标题的异步函数。 响应遵循这种类型：`{ depth: number; 蛞蝓：字符串； 文本：字符串}[]`。
+- `getHeaders()`：返回 Markdown 文件标题的异步函数。 响应遵循这种类型：`{ depth: number; slug: string; text: string }[]`。
 - `Content`：渲染 Markdown 文件内容的组件。以下是个示例：
 
   ```astro


### PR DESCRIPTION
#### What kind of changes does this PR include?

- reverse the unnecessary code translation

#### Description

- The code block translation is not necessary, and it is strange to translate `slug` to `蛞蝓`.
- Link: https://docs.astro.build/zh-cn/guides/markdown-content/#%E5%AF%BC%E5%85%A5-markdown
