### PR TITLE
Add a section on passing a class to a child component

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -114,7 +114,7 @@ interface Props {
 </div>
 ```
 
- If you'd like to destructure a props object that contains `class`, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
+ If you'd like to destructure a props object that contains a `class` prop, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
 
 ```astro title="src/components/MyComponent.astro" {6,8}
 ---

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -97,10 +97,13 @@ const backgroundColor = "rgb(24 121 78)";
 In Astro, HTML attributes like `class` do not automatically pass through to child components.
 
 
-Instead, accept a `class` prop in the child component and apply it to the root element:
+Instead, accept a `class` prop in the child component and apply it to the root element. When destructuring, you must rename it, because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
 
-```astro title="src/components/MyComponent.astro" {1}
-<div class={Astro.props.class}>
+```astro title="src/components/MyComponent.astro" {2,4}
+---
+const { class: className } = Astro.props;
+---
+<div class={className}>
   <slot/>
 </div>
 ```
@@ -117,16 +120,7 @@ import MyComponent from "../components/MyComponent.astro"
 <MyComponent class="red">This will be red!</MyComponent>
 ```
 
- If you'd like to destructure a props object that contains a `class` prop, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
 
-```astro title="src/components/MyComponent.astro" {2,4}
----
-const { class: className } = Astro.props;
----
-<div class={className}>
-  <slot/>
-</div>
-```
 
 ## External Styles
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -92,6 +92,43 @@ const backgroundColor = "rgb(24 121 78)";
 
 📚 See our [directives reference](/en/reference/directives-reference/#definevars) page to learn more about `define:vars`.
 
+### Passing a `class` to a child component
+
+In Astro, HTML attributes like `class` do not pass through to a child component unless they are used as props.
+
+```astro title="src/pages/index.astro"
+---
+import MyComponent from "../components/MyComponent.astro"
+---
+<MyComponent class="red">Color me!</MyComponent>
+```
+
+```astro title="src/components/MyComponent.astro" {6}
+---
+interface Props {
+  class: string
+}
+---
+<div class={Astro.props.class}>
+  <slot/>
+</div>
+```
+
+ If you'd like to destructure a props object that contains `class`, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
+
+```astro title="src/components/MyComponent.astro" {6,8}
+---
+interface Props {
+  class: string
+}
+
+const { class: className } = Astro.props;
+---
+<div class={className}>
+  <slot/>
+</div>
+```
+
 ## External Styles
 
 There are two ways to resolve external global stylesheets: an ESM import for files located within your project source, and an absolute URL link for files in your `public/` directory, or hosted outside of your project.

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -100,6 +100,12 @@ In Astro, HTML attributes like `class` do not pass through to a child component 
 ---
 import MyComponent from "../components/MyComponent.astro"
 ---
+<style>
+  .red {
+    color: red;
+  }
+</style>
+<!-- this won't color the text to red -->
 <MyComponent class="red">Color me!</MyComponent>
 ```
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -114,7 +114,7 @@ interface Props {
 ---
 import MyComponent from "../components/MyComponent.astro"
 ---
-<style>
+<style is:global>
   .red {
     color: red;
   }

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -99,12 +99,7 @@ In Astro, HTML attributes like `class` do not automatically pass through to chil
 
 Instead, accept a `class` prop in the child component and apply it to the root element:
 
-```astro title="src/components/MyComponent.astro" {6}
----
-interface Props {
-  class: string
-}
----
+```astro title="src/components/MyComponent.astro" {1}
 <div class={Astro.props.class}>
   <slot/>
 </div>
@@ -124,12 +119,8 @@ import MyComponent from "../components/MyComponent.astro"
 
  If you'd like to destructure a props object that contains a `class` prop, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.
 
-```astro title="src/components/MyComponent.astro" {6,8}
+```astro title="src/components/MyComponent.astro" {2,4}
 ---
-interface Props {
-  class: string
-}
-
 const { class: className } = Astro.props;
 ---
 <div class={className}>

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -96,18 +96,6 @@ const backgroundColor = "rgb(24 121 78)";
 
 In Astro, HTML attributes like `class` do not automatically pass through to child components.
 
-```astro title="src/pages/index.astro"
----
-import MyComponent from "../components/MyComponent.astro"
----
-<style>
-  .red {
-    color: red;
-  }
-</style>
-<!-- this won't color the text to red -->
-<MyComponent class="red">Color me!</MyComponent>
-```
 
 Instead, accept a `class` prop in the child component and apply it to the root element:
 
@@ -120,6 +108,18 @@ interface Props {
 <div class={Astro.props.class}>
   <slot/>
 </div>
+```
+
+```astro title="src/pages/index.astro"
+---
+import MyComponent from "../components/MyComponent.astro"
+---
+<style>
+  .red {
+    color: red;
+  }
+</style>
+<MyComponent class="red">This will be red!</MyComponent>
 ```
 
  If you'd like to destructure a props object that contains a `class` prop, you must rename it. This is because `class` is a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) in JavaScript.

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -94,7 +94,7 @@ const backgroundColor = "rgb(24 121 78)";
 
 ### Passing a `class` to a child component
 
-In Astro, HTML attributes like `class` do not pass through to a child component unless they are used as props.
+In Astro, HTML attributes like `class` do not automatically pass through to child components.
 
 ```astro title="src/pages/index.astro"
 ---
@@ -108,6 +108,8 @@ import MyComponent from "../components/MyComponent.astro"
 <!-- this won't color the text to red -->
 <MyComponent class="red">Color me!</MyComponent>
 ```
+
+Instead, accept a `class` prop in the child component and apply it to the root element:
 
 ```astro title="src/components/MyComponent.astro" {6}
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
#### Description

- Closes #995 
- Adds a new section on the Styling page, per [this comment](https://github.com/withastro/docs/pull/1011#issuecomment-1185737025)
- I focused on passing `class`, but made it clear that all HTML attributes don't automatically pass through
- Shows two examples: one where you don't destructure props at all, and one where you destructure but rename

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
