### PR TITLE
Fix more broken links to moved i18n guide

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -88,7 +88,7 @@ We encourage our maintainers to audit and improve the accessibility of our code 
 
 For PRs that are translations to existing Docs content, including new page additions as well as smaller updates and corrections:
 
-- Consult the [Internationalization Guide](/src/i18n/README.md) to familiarize yourself with the translators' process.
+- Consult the [Internationalization Guide](/TRANSLATING.md) to familiarize yourself with the translators' process.
 - If you see "LGTM" in a message within the PR, that means at least one other native speaker has approved the translation, and the PR can be immediately merged! 🥳
 - If you speak the language natively, check the content for accuracy. Note: some languages have created their own glossaries and/or language guides located in their language folder within `/src/i18n/`.
 - If you do not speak the language natively, and the PR has not had any recent activity, you can use online translation tools (e.g. Google Translate) and scan the results for anything that looks wildly out of place. Also, visit the page in the PR’s Netlify deploy preview to verify that nothing is visually out of place. While we always prefer to have a review from a native speaker of the language, having translated docs with some errors is usually better than having no docs at all.

--- a/src/components/FallbackNotice.astro
+++ b/src/components/FallbackNotice.astro
@@ -5,5 +5,5 @@ import UIString from './UIString.astro';
 
 <Aside>
 	<UIString key="fallbackContent.notice" />
-	<a href="https://github.com/withastro/docs/blob/main/src/i18n#readme"><UIString key="fallbackContent.linkText" /></a>
+	<a href="https://github.com/withastro/docs/blob/main/TRANSLATING.md"><UIString key="fallbackContent.linkText" /></a>
 </Aside>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description

- Fixes more broken links to the moved i18n guide, including the language fallback notice box and the maintainers guide.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
