### PR TITLE
[tutorial] Replace StackBlitz embeds with links

### DIFF
--- a/src/components/tutorial/StackblitzIntro.astro
+++ b/src/components/tutorial/StackblitzIntro.astro
@@ -9,7 +9,7 @@ const file = "src/pages/index.astro";
 const url = `https://stackblitz.com/edit/${slug}?file=${file}`
 ---
 <p>
-	You can find a working version of the code at this point in the tutorial <a href={url}>on Stackblitz.</a>
+	You can find a working version of the code at this point in the tutorial <a href={url}>on StackBlitz.</a>
 </p>
 <p>
 	Check your code against this example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.

--- a/src/components/tutorial/StackblitzIntro.astro
+++ b/src/components/tutorial/StackblitzIntro.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+	slug: string
+}
+
+const { slug } = Astro.props as Props;
+
+const file = "src/pages/index.astro";
+const url = `https://stackblitz.com/edit/${slug}?file=${file}`
+---
+<p>
+	You can find a working version of the code at this point in the tutorial <a href={url}>on Stackblitz.</a>
+</p>
+<p>
+	Check your code against this example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
+</p>

--- a/src/pages/en/tutorial/0-introduction/index.md
+++ b/src/pages/en/tutorial/0-introduction/index.md
@@ -17,7 +17,7 @@ Along the way, you'll:
 - Query and work with local files
 - Add interactivity to your site 
 
-You can view a working version of the finished project [on StackBlitz.](https://stackblitz.com/edit/astro-tutorial-completed?file=src%2Fpages%2Findex.astro).
+You can view a working version of the finished project [on StackBlitz](https://stackblitz.com/edit/astro-tutorial-completed?file=src%2Fpages%2Findex.astro).
 
 The finished blog will be **deployed to the web**, and can even be used as a personal website once you have completed this tutorial.
 

--- a/src/pages/en/tutorial/0-introduction/index.md
+++ b/src/pages/en/tutorial/0-introduction/index.md
@@ -17,9 +17,7 @@ Along the way, you'll:
 - Query and work with local files
 - Add interactivity to your site 
 
-Click to run a working version of the finished project:
-
-<iframe src="https://stackblitz.com/edit/astro-tutorial-completed?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
+You can view a working version of the finished project [on StackBlitz.](https://stackblitz.com/edit/astro-tutorial-completed?file=src%2Fpages%2Findex.astro).
 
 The finished blog will be **deployed to the web**, and can even be used as a personal website once you have completed this tutorial.
 

--- a/src/pages/en/tutorial/2-pages/index.md
+++ b/src/pages/en/tutorial/2-pages/index.md
@@ -7,16 +7,13 @@ setup: |
   import Checklist from '~/components/Checklist.astro';
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';
+  import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 ---
 Now that you have a working site on the web, let's add pages and posts!
 
 ## Where are we now?
 
-Click to run a working version of the code at this point in the tutorial right on this page.
-
- <iframe src="https://stackblitz.com/edit/astro-tutorial-1?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
- Check your code against the tutorial example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
-
+<StackblitzIntro slug="astro-tutorial-1"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/3-components/index.md
+++ b/src/pages/en/tutorial/3-components/index.md
@@ -9,15 +9,13 @@ setup: |
   import Checklist from '~/components/Checklist.astro';
   import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
   import Option from '~/components/tutorial/Option.astro';
+  import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 ---
 Now that you have `.astro` and `.md` files generating entire pages on your website, let's make and reuse smaller bits of HTML with Astro components!
 
 ## Where are we now?
 
-Click to run a working version of the code at this point in the tutorial right on this page.
-
- <iframe src="https://stackblitz.com/edit/astro-tutorial-2?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
- Check your code against the tutorial example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
+<StackblitzIntro slug="astro-tutorial-2"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/4-layouts/index.md
+++ b/src/pages/en/tutorial/4-layouts/index.md
@@ -7,15 +7,13 @@ setup: |
   import Badge from '~/components/Badge.astro';
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';
+  import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 ---
 Now that you can build with components, let's create some custom layouts!
 
 ## Where are we now?
 
-Click to run a working version of the code at this point in the tutorial right on this page.
-
- <iframe src="https://stackblitz.com/edit/astro-tutorial-3?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
- Check your code against the tutorial example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
+<StackblitzIntro slug="astro-tutorial-3"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/5-astro-api/index.md
+++ b/src/pages/en/tutorial/5-astro-api/index.md
@@ -9,16 +9,14 @@ setup: |
   import Checklist from '~/components/Checklist.astro';
   import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
   import Option from '~/components/tutorial/Option.astro';
+  import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 ---
 
 Now that you have some blog posts, let's use Astro's API to work with your files!
 
 ## Where are we now?
 
-Click to run a working version of the code at this point in the tutorial right on this page.
-
- <iframe src="https://stackblitz.com/edit/astro-tutorial-4?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
- Check your code against the tutorial example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
+<StackblitzIntro slug="astro-tutorial-4"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/6-islands/index.md
+++ b/src/pages/en/tutorial/6-islands/index.md
@@ -9,15 +9,13 @@ setup: |
   import Checklist from '~/components/Checklist.astro';
   import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
   import Option from '~/components/tutorial/Option.astro';
+  import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 ---
 Now that you have a fully functioning blog, let's add some interactive islands to your site!
 
 ## Where are we now?
 
-Click to run a working version of the code at this point in the tutorial right on this page.
-
- <iframe src="https://stackblitz.com/edit/astro-tutorial-5?ctl=1&embed=1&file=src/pages/index.astro"></iframe>
- Check your code against the tutorial example, or if you've just joined us, fork on StackBlitz to start coding along in your browser from here.
+<StackblitzIntro slug="astro-tutorial-5"/>
 
 ## Where are we going?
 


### PR DESCRIPTION
Added a StackblitzIntro component so we can tweak this later on.