### PR TITLE
Docs: Nanostores/Clarification on supported frameworks

### DIFF
--- a/src/pages/en/core-concepts/sharing-state.md
+++ b/src/pages/en/core-concepts/sharing-state.md
@@ -18,7 +18,7 @@ Astro recommends a different solution for shared client-side storage: [**Nano St
 
 The [Nano Stores](https://github.com/nanostores/nanostores) library allows you to author stores that any component can interact with. We recommend Nano Stores because:
 - **They're lightweight.** Nano Stores ship the bare minimum JS you'll need (less than 1 KB) with zero dependencies.
-- **They're framework-agnostic.** This means sharing state between Preact, Svelte, and Vue will be seamless! Astro is built on flexibility, so we love solutions that offer a similar developer experience no matter your preference.
+- **They're framework-agnostic.** This means sharing state between frameworks will be seamless! Astro is built on flexibility, so we love solutions that offer a similar developer experience no matter your preference.
 
 Still, there are a number of alternatives you can explore. These include:
 - [Svelte's built-in stores](https://svelte.dev/tutorial/writable-stores)


### PR DESCRIPTION
It can be a bit confusing as to why React and Solid were not mentioned--is sharing state between these two not as seamless as it is between the others? Hope that this slight change in wording can help.
Alternatives could be ".. sharing state between the supported frameworks ..", " .. Astro's supported frameworks .. "

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Small wording change in the Nanostores docs
