### PR TITLE
Updating the OG Image Generator 

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -91,6 +91,12 @@ class IntegrationPagesBuilder {
 		const githubLink = `https://github.com/${this.#sourceRepo}/tree/${
 			this.#sourceBranch
 		}/packages/integrations/${srcdir}/`;
+
+		const createDescription = (name:string, category:string):string=>{
+			const capitialise = (str:string) => str.charAt(0).toUpperCase() + str.slice(1)
+			let format_name_output = name.replace('@astrojs/','');
+			return `Documentation on how to utilise Astro's ${category.match('renderer') ? `${capitialise(format_name_output)} Framework Integration` : category.match('adapter') ? `${capitialise(format_name_output)} Server Adapter` :  `Official ${capitialise(format_name_output)} Integration`}`
+	}
 		const processor = remark()
 			.use(removeTOC)
 			.use(absoluteLinks, { base: githubLink })
@@ -109,6 +115,8 @@ class IntegrationPagesBuilder {
 
 layout: ~/layouts/IntegrationLayout.astro
 title: '${name}'
+description: ${createDescription(name,category)}
+installCMD: npx astro add ${name.replace('@astrojs/','')}
 githubURL: '${githubLink}'
 hasREADME: true
 category: ${category}

--- a/src/pages/open-graph/[...path].ts
+++ b/src/pages/open-graph/[...path].ts
@@ -103,6 +103,7 @@ export const { getStaticPaths, get } = OGImageRoute({
 				'https://api.fontsource.org/v1/fonts/noto-sans-arabic/arabic-400-normal.ttf',
 				'https://api.fontsource.org/v1/fonts/noto-sans-arabic/arabic-800-normal.ttf',
 			],
+			...page.frontmatter.installCMD && {code :page.frontmatter.installCMD}
 		};
 	},
 });

--- a/src/util/generateOpenGraphImage.js
+++ b/src/util/generateOpenGraphImage.js
@@ -1,0 +1,153 @@
+import { decodeHTMLStrict } from 'entities';
+import { CanvasKitPromise, fontManager, loadImage } from './assetLoaders';
+const [width, height] = [1200, 630];
+const edges = {
+    top: [0, 0, width, 0],
+    bottom: [0, height, width, height],
+    left: [0, 0, 0, height],
+    right: [width, 0, width, height],
+};
+const defaults = {
+    border: {
+        color: [255, 255, 255],
+        width: 0,
+        side: 'inline-start',
+    },
+    font: {
+        title: {
+            color: [255, 255, 255],
+            size: 70,
+            lineHeight: 1,
+            weight: 'Normal',
+            families: ['Noto Sans'],
+        },
+        description: {
+            color: [255, 255, 255],
+            size: 40,
+            lineHeight: 1.3,
+            weight: 'Normal',
+            families: ['Noto Sans'],
+        },
+    },
+};
+export async function generateOpenGraphImage({ title, description = '', dir = 'ltr', bgGradient = [[0, 0, 0]], border: borderConfig = {}, padding = 60, logo, font: fontConfig = {}, fonts = ['https://api.fontsource.org/v1/fonts/noto-sans/latin-400-normal.ttf'], format = 'PNG', quality = 90, code=undefined }) {
+	console.log(code && '🌹 Code:' + code)
+    const border = { ...defaults.border, ...borderConfig };
+    const font = {
+        title: { ...defaults.font.title, ...fontConfig.title },
+        description: { ...defaults.font.description, ...fontConfig.description },
+    };
+    const isRtl = dir === 'rtl';
+    const margin = {
+        'block-start': padding,
+        'block-end': padding,
+        'inline-start': padding,
+        'inline-end': padding,
+    };
+    margin[border.side] += border.width;
+    const CanvasKit = await CanvasKitPromise;
+    const textStyle = (fontConfig) => ({
+        color: CanvasKit.Color(...fontConfig.color),
+        fontFamilies: fontConfig.families,
+        fontSize: fontConfig.size,
+        fontStyle: { weight: CanvasKit.FontWeight[fontConfig.weight] },
+        heightMultiplier: fontConfig.lineHeight,
+    });
+    // Set up.
+    const surface = CanvasKit.MakeSurface(width, height);
+    const canvas = surface.getCanvas();
+    // Draw background gradient.
+    const bgRect = CanvasKit.XYWHRect(0, 0, width, height);
+    const bgPaint = new CanvasKit.Paint();
+    bgPaint.setShader(CanvasKit.Shader.MakeLinearGradient([0, 0], [0, height], bgGradient.map((rgb) => CanvasKit.Color(...rgb)), null, CanvasKit.TileMode.Clamp));
+    canvas.drawRect(bgRect, bgPaint);
+    // Draw border.
+    if (border.width) {
+        const borderStyle = new CanvasKit.Paint();
+        borderStyle.setStyle(CanvasKit.PaintStyle.Stroke);
+        borderStyle.setColor(CanvasKit.Color(...border.color));
+        borderStyle.setStrokeWidth(border.width * 2);
+        const borders = {
+            'block-start': edges.top,
+            'block-end': edges.bottom,
+            'inline-start': isRtl ? edges.right : edges.left,
+            'inline-end': isRtl ? edges.left : edges.right,
+        };
+        canvas.drawLine(...borders[border.side], borderStyle);
+    }
+    // Draw logo.
+    let logoHeight = 0;
+    if (logo) {
+        const imgBuf = await loadImage(logo.path);
+        const img = CanvasKit.MakeImageFromEncoded(imgBuf);
+        if (img) {
+            const logoH = img.height();
+            const logoW = img.width();
+            const targetW = logo.size?.[0] ?? logoW;
+            const targetH = logo.size?.[1] ?? (targetW / logoW) * logoH;
+            const xRatio = targetW / logoW;
+            const yRatio = targetH / logoH;
+            logoHeight = targetH;
+            // Matrix transform to scale the logo to the desired size.
+            const imagePaint = new CanvasKit.Paint();
+            imagePaint.setImageFilter(CanvasKit.ImageFilter.MakeMatrixTransform(CanvasKit.Matrix.scaled(xRatio, yRatio), { filter: CanvasKit.FilterMode.Linear }, null));
+            const imageLeft = isRtl
+                ? (1 / xRatio) * (width - margin['inline-start']) - logoW
+                : (1 / xRatio) * margin['inline-start'];
+            canvas.drawImage(img, imageLeft, (1 / yRatio) * margin['block-start'], imagePaint);
+        }
+    }
+    // Load and configure font families.
+    const fontMgr = await fontManager.get(fonts);
+		let Styles = {
+			textAlign: isRtl ? CanvasKit.TextAlign.Right : CanvasKit.TextAlign.Left,
+			textStyle: textStyle(font.title),
+			textDirection: isRtl ? CanvasKit.TextDirection.RTL : CanvasKit.TextDirection.LTR,
+	}
+    if (fontMgr) {
+        // Create paragraph with initial styles and add title.
+        const paragraphStyle = new CanvasKit.ParagraphStyle(Styles);
+        const paragraphBuilder = CanvasKit.ParagraphBuilder.Make(paragraphStyle, fontMgr);
+        paragraphBuilder.addText(decodeHTMLStrict(title));
+        // Add small empty line betwen title & description.
+        paragraphBuilder.pushStyle(new CanvasKit.TextStyle({ fontSize: padding / 3, heightMultiplier: 1 }));
+        paragraphBuilder.addText('\n\n');
+        // Add description.
+        paragraphBuilder.pushStyle(new CanvasKit.TextStyle(textStyle(font.description)));
+        paragraphBuilder.addText(decodeHTMLStrict(description));
+        // Draw paragraph to canvas.
+        const para = paragraphBuilder.build();
+        const paraWidth = width - margin['inline-start'] - margin['inline-end'] - padding;
+        para.layout(paraWidth);
+        const paraLeft = isRtl
+            ? width - margin['inline-start'] - para.getMaxWidth()
+            : margin['inline-start'];
+        const minTop = margin['block-start'] + logoHeight + (logoHeight ? padding : 0);
+        const maxTop = minTop + (logoHeight ? padding : 0);
+        const naturalTop = height - margin['block-end'] - para.getHeight();
+        const paraTop = Math.max(minTop, Math.min(maxTop, naturalTop));
+				
+        canvas.drawParagraph(para, paraLeft, paraTop);
+				if(code){
+					const codeStyle = new CanvasKit.ParagraphStyle(Styles)
+					const codeText = CanvasKit.ParagraphBuilder.Make(codeStyle, fontMgr)
+					codeText.addText(decodeHTMLStrict(code))
+					codeText.pushStyle(new CanvasKit.TextStyle(textStyle(font.description)));
+					const codeTop = height - minTop + padding
+					const buildCodeBlock = codeText.build();
+					buildCodeBlock.layout(paraWidth)
+					console.log(buildCodeBlock.getHeight())
+					const rectInputs = [paraLeft,codeTop,paraWidth, codeTop + buildCodeBlock.getHeight() + 13,50,50,50,50,50,50,50,50]
+					const paintRect = new CanvasKit.Paint()
+					paintRect.setColor(bgGradient.map(x=>x/2))
+					canvas.drawRRect(rectInputs,paintRect)
+					canvas.drawParagraph(buildCodeBlock,paraLeft + padding / 2, codeTop + 5)
+
+				}
+	
+    }
+    // Render canvas to a buffer.
+    const image = surface.makeImageSnapshot();
+    const imageBytes = image.encodeToBytes(CanvasKit.ImageFormat[format], quality) || new Uint8Array();
+    return Buffer.from(imageBytes);
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1JaSDGpkslQ1SW2vvdHbwpdOcEo3mA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=gkw-vfq)
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Updating @delucis `astro-og-image` to include some additional contextual information for Integrations guides, 
![image](https://user-images.githubusercontent.com/28299972/194535539-6d5cb545-db1f-4cf5-a3a3-133fae241cb9.png)

Having decided to apply a body that reads: 
```js
`Documentation on how to utilise Astro's ${category.match('renderer') ? `${capitialise(formatted_name_output)} Framework Integration` : category.match('adapter') ? `${capitialise(formatted_name_output)} Server Adapter` :  `Official ${capitialise(formatted_name_output)} Integration`}`
```

In addition to the body being added to the OG Image, I felt that it still looked bear.

Further experimentation with the `astro-og-image` had resulted in a partial attempt at generating,

![alpinejs (2)](https://user-images.githubusercontent.com/28299972/194537203-296ea0f2-d44f-4d68-a284-c938e4097a96.png)

[ ] - Styling and further design changes needed, 

The original Image generated for each of the integrations looks a bit bear. 
<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->


