### PR TITLE
fix github pages deploy guide

### DIFF
--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -14,6 +14,15 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 Astro maintains the official `withastro/action` to deploy your project with very little configuration. Follow the instructions below to deploy your Astro site to GitHub pages, and see [the package README](https://github.com/withastro/action) if you need more information.
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
+    
+```astro title="astro.config.mjs"
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+  site: 'https://astronaut.github.io'
+  base: '/my-repo'
+})
+```
     - `site` should be `https://<YOUR_USERNAME>.github.io` or `https://my-custom-domain.com`
     - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than the default `/`.
     

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -14,7 +14,7 @@ You can deploy an Astro site to GitHub Pages by using [GitHub Actions](https://g
 Astro maintains the official `withastro/action` to deploy your project with very little configuration. Follow the instructions below to deploy your Astro site to GitHub pages, and see [the package README](https://github.com/withastro/action) if you need more information.
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
-    - `site` should be something like `https://<YOUR_USERNAME>.github.io`
+    - `site` should be `https://<YOUR_USERNAME>.github.io` or `https://my-custom-domain.com`
     - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than the default `/`.
     
     :::note

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -18,7 +18,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
     - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is "/my-repo", rather than default "/".
     
     :::note
-    Don't set the base parameter if:
+    Don't set a `base` parameter if:
 
     - your repository itself is called <YOUR_USERNAME>.github.io
     - you're using a custom domain

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,23 +15,22 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     
-```js title="astro.config.mjs"
-import { defineConfig } from 'astro/config'
+    ```js title="astro.config.mjs"
+    import { defineConfig } from 'astro/config'
 
-export default defineConfig({
-  site: 'https://astronaut.github.io'
-  base: '/my-repo'
-})
-```
+    export default defineConfig({
+      site: 'https://astronaut.github.io'
+      base: '/my-repo'
+    })
+    ```
     - `site` should be `https://<YOUR_USERNAME>.github.io` or `https://my-custom-domain.com`
     - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than the default `/`.
     
     :::note
-    Don't set a `base` parameter if:
+      Don't set a `base` parameter if:
 
     - Your repository is named `<YOUR_USERNAME>.github.io`.
     - You're using a custom domain.
-
     :::
 
     :::caution

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -20,7 +20,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
     :::note
     Don't set a `base` parameter if:
 
-    - your repository itself is called <YOUR_USERNAME>.github.io
+    - your repository itself is named <YOUR_USERNAME>.github.io
     - you're using a custom domain
     :::
 

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -20,13 +20,13 @@ Astro maintains the official `withastro/action` to deploy your project with very
     :::note
     Don't set a `base` parameter if:
 
-    - your repository is named `<YOUR_USERNAME>.github.io`
-    - you're using a custom domain
+    - Your repository is named `<YOUR_USERNAME>.github.io`.
+    - You're using a custom domain.
 
     :::
 
     :::caution
-    If you are setting up `base` only to deploy to GitHub do not forget to update your routes to include your `base`.
+        If you did not previously have a value for `base` set, and are only configuring this value so that you can deploy to GitHub, you must update your internal page links to now include your `base`.
 
     ```astro
     <a href="/my-repo/about">About</a>

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -19,8 +19,8 @@ Astro maintains the official `withastro/action` to deploy your project with very
     import { defineConfig } from 'astro/config'
 
     export default defineConfig({
-      site: 'https://astronaut.github.io'
-      base: '/my-repo'
+      site: 'https://astronaut.github.io',
+      base: '/my-repo',
     })
     ```
     - `site` should be `https://<YOUR_USERNAME>.github.io` or `https://my-custom-domain.com`

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,7 +15,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     
-    ```js title="astro.config.mjs"
+    ```js title="astro.config.mjs" ins={4-5}
     import { defineConfig } from 'astro/config'
 
     export default defineConfig({

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,7 +15,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     
-```astro title="astro.config.mjs"
+```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,10 +15,13 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     - `site` should be something like `https://<YOUR_USERNAME>.github.io`
-    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`.
+    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is "/my-repo", rather than default "/".
     
     :::note
-    If your repository is named `<YOUR_USERNAME>.github.io`, you don’t need to include `base`.
+    Don't set the base parameter if:
+
+    - your repository itself is called <YOUR_USERNAME>.github.io
+    - you're using a custom domain
     :::
 
     :::caution

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -21,9 +21,17 @@ Astro maintains the official `withastro/action` to deploy your project with very
     If your repository is named `<YOUR_USERNAME>.github.io`, you don’t need to include `base`.
     :::
 
+    :::caution
+    If you are setting up `base` only to deploy to GitHub do not forget to update your routes to include your `base`.
+
+    ```astro
+    <a href="/my-repo/about">About</a>
+    ```
+    :::
+
 2. Create a new file in your project at `.github/workflows/deploy.yml` and paste in the YAML below.
 
-    ```yaml
+    ```yaml title="deploy.yml"
     name: Github Pages Astro CI
 
     on:
@@ -65,11 +73,12 @@ Astro maintains the official `withastro/action` to deploy your project with very
     The official Astro [action](https://github.com/withastro/action) scans for a lockfile to detect your preferred package manager (`npm`, `yarn`, or `pnpm`). You should commit your package manager's automatically generated `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml` file to your repository.
     :::
 
-3. Commit the new workflow file and push it to GitHub.  
+3. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.
 
-4. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.  
+4. Choose **GitHub Actions** as the **Source** of your site and press **Save**.  
 
-5. Choose the `gh-pages` branch and the `"/" (root)` folder as the **Source** of your site and press **Save**.  
+5. Commit the new workflow file and push it to GitHub.  
+
   
 Your site should now be published! When you push changes to your Astro project’s repository, the GitHub Action will automatically deploy them for you.
 

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,12 +15,12 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     - `site` should be something like `https://<YOUR_USERNAME>.github.io`
-    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than default `/`.
+    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than the default `/`.
     
     :::note
     Don't set a `base` parameter if:
 
-    - your repository itself is named `<YOUR_USERNAME>.github.io`
+    - your repository is named `<YOUR_USERNAME>.github.io`
     - you're using a custom domain
 
     :::

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -15,13 +15,14 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 1. Set the [`site`](/en/reference/configuration-reference/#site) and, if needed, [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
     - `site` should be something like `https://<YOUR_USERNAME>.github.io`
-    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is "/my-repo", rather than default "/".
+    - `base` should be your repository’s name starting with a forward slash, for example `/my-repo`. This is so that Astro understands your website's root is `/my-repo`, rather than default `/`.
     
     :::note
     Don't set a `base` parameter if:
 
-    - your repository itself is named <YOUR_USERNAME>.github.io
+    - your repository itself is named `<YOUR_USERNAME>.github.io`
     - you're using a custom domain
+
     :::
 
     :::caution


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description [(demo)](https://github.com/kevinzunigacuellar/gh-pages-rep)

- Closes #1355 and #1376
- Reorder steps: Pushing and committing the workflow before setting up pages in the repository throws an [error](https://github.com/kevinzunigacuellar/gh-pages-rep/runs/7964873732?check_suite_focus=true#step:2:27)

  ```shell
  Failed to create deployment (status: 404) with build version 
  fcb3c6ad752990f1ea041c7971c0c3f71ac43117. Ensure GitHub Pages has been enabled.
  ```
- Switch **Source** from branch to Github Actions: deploying from branch uses Jekyll to deploy [(error link)](https://github.com/kevinzunigacuellar/gh-pages-rep/runs/7964905392?check_suite_focus=true)

- Add a caution aside for people that added base only to deploy to GitHub pages to update their routes relative to `base`.

- Added a fancy codeblock title
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
