### PR TITLE
fix: missing package.json example comma

### DIFF
--- a/src/pages/en/guides/deploy/deno.md
+++ b/src/pages/en/guides/deploy/deno.md
@@ -157,7 +157,7 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
         "dev": "astro dev",
         "start": "astro dev",
         "build": "astro build",
-        "preview": "deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs"
+        "preview": "deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs",
         "deno-deploy": "npm run build && deployctl deploy --project=<MY-DENO-PROJECT> --no-static --include=./dist ./dist/server/entry.mjs"
       }
     }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description
The corrected version of #1783, inserting a missing comma to a `package.json` example.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
