### PR TITLE
Remove `as Props` from typescript guide

### DIFF
--- a/src/pages/de/core-concepts/astro-components.md
+++ b/src/pages/de/core-concepts/astro-components.md
@@ -211,7 +211,7 @@ export interface Props {
   greeting?: string;
 }
 
-const { greeting = "Hallo", name } = Astro.props as Props;
+const { greeting = "Hallo", name } = Astro.props;
 ---
 <h2>{greeting}, {name}!</h2>
 ```

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -39,6 +39,7 @@ Additionally, our templates include an `env.d.ts` file inside the `src` folder t
 ```typescript title="env.d.ts"
 /// <reference types="astro/client" />
 ```
+
 Optionally, you can delete this file and instead add the [`types` setting](https://www.typescriptlang.org/tsconfig#types) to your `tsconfig.json`:
 
 ```json title="tsconfig.json"
@@ -55,12 +56,13 @@ If your project uses a [UI framework](/en/core-concepts/framework-components/), 
 
 ## Type Imports
 
-Use explicit type imports and exports whenever possible. 
+Use explicit type imports and exports whenever possible.
 
 ```js del={1} ins={2} ins="type"
 import { SomeType } from './script';
 import type { SomeType } from './script';
 ```
+
 This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
 In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error`. Then, TypeScript will check your imports and tell you when  `import type` should be used.
@@ -77,7 +79,6 @@ In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`i
 ## Import Aliases
 
 Astro supports [import aliases](/en/guides/aliases/) that you define in your `tsconfig.json` & `jsconfig.json` `paths` configuration. [Read our guide](/en/guides/aliases/) to learn more.
-
 
 ```astro title="src/pages/about/nate.astro" "@components" "@layouts"
 ---
@@ -102,13 +103,13 @@ import Layout from '@layouts/Layout.astro';
 
 Astro supports typing your component props via TypeScript. To enable, export a TypeScript `Props` interface from your Astro component. The [Astro VSCode Extension](/en/editor-setup/) will automatically look for the `Props` export and give you proper TS support when you use that component inside another template.
 
-```astro title="src/components/HelloProps.astro" ins={2-5} ins="as Props"
+```astro title="src/components/HelloProps.astro" ins={2-5}
 ---
 export interface Props {
   name: string;
   greeting?: string;
 }
-const { greeting = 'Hello', name } = Astro.props as Props;
+const { greeting = 'Hello', name } = Astro.props;
 ---
 <h2>{greeting}, {name}!</h2>
 ```
@@ -148,6 +149,7 @@ declare namespace astroHTML.JSX {
 
 type MyAttributes = astroHTML.JSX.ImgHTMLAttributes;
 ```
+
 :::
 
 ## Type checking

--- a/src/pages/es/core-concepts/astro-components.md
+++ b/src/pages/es/core-concepts/astro-components.md
@@ -15,7 +15,6 @@ Los componentes de Astro son extremadamente flexibles. Un componente de Astro pu
 
 Lo más importante acerca de los componentes de Astro es que **se renderizan a HTML durante la construccion del proyecto**. Aún si posees código JavaScript dentro de tus componentes, este código solo se ejecuta al construir tu projecto, siendo removido de la página final que se enviará al usuario. El resultado es un sitio web más rápido y sin rastros de JavaScript.
 
-
 ## Estructura del componente
 
 Un componente de Astro se compone de dos partes principales: el **script del componente** y el **maquetado del componente**. Cada parte cumple una función diferente, pero juntas proveen un marco de trabajo más fácil de utilizar y lo suficientemente expresivo para manejar cualquier cosa que desees construir.
@@ -40,7 +39,6 @@ import Button from './Button.astro';
 </div>
 ```
 
-
 ### Script del componente
 
 Astro utiliza una valla de código (`---`) para identificar el script del componente Astro. Si has escrito Markdown anteriormente deberías estar familiarizado con un concepto similar llamado *frontmatter*. El script del componente de Astro fue inspirado por este concepto.
@@ -52,7 +50,6 @@ Puedes utilizar el script del componente para escribir cualquier código de Java
 - Importar datos, como un archivo JSON
 - Consultar contenido de una API o base de datos
 - Crear variables que luego puedes referenciar en tu maquetado
-
 
 ```astro title="src/components/MiComponente.astro"
 ---
@@ -162,6 +159,7 @@ const El = 'div'
 ---
 <El>Hola!</El> <!-- <div>Hola!</div> -->
 ```
+
 :::
 
 Astro puede mostrar HTML de forma condicional utilizando operadores lógicos y expresiones ternarias en JSX.
@@ -266,10 +264,9 @@ const name = "Astro"
 <p>I hope you have a wonderful day!</p>
 ```
 
-
 También puedes definir props con TypeScript exportando una interfaz de tipo `Props`. Astro recogerá automáticamente cualquier interfaz `Props` exportada y dará advertencias/errores de tipo para su proyecto. A estos accesorios también se les pueden dar valores predeterminados cuando se desestructuran desde `Astro.props`
 
-```astro ins={3-6} ins="as Props"
+```astro ins={3-6}
 ---
 // src/components/GreetingHeadline.astro
 export interface Props {
@@ -277,7 +274,7 @@ export interface Props {
   saludo?: string;
 }
 
-const { saludo = "Hola", nombre } = Astro.props as Props;
+const { saludo = "Hola", nombre } = Astro.props;
 ---
 <h2>{saludo}, {nombre}!</h2>
 ```
@@ -299,7 +296,7 @@ El elemento `<slot />` es un espacio reservado para contenido HTML externo, perm
 Por defecto, todos los elementos hijos que le sean enviados a un componente serán renderizados en su `<slot />`.
 
 :::note
-Diferente a _props_, que son atributos enviados a un componente Astro y disponibles para utilizar con `Astro.props`, los _slots_ renderizan elementos HTML hijos donde se lo indique.
+Diferente a *props*, que son atributos enviados a un componente Astro y disponibles para utilizar con `Astro.props`, los *slots* renderizan elementos HTML hijos donde se lo indique.
 :::
 
 ```astro "<slot />"
@@ -332,8 +329,6 @@ import Wrapper from '../components/Wrapper.astro';
 ```
 
 Este patrón es la base de la plantilla de página de un componente de Astro: una página entera de contenido HTML puede ser "envuelta" con etiquetas `<Layout></Layout>` y enviadas al componente Layout para ser renderizada dentro de elementos comunes de la página.
-
-
 
 ### Slots con nombre
 
@@ -473,7 +468,7 @@ Ten en cuenta que este enfoque saltea el procesamiento, compresión y optimizaci
 
 ### Utilizando Scripts Hoisted
 
-**Cuándo utilizarlo:** Si tu script externo vive dentro de `src/` _y_ soporta el tipo de módulos ESM.
+**Cuándo utilizarlo:** Si tu script externo vive dentro de `src/` *y* soporta el tipo de módulos ESM.
 
 Astro detecta los módulos JavaScript importados del lado del cliente y luego comprime, optimiza y añade el JS a la página automáticamente.
 
@@ -483,7 +478,6 @@ Astro detecta los módulos JavaScript importados del lado del cliente y luego co
   import './algun-script-externo.js';
 </script>
 ```
-
 
 ## Próximos Pasos
 

--- a/src/pages/ja/core-concepts/astro-components.md
+++ b/src/pages/ja/core-concepts/astro-components.md
@@ -15,11 +15,9 @@ Astroコンポーネントは非常に柔軟です。多くの場合、Astroコ�
 
 Astroコンポーネントについて知っておくべきもっとも重要なことは、**ビルド中にHTMLへ変換される**ことです。コンポーネントの内部でJavaScriptコードを実行しても、すべて事前に実行され、ユーザーに送られる最終ページからは取り除かれます。その結果、デフォルトでは、追加されるJavaScriptの痕跡のない、より高速なサイトが実現します。
 
-
 ## コンポーネント構造
 
 Astroコンポーネントは、**コンポーネントスクリプト**と**コンポーネントテンプレート**という2つの主要な部分で構成されています。それぞれのパーツは異なる仕事を行いますが、この2つを組み合わせることで、使いやすさと、どんなものにも対応できる表現力を兼ね備えたフレームワークを提供することを目指しています。
-
 
 ```astro title="src/components/EmptyComponent.astro"
 ---
@@ -107,7 +105,6 @@ const myFavoritePokemon = [/* ... */];
 <p class:list={["add", "dynamic", {classNames: true}]} />
 ```
 
-
 ## JSXに似た式
 
 Astroコンポーネントのfront-matterコンポーネント・スクリプト内で、ローカルJavaScript変数を定義できます。また、JSXに似た式を使用して、これらの変数をコンポーネントのHTMLテンプレートに挿入できます。
@@ -163,6 +160,7 @@ const El = 'div'
 ---
 <El>こんにちは！</El> <!-- <div>こんにちは！</div> としてレンダリングされます -->
 ```
+
 :::
 
 ### フラグメントと複数要素
@@ -258,7 +256,7 @@ const name = "Astro"
 
 `Props`型のインターフェイスをエクスポートすることで、TypeScriptでpropsを定義できます。Astroはエクスポートされた`Props`インターフェイスを自動的に検出し、プロジェクトに対して型の警告やエラーを出します。propsは、`Astro.props`から再構成する際に、デフォルト値を与えることもできます。
 
-```astro ins={3-6} ins="as Props"
+```astro ins={3-6}
 ---
 // src/components/GreetingHeadline.astro
 export interface Props {
@@ -266,7 +264,7 @@ export interface Props {
   greeting?: string;
 }
 
-const { greeting = "Hello", name } = Astro.props as Props;
+const { greeting = "Hello", name } = Astro.props;
 ---
 <h2>{greeting}, {name}!</h2>
 ```
@@ -457,6 +455,7 @@ CSSの `<style>` タグも、コンポーネントテンプレートの内部で
 // 絶対URLパス
 <script is:inline src="/some-external-script.js"></script>
 ```
+
 ### `src/`に配置されたスクリプトを使用する
 
 **使用するタイミング:** 外部スクリプトが `src/` 内にあり、かつ、ESMモジュールタイプをサポートしている場合。
@@ -469,7 +468,6 @@ Astroは、これらのJavaScriptクライアントサイドインポートを�
   import './some-external-script.js';
 </script>
 ```
-
 
 ## 次のステップ
 

--- a/src/pages/pt-br/guides/typescript.md
+++ b/src/pages/pt-br/guides/typescript.md
@@ -9,10 +9,9 @@ Astro vem com suporte integrado para [TypeScript](https://www.typescriptlang.org
 
 O Astro em si não realiza checagem de tipo. A checagem de tipo deve ser realizada fora do Astro, seja pela sua IDE ou por um script separado. A [extensão para VSCode do Astro](/pt-br/editor-setup/) automaticamente providencia dicas e erros do TypeScript em seus arquivos abertos.
 
-
 ## Configuração
 
-É **altamente recomendado** que você crie um arquivo `tsconfig.json` em seu projeto, para que ferramentas como Astro e o VSCode saibam como entender o seu projeto. Algumas funcionalidades (como importação de pacotes do npm) não são completamente suportadas no TypeScript sem um arquivo `tsconfig.json`. 
+É **altamente recomendado** que você crie um arquivo `tsconfig.json` em seu projeto, para que ferramentas como Astro e o VSCode saibam como entender o seu projeto. Algumas funcionalidades (como importação de pacotes do npm) não são completamente suportadas no TypeScript sem um arquivo `tsconfig.json`.
 
 Algumas opções de configuração do TypeScript precisam de atenção especial no Astro. Abaixo está nosso arquivo `tsconfig.json` inicial recomendado, que você pode copiar e colar em seu próprio projeto. Cada [template em astro.new](https://astro.new/) inclui este arquivo `tsconfig.json` por padrão.
 
@@ -69,7 +68,7 @@ import Layout from '@layouts/Layout.astro';
 
 ## Props de Componentes
 
-Astro suporta a tipagem das props dos seus componentes via TypeScript. Para habilitar, exporte uma interface TypeScript `Props` de seu componente Astro. A [extensão para VSCode do Astro](/pt-br/editor-setup/) irá automaticamente procurar pela exportação de `Props` e te dar suporte a TypeScript quando você utilizar aquele componente dentro de outro template. 
+Astro suporta a tipagem das props dos seus componentes via TypeScript. Para habilitar, exporte uma interface TypeScript `Props` de seu componente Astro. A [extensão para VSCode do Astro](/pt-br/editor-setup/) irá automaticamente procurar pela exportação de `Props` e te dar suporte a TypeScript quando você utilizar aquele componente dentro de outro template.
 
 ```astro
 ---
@@ -78,7 +77,7 @@ export interface Props {
   nome: string;
   saudacao?: string;
 }
-const { saudacao = 'Olá', nome } = Astro.props as Props;
+const { saudacao = 'Olá', nome } = Astro.props;
 ---
 <h2>{saudacao}, {nome}!</h2>
 ```
@@ -117,6 +116,7 @@ declare namespace astroHTML.JSX {
 
 type MeusAtributos = astroHTML.JSX.ImgHTMLAttributes;
 ```
+
 :::
 
 ## Checagem de Tipos

--- a/src/pages/zh-cn/core-concepts/astro-components.md
+++ b/src/pages/zh-cn/core-concepts/astro-components.md
@@ -210,7 +210,7 @@ export interface Props {
   greeting?: string;
 }
 
-const { greeting = "Hello", name } = Astro.props as Props;
+const { greeting = "Hello", name } = Astro.props;
 ---
 <h2>{greeting}, {name}!</h2>
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- Closes #1399 
