### PR TITLE
Apply PackageManagerTabs to older pages

### DIFF
--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -4,6 +4,7 @@ title: Using Integrations
 i18nReady: true
 setup: |
   import IntegrationsNav from '~/components/IntegrationsNav.astro';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 ---
 
 **Astro Integrations** add new functionality and behaviors for your project with only a few lines of code. You can write a custom integration yourself, use an official integration, or use integrations built by the community.
@@ -29,25 +30,43 @@ We will always ask for confirmation before updating any of your files, but it ne
 
 Run `astro add [integration-name]` and our automatic integration wizard will update your configuration file and install any necessary dependencies.
 
-```shell
-# Using NPM
-npx astro add react
-# Using Yarn
-yarn astro add react
-# Using PNPM
-pnpx astro add react
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add react
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpx astro add react
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add react
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 It's even possible to configure multiple integrations at the same time!
 
-```shell
-# Using NPM
-npx astro add react tailwind partytown
-# Using Yarn
-yarn astro add react tailwind partytown
-# Using PNPM
-pnpx astro add react tailwind partytown
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add react tailwind partytown
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpx astro add react tailwind partytown
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add react tailwind partytown
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 :::note[Handling Integration Dependencies]
 If you see any warnings like `Cannot find package '[package-name]'` after adding an integration, your package manager may not have installed [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) for you. To install these missing packages, run `npm install [package-name]`.

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -3,6 +3,7 @@ layout: ~/layouts/MainLayout.astro
 title: RSS
 description: An intro to RSS in Astro
 i18nReady: true
+setup: import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 ---
 
 Astro supports fast, automatic RSS feed generation for blogs and other content websites. For more information about RSS feeds in general, see [aboutfeeds.com](https://aboutfeeds.com/).
@@ -13,14 +14,23 @@ The `@astrojs/rss` package provides helpers for generating RSS feeds using [API 
 
 First, install `@astrojs/rss` using your preferred package manager:
 
-```bash
-# npm
-npm i @astrojs/rss
-# yarn
-yarn add @astrojs/rss
-# pnpm
-pnpm i @astrojs/rss
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm i @astrojs/rss
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm i @astrojs/rss
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn add @astrojs/rss
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links in your RSS feed [via the `SITE` environment variable](/en/guides/environment-variables/#default-environment-variables).
 

--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -2,7 +2,9 @@
 title: Install Astro with the Automatic CLI
 description: How to install Astro with NPM, PNPM, or Yarn via the create-astro CLI tool.
 layout: ~/layouts/MainLayout.astro
-setup: import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+setup: | 
+  import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
 Ready to install Astro? Follow our automatic or manual set-up guide to get started.
@@ -26,16 +28,27 @@ Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to br
 
 Run the following command in your terminal to start our handy install wizard, `create-astro`.
 
-```shell
-# npm
-npm create astro@latest
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  # create a new project with npm
+  npm create astro@latest
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  # create a new project with pnpm
+  pnpm create astro@latest
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  # create a new project with yarn
+  yarn create astro
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-# yarn
-yarn create astro
-
-# pnpm
-pnpm create astro@latest
-```
 
 The `create-astro` wizard will walk you through every step of setting up your new Astro project. You can run it anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
 
@@ -49,16 +62,26 @@ Astro comes with a built-in development server that has everything you need for 
 
 Every starter template comes with a pre-configured script that will run `astro dev` for you. Use your favorite package manager to run this command and start the Astro development server.
 
-```bash
-# npm
-npm run dev
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm run dev
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  # create a new project with pnpm
+  pnpm run dev
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  # create a new project with yarn
+  yarn run dev
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-# yarn
-yarn run dev
-
-# pnpm
-pnpm run dev
-```
 
 If all goes well, Astro should now be serving your project on [http://localhost:3000/](http://localhost:3000/)!
 

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -2,7 +2,9 @@
 title: Install Astro manually
 description: How to install Astro manually with NPM, PNPM, or Yarn.
 layout: ~/layouts/MainLayout.astro
-setup: import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+setup: |
+  import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
 Ready to install Astro? Follow our automatic or manual set-up guide to get started.
@@ -30,18 +32,47 @@ cd my-astro-project
 
 Once you are in your new directory, create your project `package.json` file. This is how you will manage your project dependencies, including Astro. If you aren't familiar with this file format, run the following command to create one.
 
-```bash
-npm init --yes
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm init --yes
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm init 
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn init --yes
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
 
 
 ## 2. Install Astro
 
 First, install the Astro project dependencies inside your project.
 
-```bash
-npm install astro
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm install astro
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm install astro 
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn add astro
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 Then, replace any placeholder "scripts" section of your `package.json` with the following:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

There are a few pages that haven't switched to use the `PackageManagerTabs` component. This PR updates them to do so.
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
