### PR TITLE
Add footer with link to astro.build privacy policy

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -1,0 +1,32 @@
+---
+import UIString from '../UIString.astro';
+---
+
+<ul class="footer-links">
+	<li>
+		<a href="https://astro.build/privacy/">
+			<UIString key="footer.privacyPolicy" />
+		</a>
+	</li>
+</ul>
+
+<style>
+	.footer-links {
+		display: flex;
+		gap: 1.5em;
+		justify-content: center;
+		list-style: none;
+		padding: 0;
+	}
+
+	.footer-links a {
+		color: var(--theme-text-lighter);
+		text-decoration: none;
+	}
+
+	.footer-links a:focus,
+	.footer-links a:hover {
+		color: var(--theme-text);
+		text-decoration: underline;
+	}
+</style>

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -2,15 +2,24 @@
 import UIString from '../UIString.astro';
 ---
 
-<ul class="footer-links">
-	<li>
-		<a href="https://astro.build/privacy/">
-			<UIString key="footer.privacyPolicy" />
-		</a>
-	</li>
-</ul>
+<footer>
+	<ul class="footer-links">
+		<li>
+			<a href="https://astro.build/privacy/">
+				<UIString key="footer.privacyPolicy" />
+			</a>
+		</li>
+	</ul>
+</footer>
 
 <style>
+	footer {
+		padding: 6rem 0 2rem;
+		text-align: center;
+		color: var(--theme-text-lighter);
+		font-size: var(--theme-text-xs);
+	}
+
 	.footer-links {
 		display: flex;
 		gap: 1.5em;

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -25,6 +25,8 @@ export default {
 	'rightSidebar.editPage': 'Edit this page',
 	'rightSidebar.translatePage': 'Translate this page',
 	'rightSidebar.github': 'Astro Docs on GitHub',
+	// Footer
+	'footer.privacyPolicy': 'Privacy Policy',
 	// `<ThemeToggleButton>` acessibility labels
 	'themeToggle.useLight': 'Use light theme',
 	'themeToggle.useDark': 'Use dark theme',

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -3,6 +3,7 @@ import FallbackNotice from '../components/FallbackNotice.astro';
 import HeadCommon from '../components/HeadCommon.astro';
 import HeadSEO from '../components/HeadSEO.astro';
 import Header from '../components/Header/Header.astro';
+import Footer from '../components/Footer/Footer.astro';
 import PageContent from '../components/PageContent/PageContent.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
@@ -62,6 +63,12 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				height: 100%;
 				min-width: 0;
 			}
+			footer {
+				padding: 6rem 0 2rem;
+				text-align: center;
+				color: var(--theme-text-lighter);
+				font-size: var(--theme-text-xs);
+			}
 
 			/* Allow showing left sidebar as an overlay, but only while viewport stays narrow */
 			@media not screen and (min-width: 50em) {
@@ -83,7 +90,7 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				:global(.mobile-sidebar-toggle) {
 					overflow: hidden;
 				}
-				:global(.mobile-sidebar-toggle #main-content) {
+				:global(.mobile-sidebar-toggle .main-column) {
 					visibility: hidden;
 				}
 				:global(.mobile-sidebar-toggle #left-sidebar ul) {
@@ -92,7 +99,7 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 			}
 
 			@media (min-width: 50em) {
-				#main-content {
+				.main-column {
 					margin-inline-start: var(--theme-left-sidebar-width);
 				}
 				#left-sidebar {
@@ -106,7 +113,7 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 			}
 
 			@media (min-width: 72em) {
-				#main-content {
+				.main-column {
 					margin-inline-end: var(--theme-right-sidebar-width);
 				}
 				#right-sidebar {
@@ -143,7 +150,7 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 			<aside id="right-sidebar" class="sidebar">
 				{!hideRightSidebar && <RightSidebar content={content} githubEditUrl={githubEditUrl} />}
 			</aside>
-			<div id="main-content" lang={isFallback && 'en'}>
+			<div id="main-content" class="main-column" lang={isFallback && 'en'}>
 				<div dir={isFallback ? 'ltr' : direction}>
 					<PageContent {content} {githubEditUrl} {currentPage} layoutDir={direction}>
 						<slot name="header" />
@@ -159,5 +166,8 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				</div>
 			</div>
 		</main>
+		<footer class="main-column">
+			<Footer />
+		</footer>
 	</body>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -63,12 +63,6 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				height: 100%;
 				min-width: 0;
 			}
-			footer {
-				padding: 6rem 0 2rem;
-				text-align: center;
-				color: var(--theme-text-lighter);
-				font-size: var(--theme-text-xs);
-			}
 
 			/* Allow showing left sidebar as an overlay, but only while viewport stays narrow */
 			@media not screen and (min-width: 50em) {
@@ -166,8 +160,8 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				</div>
 			</div>
 		</main>
-		<footer class="main-column">
+		<div class="main-column">
 			<Footer />
-		</footer>
+		</div>
 	</body>
 </html>

--- a/src/layouts/SplashLayout.astro
+++ b/src/layouts/SplashLayout.astro
@@ -1,6 +1,7 @@
 ---
 import HeadCommon from '../components/HeadCommon.astro';
 import Header from '../components/Header/Header.astro';
+import Footer from '../components/Footer/Footer.astro';
 import { getLanguageFromURL } from '../util';
 import { normalizeLangTag } from '../i18n/bcp-normalize';
 import { useTranslations } from '../i18n/util';
@@ -39,5 +40,6 @@ const t = useTranslations(Astro);
 				<slot />
 			</article>
 		</main>
+		<Footer />
 	</body>
 </html>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

Adds a minimal footer to the docs site with a link to [the updated astro.build privacy policy](https://astro.build/privacy/).

The link label can be translated in the `ui.ts` i18n files under the key `footer.privacyPolicy`.

<img width="655" alt="image" src="https://user-images.githubusercontent.com/357379/190003431-42a8c827-0d16-4190-acd7-d0a080d83d4b.png">


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
