### PR TITLE
Add redirects for some old paths still being visited

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,18 @@
     to = "/en/concepts/islands"
 
   [[redirects]]
+    from = "/en/getting-started/quick-start"
+    to = "/en/install/auto"
+
+  [[redirects]]
+    from = "/docs/*"
+    to = "/:splat"
+
+  [[redirects]]
+    from = "/:lang/docs/*"
+    to = "/:lang/:splat"
+
+  [[redirects]]
     from = "/:lang/core-concepts/partial-hydration"
     to = "/:lang/concepts/islands"
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code


#### Description

This PR adds some entries to our Netlify redirects config to redirect on some pages we’re seeing 404s for:

- pages starting with `/docs/...` will now redirect to the same URL minus the `/docs/` prefix
- an old “quick start” URL will now redirect to the install guide

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
