### PR TITLE
Document `create-astro --template`

### DIFF
--- a/src/pages/en/install/auto.md
+++ b/src/pages/en/install/auto.md
@@ -19,11 +19,12 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Installation
 
-`create-astro` is the fastest way to start a new Astro project from scratch.
+`create-astro` is the fastest way to start a new Astro project from scratch. It will walk you through every step of setting up your new Astro project. It allows you to choose from a few different starter templates or provide your own using the `--template` argument.
 
 :::tip[Online previews]
 Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to browse our starter templates and spin up a new Astro project without ever leaving your browser.
 :::
+
 ## 1. Run the Setup Wizard
 
 Run the following command in your terminal to start our handy install wizard, `create-astro`.
@@ -49,8 +50,7 @@ Run the following command in your terminal to start our handy install wizard, `c
   </Fragment>
 </PackageManagerTabs>
 
-
-The `create-astro` wizard will walk you through every step of setting up your new Astro project. You can run it anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
+You can run `create-astro` anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
 
 If all goes well, you should see a "Ready for liftoff!" message followed by some recommended "Next steps". `cd` into your new project directory to begin using Astro. 
 

--- a/src/pages/en/integrations/integrations.md
+++ b/src/pages/en/integrations/integrations.md
@@ -1,6 +1,8 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Built with Astro
+setup: | 
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
 
@@ -56,6 +58,26 @@ Check out our new [integrations library](https://astro.build/integrations/), and
 [The Net Ninja](https://www.youtube.com/playlist?list=PL4cUxeGkcC9hZm9NYpd4G-jhoeEk0ls--) - **Video**: Figma and Astro Static Site Build
 
 ## Repositories / Starter Templates
+
+You can start a new astro project based on an existing github repostory by passing a `--template` argument to the `create-astro` command.
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro -- --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn create astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 [delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms) - Astro Starter Template with Netlify CMS
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Added a brief mention about `--template` to the auto install page, and a shell example to the hidden `integrations.md` page.

Not sure if that's the best place to do it, but I didn't want to clutter the install page, and at least it will show up in search now.

![screen recording showing that searching for template takes you to the newly added paragraph](https://user-images.githubusercontent.com/9084735/191869080-3fe77305-0f1b-460a-9c81-ebb080f5ba0e.gif)

