### PR TITLE
Fix typo `about about ` -> `about `

### DIFF
--- a/src/pages/en/core-concepts/framework-components.md
+++ b/src/pages/en/core-concepts/framework-components.md
@@ -223,7 +223,7 @@ import MyAstroComponent from '../components/MyAstroComponent.astro';
 
 [Astro components](/en/core-concepts/astro-components/) are HTML-only templating components with no client-side runtime. But, you can use a `<script>` tag in your Astro component template to send JavaScript to the browser that executes in the global scope.
 
-📚 Learn more about about [client-side `<script>` tags in Astro components](/en/core-concepts/astro-components/#client-side-scripts)
+📚 Learn more about [client-side `<script>` tags in Astro components](/en/core-concepts/astro-components/#client-side-scripts)
 
 [mdn-io]: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
 [mdn-ric]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

I fixed a typo. `about about ` -> `about ` in the page `https://docs.astro.build/en/core-concepts/framework-components/`. Before and after images below.

<img width="705" alt="Screenshot 2022-08-30 at 11 09 40 AM" src="https://user-images.githubusercontent.com/29162020/187358440-3b1955b3-df6d-4e29-b1b4-a9fdae00a315.png">
<img width="608" alt="Screenshot 2022-08-30 at 11 10 59 AM" src="https://user-images.githubusercontent.com/29162020/187358456-bf00bbac-b71a-46d7-9279-f23f716e0d25.png">
