### PR TITLE
minor: Fix heading levels on docs homepage

### DIFF
--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -9,11 +9,11 @@ description: A basic intro to Astro.
 i18nReady: true
 ---
 
-#### What is Astro?
+<h2>What is Astro?</h2>
 
 Astro is an **all-in-one** **web framework** for building **fast,** **content-focused** websites. 
 
-#### Key Features
+## Key Features
 
 - **Component Islands:** A new web architecture for building faster websites.
 - **Server-first API design:** Move expensive hydration off of your users' devices.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

a11y guidelines state that heading levels should increment by one level at a time (e.g. `<h4>` must be preceded by an `<h3>`) We were using `<h4>` for the first two headings on the docs homepage, which violates that rule. I suspect this was to keep these headings out of the sidebar or for stylistic reasons (smaller font size).

I’ve switched back to `<h2>` to fix this a11y issue (it impacts Lighthouse scores amongst other things), and used a literal `<h2>` tag for the first mini section to avoid that showing up in the table of contents.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
