### PR TITLE
Updated Express code to serve assets

### DIFF
--- a/src/pages/en/guides/integrations-guide/node.md
+++ b/src/pages/en/guides/integrations-guide/node.md
@@ -62,6 +62,7 @@ import express from 'express';
 import { handler as ssrHandler } from './dist/server/entry.mjs';
 
 const app = express();
+app.use(express.static('dist/client/'));
 app.use(ssrHandler);
 
 app.listen(8080);


### PR DESCRIPTION
Assets where not served so the style was not applied, fixed this by adding the line `app.use(express.static('dist/client/'))`

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->


- New or updated content

#### Description


- What does this PR change? Give us a brief description.
Adds `app.use(express.static('dist/client/'))` to express's SSR code to serve assets. Using node ass SSR with old code wouldn't serve the favicon and styles.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
