### PR TITLE
[error msg fix] change "txt" lang to "js" in Github deploy instructions [en-only]

### DIFF
--- a/src/pages/de/guides/deploy/github.md
+++ b/src/pages/de/guides/deploy/github.md
@@ -76,7 +76,7 @@ Deine Website sollte jetzt veröffentlicht sein! Wenn du Änderungen an deinem A
 :::tip[Richte eine benutzerdefinierte Domäne ein]
 Optional kannst du eine benutzerdefinierte Domäne einrichten, indem du die folgende Datei `./public/CNAME` zu deinem Projekt hinzufügst:
 
-```txt title="public/CNAME"
+```js title="public/CNAME"
 sub.meine-domain.de
 ```
 

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -97,7 +97,7 @@ Your site should now be published! When you push changes to your Astro projectâ€
 :::tip[set up a custom domain]
 You can optionally set up a custom domain by adding the following `./public/CNAME` file to your project: 
 
-```txt title="public/CNAME"
+```js title="public/CNAME"
 sub.mydomain.com
 ```
 

--- a/src/pages/es/guides/deploy/github.md
+++ b/src/pages/es/guides/deploy/github.md
@@ -96,7 +96,7 @@ Astro mantiene la action oficial `withastro/action` para desplegar tu proyecto c
 :::tip[configurar un dominio personalizado]
 Opcionalmente, puedes configurar un dominio personalizado agregando el siguiente archivo `./public/CNAME` a tu proyecto:
 
-```txt title="public/CNAME"
+```js title="public/CNAME"
 sub.midominio.com
 ```
 

--- a/src/pages/fr/guides/deploy/github.md
+++ b/src/pages/fr/guides/deploy/github.md
@@ -96,7 +96,7 @@ Votre site devrait maintenant être publié ! Lorsque vous poussez des modificat
 :::tip[configurer un domaine personnalisé]
 Vous pouvez éventuellement configurer un domaine personnalisé en ajoutant le fichier suivant `./public/CNAME` à votre projet : 
 
-```txt title="public/CNAME"
+```js title="public/CNAME"
 sub.mydomain.com
 ```
 


### PR DESCRIPTION
- Minor content fixes (broken links, typos, etc.)

This should avoid the error message about "txt" not being a supported language for Markdown code. I've changed every lanaguage, so am using the `en-only` keyword to prevent a status update trigger.
