### PR TITLE
Fix i18n guide link, fix `need(s) updating` plural

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -375,7 +375,7 @@ class GitHubTranslationStatus {
 			lines.push(
 				`<summary><strong>` +
 				`${this.languageLabels[lang]} (${lang}): ` +
-				`${missing.length} missing, ${outdated.length} need${outdated.length === 1 ? '' : 's'} updating` +
+				`${missing.length} missing, ${outdated.length} need${outdated.length === 1 ? 's' : ''} updating` +
 				`</strong></summary>`
 			);
 			lines.push(``);

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -94,7 +94,7 @@ class GitHubTranslationStatus {
 			should not be translated at this point. We will add more pages to these lists soon.
 
 			Before starting, please read our
-			[i18n guide](https://github.com/withastro/docs/tree/main/src/i18n/README.md) to learn about
+			[i18n guide](https://github.com/withastro/docs/blob/main/TRANSLATING.md) to learn about
 			our translation process and how you can get involved.
 		`;
 		let humanFriendlySummary = dedent`
@@ -375,7 +375,7 @@ class GitHubTranslationStatus {
 			lines.push(
 				`<summary><strong>` +
 				`${this.languageLabels[lang]} (${lang}): ` +
-				`${missing.length} missing, ${outdated.length} needs updating` +
+				`${missing.length} missing, ${outdated.length} need${outdated.length === 1 ? '' : 's'} updating` +
 				`</strong></summary>`
 			);
 			lines.push(``);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fixes broken link to i18n guide.
- Selects the correct plural form of `need(s) updating` based on the number of pages.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
