### PR TITLE
Documenting Cascading Order: Introduction and Examples

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -315,7 +315,7 @@ import PurpleComponent from "./PurpleComponent.astro";
 ```
 
 ### Link Tags
-Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags), before any other styles in an Astro component. Therefore, these styles will have lower precedence than imported stylesheets and scoped styles:
+Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags) are evaluated in order, before any other styles in an Astro file. Therefore, these styles will have lower precedence than imported stylesheets and scoped styles:
 
 ```astro title="index.astro"
 ---

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -290,7 +290,8 @@ import "./make-it-purple.css"
 </div>
 ```
 
-Importing a component applies any CSS it imports, even if the component is never used:
+While `<style>` tags are scoped and only apply to the component that declares them, _imported_ CSS can "leak". Importing a component applies any CSS it imports, even if the component is never used:
+
 ```astro title="PurpleComponent.astro"
 ---
 import "./make-it-purple.css"

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -197,7 +197,7 @@ When evaluating multiple CSS rules that apply to the same element, the browser u
 If two rules have the same specificity, the _order of appearance_ is evaluated, and the last rule will take precedence:
 ```astro title="MyComponent.astro"
 <style>
-  h1 { color: purple}
+  h1 { color: purple }
   h1 { color: red }
 </style>
 <div>
@@ -207,7 +207,7 @@ If two rules have the same specificity, the _order of appearance_ is evaluated, 
 </div>
 ```
 
-Among Astro features, if the specificity of a rule is the same, **scoped styles** take precedence, then **imported styles**, then **`<link>` tags in the head**.
+Among Astro features, if the specificity of a rule is the same, **scoped styles** take precedence over **imported styles**. Both of these have higher precedence than **`<link>` tags in the head**.
 
 ### Scoped Styles 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -182,7 +182,7 @@ Astro components will sometimes have to evaluate multiple sources of CSS. For ex
 
 When conflicting CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which value to show.
 
-If one rule is more _specific_ than another, no matter where the CSS rule appears, it will take precedence:
+If one rule is more _specific_ than another, no matter where the CSS rule appears, its value will take precedence:
 
 ```astro title="MyComponent.astro"
 <style>
@@ -198,7 +198,7 @@ If one rule is more _specific_ than another, no matter where the CSS rule appear
 </div>
 ```
 
-If two rules have the same specificity, then the _order of appearance_ is evaluated, and the last rule will take precedence:
+If two rules have the same specificity, then the _order of appearance_ is evaluated, and the last rule's value will take precedence:
 ```astro title="MyComponent.astro"
 <style>
   h1 { color: purple }
@@ -219,7 +219,7 @@ Astro CSS rules are evaluated in this order of appearance:
 
 ### Scoped Styles 
 
-Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but they will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet with the same rule as a scoped style, the scoped style will apply:
+Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but they will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style's value will apply:
 
 ```css title="make-it-purple.css"
 h1 {

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -287,18 +287,18 @@ import "./make-it-purple.css"
 ```
 
 If a component imports CSS, that CSS will be imported at the same time, even if the component is never used:
-```astro title="PurpleParent.astro"
+```astro title="PurpleComponent.astro"
 ---
 import "./make-it-purple.css"
 ---
 <div>
-  <slot/>
+  <p>I import purple CSS.</p>
 </div>
 ```
 ```astro title="MyComponent.astro"
 ---
 import "./make-it-green.css"
-import PurpleParent from "./PurpleParent.astro";
+import PurpleComponent from "./PurpleComponent.astro";
 ---
 <style>
   h1 { color: red }

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -315,7 +315,7 @@ import PurpleComponent from "./PurpleComponent.astro";
 ```
 
 ### Link Tags
-Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags) in the head are evaluated before any other styles in an Astro component, in the order in which they appear. Therefore, these styles will always have lower precedence than imported stylesheets and scoped styles:
+Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags), before any other styles in an Astro component. Therefore, these styles will have lower precedence than imported stylesheets and scoped styles:
 
 ```astro title="index.astro"
 ---

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -263,7 +263,7 @@ import "./make-it-purple.css"
 
 ### Import Order
 
-When importing multiple stylesheets, if any styles have the same specificity, the _last one imported_ wins:
+When importing multiple stylesheets in an Astro component, the CSS rules are evaluated in the order that they are imported. A higher specificity will always determine which styles to show, no matter when the CSS is evaluated. But, when conflicting styles have the same specificity, the _last one imported_ wins:
 
 ```css title="make-it-purple.css"
 div > h1 {

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -207,6 +207,8 @@ If two rules have the same specificity, the _order of appearance_ is evaluated, 
 </div>
 ```
 
+Among Astro features, if the specificity of a rule is the same, **scoped styles** take precedence, then **imported styles**, then **`<link>` tags in the head**.
+
 ### Scoped Styles 
 
 Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but it will always come last in the _order of appearance_. It will therefore take precedence over other styles of the same specificity. For example, if we import a stylesheet with the same rule as a scoped style, the scoped style will apply:
@@ -304,7 +306,32 @@ import PurpleParent from "./PurpleParent.astro";
 </div>
 ```
 
+### Link Tags
+During compilation, scoped styles and imported stylesheets are added to the _bottom of the head_ as `<link>` tags, after any other link tags.
 
+This means that if you load a style sheet via a [link tag](#load-a-static-stylesheet-via-link-tags) in the head, it will always have lower precedence:
+
+```astro title="index.astro"
+---
+import "../components/make-it-purple.css"
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+		<link rel="stylesheet" href="/styles/make-it-blue.css" />
+	</head>
+	<body>
+		<div>
+			<h1>This will be purple</h1>
+		</div>
+	</body>
+</html>
+```
 
 ## CSS Integrations
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -315,9 +315,7 @@ import PurpleComponent from "./PurpleComponent.astro";
 ```
 
 ### Link Tags
-During compilation, scoped styles and imported stylesheets are added to the _bottom of the head_ as `<link>` tags, after any other link tags.
-
-This means that if you load a style sheet via a [link tag](#load-a-static-stylesheet-via-link-tags) in the head, it will always have lower precedence:
+Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags) in the head are evaluated before any other styles in an Astro component, in the order in which they appear. Therefore, these styles will always have lower precedence than imported stylesheets and scoped styles:
 
 ```astro title="index.astro"
 ---

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -178,7 +178,11 @@ Because this approach uses the `public/` directory, it skips the normal CSS proc
 
 ## Cascading Order
 
-When evaluating multiple CSS rules that apply to the same element, the browser uses _specificity_ and _order of appearance_ to determine which style to show. If one rule is more _specific_ than another, it will take precedence:
+Astro components will sometimes have to evaluate multiple CSS "instructions" for the same element. For example, your component might import a CSS stylesheet, include its own `<style>` tag, *and* be rendered inside a layout.
+
+When multiple CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which style to show.
+
+If one rule is more _specific_ than another, no matter when the CSS rule is evaluated, it will take precedence:
 
 ```astro title="MyComponent.astro"
 <style>
@@ -188,26 +192,26 @@ When evaluating multiple CSS rules that apply to the same element, the browser u
   }
 </style>
 <div>
-  <h1 class="red">
+  <h1>
     This header will be purple!
   </h1>
 </div>
 ```
 
-If two rules have the same specificity, the _order of appearance_ is evaluated, and the last rule will take precedence:
+If two rules have the same specificity, then the _order of appearance_ is evaluated, and the last rule will take precedence:
 ```astro title="MyComponent.astro"
 <style>
   h1 { color: purple }
   h1 { color: red }
 </style>
 <div>
-  <h1 class="red">
+  <h1>
     This header will be red!
   </h1>
 </div>
 ```
 
-Among Astro features, if the specificity of a rule is the same, the resulting styles will appear in this order:
+Astro CSS rules are evaluated in this order of appearance:
 
 - **`<link>` tags in the head** (lowest precedence)
 - **imported styles**

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -296,7 +296,7 @@ If a component imports CSS, that CSS will be imported at the same time, even if 
 import "./make-it-purple.css"
 ---
 <div>
-  <p>I import purple CSS.</p>
+  <h1>I import purple CSS.</h1>
 </div>
 ```
 ```astro title="MyComponent.astro"

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -314,6 +314,10 @@ import PurpleComponent from "./PurpleComponent.astro";
 </div>
 ```
 
+:::tip
+A common pattern in Astro is to import global CSS inside a [Layout component](/en/core-concepts/layouts/). Be sure to import the Layout component before other imports so that it has the lowest precedence.
+:::
+
 ### Link Tags
 Style sheets loaded via [link tags](#load-a-static-stylesheet-via-link-tags) are evaluated in order, before any other styles in an Astro file. Therefore, these styles will have lower precedence than imported stylesheets and scoped styles:
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -219,7 +219,7 @@ Astro CSS rules are evaluated in this order of appearance:
 
 ### Scoped Styles 
 
-Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but it will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet with the same rule as a scoped style, the scoped style will apply:
+Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but they will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet with the same rule as a scoped style, the scoped style will apply:
 
 ```css title="make-it-purple.css"
 h1 {

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -207,7 +207,11 @@ If two rules have the same specificity, the _order of appearance_ is evaluated, 
 </div>
 ```
 
-Among Astro features, if the specificity of a rule is the same, **scoped styles** take precedence over **imported styles**. Both of these have higher precedence than **`<link>` tags in the head**.
+Among Astro features, if the specificity of a rule is the same, the resulting styles will appear in this order:
+
+- **`<link>` tags in the head** (lowest precedence)
+- **imported styles**
+- **scoped styles** (highest precedence)
 
 ### Scoped Styles 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -182,7 +182,7 @@ Astro components will sometimes have to evaluate multiple sources of CSS. For ex
 
 When conflicting CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which style to show.
 
-If one rule is more _specific_ than another, no matter when the CSS rule is evaluated, it will take precedence:
+If one rule is more _specific_ than another, no matter where the CSS rule appears, it will take precedence:
 
 ```astro title="MyComponent.astro"
 <style>
@@ -290,7 +290,7 @@ import "./make-it-purple.css"
 </div>
 ```
 
-If a component imports CSS, that CSS will be imported at the same time, even if the component is never used:
+Importing a component applies any CSS it imports, even if the component is never used:
 ```astro title="PurpleComponent.astro"
 ---
 import "./make-it-purple.css"

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -178,9 +178,9 @@ Because this approach uses the `public/` directory, it skips the normal CSS proc
 
 ## Cascading Order
 
-Astro components will sometimes have to evaluate multiple CSS "instructions" for the same element. For example, your component might import a CSS stylesheet, include its own `<style>` tag, *and* be rendered inside a layout.
+Astro components will sometimes have to evaluate multiple sources of CSS. For example, your component might import a CSS stylesheet, include its own `<style>` tag, *and* be rendered inside a layout that imports CSS.
 
-When multiple CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which style to show.
+When conflicting CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which style to show.
 
 If one rule is more _specific_ than another, no matter when the CSS rule is evaluated, it will take precedence:
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -180,7 +180,7 @@ Because this approach uses the `public/` directory, it skips the normal CSS proc
 
 Astro components will sometimes have to evaluate multiple sources of CSS. For example, your component might import a CSS stylesheet, include its own `<style>` tag, *and* be rendered inside a layout that imports CSS.
 
-When conflicting CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which style to show.
+When conflicting CSS rules apply to the same element, browsers first use _specificity_ and then _order of appearance_ to determine which value to show.
 
 If one rule is more _specific_ than another, no matter where the CSS rule appears, it will take precedence:
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -215,7 +215,7 @@ Among Astro features, if the specificity of a rule is the same, the resulting st
 
 ### Scoped Styles 
 
-Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but it will always come last in the _order of appearance_. It will therefore take precedence over other styles of the same specificity. For example, if we import a stylesheet with the same rule as a scoped style, the scoped style will apply:
+Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but it will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet with the same rule as a scoped style, the scoped style will apply:
 
 ```css title="make-it-purple.css"
 h1 {
@@ -236,7 +236,7 @@ import "./make-it-purple.css"
 </div>
 ```
 
-If we make the imported style _more specific_, it will have higher precedence over the scoped style:
+If you make the imported style _more specific_, it will have higher precedence over the scoped style:
 
 ```css title="make-it-purple.css"
 div > h1 {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #1642
- Introduces the two relevant cascading order factors: specificity and order of appearance
- Describes the precedence of scoped styles, imported styles, and link tag styles relative to each other
- Shows examples for each feature
- Explains that the later imported style has higher precedence
- Explains [as per this comment](https://github.com/withastro/docs/issues/1642#issuecomment-1262917210) that when a component imports styles, they're imported at the same time as the component, and shows an example of this being relevant

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
