### PR TITLE
Add docs for how to type Props of astro components that don't want props

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -103,6 +103,12 @@ const { greeting = 'Hello', name } = Astro.props;
 <h2>{greeting}, {name}!</h2>
 ```
 
+:::tip
+
+To type a component that denies props, you can pass `type Props = Record<string, never>;` for zero props and `type Props = { children: any; };` for no props except for the default slot.
+
+:::
+
 ### Built-in attribute types
 
 Astro provides JSX type definitions to check that your markup is using valid HTML attributes. You can use these types to help build component props. For example, if you were building a `<Link>` component, you could do the following to mirror the default HTML attributes in your component’s prop types.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

This is good for when you don't want to accept props for a component and want `astro check` to deny props to a component, so inputs don't go unused.

It can be misleading otherwise when you might expect props for an astro component to get passed through to the top-level wrapper element in that component

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
