### PR TITLE
i18n(es): update `install/auto.md` and `install/manual.md`

### DIFF
--- a/src/pages/es/install/auto.md
+++ b/src/pages/es/install/auto.md
@@ -2,24 +2,24 @@
 title: Instala Astro con el CLI automático
 description: Cómo instalar Astro con NPM, PNPM, o Yarn a través de create-astro con el CLI de Astro.
 layout: ~/layouts/MainLayout.astro
-setup: | 
+setup: |
   import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
   import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true
 ---
-¿Listo para instalar Astro? Sigue nuestra guía de instalación automática o manual para comenzar.
+¿Listo para instalar Astro? Sigue nuestra guía de instalación automática o manual para empezar.
 
 #### Prerrequisitos
 
 - **Node.js** - `14.18.0`, `v16.12.0`, o mayor.
-- **Editor de código** - Recomendamos [VS Code](https://code.visualstudio.com/) con nuestra [extensión oficial](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
+- **Editor de código** - Recomendamos [VS Code](https://code.visualstudio.com/) con nuestra [extensión oficial de Astro](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro es usado a través de la interfaz de línea de comandos (CLI).
 
 <InstallGuideTabGroup />
 
 #### Instalación
 
-`create-astro` es la forma más rápida y fácil de comenzar un nuevo proyecto en Astro. Serás guiado paso a paso para configurar tu nuevo proyecto en Astro. Podrás elegir entre algunas plantillas de inicio o puedes proveer una tú mismo usando el argumento `--template`.
+`create-astro` es la forma más rápida y fácil de comenzar un nuevo proyecto en Astro. Serás guiado paso a paso para configurar tu nuevo proyecto de Astro. Podrás elegir entre algunas plantillas de inicio o puedes proveer una tú mismo usando el argumento `--template`.
 
 :::tip[Previsualizaciones en línea]
 ¿Prefieres probar Astro en tu navegador? Visita [astro.new](https://astro.new/) para ver nuestras plantillas y crear un proyecto de Astro solamente usando tu navegador.
@@ -54,11 +54,11 @@ Puedes ejecutar `create-astro` en cualquier carpeta de tu computadora, así que 
 
 Si todo ha salido bien, deberías ver un mensaje "Ready for liftoff!" seguido de algunas recomendaciones de próximos pasos, "Next steps". Entra en el nuevo directorio de tu proyecto usando `cd` y empieza a utilizar Astro.
 
-Si has salteado el paso de `npm install` durante el asistente `create-astro`, asegúrate de instalar las dependencias antes de continuar.
+Si has omitido el paso de `npm install` durante el asistente `create-astro`, asegúrate de instalar las dependencias antes de continuar.
 
 ## 2. Inicia Astro ✨
 
-Astro posee un servidor de desarrollo que tiene todo lo que necesitas para desarrollar tu proyecto. El comando `astro dev` iniciará el servidor de desarrollo local para que veas tu nuevo proyecto en acción.
+Astro posee un servidor de desarrollo que tiene todo lo que necesitas para desarrollar tu proyecto. El comando `astro dev` iniciará el servidor de desarrollo local para que veas tu nuevo proyecto en acción por primera vez.
 
 Cada plantilla de inicio posee un script pre-configurado que ejecutará `astro dev` por ti. Utiliza tu gestor de paquetes favorito para ejecutar este comando e iniciar el servidor de desarrollo de Astro.
 
@@ -84,15 +84,15 @@ Cada plantilla de inicio posee un script pre-configurado que ejecutará `astro d
 
 Astro escuchará cualquier cambio en la carpeta `src/` y actualizará automáticamente tu proyecto. De esta forma, no será necesario reiniciar el servidor local durante el desarrollo.
 
-Si no es posible abrir el proyecto en el navegador, regresa a la terminal donde has ejecutado el comando `dev` y chequea si ha ocurrido algún error o si tu proyecto está siendo servido desde una URL diferente a la que figura más arriba.
+Si no es posible abrir el proyecto en el navegador, regresa a la terminal donde has ejecutado el comando `dev` y chequea si ha ocurrido algún error o si tu proyecto está siendo servido en una URL diferente a la mencionada anteriormente.
 
 ## Siguientes pasos
 
 ¡Felicidades! ¡Estás listo para empezar a desarrollar con Astro! 🥳
 
-Estos son algunos temas que recomendamos explorar luego. Puedes leerlos en el orden que más te guste. También puedes dejar la documentación a un lado e ir a jugar un poco con el código de tu nuevo proyecto Astro y volver cuando tengas algún problema o una pregunta para responder.
+Estos son algunos temas que recomendamos explorar luego. Puedes leerlos en el orden que más te guste. También puedes dejar la documentación a un lado e ir a jugar un poco con el código de tu nuevo proyecto Astro y volver cuando tengas algún problema o alguna duda.
 
-📚 **Añade un framework:** Aprende cómo extender Astro con soporte para React, Svelte, Tailwind y más usando `npx astro add` en nuestra [Guía de integraciones](/es/guides/integrations-guide/).
+📚 **Añade un framework:** Aprende cómo extender Astro con soporte para React, Svelte, Tailwind y más, usando `npx astro add` en nuestra [Guía de integraciones](/es/guides/integrations-guide/).
 
 📚 **Despliega tu sitio:** Aprende cómo hacer el build y desplegar tu proyecto de Astro en la web con nuestra [Guía de despliegue](/es/guides/deploy/).
 

--- a/src/pages/es/install/manual.md
+++ b/src/pages/es/install/manual.md
@@ -147,7 +147,7 @@ Si deseas incluir [componentes de frameworks](/es/core-concepts/framework-compon
 
 ## 6. Crea `tsconfig.json`
 
-TypeScript es configurado usando `tsconfig.json`. Aún si tú no escribes código en TypeScript, este archivo es importante para que herramientas como Astro y VS Code sepan cómo comprender tu proyecto. Algunas características (como importaciones de paquetes npm) no tienen un soporte completo en el editor sin el archivo `tsconfig.json`.
+TypeScript es configurado usando `tsconfig.json`. Aun si tú no escribes código en TypeScript, este archivo es importante para que herramientas como Astro y VS Code sepan cómo comprender tu proyecto. Algunas características (como importaciones de paquetes npm) no tienen un soporte completo en el editor sin el archivo `tsconfig.json`.
 
 Si pretendes escribir código en TypeScript, recomendamos usar las plantillas de Astro `strict` o `strictest`. Puedes ver y comparar las tres configuraciones de las plantillas en [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 

--- a/src/pages/es/install/manual.md
+++ b/src/pages/es/install/manual.md
@@ -12,7 +12,7 @@ i18nReady: true
 #### Prerrequisitos
 
 - **Node.js** - `14.18.0`, `v16.12.0`, o mayor.
-- **Editor de código** - Recomendamos [VS Code](https://code.visualstudio.com/) con nuestra [extensión oficial](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
+- **Editor de código** - Recomendamos [VS Code](https://code.visualstudio.com/) con nuestra [extensión oficial de Astro](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro es usado a través de la interfaz de línea de comandos (CLI).
 
 <InstallGuideTabGroup />
@@ -40,7 +40,7 @@ Ya en la carpeta, crea un archivo `package.json` para tu proyecto. Esto te ayuda
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm init 
+  pnpm init
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -63,7 +63,7 @@ Primero, instala Astro dentro de tu proyecto.
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm install astro
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -87,19 +87,19 @@ A continuación, reemplaza los scripts creados por defecto en el `package.json` 
 
 Los scripts serán usados más adelante en la guía para iniciar y ejecutar diferentes comandos en Astro.
 
-## 3. Crea tu primer página
+## 3. Crea tu primera página
 
-En tu editor de código, crea un nuevo archivo en el directorio `src/pages/index.astro`. Esta será la primera página de tu proyecto de Astro.
+En tu editor de código, crea un nuevo archivo en el directorio `src/pages/index.astro`. Esta será tu primera página de Astro en el proyecto`.
 
 Copia y pega el siguiente fragmento de código (incluyendo `---` guiones) en tu nuevo archivo:
 
 ```astro title="src/pages/index.astro"
 ---
-// ¡Bienvenido a Astro! Todo entre los guiones triples son los 
-// "metadatos de su componente". Nunca corre en el navegador.
-console.log('¡Esto corre en tu terminal y no en el navegador!');
+// ¡Bienvenido a Astro! Todo entre los guiones triples son los
+// "metadatos de su componente". Nunca se ejecuta en el navegador.
+console.log('¡Esto se ejecuta en tu terminal y no en el navegador!');
 ---
-<!-- El código de abajo es "la plantilla de su componente". Es solo HTML 
+<!-- El código de abajo es "la plantilla de su componente". Es solo HTML
      con un poco de magia que te ayudará a crear la plantila del componente. -->
 <html>
   <body>
@@ -115,14 +115,14 @@ console.log('¡Esto corre en tu terminal y no en el navegador!');
 
 ## 4. Crea tu primer archivo estático
 
-Crea una carpeta `public` en la raíz de tu proyecto para almacenar todos los archivos estáticos. Astro incluirá estos archivos en la compilación final, así podrán ser seguramente referenciados desde tu código.
+Crea una carpeta `public` en la raíz de tu proyecto para almacenar todos los archivos estáticos. Astro incluirá estos archivos en la compilación final, así podrán ser referenciados de forma segura desde tus componentes.
 
-Crea un nuevo archivo en el directorio `public/robots.txt`. `robots.txt` es un archivo que informa a los robots de búsqueda como Google sobre cómo indexar tu página web.
+Crea un nuevo archivo en el directorio `public/robots.txt`. `robots.txt` es un archivo que informa a los robots de búsqueda, como Google, sobre cómo indexar tu página web.
 
 Copia y pega el siguiente fragmento de código:
 
 ```diff title="public/robots.txt"
-# Ejemplo: Permitir a todos los bots de búsqueda escanear e indexar el sitio web. 
+# Ejemplo: Permitir a todos los bots de búsqueda escanear e indexar el sitio web.
 # Sintaxis completa: https://developers.google.com/search/docs/advanced/robots/create-robots-txt
 User-agent: *
 Allow: /
@@ -130,9 +130,9 @@ Allow: /
 
 ## 5. Crea astro.config.mjs
 
-Astro es configurado usando el archivo `astro.config.mjs`. Este archivo es opcional si no necesitas configurar Astro, pero recomendamos crear uno.
+Astro es configurado usando el archivo `astro.config.mjs`. Este archivo es opcional si no necesitas configurar Astro, pero recomendamos crear uno ahora.
 
-Crea un archivo `astro.config.mjs` en la raíz del proyecto. Copia y pega el siguiente código:
+Crea un archivo `astro.config.mjs` en la raíz del proyecto y copia el siguiente código dentro de él:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -147,11 +147,11 @@ Si deseas incluir [componentes de frameworks](/es/core-concepts/framework-compon
 
 ## 6. Crea `tsconfig.json`
 
-Typescript es configurado usando `tsconfig.json`. Aún si tú no escribes código en TypeScript, este archivo es importante para que herramientas como Astro y VS Code sepan cómo comprender tu proyecto. Algunas características (como importaciones de paquetes npm) no tienen un soporte completo en el editor sin el archivo `tsconfig.json`.
+TypeScript es configurado usando `tsconfig.json`. Aún si tú no escribes código en TypeScript, este archivo es importante para que herramientas como Astro y VS Code sepan cómo comprender tu proyecto. Algunas características (como importaciones de paquetes npm) no tienen un soporte completo en el editor sin el archivo `tsconfig.json`.
 
 Si pretendes escribir código en TypeScript, recomendamos usar las plantillas de Astro `strict` o `strictest`. Puedes ver y comparar las tres configuraciones de las plantillas en [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 
-Crea `tsconfig.json` en la raíz del proyecto y copia el siguiente código en el archivo. (Puedes usar `base`, `strict` o `strictest` para tu maquetado de TypeScript):
+Crea un archivo `tsconfig.json` en la raíz del proyecto y copia el siguiente código dentro de él. (Puedes usar `base`, `strict` o `strictest` para tu maquetado de TypeScript):
 
 ``` json title="tsconfig.json" "base"
 {
@@ -162,7 +162,7 @@ Crea `tsconfig.json` en la raíz del proyecto y copia el siguiente código en el
 }
 ```
 
-Lee nuestra [guía para configurar Typescript](/es/guides/typescript/#configuración) para más información.
+Lee nuestra [guía para configurar TypeScript](/es/guides/typescript/#configuración) para más información.
 
 ## 7. Siguientes pasos
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

- What does this PR change? Give us a brief description.
  - Minimal changes to keep it similar to the english version
  - Minimal changes to keep `install/auto.md` and `install/manual.md` similar
    - Like the `auto` version using the word `comenzar` and the `manual` one using `empezar`. Now both uses the same word
  - Change `Typescript` with `TypeScript`
  - Added missing punctuation marks
  - Minimal fixes

Please label this PR with `hacktoberfest-accepted` if get approved. 🎃

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
