### PR TITLE
Use `extendDefaultPlugins` in more code samples

### DIFF
--- a/src/pages/en/guides/integrations-guide/mdx.md
+++ b/src/pages/en/guides/integrations-guide/mdx.md
@@ -407,7 +407,7 @@ import shikiTwoslash from 'remark-shiki-twoslash';
 
 export default {
   markdown: {
-  syntaxHighlight: false,
+    syntaxHighlight: false,
   },
   integrations: [mdx({
     remarkPlugins: [shikiTwoslash, { /* Shiki Twoslash config */ }],
@@ -460,7 +460,7 @@ export default {
 
 #### `markdown` (default)
 
-By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkPlugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypePlugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
+By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkPlugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypePlugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/#markdownextenddefaultplugins) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
 
 This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) to Markdown *and* MDX, and [`rehype-minify`](https://github.com/rehypejs/rehype-minify) to MDX alone:
 
@@ -491,7 +491,8 @@ import remarkToc from 'remark-toc';
 
 export default {
   markdown: {
-    remarkPlugins: [/** ignored */]
+    remarkPlugins: [/** ignored */],
+    extendDefaultPlugins: true,
   },
   integrations: [mdx({
     remarkPlugins: [remarkToc],

--- a/src/pages/en/guides/integrations-guide/mdx.md
+++ b/src/pages/en/guides/integrations-guide/mdx.md
@@ -491,8 +491,7 @@ import remarkToc from 'remark-toc';
 
 export default {
   markdown: {
-    remarkPlugins: [/** ignored */],
-    extendDefaultPlugins: true,
+    remarkPlugins: [/** ignored */]
   },
   integrations: [mdx({
     remarkPlugins: [remarkToc],

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -465,6 +465,7 @@ import { exampleRemarkPlugin } from './example-remark-plugin.mjs';
 export default {
   markdown: {
     remarkPlugins: [exampleRemarkPlugin],
+    extendDefaultPlugins: true,
   },
 };
 
@@ -507,6 +508,7 @@ import { remarkReadingTime } from './remark-reading-time.mjs';
 export default {
   markdown: {
     remarkPlugins: [remarkReadingTime],
+    extendDefaultPlugins: true,
   },
 };
 

--- a/src/pages/en/reference/configuration-reference.md
+++ b/src/pages/en/reference/configuration-reference.md
@@ -365,7 +365,7 @@ Which syntax highlighter to use, if any.
 Pass [remark plugins](https://github.com/remarkjs/remark) to customize how your Markdown is built. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 
 :::caution
-Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the [`extendDefaultPlugins`](#markdownextenddefaultplugins) flag.
 :::
 
 ```js
@@ -388,7 +388,7 @@ import remarkToc from 'remark-toc';
 Pass [rehype plugins](https://github.com/remarkjs/remark-rehype) to customize how your Markdown's output HTML is processed. You can import and apply the plugin function (recommended), or pass the plugin name as a string.
 
 :::caution
-Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the `extendDefaultPlugins` flag.
+Providing a list of plugins will **remove** our default plugins. To preserve these defaults, see the [`extendDefaultPlugins`](#markdownextenddefaultplugins) flag.
 :::
 
 ```js


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

1. Use `extendDefaultPlugins: true` in more code samples. There were a few that I didn't add it to.

   My thought process when evaluating each one was basically: Would I expect this code sample to drop the default plugins as a side effect of adding a new plugin? Or, will I likely be carefully considering the behavior of the code sample, such that I am likely to understand that it drops the default plugins?

   Another motivation for these changes is to reduce the likelihood of new users blinding copying these code samples, then being confused as to why they can no longer use GitHub-flavored Markdown.

2. Plus more extendDefaultPlugins cross-linking (minor). One indentation fix.

---

Preview links:
- [/en/guides/integrations-guide/mdx/](https://deploy-preview-1777--astro-docs-2.netlify.app/en/guides/integrations-guide/mdx/)
- [/en/guides/markdown-content/](https://deploy-preview-1777--astro-docs-2.netlify.app/en/guides/markdown-content/)
- [/en/reference/configuration-reference/](https://deploy-preview-1777--astro-docs-2.netlify.app/en/reference/configuration-reference/)

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
