### PR TITLE
Changes breaking text in congrats-bot.mjs script

### DIFF
--- a/scripts/congrats-bot.mjs
+++ b/scripts/congrats-bot.mjs
@@ -9,7 +9,7 @@ setDiscordMessage(COMMIT_AUTHOR, COMMIT_ID, COMMIT_MESSAGE);
  * @param {string} commitMsg A full commit message
  */
 function setDiscordMessage(author, id, commitMsg) {
-	const commitMessage = commitMsg.split('\n').shift().replaceAll('`', '').replaceAll('--', '––');
+	const commitMessage = commitMsg.split('\n').shift().replaceAll('`', '').replaceAll('--', '-​-');
 
 	const coAuthors = commitMsg
 		.split('\n')

--- a/scripts/congrats-bot.mjs
+++ b/scripts/congrats-bot.mjs
@@ -9,7 +9,7 @@ setDiscordMessage(COMMIT_AUTHOR, COMMIT_ID, COMMIT_MESSAGE);
  * @param {string} commitMsg A full commit message
  */
 function setDiscordMessage(author, id, commitMsg) {
-	const commitMessage = commitMsg.split('\n').shift().replaceAll('`', '');
+	const commitMessage = commitMsg.split('\n').shift().replaceAll('`', '').replaceAll('--', '––');
 
 	const coAuthors = commitMsg
 		.split('\n')


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!
- Replaces the message breaking `--` with `––` instead, as to not break discord markdown.

#### Description

- Closes #1615  <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
