### PR TITLE
fix ignored word after colon

### DIFF
--- a/src/pages/en/reference/integrations-reference.md
+++ b/src/pages/en/reference/integrations-reference.md
@@ -157,7 +157,7 @@ The **`stage`** denotes how this script (the `content`) should be inserted. Some
 
 **Previous hook:** [`astro:config:setup`](#astroconfigsetup)
 
-**Next hook:** [`astro:server:setup`](#astroserversetup) when running in "dev" or "preview" mode, or [astro:build:start](#astrobuildstart) during production builds
+**Next hook:** [`astro:server:setup`](#astroserversetup) when running in "dev" or "preview" mode, or [`astro:build:start`](#astrobuildstart) during production builds
 
 **When:** After the Astro config has resolved and other integrations have run their `astro:config:setup` hooks.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Fix ignored word "start" and unexpected line break after second colon in markdown link title

Before
![Before](https://i.imgur.com/C0F4h1i.png)
After
![After](https://i.imgur.com/uUOpd4P.png)
