### PR TITLE
Modifying `<head>`: clarity and placement in the docs

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -232,10 +232,6 @@ In Astro, you use the standard `kebab-case` format for all HTML attributes inste
 <div class="box" data-value="3" />
 ```
 
-#### Modifying `<head>`
-
-In JSX, you may see special libraries used to help you manage a page’s `<head>` tag. This is not necessary in Astro. Write `<head>` and its contents in your top-level layout.
-
 #### Comments
 
 In Astro, you can use standard HTML comments where JSX would use JavaScript style comments.

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -50,6 +50,11 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 📚 Read more about [layout components](/en/core-concepts/layouts/) in Astro.
 
+#### Modifying `<head>`
+
+Note that using a `<head>` tag works like any other HTML tag: it does not get moved to the top of the page. We recommend writing `<head>` and its contents in your top-level layout.
+
+
 
 ## Markdown Pages
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,6 +47,10 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
+:::warning
+The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
+:::
+
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,6 +47,10 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
+:::caution
+The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
+:::
+
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.
@@ -60,12 +64,6 @@ const cookie = Astro.request.headers.get('cookie');
   <!-- Page here... -->
 </html>
 ```
-
-:::caution
-The features below are only available at the page level. (You can't use them inside of components, including layout components.)
-
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
-:::
 
 ### `Astro.redirect`
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,10 +47,6 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::caution
-The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
-:::
-
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.
@@ -64,6 +60,12 @@ const cookie = Astro.request.headers.get('cookie');
   <!-- Page here... -->
 </html>
 ```
+
+:::caution
+The features below are only available at the page level. (You can't use them inside of components, including layout components.)
+
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can only be set once. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+:::
 
 ### `Astro.redirect`
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -64,7 +64,7 @@ const cookie = Astro.request.headers.get('cookie');
 :::caution
 The features below are only available at the page level. (You can't use them inside of components, including layout components.)
 
-This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers.
+This is because these features modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), which can't be modified after they're sent to the browser. In SSR mode, Astro uses HTML streaming to send each component to the browser as soon as it renders them. This makes sure the user sees your HTML as fast as possible, but it means that by the time Astro runs your component code, it has already sent the Response headers to the browser.
 :::
 
 ### `Astro.redirect`

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,7 +47,7 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::caution
+:::warning
 The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
 :::
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,7 +47,7 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::warning
+:::caution
 The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
 :::
 

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -47,10 +47,6 @@ You can find instructions at the individual adapter links above to complete the 
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory becomes a server-rendered route** and a few new features become available to you.
 
-:::warning
-The features below are not available inside layouts nor components. Because of streaming, things like headers and status codes can only be sent once, and by the time a layout or component is rendered, this had already happened.
-:::
-
 ### `Astro.request.headers`
 
 The headers for the request are available on `Astro.request.headers`. It is a [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, a Map-like object where you can retrieve headers such as the cookie.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### TL;DR

- Moves the _Modifying `<head>`_ section into the Layouts section of `/core-concepts/astro-pages`
- Clarifies that there is no special handling of the `<head>` tag

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- New or updated content

#### Description

This addresses #1378.

The behavior of the `<head>` tag has little to do with the difference between JSX and Astro components. It does have to do with certain libraries within the React ecosystem, but that is not due to the JSX syntax. Documenting `<head>` makes more sense in the Layouts section of `Astro Pages`, because we recommend using the tag in a Layout, so I moved it there. (I could also see moving this to its own section within `Astro Pages`).

The section itself was unclear, as #1378 describes. Astro does not have any special handling of `<head>`, and I updated the wording to make that more clear.
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
