### PR TITLE
Improve deploy/gitlab.md documentation

### DIFF
--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -42,7 +42,7 @@ For example, here are the correct `astro.config.mjs` settings when the `public/`
        paths:
          - node_modules/
      script:
-         # Specify the steps involved to build your app here
+       # Specify the steps involved to build your app here
        - npm install
        - npm run build
 
@@ -51,7 +51,7 @@ For example, here are the correct `astro.config.mjs` settings when the `public/`
          # The folder that contains the built files to be published.
          # This must be called "public".
          - public
-         - 
+
      only:
        # Trigger a new build and deploy only when there is a push to the
        # branch(es) below

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -14,9 +14,9 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 ## How to deploy
 
 1. Set the correct `site` in `astro.config.mjs`.
-2. Set `dist` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". This instructs Astro to put the static build output in a folder called `public`.
+2. Set `outDir` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". This instructs Astro to put the static build output in a folder called `public`.
 
-If you were using the [`public/` directory](/en/reference/configuration-reference/#publicdir) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `public`.
+If you were using the [`public/` directory](/en/reference/configuration-reference/#publicdir) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `publicDir`.
 
 For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -21,11 +21,13 @@ If you were using the [`public/` directory](/en/reference/configuration-referenc
 For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 
    ```js
+   import { defineConfig } from 'astro/config';
+   
    export default defineConfig({
      sitemap: true,
      site: 'https://astro.build/',
-     dist: 'public',
-     public: 'static',
+     outDir: 'public',
+     publicDir: 'static',
    });
    ```
 

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -16,7 +16,7 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 1. Set the correct `site` in `astro.config.mjs`.
 2. Set `dist` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". This instructs Astro to put the static build output in a folder called `public`.
 
-If you were using the [`public/` directory](/en/guides/images/#public) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `public`.
+If you were using the [`public/` directory](/en/reference/configuration-reference/#publicdir) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `public`.
 
 For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -14,9 +14,9 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 ## How to deploy
 
 1. Set the correct `site` in `astro.config.mjs`.
-2. Set `outDir` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". This instructs Astro to put the static build output in a folder called `public`.
+2. Set `outDir:public` in `astro.config.mjs`. This setting instructs Astro to put the static build output in a folder called `public`, which is the folder required by GitLab Pages for exposed files.
 
-If you were using the [`public/` directory](/en/reference/configuration-reference/#publicdir) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `publicDir`.
+If you were using the [`public/` directory](/en/core-concepts/project-structure/#public) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `publicDir`.
 
 For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -14,10 +14,11 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 ## How to deploy
 
 1. Set the correct `site` in `astro.config.mjs`.
-2. Set `dist` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". So we're instructing Astro to put the static build output in a folder of that name.
-3. If you were using the [`public/` directory](en/guides/images/#public) as a source of static files, you need to rename the folder and set `public` in `astro.config.mjs` accordantly.
+2. Set `dist` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". This instructs Astro to put the static build output in a folder called `public`.
 
-Here is an example of a `astro.config.mjs` where the `public/` directory is set to `static`.
+If you were using the [`public/` directory](/en/guides/images/#public) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `public`.
+
+For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 
    ```js
    export default defineConfig({
@@ -45,12 +46,12 @@ Here is an example of a `astro.config.mjs` where the `public/` directory is set 
 
      artifacts:
        paths:
-         # The folder that contains the built files to be published. This
-         # must be called "public".
+         # The folder that contains the built files to be published.
+         # This must be called "public".
          - public
          - 
      only:
        # Trigger a new build and deploy only when there is a push to the
-       # below branch(es)
+       # branch(es) below
        - main
    ```

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -13,30 +13,44 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 
 ## How to deploy
 
-1. Set the correct `.site` in `astro.config.mjs`.
-2. Set `dist` in `astro.config.mjs` to `public` and `public` in `astro.config.mjs` to a newly named folder that is holding everything currently in `public`. The reasoning is because `public` is a second source folder in astro, so if you would like to output to `public` you'll need to pull public assets from a different folder. Your `astro.config.mjs` might end up looking like this:
+1. Set the correct `site` in `astro.config.mjs`.
+2. Set `dist` in `astro.config.mjs` to `public`. GitLab Pages requires exposed files to be located in a folder called "public". So we're instructing Astro to put the static build output in a folder of that name.
+3. If you were using the [`public/` directory](en/guides/images/#public) as a source of static files, you need to rename the folder and set `public` in `astro.config.mjs` accordantly.
+
+Here is an example of a `astro.config.mjs` where the `public/` directory is set to `static`.
 
    ```js
    export default defineConfig({
      sitemap: true,
      site: 'https://astro.build/',
+     dist: 'public',
+     public: 'static',
    });
    ```
 
 3. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
    ```yaml
+   # The Docker image that will be used to build your app
    image: node:14
+   
    pages:
      cache:
        paths:
          - node_modules/
      script:
+         # Specify the steps involved to build your app here
        - npm install
        - npm run build
+
      artifacts:
        paths:
+         # The folder that contains the built files to be published. This
+         # must be called "public".
          - public
+         - 
      only:
+       # Trigger a new build and deploy only when there is a push to the
+       # below branch(es)
        - main
    ```


### PR DESCRIPTION
#### What kind of changes does this PR include?
- New or updated content

#### Description

As noted on #1382:
- The documentation had an unclear explanation to why we need to set `dist` to `public` and `public` to another value.
- The given `astro.config.mjs` example did not reflect the steps in the guide

This PR include my attempt to better explain that `public` is required to be the output folder for GitLab Pages, with links to the documentation to the `public` directory and an example of a `astro.config.mjs` after setting `public` to `static` and `build` to `public`. Some of the phrases are based on the example repo files, as is the decision to use `public` as `static` in the example.

It also includes useful comments that were on ".gitlab-ci.yml" from the example repo.

Finally, it fixes a small typo (removing the dot from `.site`)

I'm taking part on the hacktoberfest! :smile: