### PR TITLE
Change AlpineJS category from `other` to `renderer`

### DIFF
--- a/src/pages/en/guides/integrations-guide/alpinejs.md
+++ b/src/pages/en/guides/integrations-guide/alpinejs.md
@@ -9,7 +9,7 @@ layout: ~/layouts/IntegrationLayout.astro
 title: '@astrojs/alpinejs'
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/'
 hasREADME: true
-category: other
+category: renderer
 i18nReady: false
 setup : |
   import Video from '~/components/Video.astro'


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Chnaged AlpineJS integration category from "other" to "render", which should by result move `AlpineJS` in the https://docs.astro.build/en/guides/integrations-guide from the `Others` section to `UI Frameworks`

Before: 
![image](https://user-images.githubusercontent.com/9967336/186946825-c8775e91-f832-4fc0-accc-4af46028803e.png)

After:
![image](https://user-images.githubusercontent.com/9967336/186947295-f7273947-fd18-4e98-947e-75ef956f9908.png)

