### PR TITLE
i18n(pt-BR): update deploy/github.md translation

### DIFF
--- a/src/pages/pt-br/guides/deploy/github.md
+++ b/src/pages/pt-br/guides/deploy/github.md
@@ -70,7 +70,7 @@ O Astro mantém oficialmente o `withastro/action` para fazer o deploy do seu pro
          - name: Install, build, and upload your site
            uses: withastro/action@v0
             # with:
-              # path: . # A localização da raiz do seu projeto Astro dentro do seu repositório. (opcional)
+              # path: . # A localização da pasta raiz do seu projeto Astro dentro do seu repositório. (opcional)
               # node-version: 16 # A versão específica do Node que deve ser utilizada para a build do seu site. A versão padrão é a 16. (opcional)
               # package-manager: yarn # O gerenciador de pacotes usado para instalar as dependências e fazer a build do site. É automaticamente detectado a partir da sua lockfile. (opcional)
 

--- a/src/pages/pt-br/guides/deploy/github.md
+++ b/src/pages/pt-br/guides/deploy/github.md
@@ -69,6 +69,10 @@ O Astro mantém oficialmente o `withastro/action` para fazer o deploy do seu pro
            uses: actions/checkout@v2
          - name: Install, build, and upload your site
            uses: withastro/action@v0
+            # with:
+              # path: . # A localização da raiz do seu projeto Astro dentro do seu repositório. (opcional)
+              # node-version: 16 # A versão específica do Node que deve ser utilizada para a build do seu site. A versão padrão é a 16. (opcional)
+              # package-manager: yarn # O gerenciador de pacotes usado para instalar as dependências e fazer a build do site. É automaticamente detectado a partir da sua lockfile. (opcional)
 
      deploy:
        needs: build
@@ -81,6 +85,10 @@ O Astro mantém oficialmente o `withastro/action` para fazer o deploy do seu pro
            id: deployment
            uses: actions/deploy-pages@v1
    ```
+
+    :::note
+    A action do Astro aceita alguns parâmetros opcionais. Esses podem ser definidos removendo o comentário da linha que começa com `with:` e do parâmetro que você deseja usar.
+    :::
 
    :::caution
    A [action](https://github.com/withastro/action) oficial do Astro escaneia por uma lockfile para detectar o seu gerenciador de pacotes favorito (`npm`, `yarn` ou `pnpm`). Você deve realizar o commit do `package-lock.json`, `yarn.lock` ou `pnpm-lock.yaml` criado automaticamente pelo seu gerenciador de pacotes favorito no seu repositório.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

This PR updates the pt-BR translation for `deploy/github.md`.

I was unsure on the best way to translate "optional inputs", since "opções opcionais" would sound repetitive. I decided on "parâmetros" but I'm not sure if this is a technical term being used in the wrong context, so I would appreciate feedback on that.

I'm also unsure if it should be "o lockfile" or "a lockfile", but since in earlier translation we decided on "...escaneia por uma lockfile para detectar..." I decided to use "a lockfile".

I'm still taking part on hacktoberfest :jack_o_lantern: 