### PR TITLE
Remove broken link to env-vars examples

### DIFF
--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -9,8 +9,6 @@ Astro uses Vite for environment variables, and allows you to [use any of its met
 
 Note that while _all_ environment variables are available in server-side code, only environment variables prefixed with `PUBLIC_` are available in client-side code for security purposes.
 
-See the official [Environment Variables example](https://github.com/withastro/astro/tree/main/examples/env-vars) for best practices.
-
 ```ini title=".env"
 SECRET_PASSWORD=password123
 PUBLIC_ANYBODY=there


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
- Env-vars examples have been removed in this PR (https://github.com/withastro/astro/pull/4606), therefore the link in the documentation in no longer leading anywhere.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
