### PR TITLE
Recommend using `dependencies` over `devDependencies` in package.json

### DIFF
--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -101,6 +101,8 @@ As a general rule, any CSS or JavaScript that you write yourself should live in 
 
 This is a file used by JavaScript package managers to manage your dependencies. It also defines the scripts that are commonly used to run Astro (ex: `npm start`, `npm run build`).
 
+There are two kinds of dependencies you can specify in a `package.json`: `dependencies` and `devDependencies` ([see the NPM docs](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file)). In most cases, these work the same: Astro needs all dependencies at build time, and your package manager will install both. We recommend putting all of your dependencies in `dependencies` to start.
+
 For help creating a new `package.json` file for your project, check out the [manual setup](/en/install/manual/) instructions.
 
 ### `astro.config.mjs`

--- a/src/pages/en/core-concepts/project-structure.md
+++ b/src/pages/en/core-concepts/project-structure.md
@@ -101,7 +101,7 @@ As a general rule, any CSS or JavaScript that you write yourself should live in 
 
 This is a file used by JavaScript package managers to manage your dependencies. It also defines the scripts that are commonly used to run Astro (ex: `npm start`, `npm run build`).
 
-There are two kinds of dependencies you can specify in a `package.json`: `dependencies` and `devDependencies` ([see the NPM docs](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file)). In most cases, these work the same: Astro needs all dependencies at build time, and your package manager will install both. We recommend putting all of your dependencies in `dependencies` to start.
+There are [two kinds of dependencies](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) you can specify in a `package.json`: `dependencies` and `devDependencies`. In most cases, these work the same: Astro needs all dependencies at build time, and your package manager will install both. We recommend putting all of your dependencies in `dependencies` to start, and only use `devDependencies` if you find a specific need to do so.
 
 For help creating a new `package.json` file for your project, check out the [manual setup](/en/install/manual/) instructions.
 


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #1435 
- Explains that there are two options for specifying dependencies, and recommends `dependencies` as per #4544
- Note that our [package publishing docs](https://docs.astro.build/en/guides/publish-to-npm/) may have different advice. That page needs a complete overhaul, so I'm leaving it for now.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
