### PR TITLE
i18n(es): Update astro components and astro pages

### DIFF
--- a/src/pages/es/core-concepts/astro-components.md
+++ b/src/pages/es/core-concepts/astro-components.md
@@ -158,18 +158,6 @@ const items = ["Perro", "Gato", "Mono"];
 </ul>
 ```
 
-:::tip
-También puedes establecer etiquetas dinámicamente:
-
-```astro "El"
----
-// src/pages/index.astro
-const El = 'div'
----
-<El>Hola!</El> <!-- <div>Hola!</div> -->
-```
-:::
-
 Astro puede mostrar HTML de forma condicional utilizando operadores lógicos y expresiones ternarias en JSX.
 
 ```astro title="src/components/ConditionalHtml.astro" "visible"
@@ -180,6 +168,24 @@ const visible = true;
 
 {visible ? <p>¡Muéstrame!</p> : <p>¡O muéstrame a mi!</p>}
 ```
+
+### Etiquetas dinámicas
+
+También puedes usar etiquetas dinámicas para asignar a una variable el nombre de una etiqueta HTML o un componente importado.
+
+```astro title="src/components/DynamicTags.astro" /Element|(?<!My)Component/
+---
+import MyComponent from "./MyComponent.astro";
+const Element = 'div'
+const Component = MyComponent;
+---
+<Element>Hola!</Element> <!-- es renderizado como <div>Hola!</div> -->
+<Component /> <!-- es renderizado como <MyComponent /> -->
+```
+
+:::note
+Los nombres de las variables deben estar en mayúscula (`Element`, no `element`), para que esto funcione. De otra manera, Astro intentará renderizar el nombre de tu variable como una etiqueta literal de HTML.
+:::
 
 ### Fragmentos & elementos múltiples
 
@@ -231,10 +237,6 @@ En Astro, utiliza el formato estándar `kebab-case` para todos los atributos HTM
 <div className="box" dataValue="3" />
 <div class="box" data-value="3" />
 ```
-
-#### Modificando `<head>`
-
-En JSX, existen librerias especiales para ayudarte a administrar la etiquetas `<head>` de la página. Esto no es necesario en Astro. Escribe `<head>` y su contenido en un layout de nivel superior.
 
 #### Comentarios
 

--- a/src/pages/es/core-concepts/astro-pages.md
+++ b/src/pages/es/core-concepts/astro-pages.md
@@ -49,6 +49,9 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 📚 Lee más sobre [componentes plantilla](/es/core-concepts/layouts/) en Astro.
 
+#### Modificando `<head>` 
+
+Ten en cuenta que usar una etiqueta `<head>` funciona como cualquier otra etiqueta de HTML: no es movida al inicio de la página. Recomendamos escribir `<head>` y sus contenidos en la parte superior del layout.
 
 ## Páginas Markdown 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Translated content

#### Description

- Moved "modificando `<head>`" to Astro Pages (taking that out from Astro components)
- Update Astro Components with "Etiquetas dinámicas" section that contains a note on variables

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
