### PR TITLE
i18n(ja): Update Japanese `nav.ts`

### DIFF
--- a/src/i18n/ja/nav.ts
+++ b/src/i18n/ja/nav.ts
@@ -6,38 +6,43 @@ export default NavDictionary({
 	install: 'インストール',
 	'editor-setup': "エディタのセットアップ",
 	migrate: 'アップグレードガイド',
-	'integrations/integrations': 'Astroで構築',
-	'comparing-astro-vs-other-tools': 'Astro vs. X',
 
 	// Core Concepts
 	coreConcepts: 'コアコンセプト',
 	'concepts/why-astro': 'Astroを選ぶ理由',
+	'concepts/mpa-vs-spa': 'MPA vs. SPA',
 	'concepts/islands': 'Astroアイランド',
 
 	// Basics
 	basics: '基本',
 	'core-concepts/project-structure': 'ディレクトリ構成',
-	'core-concepts/astro-components': 'コンポーネント',
+	'core-concepts/astro-components': 'Astroコンポーネント',
 	'core-concepts/astro-pages': 'ページ',
 	'core-concepts/layouts': 'レイアウト',
 	'guides/markdown-content': 'Markdown',
+	'core-concepts/routing': 'ルーティング',
 	'guides/imports': '静的アセット',
-	'guides/troubleshooting': 'トラブルシューティング',
-
-	// Features
-	features: '特徴',
-	'guides/configuring-astro': 'Astroの設定',
-	'guides/styling': 'CSSとスタイル',
-	'guides/fonts': 'フォント',
 	'guides/data-fetching': 'データフェッチ',
 	'guides/deploy': 'デプロイ',
-	'guides/environment-variables': "環境変数",
-	'guides/aliases': "importエイリアス",
+	'guides/troubleshooting': 'トラブルシューティング',
+
+	// Guides
+	features: 'ガイド',
 	'guides/integrations-guide': 'インテグレーション',
-	'guides/rss': 'RSS',
-	'guides/server-side-rendering': 'サーバーサイドレンダリング（SSR）',
-	'guides/typescript': 'TypeScript',
 	'core-concepts/framework-components': 'UIフレームワーク',
+	'guides/server-side-rendering': 'サーバーサイドレンダリング（SSR）',
+	'guides/styling': 'CSSとスタイル',
+	'guides/images': '画像',
+	'guides/fonts': 'フォント',
+	'core-concepts/sharing-state': '状態の共有',
+	'guides/rss': 'RSS',
+
+	// Configuration
+	configuration: '設定',
+	'guides/configuring-astro': 'Astroコンフィグファイル',
+	'guides/typescript': 'TypeScript',
+	'guides/aliases': "importエイリアス",
+	'guides/environment-variables': "環境変数",
 
 	// Reference
 	reference: 'リファレンス',
@@ -46,7 +51,6 @@ export default NavDictionary({
 	'reference/api-reference': 'ランタイムAPI',
 	'reference/integrations-reference': 'インテグレーションAPI',
 	'reference/adapter-reference': 'アダプターAPI',
-	'core-concepts/routing': 'ルーティングルール',
 	'reference/directives-reference': 'テンプレートディレクティブ',
 	'guides/publish-to-npm': 'npmへの公開',
 });


### PR DESCRIPTION

#### What kind of changes does this PR include?

- Translated content

#### Description

- Japanese navigation has been updated to match the English navigation.
- https://github.com/withastro/docs/pull/1440