### PR TITLE
Fix: `yarnrc.yml` --> `.yarnrc.yml`

### DIFF
--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -143,9 +143,9 @@ const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPos
 
 ### Using Astro with Yarn 2+ (Berry)
 
-Yarn 2+, a.k.a. Berry, uses a technique called [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) to store and manage Node modules, which can [cause problems](https://github.com/withastro/astro/issues/3450) while initializing a new Astro project using `create-astro` or while working with Astro. A workaround is to set the [`nodeLinker` property](https://yarnpkg.com/configuration/yarnrc#nodeLinker) in `yarnrc.yml` to `node-modules`:
+Yarn 2+, a.k.a. Berry, uses a technique called [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) to store and manage Node modules, which can [cause problems](https://github.com/withastro/astro/issues/3450) while initializing a new Astro project using `create-astro` or while working with Astro. A workaround is to set the [`nodeLinker` property](https://yarnpkg.com/configuration/yarnrc#nodeLinker) in `.yarnrc.yml` to `node-modules`:
 
-```yaml
+```yaml title=".yarnrc.yml"
 nodeLinker: "node-modules"
 ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- `yarnrc.yml` was missing initial dot, should be `.yarnrc.yml`
- Reference: https://yarnpkg.com/configuration/yarnrc
