### PR TITLE
new: add `MarkdownLayoutProps` example to layout

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -92,7 +92,7 @@ type Props = MarkdownLayoutProps<{
   date: string;
 }>;
 
-// Now, `frontmatter`, `url`, and other markdown layout properties
+// Now, `frontmatter`, `url`, and other Markdown layout properties
 // are accessible with type safety
 const { frontmatter, url } = Astro.props;
 ---

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -79,6 +79,36 @@ const { frontmatter } = Astro.props;
 </html>
 ```
 
+You can also add type safety using [the `Props` type](/en/guides/typescript/#component-props) with the `MarkdownLayoutProps` helper:
+
+```astro title="src/layouts/BaseLayout.astro" ins={2,4-9}
+---
+import type { MarkdownLayoutProps } from 'astro';
+
+type Props = MarkdownLayoutProps<{
+  // Define frontmatter props here
+  title: string;
+  author: string;
+  date: string;
+}>;
+
+// Now, `frontmatter`, `url`, and other markdown layout properties
+// are accessible with type safety
+const { frontmatter, url } = Astro.props;
+---
+<html>
+  <head>
+    <meta rel="canonical" href={new URL(url, Astro.site).pathname}>
+    <title>{frontmatter.title}</title>
+  </head>
+  <body>
+    <h1>{frontmatter.title} by {frontmatter.author}</h1>
+    <slot />
+    <p>Written on: {frontmatter.date}</p>
+  </body>
+</html>
+```
+
 ### Markdown Layout Props
 
 :::note

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -79,7 +79,7 @@ const { frontmatter } = Astro.props;
 </html>
 ```
 
-You can also add type safety using [the `Props` type](/en/guides/typescript/#component-props) with the `MarkdownLayoutProps` helper:
+You can set a layout’s [`Props` type](/en/guides/typescript/#component-props) with the `MarkdownLayoutProps` helper:
 
 ```astro title="src/layouts/BaseLayout.astro" ins={2,4-9}
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Did you know we have a helper for type-safe markdown layouts? Well, yeah we do! This adds a little example for type safety to our existing `layout` section.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
