### PR TITLE
Remove "restart dev server" instruction from integrations

### DIFF
--- a/src/pages/en/guides/integrations-guide/alpinejs.md
+++ b/src/pages/en/guides/integrations-guide/alpinejs.md
@@ -45,8 +45,6 @@ yarn astro add alpinejs
 pnpm astro add alpinejs
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -74,8 +72,6 @@ export default defineConfig({
   integrations: [alpine()],
 });
 ```
-
-Finally, restart the dev server.
 
 ## Usage
 

--- a/src/pages/en/guides/integrations-guide/image.md
+++ b/src/pages/en/guides/integrations-guide/image.md
@@ -45,8 +45,6 @@ yarn astro add image
 pnpm astro add image
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -69,8 +67,6 @@ export default {
   integrations: [image()],
 }
 ```
-
-Then, restart the dev server.
 
 ### Update `env.d.ts`
 
@@ -496,7 +492,6 @@ const imageUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelog
 
 ## Troubleshooting
 
-*   If your installation doesn't seem to be working, make sure to restart the dev server.
 *   If you edit and save a file and don't see your site update accordingly, try refreshing the page.
 *   If refreshing the page doesn't update your preview, or if a new installation doesn't seem to be working, then restart the dev server.
 

--- a/src/pages/en/guides/integrations-guide/lit.md
+++ b/src/pages/en/guides/integrations-guide/lit.md
@@ -44,8 +44,6 @@ yarn astro add lit
 pnpm astro add lit
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/src/pages/en/guides/integrations-guide/mdx.md
+++ b/src/pages/en/guides/integrations-guide/mdx.md
@@ -44,8 +44,6 @@ yarn astro add mdx
 pnpm astro add mdx
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -69,8 +67,6 @@ export default defineConfig({
   integrations: [mdx()],
 });
 ```
-
-Finally, restart the dev server.
 
 ## Usage
 

--- a/src/pages/en/guides/integrations-guide/partytown.md
+++ b/src/pages/en/guides/integrations-guide/partytown.md
@@ -45,8 +45,6 @@ yarn astro add partytown
 pnpm astro add partytown
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -70,8 +68,6 @@ export default defineConfig({
   integrations: [partytown()],
 })
 ```
-
-Then, restart the dev server.
 
 ## Usage
 

--- a/src/pages/en/guides/integrations-guide/preact.md
+++ b/src/pages/en/guides/integrations-guide/preact.md
@@ -46,8 +46,6 @@ yarn astro add preact
 pnpm astro add preact
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -78,7 +76,6 @@ export default defineConfig({
 });
 ```
 
-Finally, restart the dev server.
 
 ## Usage
 

--- a/src/pages/en/guides/integrations-guide/prefetch.md
+++ b/src/pages/en/guides/integrations-guide/prefetch.md
@@ -41,8 +41,6 @@ yarn astro add prefetch
 pnpm astro add prefetch
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -65,8 +63,6 @@ export default {
   integrations: [prefetch()],
 }
 ```
-
-Then, restart the dev server.
 
 ## Usage
 
@@ -110,7 +106,6 @@ export default {
 
 ## Troubleshooting
 
-*   If your installation doesn't seem to be working, make sure to restart the dev server.
 *   If a link doesn't seem to be prefetching, make sure that the link is pointing to a page on the same domain and matches the integration's `selector` option.
 
 For help, check out the `#support-threads` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!

--- a/src/pages/en/guides/integrations-guide/react.md
+++ b/src/pages/en/guides/integrations-guide/react.md
@@ -44,8 +44,6 @@ yarn astro add react
 pnpm astro add react
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/src/pages/en/guides/integrations-guide/sitemap.md
+++ b/src/pages/en/guides/integrations-guide/sitemap.md
@@ -45,8 +45,6 @@ yarn astro add sitemap
 pnpm astro add sitemap
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -70,8 +68,6 @@ export default defineConfig({
   integrations: [sitemap()],
 })
 ```
-
-Then, restart the dev server.
 
 ## Usage
 

--- a/src/pages/en/guides/integrations-guide/solid-js.md
+++ b/src/pages/en/guides/integrations-guide/solid-js.md
@@ -44,8 +44,6 @@ yarn astro add solid
 pnpm astro add solid
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/src/pages/en/guides/integrations-guide/svelte.md
+++ b/src/pages/en/guides/integrations-guide/svelte.md
@@ -44,8 +44,6 @@ yarn astro add svelte
 pnpm astro add svelte
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually

--- a/src/pages/en/guides/integrations-guide/tailwind.md
+++ b/src/pages/en/guides/integrations-guide/tailwind.md
@@ -49,8 +49,6 @@ yarn astro add tailwind
 pnpm astro add tailwind
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
@@ -73,8 +71,6 @@ export default {
   integrations: [tailwind()],
 }
 ```
-
-Then, restart the dev server.
 
 ## Usage
 
@@ -167,7 +163,6 @@ module.exports = {
 
 ## Troubleshooting
 
-*   If your installation doesn't seem to be working, make sure to restart the dev server.
 *   If you edit and save a file and don't see your site update accordingly, try refreshing the page.
 *   If refreshing the page doesn't update your preview, or if a new installation doesn't seem to be working, then restart the dev server.
 

--- a/src/pages/en/guides/integrations-guide/vue.md
+++ b/src/pages/en/guides/integrations-guide/vue.md
@@ -44,8 +44,6 @@ yarn astro add vue
 pnpm astro add vue
 ```
 
-Finally, in the terminal window running Astro, press `CTRL+C` and then restart the dev server.
-
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Install dependencies manually


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Remove "restart the dev server" across our integration guides.

We will now restart the dev server on all config file changes https://github.com/withastro/astro/pull/4578, including when running `astro add`. This means... **no more user complaints (about that)!**

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
