### PR TITLE
Environment variables can't be used in config files

### DIFF
--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -143,7 +143,7 @@ This can be helpful if you have scripts with names that might be impacted by ad 
 ## Environment Variables
 Astro evaluates configuration files before it loads your other files. As such, you can't use `import.meta.env` or access environment variables that were set in `.env` files. 
 
-You can use `process.env` in a configuration file to access other environment variables, like those [set by the CLI](/en/guides/environment-variables#using-the-cli).
+You can use `process.env` in a configuration file to access other environment variables, like those [set by the CLI](/en/guides/environment-variables/#using-the-cli).
 
 ## Configuration Reference
 

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -141,8 +141,9 @@ export default defineConfig({
 This can be helpful if you have scripts with names that might be impacted by ad blockers (e.g. `ads.js` or `google-tag-manager.js`).
 
 ## Environment Variables
-Environment variables can normally be accessed with `import.meta.env`, but not in configuration files. Astro is unable to load `.env` files as the files to load can only be determined after evaluating the Astro config.
+Astro evaluates configuration files before it loads your other files. As such, you can't use `import.meta.env` or access environment variables that were set in `.env` files. 
 
+You can use `process.env` in a configuration file to access other environment variables, like those set by the CLI.
 
 ## Configuration Reference
 

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -143,7 +143,7 @@ This can be helpful if you have scripts with names that might be impacted by ad 
 ## Environment Variables
 Astro evaluates configuration files before it loads your other files. As such, you can't use `import.meta.env` or access environment variables that were set in `.env` files. 
 
-You can use `process.env` in a configuration file to access other environment variables, like those set by the CLI.
+You can use `process.env` in a configuration file to access other environment variables, like those [set by the CLI](/en/guides/environment-variables#using-the-cli).
 
 ## Configuration Reference
 

--- a/src/pages/en/guides/configuring-astro.md
+++ b/src/pages/en/guides/configuring-astro.md
@@ -140,6 +140,10 @@ export default defineConfig({
 
 This can be helpful if you have scripts with names that might be impacted by ad blockers (e.g. `ads.js` or `google-tag-manager.js`).
 
+## Environment Variables
+Environment variables can normally be accessed with `import.meta.env`, but not in configuration files. Astro is unable to load `.env` files as the files to load can only be determined after evaluating the Astro config.
+
+
 ## Configuration Reference
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for a full overview of all supported configuration options.

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -18,7 +18,7 @@ PUBLIC_ANYBODY=there
 In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 
 :::caution
-`import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro#environment-variables). 
+`import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro/#environment-variables). 
 :::
 
 ## Default environment Variables

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -2,6 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Using environment variables
 description: Learn how to use environment variables in an Astro project.
+setup: import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
 
@@ -28,6 +29,7 @@ Astro includes a few environment variables out-of-the-box:
 
 ## Setting environment variables
 
+### `.env` files
 Environment variables can be loaded from `.env` files in your project directory.
 
 You can also attach a mode (either `production` or `development`) to the filename, like `.env.production` or `.env.development`, which makes the environment variables only take effect in that mode.
@@ -49,6 +51,30 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 .env.[mode].local   # only loaded in specified mode, ignored by git
 ```
 
+### Using the CLI
+You can also add environment variables as you run your project:
+
+<PackageManagerTabs>
+ <Fragment slot="yarn">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 yarn run dev
+    ```
+ </Fragment>
+ <Fragment slot="npm">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 npm run dev
+    ```
+ </Fragment>
+ <Fragment slot="pnpm">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 pnpm run dev
+    ```
+ </Fragment>
+</PackageManagerTabs>
+
+:::caution
+Variables set this way will be available everywhere within your project, including on the client.
+:::
 ## Getting environment variables
 
 Instead of using `process.env`, with Vite you use `import.meta.env`, which uses the `import.meta` feature added in ES2020.

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -5,7 +5,6 @@ description: Learn how to use environment variables in an Astro project.
 setup: import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
-
 Astro uses Vite's built-in support for environment variables, and lets you [use any of its methods](https://vitejs.dev/guide/env-and-mode.html) to work with them.
 
 Note that while _all_ environment variables are available in server-side code, only environment variables prefixed with `PUBLIC_` are available in client-side code for security purposes.
@@ -21,7 +20,7 @@ In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBOD
 `import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro/#environment-variables). 
 :::
 
-## Default environment Variables
+## Default environment variables
 
 Astro includes a few environment variables out-of-the-box:
 

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -17,6 +17,10 @@ PUBLIC_ANYBODY=there
 
 In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 
+:::caution
+`import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro#environment-variables). 
+:::
+
 ## Default environment Variables
 
 Astro includes a few environment variables out-of-the-box:
@@ -94,8 +98,7 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
 :::caution
-- Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
-- `import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro#environment-variables). 
+Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
 
 ## IntelliSense for TypeScript

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -68,7 +68,8 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
 :::caution
-Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
+- Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
+- Environment variables are not available inside Astro config files.
 :::
 
 ## IntelliSense for TypeScript

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -69,7 +69,7 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 
 :::caution
 - Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
-- Environment variables are not available inside configuration files.
+- `import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro#environment-variables). 
 :::
 
 ## IntelliSense for TypeScript

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -6,7 +6,7 @@ setup: import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astr
 i18nReady: true
 ---
 
-Astro uses Vite for environment variables, and allows you to [use any of its methods](https://vitejs.dev/guide/env-and-mode.html) to get and set environment variables.
+Astro uses Vite's built-in support for environment variables, and lets you [use any of its methods](https://vitejs.dev/guide/env-and-mode.html) to work with them.
 
 Note that while _all_ environment variables are available in server-side code, only environment variables prefixed with `PUBLIC_` are available in client-side code for security purposes.
 
@@ -25,11 +25,11 @@ In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBOD
 
 Astro includes a few environment variables out-of-the-box:
 
-- `import.meta.env.MODE` (`development` | `production`): the mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.
-- `import.meta.env.BASE_URL` (`string`): the base url your site is being served from. This is determined by the [`base` config option](/en/reference/configuration-reference/#base).
-- `import.meta.env.PROD` (`boolean`): whether your site is running in production.
-- `import.meta.env.DEV` (`boolean`): whether your site is running in development (always the opposite of `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): [The `site` option](/en/reference/configuration-reference/#site) specified in your project's `astro.config`.
+- `import.meta.env.MODE`: The mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.
+- `import.meta.env.PROD`: `true` if your site is running in production; `false` otherwise.
+- `import.meta.env.DEV`: `true` if your site is running in development; `false` otherwise. Always the opposite of `import.meta.env.PROD`.
+- `import.meta.env.BASE_URL`: The base url your site is being served from. This is determined by the [`base` config option](/en/reference/configuration-reference/#base).
+- `import.meta.env.SITE`: This is set to the [the `site` option](/en/reference/configuration-reference/#site) specified in your project's `astro.config`.
 
 ## Setting environment variables
 

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -69,7 +69,7 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 
 :::caution
 - Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
-- Environment variables are not available inside Astro config files.
+- Environment variables are not available inside configuration files.
 :::
 
 ## IntelliSense for TypeScript

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -47,13 +47,7 @@ DB_PASSWORD="foobar"
 PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 ```
 
-```yaml
-# Supported file names:
-.env                # loaded in all cases
-.env.local          # loaded in all cases, ignored by git
-.env.[mode]         # only loaded in specified mode
-.env.[mode].local   # only loaded in specified mode, ignored by git
-```
+For more on `.env` files, [see the Vite documentation](https://vitejs.dev/guide/env-and-mode.html#env-files).
 
 ### Using the CLI
 You can also add environment variables as you run your project:

--- a/src/pages/en/guides/environment-variables.md
+++ b/src/pages/en/guides/environment-variables.md
@@ -77,10 +77,6 @@ Variables set this way will be available everywhere within your project, includi
 
 Instead of using `process.env`, with Vite you use `import.meta.env`, which uses the `import.meta` feature added in ES2020.
 
-:::tip[Don't worry about browser support!]
-Vite replaces all `import.meta.env` mentions with static values.
-:::
-
 For example, use `import.meta.env.PUBLIC_POKEAPI` to get the `PUBLIC_POKEAPI` environment variable.
 
 ```js /(?<!//.*)import.meta.env.[A-Z_]+/


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

We closed #785 as the corresponding feature was closed, but the note about Astro being unable to load env variables is still important information, even if we don't have a workaround. This PR restores that note and adds a corresponding one to the environmental variables change.

I could see us only wanting one of those two messages, or rather wanting this to be in Troubleshooting. Let me know!

@natemoo-re, if there's currently a workaround to access env variables in Astro, let me know.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
