### PR TITLE
`Astro.glob()`: `draft:true` warning

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -36,6 +36,10 @@ const posts = await Astro.glob('../pages/post/*.md'); // returns an array of pos
 
 `.glob()` can't take variables or strings that interpolate them, as they aren't statically analyzable. (See [the troubleshooting guide](/en/guides/troubleshooting/#supported-values) for a workaround.) This is because `Astro.glob()` is a wrapper of Vite's [`import.meta.glob()`](https://vitejs.dev/guide/features.html#glob-import).
 
+:::caution[Astro.glob() and Markdown Drafts]
+Although [`draft: true`](/en/guides/markdown-content/#markdown-drafts) will prevent a page from being built on your site at that page route, `Astro.glob()` currently returns **all your Markdown files**.
+:::
+
 :::note
 You can also use `import.meta.glob()` itself in your Astro project. You may want to do this when:
 - You need this feature in a file that isn't `.astro`, like an API route. `Astro.glob()` is only available in `.astro` files, while `import.meta.glob()` is available anywhere in the project.


### PR DESCRIPTION
There is a warning here: https://docs.astro.build/en/guides/markdown-content/#markdown-drafts

Seems wise to have it here as well: https://docs.astro.build/en/reference/api-reference/#astroglob

... Which is what this PR does. Happy to open an issue instead if it doesn't flow right, I was a little uncertain where exactly to put it.

This warning could instead be in the existing ["Markdown Files" subsection](https://docs.astro.build/en/reference/api-reference/#markdown-files), but I feel like it might seem a little random -- that subsection already feels a little random, as it was a bit unclear to me initially why it was there at all. Looks like it was added in https://github.com/withastro/docs/pull/291. Might open an issue about making it a little more clear, like tweaking the title or adding a short intro paragraph about where it's going.