### PR TITLE
Skip congrats bot action on `[ci] format` commits

### DIFF
--- a/.github/workflows/discord-congrats.yml
+++ b/.github/workflows/discord-congrats.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   congrats:
     name: congratsbot
-    if: ${{ github.repository_owner == 'withastro' }}
+    if: ${{ github.repository_owner == 'withastro' && github.event.commits[0].message != '[ci] format' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

#1199 added a CI task to automatically format our source code with Prettier after each commit merges into `main`. This PR adds a check to our congrats bot action so that when a `[ci] format` commit lands, we don’t congratulate the bot on Discord.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
