### PR TITLE
i18n(de): add GitHub pages deploy guide

### DIFF
--- a/src/pages/de/guides/deploy/github.md
+++ b/src/pages/de/guides/deploy/github.md
@@ -13,7 +13,7 @@ Du kannst eine Astro-Seite bei GitHub Pages veröffentlichen, indem du [GitHub A
 
 Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Seite bei GitHub Pages zu veröffentlichen und les [die Package README](https://github.com/withastro/action), falls du mehr Informationen benötigst.
 
-1. Setze die [`site`](/en/reference/configuration-reference/#site) und, falls benötigt, [`base`](/en/reference/configuration-reference/#base) Optionen in `astro.config.mjs`.
+1. Setze die [`site`](/de/reference/configuration-reference/#site) und, falls benötigt, [`base`](/de/reference/configuration-reference/#base) Optionen in `astro.config.mjs`.
     - `site` sollte in etwa `https://<DEIN_NUTZERNAME>.github.io` entsprechen
     - `base` sollte ein Schrägstrich gefolgt vom Namen deines Repositories sein, zum Beispiel `/mein-repository`.
     

--- a/src/pages/de/guides/deploy/github.md
+++ b/src/pages/de/guides/deploy/github.md
@@ -1,0 +1,84 @@
+---
+title: Veröffentliche deine Astro-Seite bei GitHub Pages
+description: Wie du deine Astro-Seite mit GitHub Pages im Internet veröffentlichst.
+layout: ~/layouts/DeployGuideLayout.astro
+i18nReady: true
+---
+
+Du kannst [GitHub Pages](https://pages.github.com/) verwenden, um eine Astro-Webseite direkt von einem Repository auf [GitHub.com](https://github.com/) zu hosten.
+
+## Wie du sie veröffentlichst
+
+Du kannst eine Astro-Seite bei GitHub Pages veröffentlichen, indem du [GitHub Actions](https://github.com/features/actions) verwendest und so deine Seite automatisch erzeugst und veröffentlichst. Um dies zu erreichen, muss dein Quelltext auf GitHub liegen.
+
+Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Seite bei GitHub Pages zu veröffentlichen und les [die Package README](https://github.com/withastro/action), falls du mehr Informationen benötigst.
+
+1. Setze die [`site`](/en/reference/configuration-reference/#site) und, falls benötigt, [`base`](/en/reference/configuration-reference/#base) Optionen in `astro.config.mjs`.
+    - `site` sollte in etwa `https://<DEIN_NUTZERNAME>.github.io` entsprechen
+    - `base` sollte ein Schrägstrich gefolgt vom Namen deines Repositories sein, zum Beispiel `/mein-repository`.
+    
+    :::note
+    Falls dein Repository `<DEIN_NUTZERNAME>.github.io` heißt, benötigst du die Option `base` nicht.
+    :::
+
+2. Erstelle eine neue Datei `.github/workflows/deploy.yml` in deinem Projekt und füge den folgende YAML-Ausschnitt ein.
+
+    ```yaml
+    name: Github Pages Astro CI
+
+    on:
+      # Löst den Workflow bei jedem Push auf den `main` Branch aus
+      # Verwendest du einen anderen Branch-Namen? Ersetze `main` durch den Namen deines Branches
+      push:
+        branches: [ main ]
+      # Erlaubt es dir diesen Workflow manuell über den Actions-Tab auf GitHub zu starten
+      workflow_dispatch:
+      
+    # Erlaubt diesem Job das Repository zu klonen und eine Veröffentlichung bei GitHub Pages zu erstellen
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checke dein Repository mit Git aus
+            uses: actions/checkout@v2          
+          - name: Installiere Abhängigkeiten, erzeuge deine Seite und lade sie hoch
+            uses: withastro/action@v0
+
+      deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+          name: github-pages
+          url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+          - name: Bei GitHub Pages veröffentlichen
+            id: deployment
+            uses: actions/deploy-pages@v1
+    ```
+    
+    :::caution
+    Die offizielle Astro [Action](https://github.com/withastro/action) such nach einem Lockfile, um deinen bevorzugten Paketmanager (`npm`, `yarn` oder `pnpm`) zu erkennen. Du solltest die von deinem Paketmanager automatisch generierte Datei `package-lock.json`, `yarn.lock` oder `pnpm-lock.yaml` zu deinem Repository hinzufügen.
+    :::
+
+3. Committe die neue Workflow-Datei und pushe sie zu GitHub.
+
+4. Auf GitHub, gehe zum Tab **Settings** deines Repositories und suche den Abschnitt **Pages**.  
+
+5. Wähle den `gh-pages` Branch und das `"/" (root)` Verzeichnis als **Source** deiner Seite aus und drücke **Save**.  
+  
+Deine Seite sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem Astro-Projekt zu deinem Repository pushst, wird die GitHub Action diese automatisch veröffentlichen.
+
+:::tip[Richte eine benutzerdefinierte Domäne ein]
+Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folgende Datei `./public/CNAME` zu deinem Projekt hinzufügst:
+
+```txt title="public/CNAME"
+sub.meine-domain.de
+```
+
+Dadurch wird deine Seite auf deiner benutzerdefinierten Domäne, statt auf `<DEIN_NUTZERNAME>.github.io`, veröffentlicht. Vergiss nicht, auch [den DNS Eintrag deines Domänen-Anbieters anzupassen](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
+:::

--- a/src/pages/de/guides/deploy/github.md
+++ b/src/pages/de/guides/deploy/github.md
@@ -1,17 +1,17 @@
 ---
-title: Veröffentliche deine Astro-Seite bei GitHub Pages
-description: Wie du deine Astro-Seite mit GitHub Pages im Internet veröffentlichst.
+title: Veröffentliche deine Astro-Site bei GitHub Pages
+description: Wie du deine Astro-Site mit GitHub Pages im Internet veröffentlichst.
 layout: ~/layouts/DeployGuideLayout.astro
 i18nReady: true
 ---
 
-Du kannst [GitHub Pages](https://pages.github.com/) verwenden, um eine Astro-Webseite direkt von einem Repository auf [GitHub.com](https://github.com/) zu hosten.
+Du kannst [GitHub Pages](https://pages.github.com/) verwenden, um eine Astro-Website direkt von einem Repository auf [GitHub.com](https://github.com/) zu hosten.
 
 ## Wie du sie veröffentlichst
 
-Du kannst eine Astro-Seite bei GitHub Pages veröffentlichen, indem du [GitHub Actions](https://github.com/features/actions) verwendest und so deine Seite automatisch erzeugst und veröffentlichst. Um dies zu erreichen, muss dein Quelltext auf GitHub liegen.
+Du kannst eine Astro-Site bei GitHub Pages veröffentlichen, indem du [GitHub Actions](https://github.com/features/actions) verwendest und so deine Site automatisch erzeugst und veröffentlichst. Um dies zu erreichen, muss dein Quelltext auf GitHub liegen.
 
-Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Seite bei GitHub Pages zu veröffentlichen und les [die Package README](https://github.com/withastro/action), falls du mehr Informationen benötigst.
+Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Site bei GitHub Pages zu veröffentlichen und les [die Package README](https://github.com/withastro/action), falls du mehr Informationen benötigst.
 
 1. Setze die [`site`](/de/reference/configuration-reference/#site) und, falls benötigt, [`base`](/de/reference/configuration-reference/#base) Optionen in `astro.config.mjs`.
     - `site` sollte in etwa `https://<DEIN_NUTZERNAME>.github.io` entsprechen
@@ -46,7 +46,7 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
         steps:
           - name: Checke dein Repository mit Git aus
             uses: actions/checkout@v2          
-          - name: Installiere Abhängigkeiten, erzeuge deine Seite und lade sie hoch
+          - name: Installiere Abhängigkeiten, erzeuge deine Site und lade sie hoch
             uses: withastro/action@v0
 
       deploy:
@@ -69,9 +69,9 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
 
 4. Auf GitHub, gehe zum Tab **Settings** deines Repositories und suche den Abschnitt **Pages**.  
 
-5. Wähle den `gh-pages` Branch und das `"/" (root)` Verzeichnis als **Source** deiner Seite aus und drücke **Save**.  
+5. Wähle den `gh-pages` Branch und das `"/" (root)` Verzeichnis als **Source** deiner Site aus und drücke **Save**.  
   
-Deine Seite sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem Astro-Projekt zu deinem Repository pushst, wird die GitHub Action diese automatisch veröffentlichen.
+Deine Site sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem Astro-Projekt zu deinem Repository pushst, wird die GitHub Action diese automatisch veröffentlichen.
 
 :::tip[Richte eine benutzerdefinierte Domäne ein]
 Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folgende Datei `./public/CNAME` zu deinem Projekt hinzufügst:
@@ -80,5 +80,5 @@ Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folg
 sub.meine-domain.de
 ```
 
-Dadurch wird deine Seite auf deiner benutzerdefinierten Domäne, statt auf `<DEIN_NUTZERNAME>.github.io`, veröffentlicht. Vergiss nicht, auch [den DNS Eintrag deines Domänen-Anbieters anzupassen](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
+Dadurch wird deine Site auf deiner benutzerdefinierten Domäne, statt auf `<DEIN_NUTZERNAME>.github.io`, veröffentlicht. Vergiss nicht, auch [den DNS Eintrag deines Domänen-Anbieters anzupassen](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
 :::

--- a/src/pages/de/guides/deploy/github.md
+++ b/src/pages/de/guides/deploy/github.md
@@ -1,6 +1,6 @@
 ---
-title: Veröffentliche deine Astro-Site bei GitHub Pages
-description: Wie du deine Astro-Site mit GitHub Pages im Internet veröffentlichst.
+title: Veröffentliche deine Astro-Website bei GitHub Pages
+description: Wie du deine Astro-Website mit GitHub Pages im Internet veröffentlichst.
 layout: ~/layouts/DeployGuideLayout.astro
 i18nReady: true
 ---
@@ -9,11 +9,11 @@ Du kannst [GitHub Pages](https://pages.github.com/) verwenden, um eine Astro-Web
 
 ## Wie du sie veröffentlichst
 
-Du kannst eine Astro-Site bei GitHub Pages veröffentlichen, indem du [GitHub Actions](https://github.com/features/actions) verwendest und so deine Site automatisch erzeugst und veröffentlichst. Um dies zu erreichen, muss dein Quelltext auf GitHub liegen.
+Du kannst eine Astro-Website bei GitHub Pages veröffentlichen, indem du [GitHub Actions](https://github.com/features/actions) verwendest und so deine Website automatisch erzeugst und veröffentlichst. Um dies zu erreichen, muss dein Quelltext auf GitHub liegen.
 
-Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Site bei GitHub Pages zu veröffentlichen und les [die Package README](https://github.com/withastro/action), falls du mehr Informationen benötigst.
+Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimaler Konfiguration veröffentlicht. Folge den unten angeführten Anweisungen, um deine Astro-Website bei GitHub Pages zu veröffentlichen, und lies [die README des Pakets](https://github.com/withastro/action), falls du mehr Informationen benötigst.
 
-1. Setze die [`site`](/de/reference/configuration-reference/#site) und, falls benötigt, [`base`](/de/reference/configuration-reference/#base) Optionen in `astro.config.mjs`.
+1. Setze die Optionen [`site`](/de/reference/configuration-reference/#site) und bei Bedarf auch [`base`](/de/reference/configuration-reference/#base) in `astro.config.mjs`.
     - `site` sollte in etwa `https://<DEIN_NUTZERNAME>.github.io` entsprechen
     - `base` sollte ein Schrägstrich gefolgt vom Namen deines Repositories sein, zum Beispiel `/mein-repository`.
     
@@ -21,17 +21,17 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
     Falls dein Repository `<DEIN_NUTZERNAME>.github.io` heißt, benötigst du die Option `base` nicht.
     :::
 
-2. Erstelle eine neue Datei `.github/workflows/deploy.yml` in deinem Projekt und füge den folgende YAML-Ausschnitt ein.
+2. Erstelle eine neue Datei `.github/workflows/deploy.yml` in deinem Projekt und füge den folgenden YAML-Code ein:
 
     ```yaml
     name: Github Pages Astro CI
 
     on:
-      # Löst den Workflow bei jedem Push auf den `main` Branch aus
+      # Löst den Workflow bei jedem Push auf den `main`-Branch aus
       # Verwendest du einen anderen Branch-Namen? Ersetze `main` durch den Namen deines Branches
       push:
         branches: [ main ]
-      # Erlaubt es dir diesen Workflow manuell über den Actions-Tab auf GitHub zu starten
+      # Erlaubt es dir, diesen Workflow manuell über den Actions-Tab auf GitHub zu starten
       workflow_dispatch:
       
     # Erlaubt diesem Job das Repository zu klonen und eine Veröffentlichung bei GitHub Pages zu erstellen
@@ -46,7 +46,7 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
         steps:
           - name: Checke dein Repository mit Git aus
             uses: actions/checkout@v2          
-          - name: Installiere Abhängigkeiten, erzeuge deine Site und lade sie hoch
+          - name: Installiere Abhängigkeiten, erzeuge deine Website und lade sie hoch
             uses: withastro/action@v0
 
       deploy:
@@ -62,16 +62,16 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
     ```
     
     :::caution
-    Die offizielle Astro [Action](https://github.com/withastro/action) such nach einem Lockfile, um deinen bevorzugten Paketmanager (`npm`, `yarn` oder `pnpm`) zu erkennen. Du solltest die von deinem Paketmanager automatisch generierte Datei `package-lock.json`, `yarn.lock` oder `pnpm-lock.yaml` zu deinem Repository hinzufügen.
+    Die offizielle Astro-[Action](https://github.com/withastro/action) sucht nach einem Lockfile, um deinen bevorzugten Paketmanager (`npm`, `yarn` oder `pnpm`) zu erkennen. Du solltest die von deinem Paketmanager automatisch generierte Datei `package-lock.json`, `yarn.lock` oder `pnpm-lock.yaml` zu deinem Repository hinzufügen.
     :::
 
 3. Committe die neue Workflow-Datei und pushe sie zu GitHub.
 
-4. Auf GitHub, gehe zum Tab **Settings** deines Repositories und suche den Abschnitt **Pages**.  
+4. Gehe auf GitHub zum Tab **Settings** deines Repositories und suche den Abschnitt **Pages**.  
 
-5. Wähle den `gh-pages` Branch und das `"/" (root)` Verzeichnis als **Source** deiner Site aus und drücke **Save**.  
+5. Wähle den `gh-pages`-Branch und das `"/" (root)`-Verzeichnis als **Source** deiner Website aus und drücke **Save**.  
   
-Deine Site sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem Astro-Projekt zu deinem Repository pushst, wird die GitHub Action diese automatisch veröffentlichen.
+Deine Website sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem Astro-Projekt zu deinem Repository pushst, wird die GitHub Action diese automatisch veröffentlichen.
 
 :::tip[Richte eine benutzerdefinierte Domäne ein]
 Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folgende Datei `./public/CNAME` zu deinem Projekt hinzufügst:
@@ -80,5 +80,5 @@ Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folg
 sub.meine-domain.de
 ```
 
-Dadurch wird deine Site auf deiner benutzerdefinierten Domäne, statt auf `<DEIN_NUTZERNAME>.github.io`, veröffentlicht. Vergiss nicht, auch [den DNS Eintrag deines Domänen-Anbieters anzupassen](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
+Dadurch wird deine Website auf deiner benutzerdefinierten Domäne veröffentlicht, und nicht auf `<DEIN_NUTZERNAME>.github.io`. Vergiss nicht, auch [den DNS-Eintrag deines Domänen-Anbieters anzupassen](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
 :::

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -18,7 +18,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
     - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`.
     
     :::note
-    If your repository is named `<YOUR_USERNAME>.github.io`, you don’t need to include `base`.)
+    If your repository is named `<YOUR_USERNAME>.github.io`, you don’t need to include `base`.
     :::
 
 2. Create a new file in your project at `.github/workflows/deploy.yml` and paste in the YAML below.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Translated content

#### Description

This PR adds a German translation of the guide for deploying Astro sites to GitHub pages.
It also removes a superfluous closing bracket.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
