### PR TITLE
New `remark` and `rehype` plugin explainer with `extends`

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -366,54 +366,29 @@ The instructions below are for configuring standard Markdown. To configure MDX p
 
 ### Markdown Plugins
 
-Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for some full curated lists!
+Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins!
 
-You can apply these plugins in your Astro config:
+This example applies the [remark-toc](https://github.com/remarkjs/remark-toc) and [rehype-minify](https://github.com/rehypejs/rehype-minify) plugins. See each project's README for installation instructions.
 
-<Tabs client:visible>
-<Fragment slot="tab.1.withDefaults">With defaults</Fragment>
-<Fragment slot="tab.2.withoutDefaults">Without defaults</Fragment>
-<Fragment slot="panel.1.withDefaults">
+:::tip
+We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text and formatting quotes for readability. When adding your own plugins, you can preserve these defaults with the `extendDefaultPlugins` flag.
+:::
 
-We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) remark plugins by default. This brings some niceties like auto-generating clickable links from text (ex. `https://example.com`) and formatting quotes for readability. To apply your own plugins while preserving these defaults, use a nested `extends` object like so:
-
-```js title="astro.config.mjs" ins={2,3,8,11}
+```js title="astro.config.mjs" ins={2,3,7,8,11}
 import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
 import rehypeMinifyHtml from 'rehype-minify';
 
 export default defineConfig({
   markdown: {
-    // Preserve our default remark plugins
-    remarkPlugins: { extends: [remarkToc] },
-    // We do not provide rehype plugins by default,
-    // so you are free to include or ignore "extends" here
-    rehypePlugins: [rehypeMinifyHtml],
-  },
-}
-```
-
-</Fragment>
-<Fragment slot="panel.2.withoutDefaults">
-
-To apply plugins *without* Astro's defaults, you can apply a plain array:
-
-```js title="astro.config.mjs" ins={2,3,8,9}
-import { defineConfig } from 'astro/config';
-import remarkToc from 'remark-toc';
-import rehypeMinifyHtml from 'rehype-minify';
-
-export default defineConfig({
-  markdown: {
-    // Remove our default remark plugins
     remarkPlugins: [remarkToc],
     rehypePlugins: [rehypeMinifyHtml],
+    // Preserve Astro's default plugins: GitHub-flavored Markdown and Smartypants
+    // default: false
+    extendDefaultPlugins: true,
   },
 }
 ```
-
-</Fragment>
-</Tabs>
 
 ### Injecting frontmatter
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -432,44 +432,6 @@ export default defineConfig({
 }
 ```
 
-#### How to add a Markdown plugin in Astro
-
-1. Install the npm package dependency in your project.
-
-2. Update `remarkPlugins` or `rehypePlugins` inside the `markdown` options:
-
-    ```js
-    // astro.config.mjs
-    export default {
-      markdown: {
-        remarkPlugins: [
-          // Add a Remark plugin that you want to enable for your project.
-          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
-          // ['remark-autolink-headings', { behavior: 'prepend'}],
-        ],
-        rehypePlugins: [
-          // Add a Rehype plugin that you want to enable for your project.
-          // If you need to provide options for the plugin, you can use an array and put the options as the second item.
-          // 'rehype-slug',
-          // ['rehype-autolink-headings', { behavior: 'prepend'}],
-        ],
-      },
-    };
-    ```
-
-    You can provide names of the plugins as well as import them:
-
-    ```js ins={2,6}
-    // astro.config.mjs
-    import autolinkHeadings from 'remark-autolink-headings';
-
-    export default {
-      markdown: {
-        remarkPlugins: [[autolinkHeadings, { behavior: 'prepend' }]],
-      },
-    };
-    ```
-
 ### Injecting frontmatter
 
 You may want to add frontmatter properties to your Markdown files programmatically. By using a [remark or rehype plugin](#markdown-plugins), you can generate these properties based on a file's contents.

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -1,4 +1,6 @@
 ---
+setup: |
+  import Tabs from '../../../components/tabs/Tabs';
 layout: ~/layouts/MainLayout.astro
 title: Markdown & MDX
 description: Learn how to create content using Markdown or MDX with Astro
@@ -366,11 +368,69 @@ The instructions below are for configuring standard Markdown. To configure MDX p
 
 Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. You can provide your plugins in `astro.config.mjs`.
 
-:::note
-Enabling custom `remarkPlugins` or `rehypePlugins` will remove these built-in plugins and you need to explicitly add these plugins if desired.
+#### remarkPlugins
 
-By default, Astro comes with [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [remark-smartypants](https://github.com/silvenon/remark-smartypants) pre-enabled.
-:::
+**Default plugins:** [remark-gfm](https://github.com/remarkjs/remark-gfm), [remark-smartypants](https://github.com/silvenon/remark-smartypants)
+
+[Remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) allow you to extend your Markdown with new capabilities. This includes [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list.
+
+We apply [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) by default. This brings some niceties like auto-generating clickable links from text (ex. `https://example.com`) and formatting quotes for readability. When applying your own plugins, you can choose to preserve or remove these defaults.
+
+<Tabs client:visible>
+<Fragment slot="tab.1.withDefaults">With defaults</Fragment>
+<Fragment slot="tab.2.withoutDefaults">Without defaults</Fragment>
+<Fragment slot="panel.1.withDefaults">
+
+To apply plugins while preserving Astro's default plugins, use a nested `extends` object like so:
+
+```js title="astro.config.mjs" ins={2,6}
+import { defineConfig } from 'astro/config';
+import remarkToc from 'remark-toc';
+
+export default defineConfig({
+  markdown: {
+    remarkPlugins: { extends: [remarkToc] },
+  },
+}
+```
+
+</Fragment>
+<Fragment slot="panel.2.withoutDefaults">
+
+To apply plugins *without* Astro's defaults, you can apply a plain array:
+
+```js title="astro.config.mjs" ins={2,6}
+import { defineConfig } from 'astro/config';
+import remarkToc from 'remark-toc';
+
+export default defineConfig({
+  markdown: {
+    remarkPlugins: [remarkToc],
+  },
+}
+```
+
+</Fragment>
+</Tabs>
+
+#### rehypePlugins
+
+[Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) allow you to transform the HTML that your Markdown generates. We encourage you to browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a curated list.
+
+We apply our own (non-overridable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
+
+To apply additional rehype plugins, pass an array to the `rehypePlugins` option like so:
+
+```js title="astro.config.mjs" ins={2,6}
+import { defineConfig } from 'astro/config';
+import rehypeMinifyHtml from 'rehype-minify';
+
+export default defineConfig({
+  markdown: {
+    rehypePlugins: [rehypeMinifyHtml],
+  },
+}
+```
 
 #### How to add a Markdown plugin in Astro
 

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -371,7 +371,7 @@ Astro supports third-party [remark](https://github.com/remarkjs/remark) and [reh
 This example applies the [remark-toc](https://github.com/remarkjs/remark-toc) and [rehype-minify](https://github.com/rehypejs/rehype-minify) plugins. See each project's README for installation instructions.
 
 :::tip
-We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text and formatting quotes for readability. When adding your own plugins, you can preserve these defaults with the `extendDefaultPlugins` flag.
+Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text and formatting quotes for readability. When adding your own plugins, you can preserve these defaults with the `extendDefaultPlugins` flag.
 :::
 
 ```js title="astro.config.mjs" ins={2,3,7,8,11}

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -87,9 +87,11 @@ Markdown and MDX files do not return identical `Astro.props` objects. See the MD
 
 A Markdown layout will have access to the following information via `Astro.props`:
 
+- **`file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
+- **`url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - all frontmatter from the Markdown or MDX document.
-  - **`frontmatter.file`** - The absolute path of this file (e.g. `/home/user/projects/.../file.md`).
-  - **`frontmatter.url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
+  - **`frontmatter.file`** - The same as the top-level `file` property.
+  - **`frontmatter.url`** - The same as the top-level `url` property.
 - **`headings`** - A list of headings (`h1 -> h6`) in the Markdown document with associated metadata. This list follows the type: `{ depth: number; slug: string; text: string }[]`.
 - **`rawContent()`** - A function that returns the raw Markdown document as a string.
 - **`compiledContent()`** - A function that returns the Markdown document compiled to an HTML string.
@@ -98,6 +100,8 @@ An example blog post may pass the following `Astro.props` object to its layout:
 
 ```js
 Astro.props = {
+  file: "/home/user/projects/.../file.md",
+  url: "/en/guides/markdown-content/",
   frontmatter: {
     /** Frontmatter from a blog post */
     title: "Astro 0.18 Release",

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -366,30 +366,29 @@ The instructions below are for configuring standard Markdown. To configure MDX p
 
 ### Markdown Plugins
 
-Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. You can provide your plugins in `astro.config.mjs`.
+Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for some full curated lists!
 
-#### remarkPlugins
-
-**Default plugins:** [remark-gfm](https://github.com/remarkjs/remark-gfm), [remark-smartypants](https://github.com/silvenon/remark-smartypants)
-
-[Remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) allow you to extend your Markdown with new capabilities. This includes [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list.
-
-We apply [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) by default. This brings some niceties like auto-generating clickable links from text (ex. `https://example.com`) and formatting quotes for readability. When applying your own plugins, you can choose to preserve or remove these defaults.
+You can apply these plugins in your Astro config:
 
 <Tabs client:visible>
 <Fragment slot="tab.1.withDefaults">With defaults</Fragment>
 <Fragment slot="tab.2.withoutDefaults">Without defaults</Fragment>
 <Fragment slot="panel.1.withDefaults">
 
-To apply plugins while preserving Astro's default plugins, use a nested `extends` object like so:
+We apply the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) remark plugins by default. This brings some niceties like auto-generating clickable links from text (ex. `https://example.com`) and formatting quotes for readability. To apply your own plugins while preserving these defaults, use a nested `extends` object like so:
 
-```js title="astro.config.mjs" ins={2,6}
+```js title="astro.config.mjs" ins={2,3,8,11}
 import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
+import rehypeMinifyHtml from 'rehype-minify';
 
 export default defineConfig({
   markdown: {
+    // Preserve our default remark plugins
     remarkPlugins: { extends: [remarkToc] },
+    // We do not provide rehype plugins by default,
+    // so you are free to include or ignore "extends" here
+    rehypePlugins: [rehypeMinifyHtml],
   },
 }
 ```
@@ -399,38 +398,22 @@ export default defineConfig({
 
 To apply plugins *without* Astro's defaults, you can apply a plain array:
 
-```js title="astro.config.mjs" ins={2,6}
+```js title="astro.config.mjs" ins={2,3,8,9}
 import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
+import rehypeMinifyHtml from 'rehype-minify';
 
 export default defineConfig({
   markdown: {
+    // Remove our default remark plugins
     remarkPlugins: [remarkToc],
+    rehypePlugins: [rehypeMinifyHtml],
   },
 }
 ```
 
 </Fragment>
 </Tabs>
-
-#### rehypePlugins
-
-[Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) allow you to transform the HTML that your Markdown generates. We encourage you to browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a curated list.
-
-We apply our own (non-overridable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
-
-To apply additional rehype plugins, pass an array to the `rehypePlugins` option like so:
-
-```js title="astro.config.mjs" ins={2,6}
-import { defineConfig } from 'astro/config';
-import rehypeMinifyHtml from 'rehype-minify';
-
-export default defineConfig({
-  markdown: {
-    rehypePlugins: [rehypeMinifyHtml],
-  },
-}
-```
 
 ### Injecting frontmatter
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

We have a new way to preserver Astro's default remark plugins when you apply your own: `extends`! https://github.com/withastro/astro/pull/4474.

This PR addresses a couple concerns:
- Add short explainers on remark and rehype based on [the MDX docs](https://docs.astro.build/en/guides/integrations-guide/mdx/#remarkplugins). New markdown users _probably_ don't know what these plugins can do or where to find a list of popular options (I definitely didn't a month ago). This should make plugins easier to understand.
- Move tip on Astro's defaults to in-line explainer
- Replace `remark-autolink-headings` example with `remark-toc`. Autolink headings is the one plugin we _shouldn't_ recommend, since it conflicts with Astro's own heading ID plugin 😅 
- Add new code examples with and without `extends`

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
