### PR TITLE
Workaround for `import.meta.glob` perf issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint": "^8.21.0",
     "eslint-plugin-astro": "^0.14.0",
     "fast-glob": "^3.2.11",
+    "gray-matter": "^4.0.3",
     "hastscript": "^7.0.2",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ specifiers:
   eslint: ^8.21.0
   eslint-plugin-astro: ^0.14.0
   fast-glob: ^3.2.11
+  gray-matter: ^4.0.3
   hastscript: ^7.0.2
   html-escaper: ^3.0.3
   htmlparser2: ^7.2.0
@@ -89,6 +90,7 @@ devDependencies:
   eslint: 8.21.0
   eslint-plugin-astro: 0.14.0_eslint@8.21.0
   fast-glob: 3.2.11
+  gray-matter: 4.0.3
   hastscript: 7.0.2
   html-escaper: 3.0.3
   htmlparser2: 7.2.0


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Closes #1695 

- Removes an `import.meta.glob` call that was tanking dev server performance on start up

- The workaround is not particularly pretty. Basically I hand-roll a minimal version of Astro’s glob + parse Markdown pipeline that does just what we need in this context: globs all the `.md` pages, parses their frontmatter with `gray-matter` and gives us `title` and `description`. At least in my local tests, this resolves our issues although obviously it’s not battle tested, so a Windows test might throw up some path weirdness?

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
