### PR TITLE
[tutorial] consistent page descriptions

### DIFF
--- a/src/pages/en/tutorial/1-setup/1.md
+++ b/src/pages/en/tutorial/1-setup/1.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Create your online accounts
+description: "Tutorial: Build your first Astro blog —\nCreate the online accounts that you'll need to complete the tutorial"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/2.md
+++ b/src/pages/en/tutorial/1-setup/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Prepare your dev environment
+description: "Tutorial: Build your first Astro blog —\nInstall the local tools that you’ll need to complete the tutorial"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/3.md
+++ b/src/pages/en/tutorial/1-setup/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Create your first Astro project
+description: "Tutorial: Build your first Astro blog —\nCreate a new project for the Astro tutorial and get ready to code"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/4.md
+++ b/src/pages/en/tutorial/1-setup/4.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Write your first line of Astro
+description: "Tutorial: Build your first Astro blog —\nMake your first edits to your tutorial project's home page"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/5.md
+++ b/src/pages/en/tutorial/1-setup/5.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Store your repository online
+description: "Tutorial: Build your first Astro blog —\nCreate a GitHub repo for your tutorial project"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/6.md
+++ b/src/pages/en/tutorial/1-setup/6.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Deploy your site to the web
+description: "Tutorial: Build your first Astro blog —\nConnect your tutorial project's GitHub repo to Netlify and deploy to the web"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/index.md
+++ b/src/pages/en/tutorial/1-setup/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Create and deploy your first Astro site
 title: "Check in: Unit 1 - Setup"
-description: Build your first Astro blog | Prepare your developent environment, and create and deploy your first Astro site
+description: "Tutorial: Build your first Astro blog —\nPrepare your developent environment, and create and deploy your first Astro site"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/1-setup/index.md
+++ b/src/pages/en/tutorial/1-setup/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Create and deploy your first Astro site
 title: "Check in: Unit 1 - Setup"
-description: "Tutorial: Build your first Astro blog —\nPrepare your developent environment, and create and deploy your first Astro site"
+description: "Tutorial: Build your first Astro blog —\nPrepare your development environment, and create and deploy your first Astro site"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/2-pages/1.md
+++ b/src/pages/en/tutorial/2-pages/1.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Create your first Astro page
+description: "Tutorial: Build your first Astro blog —\nAdd new pages to your site with navigation links between them"
 setup: |
   import Checklist from '~/components/Checklist.astro';
   import Blanks from '~/components/tutorial/Blanks.astro';

--- a/src/pages/en/tutorial/2-pages/2.md
+++ b/src/pages/en/tutorial/2-pages/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Write your first Markdown blog post
+description: "Tutorial: Build your first Astro blog —\nAdd Markdown pages to your site"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/2-pages/3.md
+++ b/src/pages/en/tutorial/2-pages/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Add dynamic HTML content about you
+description: "Tutorial: Build your first Astro blog —\nUse variables and conditional rendering on your Astro pages"
 setup: |
   import Checklist from '~/components/Checklist.astro';
   import Blanks from '~/components/tutorial/Blanks.astro';

--- a/src/pages/en/tutorial/2-pages/4.md
+++ b/src/pages/en/tutorial/2-pages/4.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Style your About page
+description: "Tutorial: Build your first Astro blog —\nAdd an Astro style tag for scoped styling on the page"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Add global styles to your site
+description: "Tutorial: Build your first Astro blog —\nCreate a global stylesheet for site-wide styling "
 setup: |
   import Badge from '~/components/Badge.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/2-pages/index.md
+++ b/src/pages/en/tutorial/2-pages/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Add, style and link to pages on your site
 title: "Check in: Unit 2 - Pages"
-description: Build your first Astro blog | See how the two sections of a `.astro` file work together to create pages on your site
+description: "Tutorial: Build your first Astro blog —\nCreate, style and link to pages posts on your site"
 setup: |
   import Checklist from '~/components/Checklist.astro';
   import Badge from '~/components/Badge.astro';

--- a/src/pages/en/tutorial/3-components/1.md
+++ b/src/pages/en/tutorial/3-components/1.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Refactor page links into a Navigation component
+description: "Tutorial: Build your first Astro blog —\nReplace elements repeated on multiple pages with a reusable component"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Blanks from '~/components/tutorial/Blanks.astro';

--- a/src/pages/en/tutorial/3-components/2.md
+++ b/src/pages/en/tutorial/3-components/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Create a Footer with styled social media links
+description: "Tutorial: Build your first Astro blog —\nBuild a new component from scratch, then add it to your pages"
 setup: |
   import Checklist from '~/components/Checklist.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/3-components/3.md
+++ b/src/pages/en/tutorial/3-components/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Build it yourself - Header
+description: "Tutorial: Build your first Astro blog —\nUse everything you've learned so far to build a header with responsive navigation"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/3-components/4.md
+++ b/src/pages/en/tutorial/3-components/4.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Send your first JavaScript to the browser
+description: "Tutorial: Build your first Astro blog —\nAdd client-side interactivity to your mobile navigation with an Astro script tag"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Blanks from '~/components/tutorial/Blanks.astro';

--- a/src/pages/en/tutorial/3-components/index.md
+++ b/src/pages/en/tutorial/3-components/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Build and design with Astro UI components
 title: "Check in: Unit 2 - Components"
-description: Build your first Astro blog | Build Astro components to reuse code for common elements across your website. 
+description: "Tutorial: Build your first Astro blog —\nBuild Astro components to reuse code for common elements across your website"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/4-layouts/1.md
+++ b/src/pages/en/tutorial/4-layouts/1.md
@@ -1,10 +1,11 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Build your first layout
+description: "Tutorial: Build your first Astro blog —\nRefactor common elements into a reusable page layout"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';
-    import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
+  import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
   import Option from '~/components/tutorial/Option.astro';
   import PreCheck from '~/components/tutorial/PreCheck.astro';
 ---

--- a/src/pages/en/tutorial/4-layouts/2.md
+++ b/src/pages/en/tutorial/4-layouts/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Create and pass data to a custom blog layout
+description: "Tutorial: Build your first Astro blog —\nCreate a blog post layout for your Markdown files and pass it frontmatter values as props"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/4-layouts/3.md
+++ b/src/pages/en/tutorial/4-layouts/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Combine layouts to get the best of both worlds
+description: "Tutorial: Build your first Astro blog —\nAdd your basic page layout to the layout that formats your blog posts"
 setup: |
   import Blanks from '~/components/tutorial/Blanks.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/4-layouts/index.md
+++ b/src/pages/en/tutorial/4-layouts/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Save time and energy with reusable page layouts
 title: "Check in: Unit 4 - Layouts"
-description: Build your first Astro blog | Use Astro layouts to share common elements and styles across your pages and posts
+description: "Tutorial: Build your first Astro blog —\nUse Astro layouts to share common elements and styles across your pages and posts"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/5-astro-api/1.md
+++ b/src/pages/en/tutorial/5-astro-api/1.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title:  Create a blog post archive
+description: "Tutorial: Build your first Astro blog —\nUse Astro.glob() to access data from files in your project"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Generate tag pages
+description: "Tutorial: Build your first Astro blog —\nUse getStaticPaths() to create multiple pages (routes) at once"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Build a tag index page
+description: "Tutorial: Build your first Astro blog —\nUse everything you've learned so far to build a Tag Index page"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/5-astro-api/4.md
+++ b/src/pages/en/tutorial/5-astro-api/4.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Add an RSS feed
+description: "Tutorial: Build your first Astro blog —\nInstall Astro's official package for creating a feed that your readers can subscribe to"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/5-astro-api/index.md
+++ b/src/pages/en/tutorial/5-astro-api/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Beef up your blog
 title: "Check in: Unit 5 - Astro API"
-description: Build your first Astro blog | Fetching and using data from project files to dynamically generate page content and routes
+description: "Tutorial: Build your first Astro blog —\nFetching and using data from project files to dynamically generate page content and routes"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/6-islands/1.md
+++ b/src/pages/en/tutorial/6-islands/1.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Build your first Astro island
+description: "Tutorial: Build your first Astro blog —\nUse a Preact component to greet your visitors with a randomly-selected message"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/6-islands/2.md
+++ b/src/pages/en/tutorial/6-islands/2.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Back on dry land. Take your blog from day to night, no island required!
+description: "Tutorial: Build your first Astro blog —\nBuild a light/dark theme toggle using only JavaScript and CSS"
 setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';

--- a/src/pages/en/tutorial/6-islands/3.md
+++ b/src/pages/en/tutorial/6-islands/3.md
@@ -1,7 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Congratulations!
-description: "Tutorial: Build your first Astro blog —\nWrap up"
+description: "Tutorial: Build your first Astro blog —\nCheck out the final version of your project and find out what’s next with Astro!"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/6-islands/3.md
+++ b/src/pages/en/tutorial/6-islands/3.md
@@ -1,6 +1,7 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
 title: Congratulations!
+description: "Tutorial: Build your first Astro blog —\nWrap up"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';

--- a/src/pages/en/tutorial/6-islands/index.md
+++ b/src/pages/en/tutorial/6-islands/index.md
@@ -2,7 +2,7 @@
 layout: ~/layouts/TutorialLayout.astro
 unitTitle: Set sail for Astro islands
 title: "Check in: Unit 6 - Astro Islands"
-description: Build your first Astro blog | Use Astro islands to bring frontend framework components into your Astro site
+description: "Tutorial: Build your first Astro blog —\nUse Astro islands to bring frontend framework components into your Astro site"
 setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';


### PR DESCRIPTION
Added or updated the `description` property on all tutorial pages with a consistent formatting. This mostly matters for OG Social image sharing.

The format is:

> `title` (also visible in the tutorial nav, so will not mention that it's part of a tutorial)
> Tutorial: Build your first Astro Blog  —
> `description`

![image](https://user-images.githubusercontent.com/5098874/196737702-23a0a98e-1fbb-4705-a23a-5718eea83006.png)
