### PR TITLE
Adding hashes to links

### DIFF
--- a/src/components/tabs/JavascriptFlavorTabs.astro
+++ b/src/components/tabs/JavascriptFlavorTabs.astro
@@ -1,0 +1,15 @@
+---
+import Tabs from './Tabs';
+---
+
+<Tabs client:visible sharedStore="javascript-flavors">
+	<Fragment slot="tab.js">JavaScript</Fragment>
+	<Fragment slot="tab.ts">TypeScript</Fragment>
+
+	<Fragment slot="panel.js">
+		<slot name="js" />
+	</Fragment>
+	<Fragment slot="panel.ts">
+		<slot name="ts" />
+	</Fragment>
+</Tabs>

--- a/src/pages/en/comparing-astro-vs-other-tools.md
+++ b/src/pages/en/comparing-astro-vs-other-tools.md
@@ -58,7 +58,7 @@ Elder.js uses a custom routing solution that may feel unfamiliar to new develope
 
 Elder.js was designed to run on large websites, and claims to build one website of ~20k pages in less than 10 minutes (on a modest VM). At the time of writing, Astro builds ~1k pages in 66 seconds but has not yet been tested on 20k+ page projects.
 
-Elder.js supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+Elder.js supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 ## Eleventy vs. Astro
 
@@ -87,7 +87,7 @@ By contrast, Astro automatically builds your client-side JavaScript & CSS for yo
 
 Gatsby uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro’s HTML-like component syntax which is similar to HTML + JSX.
 
-Gatsby v4 supports both Static Site Generation (SSG) with incremental rebuilds, Deferred Static Generation (DSG), and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+Gatsby v4 supports both Static Site Generation (SSG) with incremental rebuilds, Deferred Static Generation (DSG), and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 Gatsby requires a custom GraphQL API for working with all of your site content. While some developers enjoy this model, a common criticism of Gatsby is that this model becomes too complex and difficult to maintain over time, especially as sites grow. Astro has no GraphQL requirement, providing familiar APIs (like `fetch()` and top-level `await`) for data loading close to where the data is needed. However, you are free choose to use any server-side or client-side GraphQL libraries with Astro.
 
@@ -157,7 +157,7 @@ SvelteKit uses Svelte to render your website. Astro is more flexible: you are fr
 
 Both SvelteKit and Astro are frameworks for building websites. SvelteKit does best with highly dynamic websites (like dashboards and inboxes) while Astro does best with highly static websites (like content and eCommerce websites).
 
-SvelteKit supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+SvelteKit supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 #### Comparing SvelteKit vs. Astro Performance
 
@@ -184,7 +184,7 @@ Next.js uses React to render your website. Astro is more flexible: you are free 
 
 Both Next.js and Astro are frameworks for building websites. Next.js does best with highly dynamic websites (like dashboards and inboxes) while Astro does best with highly static websites (like content and eCommerce websites).
 
-Next.js supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+Next.js supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 #### Comparing Next.js vs. Astro Performance
 
@@ -211,7 +211,7 @@ Nuxt uses Vue to render your website. Astro is more flexible: you are free to bu
 
 Both Nuxt and Astro are frameworks for building websites. Nuxt does best with highly dynamic websites (like dashboards and inboxes) while Astro does best with highly static websites (like content and eCommerce websites).
 
-Nuxt supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+Nuxt supports both Static Site Generation (SSG) and Server-Side Rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 #### Comparing Nuxt vs. Astro Performance
 
@@ -236,7 +236,7 @@ Nuxt has great built-in image optimizations. While Astro does not have a compara
 
 Remix uses React to render your website. Astro is more flexible: you are free to build UI with any popular component library (React, Preact, Vue, Svelte, Solid and others) or Astro’s HTML-like component syntax which is similar to HTML + JSX.
 
-Remix supports only server-side rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#enabling-ssr-in-your-project): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
+Remix supports only server-side rendering (SSR). Astro can build statically via SSG, or deploy to SSR environments via [adapters](/en/guides/server-side-rendering/#adding-an-adapter): Deno, Vercel serverless, Netlify serverless and Node.js, with more to come.
 
 #### Case Study: Building a Documentation Website
 

--- a/src/pages/en/concepts/islands.md
+++ b/src/pages/en/concepts/islands.md
@@ -14,14 +14,14 @@ setup: |
 The term "Astro Island" refers to an interactive UI component on an otherwise static page of HTML. Multiple islands can exist on a page, and an island always renders in isolation. Think of them as islands in a sea of static, non-interactive HTML.
 
 <IslandsDiagram>
-    <Fragment slot="headerApp">Header (interactive island)</Fragment>
-    <Fragment slot="sidebarApp">Sidebar (static HTML)</Fragment>
-    <Fragment slot="main">
-        Static content like text, images, etc.
-    </Fragment>
-    <Fragment slot="carouselApp">Image carousel (interactive island)</Fragment>
-    <Fragment slot="footer">Footer (static HTML)</Fragment>
-    <Fragment slot="source">Source: [Islands Architecture: Jason Miller](https://jasonformat.com/islands-architecture/)</Fragment>
+  <Fragment slot="headerApp">Header (interactive island)</Fragment>
+  <Fragment slot="sidebarApp">Sidebar (static HTML)</Fragment>
+  <Fragment slot="main">Static content like text, images, etc.</Fragment>
+  <Fragment slot="carouselApp">Image carousel (interactive island)</Fragment>
+  <Fragment slot="footer">Footer (static HTML)</Fragment>
+  <Fragment slot="source">
+    Source: [Islands Architecture: Jason Miller](https://jasonformat.com/islands-architecture/)
+  </Fragment>
 </IslandsDiagram>
 
 In Astro, you can use any supported UI framework (React, Svelte, Vue, etc.) to render islands in the browser. You can mix and match different frameworks on the same page, or just pick your favorite.

--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -78,11 +78,11 @@ When a Markdown file includes a layout, it passes a `frontmatter` property to th
 const {frontmatter} = Astro.props;
 ---
 <html>
-   <!-- ... -->
+  <!-- ... -->
   <h1>{frontmatter.title}</h1>
   <h2>Post author: {frontmatter.author}</h2>
   <slot />
-   <!-- ... -->
+  <!-- ... -->
 </html>
 ```
 

--- a/src/pages/en/core-concepts/sharing-state.md
+++ b/src/pages/en/core-concepts/sharing-state.md
@@ -3,7 +3,6 @@ layout: ~/layouts/MainLayout.astro
 title: Sharing State
 i18nReady: true
 setup: |
-  import Tabs from '../../../components/tabs/Tabs'
   import UIFrameworkTabs from '~/components/tabs/UIFrameworkTabs.astro'
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
@@ -69,22 +68,22 @@ To get started, install Nano Stores alongside their helper package for your favo
 <UIFrameworkTabs>
   <Fragment slot="preact">
   ```shell
-  npm i nanostores @nanostores/preact
+  npm install nanostores @nanostores/preact
   ```
   </Fragment>
   <Fragment slot="react">
   ```shell
-  npm i nanostores @nanostores/react
+  npm install nanostores @nanostores/react
   ```
   </Fragment>
   <Fragment slot="solid">
   ```shell
-  npm i nanostores @nanostores/solid
+  npm install nanostores @nanostores/solid
   ```
   </Fragment>
   <Fragment slot="svelte">
   ```shell
-  npm i nanostores
+  npm install nanostores
   ```
   :::note
   No helper package here! Nano Stores can be used like standard Svelte stores.
@@ -92,7 +91,7 @@ To get started, install Nano Stores alongside their helper package for your favo
   </Fragment>
   <Fragment slot="vue">
   ```shell
-  npm i nanostores @nanostores/vue
+  npm install nanostores @nanostores/vue
   ```
   </Fragment>
 </UIFrameworkTabs>

--- a/src/pages/en/core-concepts/sharing-state.md
+++ b/src/pages/en/core-concepts/sharing-state.md
@@ -4,6 +4,7 @@ title: Sharing State
 i18nReady: true
 setup: |
   import UIFrameworkTabs from '~/components/tabs/UIFrameworkTabs.astro'
+  import JavascriptFlavorTabs from '~/components/tabs/JavascriptFlavorTabs.astro'
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
 
@@ -314,98 +315,93 @@ Now, let's keep track of the items inside your cart. To avoid duplicates and kee
 
 Let's add a `cartItem` store to our `cartStore.js` from earlier. You can also switch to a TypeScript file to define the shape if you're so inclined.
 
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  import { atom, map } from 'nanostores';
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-import { atom, map } from 'nanostores';
+  export const isCartOpen = atom(false);
 
-export const isCartOpen = atom(false);
+  /**
+   * @typedef {Object} CartItem
+   * @property {string} id
+   * @property {string} name
+   * @property {string} imageSrc
+   * @property {number} quantity
+   */
 
-/**
- * @typedef {Object} CartItem
- * @property {string} id
- * @property {string} name
- * @property {string} imageSrc
- * @property {number} quantity
- */
+  /** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
+  export const cartItems = map({});
 
-/** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
-export const cartItems = map({});
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  import { atom, map } from 'nanostores';
 
+  export const isCartOpen = atom(false);
+
+  export type CartItem = {
+    id: string;
+    name: string;
+    imageSrc: string;
+    quantity: number;
+  }
+
+  export const cartItems = map<Record<string, CartItem>>({});
 ```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-import { atom, map } from 'nanostores';
-
-export const isCartOpen = atom(false);
-
-export type CartItem = {
-  id: string;
-  name: string;
-  imageSrc: string;
-  quantity: number;
-}
-
-export const cartItems = map<Record<string, CartItem>>({});
-```
-</Fragment>
-</Tabs>
+  </Fragment>
+</JavascriptFlavorTabs>
 
 Now, let's export an `addCartItem` helper for our components to use.
 - **If that item doesn't exist in your cart**, add the item with a starting quantity of 1.
 - **If that item _does_ already exist**, bump the quantity by 1.
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-...
-export function addCartItem({ id, name, imageSrc }) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    })
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  ...
+  export function addCartItem({ id, name, imageSrc }) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      })
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-...
-type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
-export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    });
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  ...
+  type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
+  export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      });
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-</Tabs>
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 :::note
 <details>

--- a/src/pages/en/guides/deploy.md
+++ b/src/pages/en/guides/deploy.md
@@ -78,7 +78,7 @@ By default, the build output will be placed at `dist/`. This location can be cha
 :::note
 Before deploying your Astro site with [SSR (server-side rendering)](/en/guides/server-side-rendering/) enabled, make sure you have:
 
-    - Installed the [appropriate adapter](/en/guides/server-side-rendering/#enabling-ssr-in-your-project) to your project dependencies (either manually, or using the adapter's `astro add` command, e.g. `npx astro add netlify`).
-    - [Added the adapter](/en/reference/configuration-reference/#integrations) to your `astro.config.mjs` file's import and default export when installing manually. (The `astro add` command will take care of this step for you!)
+    - Installed the [appropriate adapter](/en/guides/server-side-rendering/#adding-an-adapter) to your project dependencies (either manually, or using the adapter's `astro add` command, e.g. `npx astro add netlify`).
+    - [Added the adapter](/en/reference/configuration-reference/#adapter) to your `astro.config.mjs` file's import and default export when installing manually. (The `astro add` command will take care of this step for you!)
 :::
 

--- a/src/pages/en/guides/deploy/gitlab.md
+++ b/src/pages/en/guides/deploy/gitlab.md
@@ -16,9 +16,9 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 1. Set the correct `site` in `astro.config.mjs`.
 2. Set `outDir:public` in `astro.config.mjs`. This setting instructs Astro to put the static build output in a folder called `public`, which is the folder required by GitLab Pages for exposed files.
 
-If you were using the [`public/` directory](/en/core-concepts/project-structure/#public) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `publicDir`.
+   If you were using the [`public/` directory](/en/core-concepts/project-structure/#public) as a source of static files in your Astro project, rename it and use that new folder name in `astro.config.mjs` for the value of `publicDir`.
 
-For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
+   For example, here are the correct `astro.config.mjs` settings when the `public/` directory is renamed to `static/`:
 
    ```js
    import { defineConfig } from 'astro/config';

--- a/src/pages/en/guides/deploy/layer-zero.md
+++ b/src/pages/en/guides/deploy/layer-zero.md
@@ -17,7 +17,7 @@ Check out [the Astro guide in Layer0’s docs](https://docs.layer0.co/guides/ast
 
     ```bash
     # First, globally install the Layer0 CLI:
-    $ npm i -g @layer0/cli
+    $ npm install -g @layer0/cli
 
     # Then, add Layer0 to your Astro site:
     $ 0 init

--- a/src/pages/en/guides/deploy/netlify.md
+++ b/src/pages/en/guides/deploy/netlify.md
@@ -99,7 +99,7 @@ Using [`pnpm` on Netlify?](https://answers.netlify.com/t/using-pnpm-and-pnpm-wor
 [build.environment]
   NPM_FLAGS = "--version" # prevent Netlify npm install
 [build]
-  command = 'npx pnpm i --store=node_modules/.pnpm-store && npm run build'
+  command = 'npx pnpm install --store=node_modules/.pnpm-store && npm run build'
   publish = 'dist'
 ```
 

--- a/src/pages/en/guides/deploy/surge.md
+++ b/src/pages/en/guides/deploy/surge.md
@@ -12,7 +12,7 @@ You can deploy your Astro project to [Surge](https://surge.sh/) a single-command
 1. Install [the Surge CLI](https://www.npmjs.com/package/surge) globally from the Terminal, if you haven't already.
 
     ```shell
-    npm i -g surge
+    npm install -g surge
     ```
 
 2. Build your Astro site from your project’s root directory.

--- a/src/pages/en/guides/deploy/vercel.md
+++ b/src/pages/en/guides/deploy/vercel.md
@@ -78,7 +78,7 @@ After your project has been imported and deployed, all subsequent pushes to bran
 1. Install the [Vercel CLI](https://vercel.com/cli) and run `vercel` to deploy.
 
     ```bash
-    npm i -g vercel
+    npm install -g vercel
     vercel
     ```
 

--- a/src/pages/en/guides/fonts.md
+++ b/src/pages/en/guides/fonts.md
@@ -65,12 +65,12 @@ The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts 
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      npm i @fontsource/twinkle-star
+      npm install @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm i @fontsource/twinkle-star
+      pnpm install @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -1,6 +1,4 @@
 ---
-setup: |
-  import Tabs from '../../../components/tabs/Tabs';
 layout: ~/layouts/MainLayout.astro
 title: Markdown & MDX
 description: Learn how to create content using Markdown or MDX with Astro
@@ -465,12 +463,13 @@ import { exampleRemarkPlugin } from './example-remark-plugin.mjs';
 export default {
   markdown: {
     remarkPlugins: [exampleRemarkPlugin],
+    extendDefaultPlugins: true,
   },
 };
 
 ```
 
-...every Markdown file will have `customProperty` in its frontmatter! This is available when [importing your markdown](#importing-markdown) and from [the `Astro.props.frontmatter` property in your layouts](#markdown-and-mdx-pages).
+...every Markdown file will have `customProperty` in its frontmatter! This is available when [importing your markdown](#importing-markdown) and from [the `Astro.props.frontmatter` property in your layouts](#frontmatter-layout).
 
 #### Example: calculate reading time
 
@@ -479,7 +478,7 @@ You can use a [remark plugin](https://github.com/remarkjs/remark) to add a readi
 - [`mdast-util-to-string`](https://www.npmjs.com/package/mdast-util-to-string) to extract all text from your markdown
 
 ```shell
-npm i reading-time mdast-util-to-string
+npm install reading-time mdast-util-to-string
 ```
 
 We can apply these packages to a remark plugin like so:
@@ -507,6 +506,7 @@ import { remarkReadingTime } from './remark-reading-time.mjs';
 export default {
   markdown: {
     remarkPlugins: [remarkReadingTime],
+    extendDefaultPlugins: true,
   },
 };
 

--- a/src/pages/en/guides/rss.md
+++ b/src/pages/en/guides/rss.md
@@ -10,19 +10,19 @@ Astro supports fast, automatic RSS feed generation for blogs and other content w
 
 ## Setting up `@astrojs/rss`
 
-The `@astrojs/rss` package provides helpers for generating RSS feeds using [API endpoints](/en/core-concepts/endpoints/#static-file-endpoints). This unlocks both static builds _and_ on-demand generation when using an [SSR adapter](/en/guides/server-side-rendering/#enabling-ssr-in-your-project).
+The `@astrojs/rss` package provides helpers for generating RSS feeds using [API endpoints](/en/core-concepts/endpoints/#static-file-endpoints). This unlocks both static builds _and_ on-demand generation when using an [SSR adapter](/en/guides/server-side-rendering/#adding-an-adapter).
 
 First, install `@astrojs/rss` using your preferred package manager:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  npm i @astrojs/rss
+  npm install @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm i @astrojs/rss
+  pnpm install @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/pages/en/guides/server-side-rendering.md
+++ b/src/pages/en/guides/server-side-rendering.md
@@ -2,6 +2,8 @@
 layout: ~/layouts/MainLayout.astro
 title: Server-side Rendering
 i18nReady: true
+setup: |
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 ---
 
 **Server-side Rendering**, aka SSR, can be enabled in Astro. When you enable SSR you can:
@@ -23,6 +25,8 @@ To get started, enable SSR features in development mode with the `output: server
     });
     ```
 
+### Adding an Adapter
+
 When it's time to deploy an SSR project, you also need to add an adapter. This is because SSR requires a server _runtime_: the environment that runs your server-side code. Each adapter allows Astro to output a script that runs your project on a specific runtime.
 
 The following adapters are available today with more to come in the future:
@@ -33,21 +37,53 @@ The following adapters are available today with more to come in the future:
 - [Node.js](/en/guides/integrations-guide/node/)
 - [Vercel](/en/guides/integrations-guide/vercel/)
 
+#### `astro add` Install
 
 You can add any of the official adapters with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step. For example, to install the Netlify adapter, run:
 
-```bash
-npx astro add netlify
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add netlify
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpx astro add netlify
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add netlify
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+#### Manual Install
 
 You can also add an adapter manually by installing the package and updating `astro.config.mjs` yourself. (See the links above for adapter-specific instructions to complete the following two steps to enable SSR.) Using `my-adapter` as an example placeholder, the instructions will look something like:
 
 1. Install the adapter to your project dependencies using your preferred package manager. If you’re using npm or aren’t sure, run this in the terminal:
 
-    ```bash
-    npm install @astrojs/my-adapter
-    ```
-1. [Add the adapter](/en/reference/configuration-reference/) to your `astro.config.mjs` file's import and default export
+   <PackageManagerTabs>
+     <Fragment slot="npm">
+     ```shell
+     npm install @astrojs/my-adapter
+     ```
+     </Fragment>
+     <Fragment slot="pnpm">
+     ```shell
+     pnpm install @astrojs/my-adapter 
+     ```
+     </Fragment>
+     <Fragment slot="yarn">
+     ```shell
+     yarn add @astrojs/my-adapter
+     ```
+     </Fragment>
+   </PackageManagerTabs>
+
+1. [Add the adapter](/en/reference/configuration-reference/#adapter) to your `astro.config.mjs` file's import and default export
 
     ```js ins={3,6-7}
     // astro.config.mjs

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -389,7 +389,7 @@ You can also use all of the above CSS preprocessors within JS frameworks as well
 
 ## PostCSS
 
-Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project, create a `postcss.config.cjs` file in the project root. You can import plugins using `require()` after installing them (for example `npm i autoprefixer`).
+Astro comes with PostCSS included as part of [Vite](https://vitejs.dev/guide/features.html#postcss). To configure PostCSS for your project, create a `postcss.config.cjs` file in the project root. You can import plugins using `require()` after installing them (for example `npm install autoprefixer`).
 
 ```js title="postcss.config.cjs" ins={3-4}
 module.exports = {

--- a/src/pages/en/migrate.md
+++ b/src/pages/en/migrate.md
@@ -631,7 +631,7 @@ To migrate to v0.21+, please convert all JSX Astro components (that is, any Astr
 
 Autoprefixer is no longer run by default. To enable:
 
-1. Install the latest version (`npm i autoprefixer`)
+1. Install the latest version (`npm install autoprefixer`)
 2. Create a `postcss.config.cjs` file at the root of your project with:
    ```js
    module.exports = {
@@ -645,7 +645,7 @@ Autoprefixer is no longer run by default. To enable:
 
 Ensure you have PostCSS installed. This was optional in previous releases, but is required now:
 
-1. Install the latest version of postcss (`npm i -D postcss`)
+1. Install the latest version of postcss (`npm install -D postcss`)
 2. Create a `postcss.config.cjs` file at the root of your project with:
    ```js
    module.exports = {

--- a/src/pages/en/reference/adapter-reference.md
+++ b/src/pages/en/reference/adapter-reference.md
@@ -4,7 +4,7 @@ title: Astro Adapter API
 i18nReady: true
 ---
 
-Astro is designed to make it easy to deploy to any cloud provider for SSR (server-side rendering). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/).
+Astro is designed to make it easy to deploy to any cloud provider for [SSR (server-side rendering)](/en/guides/server-side-rendering/). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/). See the [SSR guide](/en/guides/server-side-rendering/#adding-an-adapter) to learn how to use an existing adapter.
 
 ## What is an adapter
 

--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -1,7 +1,7 @@
 ---
 setup: |
-  import Since from '~/components/Since.astro';
-  import Tabs from '../../../components/tabs/Tabs';
+  import Since from '~/components/Since.astro'
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 layout: ~/layouts/MainLayout.astro
 title: API Reference
 i18nReady: true
@@ -541,31 +541,25 @@ This component provides syntax highlighting for code blocks at build time (no cl
 
 ### `<Prism />`
 
-:::note[Installation]
-
 To use the `Prism` highlighter component, first **install** the `@astrojs/prism` package:
 
-<Tabs client:visible>
-  <Fragment slot="tab.1.npm">npm</Fragment>
-  <Fragment slot="tab.2.yarn">yarn</Fragment>
-  <Fragment slot="tab.3.pnpm">pnpm</Fragment>
-  <Fragment slot="panel.1.npm">
+<PackageManagerTabs>
+  <Fragment slot="npm">
   ```shell
-  npm i @astrojs/prism
+  npm install @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.2.yarn">
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm install @astrojs/prism
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
   ```shell
   yarn add @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.3.pnpm">
-  ```shell
-  pnpm i @astrojs/prism
-  ```
-  </Fragment>
-</Tabs>
-:::
+</PackageManagerTabs>
 
 ```astro
 ---

--- a/src/pages/es/core-concepts/sharing-state.md
+++ b/src/pages/es/core-concepts/sharing-state.md
@@ -3,8 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: Compartiendo Estado
 i18nReady: true
 setup: |
-  import Tabs from '../../../components/tabs/Tabs'
   import UIFrameworkTabs from '~/components/tabs/UIFrameworkTabs.astro'
+  import JavascriptFlavorTabs from '~/components/tabs/JavascriptFlavorTabs.astro'
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
 
@@ -316,97 +316,93 @@ Ahora, llevemos la cuenta de los ítems que hay dentro de tu carrito. Para evita
 Agreguemos una store `cartItem` a nuestro `cartStore.js` anterior. También puedes utilizar un archivo TypeScript si deseas definir el tipo de dato.
 
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-import { atom, map } from 'nanostores';
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  import { atom, map } from 'nanostores';
 
-export const isCartOpen = atom(false);
+  export const isCartOpen = atom(false);
 
-/**
- * @typedef {Object} CartItem
- * @property {string} id
- * @property {string} name
- * @property {string} imageSrc
- * @property {number} quantity
- */
+  /**
+   * @typedef {Object} CartItem
+   * @property {string} id
+   * @property {string} name
+   * @property {string} imageSrc
+   * @property {number} quantity
+   */
 
-/** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
-export const cartItems = map({});
+  /** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
+  export const cartItems = map({});
 
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-import { atom, map } from 'nanostores';
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  import { atom, map } from 'nanostores';
 
-export const isCartOpen = atom(false);
+  export const isCartOpen = atom(false);
 
-export type CartItem = {
-  id: string;
-  name: string;
-  imageSrc: string;
-  quantity: number;
-}
+  export type CartItem = {
+    id: string;
+    name: string;
+    imageSrc: string;
+    quantity: number;
+  }
 
-export const cartItems = map<Record<string, CartItem>>({});
-```
-</Fragment>
-</Tabs>
+  export const cartItems = map<Record<string, CartItem>>({});
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 Ahora, exportemos una función helper `addCartItem` para que usen nuestros componentes.
 - **Si el ítem no existe en el carrito**, añade el carrito con una cantidad inicial de 1.
 - **Si el ítem _ya existe_**, aumenta la cantidad en 1.
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-...
-export function addCartItem({ id, name, imageSrc }) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    })
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  ...
+  export function addCartItem({ id, name, imageSrc }) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      })
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-...
-type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
-export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    });
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  ...
+  type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
+  export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      });
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-</Tabs>
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 :::note
 <details>

--- a/src/pages/es/reference/api-reference.md
+++ b/src/pages/es/reference/api-reference.md
@@ -1,7 +1,7 @@
 ---
 setup: |
   import Since from '~/components/Since.astro';
-  import Tabs from '../../../components/tabs/Tabs';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 layout: ~/layouts/MainLayout.astro
 title: Referencia de la API
 i18nReady: true
@@ -545,26 +545,23 @@ Este componente proporciona resaltado de sintaxis para bloques de código en el 
 
 Para usar el componente resaltador `Prism`, primero **instala** el paquete `@astrojs/prism`:
 
-<Tabs client:visible>
-  <Fragment slot="tab.1.npm">npm</Fragment>
-  <Fragment slot="tab.2.yarn">yarn</Fragment>
-  <Fragment slot="tab.3.pnpm">pnpm</Fragment>
-  <Fragment slot="panel.1.npm">
+<PackageManagerTabs>
+  <Fragment slot="npm">
   ```shell
-  npm i @astrojs/prism
+  npm install @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.2.yarn">
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm install @astrojs/prism
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
   ```shell
   yarn add @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.3.pnpm">
-  ```shell
-  pnpm i @astrojs/prism
-  ```
-  </Fragment>
-</Tabs>
+</PackageManagerTabs>
 :::
 
 ```astro

--- a/src/pages/pt-br/core-concepts/sharing-state.md
+++ b/src/pages/pt-br/core-concepts/sharing-state.md
@@ -3,8 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: Compartilhamento de Estado
 i18nReady: true
 setup: |
-  import Tabs from '../../../components/tabs/Tabs'
   import UIFrameworkTabs from '~/components/tabs/UIFrameworkTabs.astro'
+  import JavascriptFlavorTabs from '~/components/tabs/JavascriptFlavorTabs.astro'
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
 
@@ -316,97 +316,93 @@ Agora, vamos rastrear os itens dentro de seu carrinho. Para evitar duplicações
 Vamos adicionar uma store `itensCarrinho` a nossa `storeCarrinho.js` de anteriormente. Você também pode trocar para um arquivo TypeScript para definir a forma se quiser.
 
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/storeCarrinho.js
-import { atom, map } from 'nanostores';
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/storeCarrinho.js
+  import { atom, map } from 'nanostores';
 
-export const isCarrinhoAberto = atom(false);
+  export const isCarrinhoAberto = atom(false);
 
-/**
- * @typedef {Object} ItemCarrinho
- * @property {string} id
- * @property {string} nome
- * @property {string} srcImagem
- * @property {number} quantidade
- */
+  /**
+   * @typedef {Object} ItemCarrinho
+   * @property {string} id
+   * @property {string} nome
+   * @property {string} srcImagem
+   * @property {number} quantidade
+   */
 
-/** @type {import('nanostores').MapStore<Record<string, ItemCarrinho>>} */
-export const itensCarrinho = map({});
+  /** @type {import('nanostores').MapStore<Record<string, ItemCarrinho>>} */
+  export const itensCarrinho = map({});
 
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/storeCarrinho.ts
-import { atom, map } from 'nanostores';
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/storeCarrinho.ts
+  import { atom, map } from 'nanostores';
 
-export const isCarrinhoAberto = atom(false);
+  export const isCarrinhoAberto = atom(false);
 
-export type ItemCarrinho = {
-  id: string;
-  nome: string;
-  srcImagem: string;
-  quantidade: number;
-}
+  export type ItemCarrinho = {
+    id: string;
+    nome: string;
+    srcImagem: string;
+    quantidade: number;
+  }
 
-export const itensCarrinho = map<Record<string, ItemCarrinho>>({});
-```
-</Fragment>
-</Tabs>
+  export const itensCarrinho = map<Record<string, ItemCarrinho>>({});
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 Agora, vamos exportar um helper `adicionarItemCarrinho` para nossos componentes utilizarem.
 - **Se o item não existe em seu carrinho**, adicione o item com uma quantidade inicial de 1.
 - **Se o item _já_ existe**, aumente a quantidade em 1.
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/storeCarrinho.js
-...
-export function adicionarItemCarrinho({ id, nome, srcImagem }) {
-  const entradaExistente = itensCarrinho.get()[id];
-  if (entradaExistente) {
-    itensCarrinho.setKey(id, {
-      ...entradaExistente,
-      quantidade: entradaExistente.quantidade + 1,
-    })
-  } else {
-    itensCarrinho.setKey(
-      id,
-      { id, nome, srcImagem, quantidade: 1 }
-    );
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/storeCarrinho.js
+  ...
+  export function adicionarItemCarrinho({ id, nome, srcImagem }) {
+    const entradaExistente = itensCarrinho.get()[id];
+    if (entradaExistente) {
+      itensCarrinho.setKey(id, {
+        ...entradaExistente,
+        quantidade: entradaExistente.quantidade + 1,
+      })
+    } else {
+      itensCarrinho.setKey(
+        id,
+        { id, nome, srcImagem, quantidade: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/storeCarrinho.ts
-...
-type InfoVisivelItem = Pick<CartItem, 'id' | 'nome' | 'srcImagem'>;
-export function adicionarItemCarrinho({ id, nome, srcImagem }: InfoVisivelItem) {
-  const entradaExistente = itensCarrinho.get()[id];
-  if (entradaExistente) {
-    itensCarrinho.setKey(id, {
-      ...entradaExistente,
-      quantidade: entradaExistente.quantidade + 1,
-    });
-  } else {
-    itensCarrinho.setKey(
-      id,
-      { id, nome, srcImagem, quantidade: 1 }
-    );
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/storeCarrinho.ts
+  ...
+  type InfoVisivelItem = Pick<CartItem, 'id' | 'nome' | 'srcImagem'>;
+  export function adicionarItemCarrinho({ id, nome, srcImagem }: InfoVisivelItem) {
+    const entradaExistente = itensCarrinho.get()[id];
+    if (entradaExistente) {
+      itensCarrinho.setKey(id, {
+        ...entradaExistente,
+        quantidade: entradaExistente.quantidade + 1,
+      });
+    } else {
+      itensCarrinho.setKey(
+        id,
+        { id, nome, srcImagem, quantidade: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-</Tabs>
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 :::note
 <details>

--- a/src/pages/pt-br/reference/api-reference.md
+++ b/src/pages/pt-br/reference/api-reference.md
@@ -1,7 +1,7 @@
 ---
 setup: |
   import Since from '~/components/Since.astro';
-  import Tabs from '../../../components/tabs/Tabs';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 layout: ~/layouts/MainLayout.astro
 title: Referência da API
 i18nReady: true
@@ -519,26 +519,23 @@ Este componente providencia syntax highlighting para blocos de código em tempo 
 
 Para usar o componente highlighter `Prism`, primeiro **instale** o pacote `@astrojs/prism`:
 
-<Tabs client:visible>
-  <Fragment slot="tab.1.npm">npm</Fragment>
-  <Fragment slot="tab.2.yarn">yarn</Fragment>
-  <Fragment slot="tab.3.pnpm">pnpm</Fragment>
-  <Fragment slot="panel.1.npm">
+<PackageManagerTabs>
+  <Fragment slot="npm">
   ```shell
-  npm i @astrojs/prism
+  npm install @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.2.yarn">
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm install @astrojs/prism
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
   ```shell
   yarn add @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.3.pnpm">
-  ```shell
-  pnpm i @astrojs/prism
-  ```
-  </Fragment>
-</Tabs>
+</PackageManagerTabs>
 :::
 
 ```astro

--- a/src/pages/zh-cn/core-concepts/sharing-state.md
+++ b/src/pages/zh-cn/core-concepts/sharing-state.md
@@ -3,8 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: 状态共享
 i18nReady: false
 setup: |
-  import Tabs from '../../../components/tabs/Tabs'
   import UIFrameworkTabs from '~/components/tabs/UIFrameworkTabs.astro'
+  import JavascriptFlavorTabs from '~/components/tabs/JavascriptFlavorTabs.astro'
   import LoopingVideo from '~/components/LoopingVideo.astro'
 ---
 当我们使用 [群岛结构 / 部分激活](/zh-cn/concepts/islands/)，你可能会遇到这样的问题：**我想在我的组件之间共享状态。**
@@ -321,97 +321,93 @@ export default function CartFlyout() {
 让我们在先前的 `cartStore.js` 中添加一个 `cartItem` 状态库。如果你愿意的话，你也可以使用 TypeScript 文件来定义。
 
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-import { atom, map } from 'nanostores';
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  import { atom, map } from 'nanostores';
 
-export const isCartOpen = atom(false);
+  export const isCartOpen = atom(false);
 
-/**
- * @typedef {Object} CartItem
- * @property {string} id
- * @property {string} name
- * @property {string} imageSrc
- * @property {number} quantity
- */
+  /**
+   * @typedef {Object} CartItem
+   * @property {string} id
+   * @property {string} name
+   * @property {string} imageSrc
+   * @property {number} quantity
+   */
 
-/** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
-export const cartItems = map({});
+  /** @type {import('nanostores').MapStore<Record<string, CartItem>>} */
+  export const cartItems = map({});
 
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-import { atom, map } from 'nanostores';
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  import { atom, map } from 'nanostores';
 
-export const isCartOpen = atom(false);
+  export const isCartOpen = atom(false);
 
-export type CartItem = {
-  id: string;
-  name: string;
-  imageSrc: string;
-  quantity: number;
-}
+  export type CartItem = {
+    id: string;
+    name: string;
+    imageSrc: string;
+    quantity: number;
+  }
 
-export const cartItems = map<Record<string, CartItem>>({});
-```
-</Fragment>
-</Tabs>
+  export const cartItems = map<Record<string, CartItem>>({});
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 现在，让我们导出一个 `addCartItem` 函数供我们的组件使用。
 - **如果你的购物车中不存在该商品**，添加商品并设置初始数量 1。
 - **如果购物车中_已经_存在该商品**，则将该商品数量增加 1。
 
-<Tabs client:visible sharedStore="js-ts">
-<Fragment slot="tab.js">JavaScript</Fragment>
-<Fragment slot="tab.ts">TypeScript</Fragment>
-<Fragment slot="panel.js">
-```js
-// src/cartStore.js
-...
-export function addCartItem({ id, name, imageSrc }) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    })
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+<JavascriptFlavorTabs>
+  <Fragment slot="js">
+  ```js
+  // src/cartStore.js
+  ...
+  export function addCartItem({ id, name, imageSrc }) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      })
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-<Fragment slot="panel.ts">
-```ts
-// src/cartStore.ts
-...
-type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
-export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
-  const existingEntry = cartItems.get()[id];
-  if (existingEntry) {
-    cartItems.setKey(id, {
-      ...existingEntry,
-      quantity: existingEntry.quantity + 1,
-    });
-  } else {
-    cartItems.setKey(
-      id,
-      { id, name, imageSrc, quantity: 1 }
-    );
+  ```
+  </Fragment>
+  <Fragment slot="ts">
+  ```ts
+  // src/cartStore.ts
+  ...
+  type ItemDisplayInfo = Pick<CartItem, 'id' | 'name' | 'imageSrc'>;
+  export function addCartItem({ id, name, imageSrc }: ItemDisplayInfo) {
+    const existingEntry = cartItems.get()[id];
+    if (existingEntry) {
+      cartItems.setKey(id, {
+        ...existingEntry,
+        quantity: existingEntry.quantity + 1,
+      });
+    } else {
+      cartItems.setKey(
+        id,
+        { id, name, imageSrc, quantity: 1 }
+      );
+    }
   }
-}
-```
-</Fragment>
-</Tabs>
+  ```
+  </Fragment>
+</JavascriptFlavorTabs>
 
 :::note
 <details>

--- a/src/pages/zh-cn/reference/api-reference.md
+++ b/src/pages/zh-cn/reference/api-reference.md
@@ -3,7 +3,7 @@ layout: ~/layouts/MainLayout.astro
 title: API 参考
 setup:
   import Since from '~/components/Since.astro';
-  import Tabs from '../../../components/tabs/Tabs';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 ---
 
 ## `Astro`
@@ -519,26 +519,23 @@ import { Code } from 'astro/components';
 
 要安装 `Prism` 高亮器组件, 需要**先安装** `@astrojs/prism` 包：
 
-<Tabs client:visible>
-  <Fragment slot="tab.1.npm">npm</Fragment>
-  <Fragment slot="tab.2.yarn">yarn</Fragment>
-  <Fragment slot="tab.3.pnpm">pnpm</Fragment>
-  <Fragment slot="panel.1.npm">
+<PackageManagerTabs>
+  <Fragment slot="npm">
   ```shell
-  npm i @astrojs/prism
+  npm install @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.2.yarn">
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm install @astrojs/prism
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
   ```shell
   yarn add @astrojs/prism
   ```
   </Fragment>
-  <Fragment slot="panel.3.pnpm">
-  ```shell
-  pnpm i @astrojs/prism
-  ```
-  </Fragment>
-</Tabs>
+</PackageManagerTabs>
 :::
 
 ```astro


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.) **<-- mostly**
- New or updated content **<-- a smidgen**

This PR began with adding hashes to links.

Along the way, I found & fixed / improved:
* Added `extendDefaultPlugins: true` to 2 examples, to reduce surprising side effects that may otherwise occur when blindly copying code from examples.
* Indentation.
* `npm i` --> `npm install` (for consistency).
* Changed and added a few links.
* Removed unnecessary `import Tabs` from 2 pages
* Switched 1 page from `Tabs` to `PackageManagerTabs`
* Added `PackageManagerTabs` to 1 page.
* Added a link from [reference/adapter-reference](https://docs.astro.build/en/reference/adapter-reference/) to the [SSR guide](https://docs.astro.build/en/guides/server-side-rendering/), as there was otherwise no convenient path from `reference/adapter-reference` to other adapter docs.
* Added some new headers to [guides/server-side-rendering](https://docs.astro.build/en/guides/server-side-rendering/), in part so I could link directly to `#adding-an-adapter`, but also because I think it will scan better.

---

During the same editing session, I edited 4 auto-generated files:
https://github.com/withastro/docs/compare/main...mrienstra:docs:placeholder-1

I'll have to open another PR for those changes, the sources in question being:
- https://github.com/withastro/astro/blob/main/packages/integrations/mdx/README.md
- https://github.com/withastro/astro/blob/main/packages/integrations/partytown/README.md
- https://github.com/withastro/astro/blob/main/packages/integrations/sitemap/README.md
- https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts