### PR TITLE
Delete outdated mention of `--experimental-integrations`

### DIFF
--- a/src/pages/en/guides/integrations-guide.md
+++ b/src/pages/en/guides/integrations-guide.md
@@ -127,13 +127,6 @@ integrations: [
 
 You can find many integrations developed by the community in the [Astro Integrations Directory](https://astro.build/integrations/). Follow links there for detailed usage and configuration instructions.
 
-:::note[Experimental status]
-**To enable third-party integrations:** Run Astro with the `--experimental-integrations` CLI flag, or include `experimental: { integrations: true }` in your Astro config file.
-
-Official Astro integrations (those published to `@astrojs/` on npm) are supported by default. You don’t need the experimental flag to use those.
-:::
-
-
 ## Building Your Own Integration
 
 Astro's Integration API is inspired by Rollup and Vite, and designed to feel familiar to anyone who has ever written a Rollup or Vite plugin before.

--- a/src/pages/es/guides/integrations-guide.md
+++ b/src/pages/es/guides/integrations-guide.md
@@ -127,13 +127,6 @@ integrations: [
 
 Puedes encontrar integraciones desarrolladas por la comunidad en el [Directorio de Integraciones de Astro](https://astro.build/integrations/). Puedes seguir los hipervínculos para averiguar cómo se utilizan y ver instrucciones de configuración.
 
-:::note[Estado experimental]
-**Para habilitar integraciones de terceros:** Ejecuta Astro con el flag `--experimental-integrations` en tu Terminal o puedes incluir `experimental: {integrations: true}` en tu archivo de configuración de Astro.
-
-Las integraciones oficiales de Astro (publicadas con el prefijo `@astrojs/` en npm) son actualmente compatibles por defecto. No necesitas usar ninguna flag para poder utilizarlas.
-:::
-
-
 ## Construyendo tu propia integración
 
 La API de integración de Astro está inspirada en Rollup y Vite, y está diseñada para sentirse familiar para cualquiera que haya escrito antes un plugin de Rollup o Vite.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Delete mention of the `--experimental-integrations` flag which is no longer needed.
- The Spanish translation also included this information and is otherwise completely up-to-date so I’ve removed this there too.
- `fr`, `pt-BR` and `zh-CN` also still include this, but those pages also need other updates, so I’ll leave that to our translators

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
