### PR TITLE
Add remark rehype options to markdown content docs

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -556,3 +556,50 @@ When using Prism, you'll need to add a stylesheet to your project for syntax hig
 3. Loading this [into your page's `<head>`](/en/core-concepts/astro-pages/#page-html) via a `<link>` tag.
 
 You can also visit the [list of languages supported by Prism](https://prismjs.com/#supported-languages) for options and usage.
+
+### Remark-rehype options and footnotes accessibility
+
+[GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) allows you to author footnotes. For accessibility reasons, this will add an `h2` element with the word "Footnotes", as well as `aria-label`s in the back links that say "Back to content". You might want to translate this to the language of your site. The Markdown is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options), including some to translate this content.
+
+You can use remark-rehype options in your config file like so:
+
+```js
+// astro.config.mjs
+export default {
+  markdown: {
+    remarkRehype: {
+		  footnoteLabel: 'Catatan kaki',
+		  footnoteBackLabel: 'Kembali ke konten',
+		},
+  },
+};
+```
+
+#### CSS
+
+The created `h2` comes with a `sr-only` class. This is a widely accepted way of keeping things accessible while hiding content from visual users. You can add relevant css code to hide this class in your project, for instance:
+
+```css
+.sr-only{
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+```
+
+If you are using tailwind you can add this class in the safelist of your config file, this will ensure it is present in the output stylesheet, even though it does not appear in the files you are authoring:
+
+```js
+//tailwind.config.cjs
+module.exports = {
+//...
+  safelist: ['sr-only'],
+//...
+};
+```

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -557,9 +557,9 @@ When using Prism, you'll need to add a stylesheet to your project for syntax hig
 
 You can also visit the [list of languages supported by Prism](https://prismjs.com/#supported-languages) for options and usage.
 
-### Remark-rehype options and footnotes accessibility
+### Remark-rehype options
 
-[GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) allows you to author footnotes. For accessibility reasons, this will add an `h2` element with the word "Footnotes", as well as `aria-label`s in the back links that say "Back to content". You might want to translate this to the language of your site. The Markdown is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options), including some to translate this content.
+Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
 
 You can use remark-rehype options in your config file like so:
 
@@ -572,34 +572,5 @@ export default {
 		  footnoteBackLabel: 'Kembali ke konten',
 		},
   },
-};
-```
-
-#### CSS
-
-The created `h2` comes with a `sr-only` class. This is a widely accepted way of keeping things accessible while hiding content from visual users. You can add relevant css code to hide this class in your project, for instance:
-
-```css
-.sr-only{
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-```
-
-If you are using tailwind you can add this class in the safelist of your config file, this will ensure it is present in the output stylesheet, even though it does not appear in the files you are authoring:
-
-```js
-//tailwind.config.cjs
-module.exports = {
-//...
-  safelist: ['sr-only'],
-//...
 };
 ```

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -410,6 +410,24 @@ By default, Astro comes with [GitHub-flavored Markdown](https://github.com/remar
     };
     ```
 
+#### Remark-rehype options
+
+Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
+
+You can use remark-rehype options in your config file like so:
+
+```js
+// astro.config.mjs
+export default {
+  markdown: {
+    remarkRehype: {
+		  footnoteLabel: 'Catatan kaki',
+		  footnoteBackLabel: 'Kembali ke konten',
+		},
+  },
+};
+```
+
 ### Injecting frontmatter
 
 You may want to add frontmatter properties to your Markdown files programmatically. By using a [remark or rehype plugin](#markdown-plugins), you can generate these properties based on a file's contents.
@@ -556,21 +574,3 @@ When using Prism, you'll need to add a stylesheet to your project for syntax hig
 3. Loading this [into your page's `<head>`](/en/core-concepts/astro-pages/#page-html) via a `<link>` tag.
 
 You can also visit the [list of languages supported by Prism](https://prismjs.com/#supported-languages) for options and usage.
-
-### Remark-rehype options
-
-Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
-
-You can use remark-rehype options in your config file like so:
-
-```js
-// astro.config.mjs
-export default {
-  markdown: {
-    remarkRehype: {
-		  footnoteLabel: 'Catatan kaki',
-		  footnoteBackLabel: 'Kembali ke konten',
-		},
-  },
-};
-```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- What does this PR change? Give us a brief description.

It looks like https://github.com/withastro/astro/pull/4138 is going to make it in the next minor release, so i'm reopening this PR in order to document the new options!

That Astro PR adds the possibility to use remark rehype options in the Astro config, for instance if a user wants to translate automatically generated elements related to the footnotes. This Astro docs PR adds the relevant docs.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
