### PR TITLE
Fix heading level in Cloudflare deploy guide

### DIFF
--- a/src/pages/en/guides/deploy/cloudflare.md
+++ b/src/pages/en/guides/deploy/cloudflare.md
@@ -109,7 +109,7 @@ To get started, create a `/functions` directory at the root of your project. Wri
 
 📚 Read more about [SSR in Astro](/en/guides/server-side-rendering/).
 
-### Troubleshooting
+## Troubleshooting
 
 
 If you're encountering errors, double-check the version of `node` you're using locally (`node -v`) matches the version you're specifying in the environment variable.


### PR DESCRIPTION
Troubleshooting section wasn't intended to be for SSR only, so hoisting the heading level!

