### PR TITLE
Tutorial: add step to install astro extension

### DIFF
--- a/src/pages/en/tutorial/1-setup/3.md
+++ b/src/pages/en/tutorial/1-setup/3.md
@@ -78,7 +78,9 @@ When the install wizard is complete, you no longer need this terminal. You can n
 
 1. Open VS Code. You will be prompted to open a folder. Choose the folder that you created during the setup wizard.
 
-2. Make sure the terminal is visible (<kbd>CTRL</kbd>+<kbd>J</kbd> to toggle) and that you can see the command prompt, such as:
+2. If this is your first time opening an Astro project, you should see a notification asking if you would like to install recommended extensions. Click to see the recommended extensions, and choose the [Astro language support extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode). This will provide syntax highlighting and autocompletions for your Astro code.
+
+3. Make sure the terminal is visible (<kbd>CTRL</kbd>+<kbd>J</kbd> to toggle) and that you can see the command prompt, such as:
 
 ```sh
 user@machine:~/tutorial$


### PR DESCRIPTION
Adding a step to install the Astro extension when you first open the project in VSCode
