### PR TITLE
Add clarification to dynamic tags about hydration directives

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -183,11 +183,11 @@ const Component = MyComponent;
 <Component /> <!-- renders as <MyComponent /> -->
 ```
 
-There are a some things to bear in mind when using dynamic tags:
+When using dynamic tags:
 
-- **Variable names must be capitalized**, for example use `Element`, not `element`. Otherwise, Astro will try to render your variable name as a literal HTML tag.
+- **Variable names must be capitalized.** For example, use `Element`, not `element`. Otherwise, Astro will try to render your variable name as a literal HTML tag.
 
-- **Hydration directives are not supported.** When using [`client:*` hydration directives](/en/core-concepts/framework-components/#hydrating-interactive-components), Astro needs to know what components to bundle for production, and the dynamic tag pattern prevents this from working.
+- **Hydration directives are not supported.** When using [`client:*` hydration directives](/en/core-concepts/framework-components/#hydrating-interactive-components), Astro needs to know which components to bundle for production, and the dynamic tag pattern prevents this from working.
 
 ### Fragments & Multiple Elements
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -187,7 +187,7 @@ There are a some things to bear in mind when using dynamic tags:
 
 - **Variable names must be capitalized**, for example use `Element`, not `element`. Otherwise, Astro will try to render your variable name as a literal HTML tag.
 
-- **Hydration directives are not supported.** When using `client:*` hydration directives, Astro needs to know what components to bundle for production, and the dynamic tag pattern prevents this from working.
+- **Hydration directives are not supported.** When using [`client:*` hydration directives](/en/core-concepts/framework-components/#hydrating-interactive-components), Astro needs to know what components to bundle for production, and the dynamic tag pattern prevents this from working.
 
 ### Fragments & Multiple Elements
 

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -183,9 +183,11 @@ const Component = MyComponent;
 <Component /> <!-- renders as <MyComponent /> -->
 ```
 
-:::note
-Variable names must be capitalized (`Element`, not `element`), for this to work. Otherwise, Astro will try to render your variable name as a literal HTML tag.
-:::
+There are a some things to bear in mind when using dynamic tags:
+
+- **Variable names must be capitalized**, for example use `Element`, not `element`. Otherwise, Astro will try to render your variable name as a literal HTML tag.
+
+- **Hydration directives are not supported.** When using `client:*` hydration directives, Astro needs to know what components to bundle for production, and the dynamic tag pattern prevents this from working.
 
 ### Fragments & Multiple Elements
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Matthew clarified in [a support thread](https://discord.com/channels/830184174198718474/1021446382982266910/1021468769102598206) the other day that the dynamic tag pattern we document won’t work for components using `client:*` hydration directives.

This PR updates that section in the component docs to note this limitation.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
