### PR TITLE
Use `import type` for `APIContext` imports in reference

### DIFF
--- a/src/pages/en/reference/api-reference.md
+++ b/src/pages/en/reference/api-reference.md
@@ -387,7 +387,7 @@ And would render HTML like this:
 [Endpoint functions](/en/core-concepts/endpoints/) receive a context object as the first parameter. It mirrors many of the `Astro` global properties.
 
 ```ts title="endpoint.json.ts"
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function get(context: APIContext) {
   // ...
@@ -403,7 +403,7 @@ In static builds, this will be the `params` returned by `getStaticPaths()` used 
 In SSR builds, this can be any value matching the path segments in the dynamic route pattern.
 
 ```ts title="src/pages/posts/[id].json.ts"
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function getStaticPaths() {
   return [
@@ -427,7 +427,7 @@ See also: [`params`](#params)
 `context.props` is an object containing any `props` passed from `getStaticPaths()`. Because `getStaticPaths()` is not used when building for SSR (server-side rendering), `context.props` is only available in static builds.
 
 ```ts title="src/pages/posts/[id].json.ts"
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function getStaticPaths() {
   return [
@@ -451,7 +451,7 @@ See also: [Data Passing with `props`](#data-passing-with-props)
 A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. It can be used to get the `url`, `headers`, `method`, and even body of the request.
 
 ```ts
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function get({ request }: APIContext) {
   return {
@@ -479,7 +479,7 @@ See also: [Astro.url](#astrourl)
 Specifies the [IP address](https://en.wikipedia.org/wiki/IP_address) of the request. This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
 
 ```ts
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function get({ clientAddress }: APIContext) {
   return {
@@ -502,7 +502,7 @@ See also: [Astro.site](#astrosite)
 `context.generator` is a convenient way to indicate the version of Astro your project is running. It follows the format `"Astro v1.x.x"`.
 
 ```ts title="src/pages/site-info.json.ts"
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function get({ generator, site }: APIContext) {
   const body = JSON.stringify({ generator, site });
@@ -517,7 +517,7 @@ See also: [Astro.generator](#astrogenerator)
 `context.redirect()` returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object that allows you to redirect to another page. This function is only available when building for SSR (server-side rendering) and should not be used for static sites.
 
 ```ts
-import { APIContext } from 'astro';
+import type { APIContext } from 'astro';
 
 export function get({ redirect }: APIContext) {
   return redirect('/login', 302);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Minor, `import { APIContext }` --> `import type { APIContext }`

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
