### PR TITLE
ci: make linkcheck 2 times faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:a11y": "start-test 'yarn build && yarn preview' 3000 'yarn lint:a11y:local'",
     "lint:a11y:local": "pa11y-ci --sitemap 'http://localhost:3000/sitemap.xml' --sitemap-find 'https://docs.astro.build' --sitemap-replace 'http://localhost:3000'",
     "lint:a11y:remote": "pa11y-ci --sitemap 'https://docs.astro.build/sitemap.xml'",
-    "lint:linkcheck": "astro build && tsm --require=./scripts/lib/filter-warnings.cjs ./scripts/lint-linkcheck.ts",
+    "lint:linkcheck": "SKIP_OG=true astro build && tsm --require=./scripts/lib/filter-warnings.cjs ./scripts/lint-linkcheck.ts",
     "lint:linkcheck:nobuild": "tsm --require=./scripts/lib/filter-warnings.cjs ./scripts/lint-linkcheck.ts",
     "lint:slugcheck": "node ./scripts/lint-slugcheck.mjs",
     "lint:eslint": "eslint . --ext .js,.ts,.astro",

--- a/src/pages/open-graph/[...path].ts
+++ b/src/pages/open-graph/[...path].ts
@@ -14,8 +14,7 @@ import { readFile } from 'fs/promises';
 // combo to extract title & description from each page.
 
 /** Paths for all of our Markdown content we want to generate OG images for. */
-// @ts-expect-error 2339 - env does not exist in import.meta as this file is not included in tsconfig.json
-const paths = !import.meta.env.SKIP_OG ? await glob('src/pages/**/*.md') : [];
+const paths = process.env.SKIP_OG ? [] : await glob('src/pages/**/*.md');
 
 /**
  * An object mapping file paths to a file loader method, mimicking

--- a/src/pages/open-graph/[...path].ts
+++ b/src/pages/open-graph/[...path].ts
@@ -14,7 +14,8 @@ import { readFile } from 'fs/promises';
 // combo to extract title & description from each page.
 
 /** Paths for all of our Markdown content we want to generate OG images for. */
-const paths = await glob('src/pages/**/*.md');
+// @ts-expect-error 2339 - env does not exist in import.meta as this file is not included in tsconfig.json
+const paths = !import.meta.env.SKIP_OG ? await glob('src/pages/**/*.md') : [];
 
 /**
  * An object mapping file paths to a file loader method, mimicking


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

It makes the `lint:linkcheck` command run 2 times faster by disabling OG image generation.

##### Local

![Hyperfine](https://user-images.githubusercontent.com/37726261/194965580-08079cd9-994b-4781-88d3-ed1fc0ee1260.png)

##### CI

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/37726261/194965964-5032c239-6443-4055-a5de-e82de792c1a3.png) | ![After](https://user-images.githubusercontent.com/37726261/194965998-bf427680-ff97-40bf-8b03-c74b4745a273.png) |

I'm participating in Hacktoberfest, so if PR is ok, I'd like it to be labeled as hacktoberfest-accepted.