### PR TITLE
i18n(es): update deploy guides

### DIFF
--- a/src/pages/es/guides/deploy.md
+++ b/src/pages/es/guides/deploy.md
@@ -78,7 +78,7 @@ De forma predeterminada, el resultado de compilación se colocará en `dist/`. E
 :::note
 Antes de implementar tu proyecto de Astro con [SSR (renderizado en el servidor)](/es/guides/server-side-rendering/) habilitado, asegúrate de tener:
 
-    - El [adaptador apropiado](/es/guides/server-side-rendering/#habilitando-ssr-en-su-proyecto) en las dependencias de tu proyecto
-    - [Agregar el adaptador](/es/reference/configuration-reference/#integraciones) a la importación y exportación predeterminada del archivo `astro.config.mjs`
+    - Instalado el [adaptador apropiado](/es/guides/server-side-rendering/#habilitando-ssr-en-su-proyecto) en tus dependencias (ya sea manualmente, o usando el comando `astro add`, p. ej. `npx astro add netlify`).
+    - [Agregado el adaptador](/es/reference/configuration-reference/#integraciones) a tu *import* y *default export* en tu archivo `astro.config.mjs` cuando es instalado manualmente. (¡El comando `astro add` se hará cargo de este paso por ti!)
 :::
 

--- a/src/pages/es/guides/deploy/cloudflare.md
+++ b/src/pages/es/guides/deploy/cloudflare.md
@@ -64,14 +64,21 @@ Entonces será posible actualizar el script preview en tu `package.json` por `"p
 
 ## Cómo desplegar un sitio con SSR
 
-Puedes desplegar tu proyecto de Astro con SSR en Cloudflare Pages usando el [adaptador `@astrojs/cloudflare`](https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare#readme).
+Puedes desplegar tu proyecto de Astro con SSR en Cloudflare Pages usando el [adaptador `@astrojs/cloudflare`](/es/guides/integrations-guide/cloudflare/).
 
-Para habilitar un sitio con SSR y desplegarlo en Cloudflare Pages, necesitarás:
-
-1. Añadir el [adaptador `@astrojs/cloudflare`](https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare#readme) al `package.json` de tu proyecto ejecutando:
+Añade el adaptador de Cloudflare que activa SSR en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
 
 ```bash
-npm install --save-dev @astrojs/cloudflare
+npx astro add cloudflare
+```
+
+
+Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
+
+1. Añadir el adaptador `@astrojs/cloudflare` a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+
+```bash
+npm install @astrojs/cloudflare
 ```
 
 2. Añadir lo siguiente a tu archivo `astro.config.mjs`:

--- a/src/pages/es/guides/deploy/cloudflare.md
+++ b/src/pages/es/guides/deploy/cloudflare.md
@@ -73,9 +73,11 @@ npx astro add cloudflare
 ```
 
 
-Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
+Si prefieres instalar el adaptador manualmente, sigue los siguientes pasos:
 
-1. Añadir el adaptador `@astrojs/cloudflare` a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+
+1. Añadir el adaptador `@astrojs/cloudflare` a las dependencias de tu proyecto usando tu gestor de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+
 
 ```bash
 npm install @astrojs/cloudflare

--- a/src/pages/es/guides/deploy/deno.md
+++ b/src/pages/es/guides/deploy/deno.md
@@ -21,7 +21,16 @@ Tu proyecto de Astro puede ser desplegado en [Deno Deploy](https://deno.com/depl
 
 Para activar SSR en tu proyecto de Astro y desplegarlo en Deno Deploy:
 
-1. Instala [el adaptador de Deno](https://github.com/withastro/astro/tree/main/packages/integrations/deno) en las dependencias de tu proyecto.
+Añadir [el adaptador de Deno](/es/guides/integrations-guide/deno/) para activar SSR en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+
+
+```bash
+npx astro add deno
+```
+
+Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
+
+1. Añadir [el adaptador `@astrojs/deno`](https://github.com/withastro/astro/tree/main/packages/integrations/deno) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
 
     ```bash
       npm install @astrojs/deno
@@ -40,7 +49,7 @@ Para activar SSR en tu proyecto de Astro y desplegarlo en Deno Deploy:
     });
     ```
 
-3. Actualiza el script `preview` en `package.json` con el siguiente cambio.
+Luego, actualiza el script `preview` en `package.json` con el siguiente cambio.
 
     ```json del={8} ins={9}
     // package.json

--- a/src/pages/es/guides/deploy/deno.md
+++ b/src/pages/es/guides/deploy/deno.md
@@ -30,7 +30,7 @@ npx astro add deno
 
 Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
 
-1. Añadir [el adaptador `@astrojs/deno`](https://github.com/withastro/astro/tree/main/packages/integrations/deno) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+1. Añadir [el adaptador `@astrojs/deno`](https://github.com/withastro/astro/tree/main/packages/integrations/deno) a las dependencias de tu proyecto usando tu gestor de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
 
     ```bash
       npm install @astrojs/deno

--- a/src/pages/es/guides/deploy/flightcontrol.md
+++ b/src/pages/es/guides/deploy/flightcontrol.md
@@ -11,11 +11,11 @@ Es compatible con sitios estáticos y SSR.
 
 1. Crea una cuenta de Flightcontrol en [app.flightcontrol.dev/signup](https://app.flightcontrol.dev/signup?ref=astro)
 2. Ve a [app.flightcontrol.dev/projects/new/1](https://app.flightcontrol.dev/projects/new/1)
-3. Conecta tu cuenta de Github y selecciona tu repositorio
+3. Conecta tu cuenta de Github y selecciona tu repositorio.
 4. Selecciona el "Tipo de configuración" deseado:
     - `GUI` (toda la configuración administrada a través de flightcontrol dashboard) donde seleccionará el preajuste `Astro Static` o `Astro SSR`
-    - `flightcontrol.json` (opción "infraestructura como código" donde toda la configuración está alojada en tu repositorio) donde seleccionará una configuración ejemplo de Astro, luego la agregará al repositorio como `flightcontrol.json`
-5. Ajusta cualquier configuración según sea necesario
+    - `flightcontrol.json` (opción "infraestructura como código" donde toda la configuración está alojada en tu repositorio) donde seleccionará una configuración ejemplo de Astro, luego la agregará al repositorio como `flightcontrol.json`.
+5. Ajusta cualquier configuración según sea necesario.
 6. Haz clic en "Crear proyecto" y completa los pasos necesarios, como vincular su cuenta de AWS.
 
 ### Configuración SSR

--- a/src/pages/es/guides/deploy/github.md
+++ b/src/pages/es/guides/deploy/github.md
@@ -14,16 +14,36 @@ Puedes desplegar un proyecto de Astro en GitHub pages usando [GitHub Actions](ht
 Astro mantiene la action oficial `withastro/action` para desplegar tu proyecto con muy poca configuración. Sigue las instrucciones a continuación para desplegar tu proyecto de Astro en GitHub pages y consulta el [README](https://github.com/withastro/action) si necesitas más información.
 
 1. Configura las opciones [`site`](/es/reference/configuration-reference/#site) y, si es necesario, [`base`](/es/reference/configuration-reference/#base) en `astro.config.mjs`.
-     - `site` debe ser algo así como `https://<TU_NOMBRE_DE_USUARIO>.github.io`
-     - `base` debe ser el nombre de tu repositorio comenzando con una barra diagonal, por ejemplo `/my-repo`.
-    
-     :::note
-     Si tu repositorio se llama `<TU_NOMBRE_DE_USUARIO>.github.io`, no necesitas incluir `base`.
-     :::
-     
+
+    ```js title="astro.config.mjs" ins={4-5}
+    import { defineConfig } from 'astro/config'
+
+    export default defineConfig({
+      site: 'https://astronaut.github.io',
+      base: '/mi-repo',
+    })
+    ```
+    - `site` debe ser `https://<TU_NOMBRE_DE_USUARIO>.github.io` o `https://mi-dominio.com`
+    - `base` debe ser el nombre de tu repositorio comenzando con una barra diagonal, por ejemplo `/mi-repo`. Esto es para que Astro entienda que el *root* de tu sitio web es `/mi-repo`, en lugar de `/` que es el valor por defecto.
+
+    :::note
+      No necesitas configuar el parametro `base` si:
+
+    - Tu repositorio se llama `<TU_NOMBRE_DE_USUARIO>.github.io`.
+    - Estás usando un dominio personalizado.
+    :::
+
+    :::caution
+        Si previamente no configuraste un valor para `base`, y acabas de configurarlo para desplegar en GitHub, ahora debes actualizar tus enlaces internos que ahora deben incluir `base`
+
+    ```astro
+    <a href="/mi-repo/nosotros">Nosotros</a>
+    ```
+    :::
+
 2. Crea un nuevo archivo en tu proyecto en `.github/workflows/deploy.yml`, dentro del mismo copia y pega el siguiente código YAML.
 
-    ```yaml
+    ```yaml title="deploy.yml"
     name: Github Pages Astro CI
 
     on:
@@ -65,18 +85,18 @@ Astro mantiene la action oficial `withastro/action` para desplegar tu proyecto c
     La [action oficial de Astro](https://github.com/withastro/action) busca un archivo lockfile para detectar tu gestor de paquetes (`npm`, `yarn` o `pnpm`). Debes tener el archivo `package-lock.json`, `yarn.lock` o `pnpm-lock.yaml`, generado automáticamente por tu gestor de paquetes, en tu repositorio.
     :::
 
-3. Confirma el nuevo workflow y envíalo a GitHub.
+3. En GitHub, ve a la pestaña **Settings** de tu repositorio y busca la sección **Pages**.
 
-4. En GitHub, ve a la pestaña **Settings** de tu repositorio y busca la sección **Pages**.
+4. Elige **GitHub Actions** como el **Source** de tu sitio y presiona **Save**.  
 
-5. Elige la rama `gh-pages` y la carpeta `"/" (raíz)` como **Source** de tu proyecto y presiona **Save**.
+5. Has *commit* del nuevo archivo workflow y has *push* a GitHub. 
 
-¡Tu proyecto está listo para ser desplegado! Cuando haya cambios en tu repositorio, GitHub Action los implementará automáticamente por ti.
+¡Tu sitio debería estar publicado! Cuando haya cambios en tu repositorio, GitHub Action los implementará automáticamente por ti.
 
 :::tip[configurar un dominio personalizado]
 Opcionalmente, puedes configurar un dominio personalizado agregando el siguiente archivo `./public/CNAME` a tu proyecto:
 
-```txt title="público/CNAME"
+```txt title="public/CNAME"
 sub.midominio.com
 ```
 

--- a/src/pages/es/guides/deploy/github.md
+++ b/src/pages/es/guides/deploy/github.md
@@ -34,7 +34,7 @@ Astro mantiene la action oficial `withastro/action` para desplegar tu proyecto c
     :::
 
     :::caution
-        Si previamente no configuraste un valor para `base`, y acabas de configurarlo para desplegar en GitHub, ahora debes actualizar tus enlaces internos que ahora deben incluir `base`
+        Si previamente no configuraste un valor para `base`, y acabas de configurarlo para desplegar en GitHub, recuerda actualizar tus enlaces internos para que incluyan la `base`
 
     ```astro
     <a href="/mi-repo/nosotros">Nosotros</a>
@@ -87,11 +87,11 @@ Astro mantiene la action oficial `withastro/action` para desplegar tu proyecto c
 
 3. En GitHub, ve a la pestaña **Settings** de tu repositorio y busca la sección **Pages**.
 
-4. Elige **GitHub Actions** como el **Source** de tu sitio y presiona **Save**.  
+4. Elige **GitHub Actions** como el **Source** de tu proyecto y presiona **Save**.  
 
 5. Has *commit* del nuevo archivo workflow y has *push* a GitHub. 
 
-¡Tu sitio debería estar publicado! Cuando haya cambios en tu repositorio, GitHub Action los implementará automáticamente por ti.
+¡Tu proyecto debería estar publicado! Cuando haya cambios en tu repositorio, GitHub Action los implementará automáticamente por ti.
 
 :::tip[configurar un dominio personalizado]
 Opcionalmente, puedes configurar un dominio personalizado agregando el siguiente archivo `./public/CNAME` a tu proyecto:

--- a/src/pages/es/guides/deploy/netlify.md
+++ b/src/pages/es/guides/deploy/netlify.md
@@ -20,31 +20,37 @@ Tu proyecto de Astro es un sitio estático por defecto. No necesitas ninguna con
 
 Para habilitar SSR en tu proyecto de Astro y hacer un despliegue en Netlify:
 
-1. Instala [el adaptador de Netlify](https://github.com/withastro/astro/tree/main/packages/integrations/netlify) en las dependencias de tu proyecto.
+Añadir [el adaptador de Netlify](/es/guides/integrations-guide/netlify/) en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+
+```bash
+npx astro add netlify
+```
+
+Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
+
+1. Añade [el adaptador de `@astrojs/netlify`](https://github.com/withastro/astro/tree/main/packages/integrations/netlify) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
 
     ```bash
-      npm install --save-dev @astrojs/netlify
+      npm install @astrojs/netlify
     ```
 
 2. Añade dos nuevas lineas a tu archivo de configuración del proyecto `astro.config.mjs`.
 
-    ```diff
+    ```js title="astro.config.mjs" ins={2, 5-6}
     import { defineConfig } from 'astro/config';
-    + import netlify from '@astrojs/netlify/functions';
+    import netlify from '@astrojs/netlify/functions';
 
     export default defineConfig({
-    +   output: 'server',
-    +   adapter: netlify(),
+      output: 'server',
+      adapter: netlify(),
     });
     ```
- 
+
     En cambio, si deseas renderizar tu proyecto usando [las Edge Functions experimentales de Netlify](https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/#app), cambia la importación de `netlify/functions` en la configuración de Astro para usar `netlify/edge-functions`.
-      ```diff
+      ```js title="astro.config.mjs" ins={3} del={2}
       import { defineConfig } from 'astro/config';
-      // change this line
-      - import netlify from '@astrojs/netlify/functions';
-      // to this line
-      + import netlify from '@astrojs/netlify/edge-functions';
+      import netlify from '@astrojs/netlify/functions';
+      import netlify from '@astrojs/netlify/edge-functions';
 
       export default defineConfig({
         output: 'server',

--- a/src/pages/es/guides/deploy/netlify.md
+++ b/src/pages/es/guides/deploy/netlify.md
@@ -20,7 +20,7 @@ Tu proyecto de Astro es un sitio estático por defecto. No necesitas ninguna con
 
 Para habilitar SSR en tu proyecto de Astro y hacer un despliegue en Netlify:
 
-Añadir [el adaptador de Netlify](/es/guides/integrations-guide/netlify/) en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+Añade [el adaptador de Netlify](/es/guides/integrations-guide/netlify/) a tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
 
 ```bash
 npx astro add netlify
@@ -28,7 +28,7 @@ npx astro add netlify
 
 Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
 
-1. Añade [el adaptador de `@astrojs/netlify`](https://github.com/withastro/astro/tree/main/packages/integrations/netlify) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+1. Añade [el adaptador de `@astrojs/netlify`](https://github.com/withastro/astro/tree/main/packages/integrations/netlify) a las dependencias de tu proyecto usando tu gestor de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
 
     ```bash
       npm install @astrojs/netlify

--- a/src/pages/es/guides/deploy/vercel.md
+++ b/src/pages/es/guides/deploy/vercel.md
@@ -32,7 +32,8 @@ Actualmente hay un problema con Vercel que muestra una página 404 con sitios he
 
 Para habilitar SSR en tu proyecto de Astro y desplegar en Vercel:
 
-Añadir [el adaptador de Vercel](/es/guides/integrations-guide/vercel/) en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+Añade [el adaptador de Vercel](/es/guides/integrations-guide/vercel/) a tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+
 
 ```bash
 npx astro add vercel
@@ -40,7 +41,8 @@ npx astro add vercel
 
 Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
 
-1. Añade [el adaptador de `@astrojs/vercel`](/es/guides/integrations-guide/vercel/) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+1. Añade [el adaptador de `@astrojs/vercel`](/es/guides/integrations-guide/vercel/) a las dependencias de tu proyecto usando tu gestor de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
+
 
     ```bash
       npm install @astrojs/vercel

--- a/src/pages/es/guides/deploy/vercel.md
+++ b/src/pages/es/guides/deploy/vercel.md
@@ -16,28 +16,45 @@ Tu proyecto de Astro puede ser desplegado en Vercel como un sitio estático, o c
 
 ### Sitio Estático
 
-Tu proyecto de Astro es un sitio estático por defecto. No necesitas ninguna configuración adicional para desplegar un sitio estático de Astro en Vercel. 
+Tu proyecto de Astro es un sitio estático por defecto. No necesitas ninguna configuración adicional para desplegar un sitio estático de Astro en Vercel.
+
+:::note
+Actualmente hay un problema con Vercel que muestra una página 404 con sitios hechos con Astro. Mientras esto se resuelve, añade el siguiente archivo de configuración en la raíz de tu proyecto:
+
+```json title="vercel.json"
+{
+  "cleanUrls": true,
+}
+```
+:::
 
 ### Adaptador para SSR
 
 Para habilitar SSR en tu proyecto de Astro y desplegar en Vercel:
 
-1. Instala [el adaptador de Vercel](https://github.com/withastro/astro/tree/main/packages/integrations/vercel) en las dependencias de tu proyecto.
+Añadir [el adaptador de Vercel](/es/guides/integrations-guide/vercel/) en tu proyecto de Astro con el siguiente comando `astro add` que se muestra debajo. Este instalará el adaptador y hará los cambios apropiados a tu archivo `astro.config.mjs` en un solo paso.
+
+```bash
+npx astro add vercel
+```
+
+Si prefieres instalar el adaptador manualmente, sigue los siguientes dos pasos:
+
+1. Añade [el adaptador de `@astrojs/vercel`](/es/guides/integrations-guide/vercel/) a las dependencias de tu proyecto usando tu manejador de paquetes preferido. Si estás usando npm o no estás seguro, ejecuta esto en la terminal:
 
     ```bash
-      npm install --save-dev @astrojs/vercel
+      npm install @astrojs/vercel
     ```
 
 1. Añade dos líneas nuevas a tu archivo de configuración del proyecto `astro.config.mjs`.
 
-    ```diff
-    // astro.config.mjs
+    ```js title="astro.config.mjs" ins={2, 5-6}
     import { defineConfig } from 'astro/config';
-    + import vercel from '@astrojs/vercel/serverless';
-
+    import vercel from '@astrojs/vercel/serverless';
+    
     export default defineConfig({
-    +   output: 'server',
-    +   adapter: vercel(),
+      output: 'server',
+      adapter: vercel(),
     });
     ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content


#### Description

- Update with these changes:
  - [guides/deploy.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy.md?since=2022-08-24T23:34:17.000Z)
  - [guides/deploy/cloudflare.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy/cloudflare.md?since=2022-08-27T23:04:47.000Z)
  - [guides/deploy/deno.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy/deno.md?since=2022-08-24T21:23:17.000Z)
  - [guides/deploy/github.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy/github.md?since=2022-08-18T22:00:08.000Z)
  - [guides/deploy/netlify.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy/netlify.md?since=2022-08-20T08:32:29.000Z)
  - [guides/deploy/vercel.md](https://github.com/withastro/docs/commits/main/src/pages/en/guides/deploy/vercel.md?since=2022-08-17T21:14:04.000Z)
