### PR TITLE
Improve configuration reference warning and edit this page link

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -8,13 +8,18 @@ const STUB = ``; // fs.readFileSync('/PATH/TO/MONOREPO/astro/packages/astro/src/
 const HEADER = `---
 # NOTE: This file is auto-generated from 'scripts/docgen.mjs'
 # Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts 
 
 layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
 i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts
 setup: |
   import Since from '../../../components/Since.astro';
+  import DontEditWarning from '../../../components/DontEditWarning.astro';
 ---
+
+<DontEditWarning />
 
 The following reference covers all supported configuration options in Astro. To learn more about configuring Astro, read our guide on [Configuring Astro](/en/guides/configuring-astro/).
 

--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -86,6 +86,7 @@ class IntegrationPagesBuilder {
 layout: ~/layouts/IntegrationLayout.astro
 title: '${name}'
 githubURL: '${githubLink}'
+hasREADME: true
 category: ${category}
 i18nReady: false
 setup : |

--- a/src/components/DontEditWarning.astro
+++ b/src/components/DontEditWarning.astro
@@ -1,0 +1,9 @@
+---
+import Aside from './Aside.astro';
+const isDevMode = import.meta.env.DEV;
+---
+{ isDevMode &&
+<Aside type="danger" title="Don't edit this page directly!">
+    This page is generated from the type definitions in the main Astro repo, the "Edit this page" link in the right sidebar will redirect you to the correct file.
+</Aside>
+}

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -23,7 +23,7 @@ const currentFile = isFallback ? filePath.replace(`/${lang}/`, '/en/') : filePat
 const t = useTranslations(Astro);
 const formatTitle = (content) => (content.title ? `${content.title} 🚀 ${t('site.title')}` : t('site.title'));
 const githubEditUrl = content.githubURL && (lang === 'en' || isFallback)
-  ? `${content.githubURL}README.md`
+  ? `${content.githubURL}${content.hasREADME ? 'README.md' : ''}`
   : `https://github.com/withastro/docs/blob/main/${currentFile}`;
 // Ensures the canonicalURL always has an trailing slash.
 const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro.site);

--- a/src/pages/en/guides/integrations-guide/cloudflare.md
+++ b/src/pages/en/guides/integrations-guide/cloudflare.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/cloudflare'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
+hasREADME: true
 category: adapter
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/deno.md
+++ b/src/pages/en/guides/integrations-guide/deno.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/deno'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/deno/'
+hasREADME: true
 category: adapter
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/image.md
+++ b/src/pages/en/guides/integrations-guide/image.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/image'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/image/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/lit.md
+++ b/src/pages/en/guides/integrations-guide/lit.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/lit'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/lit/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/mdx.md
+++ b/src/pages/en/guides/integrations-guide/mdx.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/mdx'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/mdx/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/netlify.md
+++ b/src/pages/en/guides/integrations-guide/netlify.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/netlify'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/netlify/'
+hasREADME: true
 category: adapter
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/node.md
+++ b/src/pages/en/guides/integrations-guide/node.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/node'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/node/'
+hasREADME: true
 category: adapter
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/partytown.md
+++ b/src/pages/en/guides/integrations-guide/partytown.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/partytown'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/partytown/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/preact.md
+++ b/src/pages/en/guides/integrations-guide/preact.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/preact'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/preact/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/prefetch.md
+++ b/src/pages/en/guides/integrations-guide/prefetch.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/prefetch'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/prefetch/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/react.md
+++ b/src/pages/en/guides/integrations-guide/react.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/react'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/react/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/sitemap.md
+++ b/src/pages/en/guides/integrations-guide/sitemap.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/sitemap'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/sitemap/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/solid-js.md
+++ b/src/pages/en/guides/integrations-guide/solid-js.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/solid-js'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/solid/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/svelte.md
+++ b/src/pages/en/guides/integrations-guide/svelte.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/svelte'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/svelte/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/tailwind.md
+++ b/src/pages/en/guides/integrations-guide/tailwind.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/tailwind'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/tailwind/'
+hasREADME: true
 category: other
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/vercel.md
+++ b/src/pages/en/guides/integrations-guide/vercel.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/vercel'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/vercel/'
+hasREADME: true
 category: adapter
 i18nReady: false
 setup : |

--- a/src/pages/en/guides/integrations-guide/vue.md
+++ b/src/pages/en/guides/integrations-guide/vue.md
@@ -8,6 +8,7 @@
 layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/vue'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/vue/'
+hasREADME: true
 category: renderer
 i18nReady: false
 setup : |

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -1,13 +1,18 @@
 ---
 # NOTE: This file is auto-generated from 'scripts/docgen.mjs'
 # Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts 
 
 layout: ~/layouts/MainLayout.astro
 title: Configuration Reference
 i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts
 setup: |
   import Since from '../../../components/Since.astro';
+  import DontEditWarning from '../../../components/DontEditWarning.astro';
 ---
+
+<DontEditWarning />
 
 The following reference covers all supported configuration options in Astro. To learn more about configuring Astro, read our guide on [Configuring Astro](/en/guides/configuring-astro/).
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR changes the configuration reference "edit this page" link to the proper Astro type definitions file instead of the docs generated file that shouldn't be changed. Also, a dev-only warning as added so none of us forget about this:

![image](https://user-images.githubusercontent.com/61414485/185770187-5779ea9c-282f-43b4-abcc-ca4c7d97ee4a.png)

Note: The comments we have in the file don't show up in GitHub's Markdown Preview, so it's easy to don't see them. Now, having the weird `<DontEditWarning/>` we have an extra security/warning layer.

Observations:
- Before, we added `README.md` to pages' "edit this page" link with the custom `githubURL` prop by default. Instead of doing this, I opted for adding the `hasREADME` frontmatter prop so we can opt-in/out of this behavior as we please, we can sure discuss what could be the best approach here.
- I tried a few methods (slots, `<a>` tag directly, Markdown, etc.) to have a link to the correct file inside the aside, but all of these I tried caused errors, so I opted for just saying that you should click the edit this page link instead.
