### PR TITLE
i18n(es): astro-components update

### DIFF
--- a/src/pages/es/core-concepts/astro-components.md
+++ b/src/pages/es/core-concepts/astro-components.md
@@ -111,6 +111,12 @@ const misPokemonesFavoritos = [/* ... */];
 
 Puedes definir variables locales de JavaScript dentro del script del componente de Astro. ¡Luego puedes inyectar estas variables en el maquetado del componente usando expresiones similares a JSX!
 
+:::note[dinámico vs reactivo]
+Usando este enfoque, puedes incluir valores ***dinámicos*** que son calculados en el *frontmatter*. Sin embargo, una vez incluidos, estos valores no son ***reactivos*** por lo que nunca cambiarán. Los componentes Astro son maquetados que solo son ejecutados una vez, en la construcción de la página.
+
+Lee abajo para más ejemplos sobre las [diferencias entre Astro y JSX](/es/comparing-astro-vs-other-tools/#astro-vs-jsx)
+:::
+
 ### Variables
 
 Las variables locales pueden ser agregadas al maquetado usando la sintaxis de llaves:

--- a/src/pages/es/core-concepts/astro-components.md
+++ b/src/pages/es/core-concepts/astro-components.md
@@ -101,7 +101,7 @@ const misPokemonesFavoritos = [/* ... */];
 <!-- Puedes mezclar HTML con expresiones de JavaScript, similar a JSX: -->
 <ul>
   {misPokemonesFavoritos.map((data) => <li>{data.name}</li>)}
-<ul>
+</ul>
 
 <!-- ¡Use una directiva de maquetado para crear nombres de clase a partir de múltiples strings o incluso objetos! -->
 <p class:list={["agregar", "dinámico", {classNames: true}]} />


### PR DESCRIPTION
added note on dynamic vs reactive values

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- Translated content

#### Description

- Update Astro Components (JSX-like Expressions section) with a note on dynamic vs reactive values

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
