### PR TITLE
Quickstart button: launch in new window

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -6,7 +6,7 @@ const { variant = 'primary' } = Astro.props;
 ---
 
 <span class:list={[`link pixel variant-${variant}`, className]} {style}>
-	<a {href}>
+	<a {href} target="_blank">
 		<span><slot /></span>
 	</a>
 </span>

--- a/src/pages/en/getting-started.md
+++ b/src/pages/en/getting-started.md
@@ -35,7 +35,7 @@ Check out our detailed [Why Astro](/en/concepts/why-astro/) breakdown to learn m
 Visit [astro.new](https://astro.new/) and choose from a variety of templates to get started. Play around with a full, working version of Astro right in your browser!
 
 <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-    <Button href="https://astro.new/basics?on=stackblitz">Quickstart!</Button>
+    <Button href="https://astro.new/basics?on=stackblitz">Launch basic template!</Button>
     <Button variant="outline" href="https://astro.new/">View all templates →</Button>
 </div>
 


### PR DESCRIPTION
In PRs no one asked for....

Experimenting with having the Quickstart button open in a new tab. (I never really liked that it took you away from Docs, especially since sometimes phrases like "Quick start" actually do take you to more docs, not *away* from docs, and launching an entirely different site.)

Therefore, also changed the wording of the button to be more in line with making it clear that the link was going to open our basic template. And, I think it's a more explicit comparison with "viewing all other templates." 

The only downside, being slightly longer, is that on mobile the button and the text are not always going to fit all on one line anymore. In tablet view, (except for the very smallest version of tablet view) it is still all on one line. But, I still like the more explicit description of what the button is going to do, and that it no longer takes you away from docs.  Open to thoughts on this!