### PR TITLE
[tutorial] removed references to JSX

### DIFF
--- a/src/pages/en/tutorial/2-pages/3.md
+++ b/src/pages/en/tutorial/2-pages/3.md
@@ -107,7 +107,7 @@ Open `about.astro` which should look like this:
 
 </Box>
 
-## Write JSX-like expressions in Astro
+## Write JavaScript expressions in Astro
 
 1. Add the following JavaScript to your frontmatter, between the **code fences**:
 

--- a/src/pages/en/tutorial/4-layouts/1.md
+++ b/src/pages/en/tutorial/4-layouts/1.md
@@ -144,7 +144,7 @@ You still have some Astro components repeatedly rendered on every page. Let's re
 
 1. When would you choose to give `<BaseLayout>` props instead of only using its own `<slot />` to render child content?
 
-    || Component attributes gives your layout values that you can use wherever you write JavaScript or JSX-like expressions. This is useful for page-specific values like a title that you may wish to include dynamically in multiple places. Content rendered by a `<slot />` is injected as a single chunk of HTML, into one specific location. Its contents are not available as individual pieces. ||
+    || Component attributes gives your layout values that you can use wherever you write JavaScript expressions. This is useful for page-specific values like a title that you may wish to include dynamically in multiple places. Content rendered by a `<slot />` is injected as a single chunk of HTML, into one specific location. Its contents are not available as individual pieces. ||
 
 1. What are the two steps required so that a layout component receives a value as a prop?
 

--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -78,7 +78,7 @@ But, since you already have the directory `/tags/`, you can take advantage of an
 
 ## Create an array of tags
 
-You have previously [displayed items in a list from an array using `map()`](/en/tutorial/2-pages/3/#write-javascript-expressions-in-astro). What would look like to define an array of all your tags, then display them in a list on this page?
+You have previously displayed items in a list from an array using `map()`. What would look like to define an array of all your tags, then display them in a list on this page?
 
 <details>
     <summary>See the code</summary>

--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -78,7 +78,7 @@ But, since you already have the directory `/tags/`, you can take advantage of an
 
 ## Create an array of tags
 
-You have previously [displayed items in a list from an array using `map()`](/en/tutorial/2-pages/3/#write-jsx-like-expressions-in-astro). What would look like to define an array of all your tags, then display them in a list on this page?
+You have previously [displayed items in a list from an array using `map()`](/en/tutorial/2-pages/3/#write-javascript-expressions-in-astro). What would look like to define an array of all your tags, then display them in a list on this page?
 
 <details>
     <summary>See the code</summary>


### PR DESCRIPTION
Replaced "JSX-like expressions" with "JavaScript expressions" in the two places it showed up.

Also, removed an internal link.