### PR TITLE
Fix OG image generation for pages like `index.md`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^5.32.0",
     "astro": "1.4.7",
     "astro-eslint-parser": "^0.4.5",
-    "astro-og-canvas": "^0.1.4",
+    "astro-og-canvas": "^0.1.5",
     "bcp-47-normalize": "^2.1.0",
     "chroma-js": "^2.4.2",
     "dedent-js": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ specifiers:
   '@typescript-eslint/parser': ^5.32.0
   astro: 1.4.7
   astro-eslint-parser: ^0.4.5
-  astro-og-canvas: ^0.1.4
+  astro-og-canvas: ^0.1.5
   bcp-47-normalize: ^2.1.0
   chroma-js: ^2.4.2
   dedent-js: ^1.0.1
@@ -83,7 +83,7 @@ devDependencies:
   '@typescript-eslint/parser': 5.32.0_qugx7qdu5zevzvxaiqyxfiwquq
   astro: 1.4.7_sass@1.54.3
   astro-eslint-parser: 0.4.5
-  astro-og-canvas: 0.1.4_astro@1.4.7
+  astro-og-canvas: 0.1.5_astro@1.4.7
   bcp-47-normalize: 2.1.0
   chroma-js: 2.4.2
   dedent-js: 1.0.1
@@ -1398,8 +1398,8 @@ packages:
       - supports-color
     dev: true
 
-  /astro-og-canvas/0.1.4_astro@1.4.7:
-    resolution: {integrity: sha512-BQE784rtHP6xuTKMm8ct1k6V4e1RX7RgqOUKGOqvTCdUt69MKyf+SPH7fljLIH7ub2xETjbRFqf/w3YUYjMHmg==}
+  /astro-og-canvas/0.1.5_astro@1.4.7:
+    resolution: {integrity: sha512-5fzA7pVRhlh4t4tuX73TwYsP9phb5S+UU1Hhzu/D5GsP3djwuDpw8sTLohIxxsKbvWErko4HCvU2qDMtCoX7KA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       astro: ^1.0.0

--- a/src/pages/open-graph/[...path].ts
+++ b/src/pages/open-graph/[...path].ts
@@ -31,7 +31,7 @@ const pages = Object.fromEntries(
 			return {
 				frontmatter: file.data,
 				// An Astro `.md` import includes the page URL, so we’re faking that.
-				url: path.replace('src/pages', '').replace(/\.md/, ''),
+				url: path.replace('src/pages', '').replace(/(\/index)?\.md$/, ''),
 			};
 		},
 	])


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

After merging #1089 I noticed Open Graph images weren’t showing correctly for some pages in the tutorial because they use `/directory/index.md` naming for some pages and this was not handled correctly (generating `/directory/index.png` images instead of the expected `/directory.png`).

This PR fixes that by tweaking some logic in our endpoint but mainly by upgrading `astro-og-canvas` where I fixed the core logic (https://github.com/delucis/astro-og-canvas/commit/98be21325b1ea6c176ad563e96af0ba333b899c2).

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
