### PR TITLE
Add warning about SSR features inside layouts

### DIFF
--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,6 +47,10 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
+:::warning
+The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
+:::
+
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,10 +47,6 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::caution
-The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
-:::
-
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.
@@ -64,6 +60,12 @@ const cookie = Astro.request.headers.get('cookie');
   <!-- Page here... -->
 </html>
 ```
+
+:::caution
+The features below are only available at the page level. (You can't use them inside of components, including layout components.)
+
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+:::
 
 ### `Astro.redirect`
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as it renders them. This makes sure the user sees your HTML as fast as possible, but it also means that by the time Astro runs your component code, it has already sent the Response headers.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,7 +47,7 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::warning
+:::caution
 The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
 :::
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Recently discovered that layouts and components can't use SSR features. This wasn't previously mentioned in the docs, so I'm adding a little warning for this.

Matthew's comment on the subject ("Is not being able to use SSR features on layouts expected behavior?"): 
> It's because of streaming. You can only send headers / status code once and by the time we render a layout the headers are already sent. so it is intentional, but unfortunate.

NOTE: I tested all three features listed below and all of them didn't seem to work. I did expect that `Astro.request.headers.get` or `Astro.redirect` would work, but that doesn't seem to be the case. I appreciate someone double-checking this so we are sure I haven't made a mistake here.
