### PR TITLE
Script is:inline clarifications

### DIFF
--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -213,7 +213,9 @@ const message = "Astro is awesome!";
 ```
 
 :::caution
-Using `define:vars` on a `<script>` or `<style>` tag implies the [`is:inline` directive](#isinline), which means your scripts or styles won't be bundled and will be inlined directly into the HTML.
+Using `define:vars` on a `<script>` or `<style>` tag implies the [`is:inline` directive](#isinline), which means your scripts or styles won't be bundled and will be inlined directly into the HTML. 
+
+This is because when Astro bundles scripts, it creates one bundle for all instances of the script on the page and runs that once. `define:vars` requires a script to rerun with each set of values, so Astro creates an inline script instead.
 :::
 
 ## Advanced Directives

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -164,7 +164,7 @@ By default, Astro will process, optimize, and bundle any `<script>` and `<style>
 
 The `is:inline` directive means that `<style>` and `<script>` tags:
 
-- Will not be bundled into an external file.
+- Will not be bundled into an external file. This means that attributes like `defer` which control the loading of an external file will have no effect.
 - Will not be deduplicated—the element will appear as many times as it is rendered.
 - Will not have its `import`/`@import`/`url()` references resolved relative to the `.astro` file.
 - Will be pre-processed, for example a `<style lang="sass">` attribute will still generate plain CSS.

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -215,7 +215,7 @@ const message = "Astro is awesome!";
 :::caution
 Using `define:vars` on a `<script>` or `<style>` tag implies the [`is:inline` directive](#isinline), which means your scripts or styles won't be bundled and will be inlined directly into the HTML. 
 
-This is because when Astro bundles scripts, it creates one bundle for all instances of the script on the page and runs that once. `define:vars` requires a script to rerun with each set of values, so Astro creates an inline script instead.
+This is because when Astro bundles a script, it includes and runs the script once even if you include the component containing the script multiple times on one page. `define:vars` requires a script to rerun with each set of values, so Astro creates an inline script instead.
 :::
 
 ## Advanced Directives

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -164,7 +164,7 @@ By default, Astro will process, optimize, and bundle any `<script>` and `<style>
 
 The `is:inline` directive means that `<style>` and `<script>` tags:
 
-- Will not be bundled into an external file. This means that attributes like `defer` which control the loading of an external file will have no effect.
+- Will not be bundled into an external file. This means that [attributes like `defer`](https://javascript.info/script-async-defer) which control the loading of an external file will have no effect.
 - Will not be deduplicated—the element will appear as many times as it is rendered.
 - Will not have its `import`/`@import`/`url()` references resolved relative to the `.astro` file.
 - Will be pre-processed, for example a `<style lang="sass">` attribute will still generate plain CSS.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- To address #1407, explain that `defer` and similar attributes don't work on inlined scripts
- Explain _why_ `define:vars` implies `is:inline`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
