### PR TITLE
Remove CSS-in-JS reference

### DIFF
--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -101,8 +101,6 @@ import './style.css';
 
 Astro supports importing CSS files directly into your application. Imported styles expose no exports, but importing one will automatically add those styles to the page. This works for all CSS files by default, and can support compile-to-CSS languages like Sass & Less via plugins.
 
-If you prefer not to write CSS, Astro also supports all popular CSS-in-JS libraries (ex: styled-components) for styling.
-
 ## CSS Modules
 
 ```jsx


### PR DESCRIPTION
Astro doesn't support CSS-in-JS for `.astro` files, and it only supports _some_ CSS-in-JS for framework components. This PR removes the mention of CSS-in-JS.

We may also want to outline the extent of its support in framework components, but for now this removes a misleading statement.