### PR TITLE
[tutorial] Consistent semicolons

### DIFF
--- a/src/pages/en/tutorial/2-pages/3.md
+++ b/src/pages/en/tutorial/2-pages/3.md
@@ -51,7 +51,7 @@ Open `about.astro` which should look like this:
 
     ```astro title="src/pages/about.astro" ins={2}
     ---
-    const pageTitle = "About Me"
+    const pageTitle = "About Me";
     ---
     ```
 
@@ -115,16 +115,16 @@ Open `about.astro` which should look like this:
 
     ```astro title="src/pages/about.astro" ins={4-9, 11}
     ---
-    const pageTitle = "About Me"
+    const pageTitle = "About Me";
 
     const identity = {
       firstName: "Sarah",
       country: "Canada",
       occupation: "Technical Writer",
       hobbies: ["photography", "birdwatching", "baseball"],
-    }
+    };
 
-    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"]
+    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"];
     ---
     ```
 
@@ -177,20 +177,20 @@ You can also use your script variables to choose **whether or not** to render in
 
     ```astro title="src/pages/about.astro" ins={13-15}
     ---
-    const pageTitle = "About Me"
+    const pageTitle = "About Me";
 
     const identity = {
       firstName: "Sarah",
       country: "Canada",
       occupation: "Technical Writer",
       hobbies: ["photography", "birdwatching", "baseball"],
-    }
+    };
 
-    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"]
+    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"];
 
-    const happy = true
-    const finished = false
-    const goal = 3
+    const happy = true;
+    const finished = false;
+    const goal = 3;
     ---
     ```
 
@@ -222,10 +222,10 @@ Given the following `.astro` script:
 
 ```astro title="src/pages/about.astro"
 ---
-operatingSystem = "Linux"
-quantity = 3
-footwear = "boots"
-student = false
+operatingSystem = "Linux";
+quantity = 3;
+footwear = "boots";
+student = false;
 ---
 ```
 

--- a/src/pages/en/tutorial/2-pages/4.md
+++ b/src/pages/en/tutorial/2-pages/4.md
@@ -73,22 +73,22 @@ The Astro `<style>` tag can also reference any variables from your frontmatter s
 
     ```astro title="src/pages/about.astro" ins={17}
     ---
-    const pageTitle = "About Me"
+    const pageTitle = "About Me";
 
     const identity = {
       firstName: "Sarah",
       country: "Canada",
       occupation: "Technical Writer",
       hobbies: ["photography", "birdwatching", "baseball"],
-    }
+    };
 
-    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"]
+    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"];
 
-    const happy = true
-    const finished = false
-    const goal = 3
+    const happy = true;
+    const finished = false;
+    const goal = 3;
   
-    const skillColor = "green"
+    const skillColor = "green";
     ---
     ```
 
@@ -142,25 +142,25 @@ The Astro `<style>` tag can also reference any variables from your frontmatter s
 
 ```astro title="src/pages/about.astro" ins={18-20}
 ---
-const pageTitle = "About Me"
+const pageTitle = "About Me";
 
 const identity = {
   firstName: "Sarah",
   country: "Canada",
   occupation: "Technical Writer",
   hobbies: ["photography", "birdwatching", "baseball"],
-}
+};
 
-const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"]
+const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"];
 
-const happy = true
-const finished = false
-const goal = 3
+const happy = true;
+const finished = false;
+const goal = 3;
 
-const skillColor = "green"
-const fontWeight = "bold"
-const textCase = "uppercase"
-const bulletStyle = "'*'"
+const skillColor = "green";
+const fontWeight = "bold";
+const textCase = "uppercase";
+const bulletStyle = "'*'";
 ---
 ```
 </details>

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -48,27 +48,27 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
 
     ```astro title="src/pages/about.astro" ins={22}
     ---
-    const pageTitle = "About Me"
+    const pageTitle = "About Me";
 
     const identity = {
       firstName: "Sarah",
       country: "Canada",
       occupation: "Technical Writer",
       hobbies: ["photography", "birdwatching", "baseball"],
-    }
+    };
 
-    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"]
+    const skills = ["HTML", "CSS", "JavaScript", "React", "Astro", "Writing Docs"];
 
-    const happy = true
-    const finished = false
-    const goal = 3
+    const happy = true;
+    const finished = false;
+    const goal = 3;
 
-    const skillColor = "green"
-    const fontWeight = "bold"
-    const textCase = "uppercase"
-    const bulletStyle = "'*'"
+    const skillColor = "green";
+    const fontWeight = "bold";
+    const textCase = "uppercase";
+    const bulletStyle = "'*'";
 
-    import '../styles/global.css'
+    import '../styles/global.css';
     ---
     ```
 
@@ -88,7 +88,7 @@ Add the following import statement to the two other page files: `src/pages/index
 ```astro
 ---
 // src/pages/index.astro
-import '../styles/global.css'
+import '../styles/global.css';
 ---
 ```
 </details>

--- a/src/pages/en/tutorial/3-components/2.md
+++ b/src/pages/en/tutorial/3-components/2.md
@@ -23,8 +23,8 @@ Now that you have used Astro components on a page, let's use a component within 
 
     ```astro title="src/components/Footer.astro"
     ---
-    const platform = "github"
-    const username = "withastro"
+    const platform = "github";
+    const username = "withastro";
     ---
     <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
     ```
@@ -62,10 +62,10 @@ If you've been following along with each step in the tutorial, your `index.astro
 
 ```astro title="src/pages/index.astro"
 ---
-const pageTitle = "Home Page"
+const pageTitle = "Home Page";
 import Navigation from '../components/Navigation.astro';
 import Footer from '../components/Footer.astro';
-import '../styles/global.css'
+import '../styles/global.css';
 ---
 
 <html lang="en">
@@ -94,7 +94,7 @@ import '../styles/global.css'
 
     ```astro title="src/components/Social.astro"
     ---
-    const {platform, username} = Astro.props
+    const {platform, username} = Astro.props;
     ---
     <span><a href={`https://www.${platform}.com/${username}`}>{platform}</a></span>
     ```
@@ -105,8 +105,8 @@ import '../styles/global.css'
 
     ```astro title="src/components/Footer.astro" del={2,3,6} ins={4,7-9}
     ---
-    const platform = "github"
-    const username = "withastro"
+    const platform = "github";
+    const username = "withastro";
     import Social from './Social.astro';
     ---
     <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
@@ -123,7 +123,7 @@ import '../styles/global.css'
 
     ```astro title="src/components/social.astro" ins={6-17} 'class="social-platform'
     ---
-    const {platform, username} = Astro.props
+    const {platform, username} = Astro.props;
     ---
     <span class="social-platform"><a href={`https://www.${platform}.com/${username}`}>{platform}</a></span>
 
@@ -145,7 +145,7 @@ import '../styles/global.css'
 
     ```astro title="src/components/footer.astro" ins={4-8,10}
     ---
-    import Social from './Social.astro'
+    import Social from './Social.astro';
     ---
     <style>
        .spacer {
@@ -167,7 +167,7 @@ import '../styles/global.css'
 
 1. What line of code do you need to write in an Astro component to **receive values** of `title`, `author`, and`date` **as props**?
 
-    || `const { title, author, date } = Astro.props` ||
+    || `const { title, author, date } = Astro.props;` ||
     
 
 2. How do you **send values as props** to an Astro component?

--- a/src/pages/en/tutorial/3-components/3.md
+++ b/src/pages/en/tutorial/3-components/3.md
@@ -57,11 +57,11 @@ Since your site will be viewed on different devices, let's create a page navigat
 
     ```astro title="src/pages/index.astro" ins={4,18} del={3,17}
     ---
-    const pageTitle = "Home Page"
+    const pageTitle = "Home Page";
     import Navigation from '../components/Navigation.astro';
     import Header from '../components/Header.astro';
     import Footer from '../components/Footer.astro';
-    import '../styles/global.css'
+    import '../styles/global.css';
     ---
     <html lang="en">
         <head>

--- a/src/pages/en/tutorial/4-layouts/1.md
+++ b/src/pages/en/tutorial/4-layouts/1.md
@@ -26,10 +26,10 @@ You still have some Astro components repeatedly rendered on every page. Let's re
 
     ```astro title="src/layouts/BaseLayout.astro"
     ---
-    const pageTitle = "Home Page"
+    const pageTitle = "Home Page";
     import Header from '../components/Header.astro';
     import Footer from '../components/Footer.astro';
-    import '../styles/global.css'
+    import '../styles/global.css';
     ---
     <html lang="en">
       <head>
@@ -56,8 +56,8 @@ You still have some Astro components repeatedly rendered on every page. Let's re
 
     ```astro title="src/pages/index.astro"
     ---
-    import BaseLayout from '../layouts/BaseLayout.astro'
-    const pageTitle = "Home Page"
+    import BaseLayout from '../layouts/BaseLayout.astro';
+    const pageTitle = "Home Page";
     ---
     <BaseLayout>
       <h2>My awesome blog subtitle</h2>
@@ -70,10 +70,10 @@ You still have some Astro components repeatedly rendered on every page. Let's re
 
     ```astro title="src/layouts/BaseLayout.astro" ins={18}
     ---
-    const pageTitle = "Home Page"
+    const pageTitle = "Home Page";
     import Header from '../components/Header.astro';
     import Footer from '../components/Footer.astro';
-    import '../styles/global.css'
+    import '../styles/global.css';
     ---
     <html lang="en">
       <head>
@@ -113,8 +113,8 @@ You still have some Astro components repeatedly rendered on every page. Let's re
 
     ```astro title="src/pages/index.astro" 'title={pageTitle}'
     ---
-    import BaseLayout from '../layouts/BaseLayout.astro'
-    const pageTitle = "Home Page"
+    import BaseLayout from '../layouts/BaseLayout.astro';
+    const pageTitle = "Home Page";
     ---
     <BaseLayout pageTitle={pageTitle}>
       <h2>My awesome blog subtitle</h2>
@@ -127,8 +127,8 @@ You still have some Astro components repeatedly rendered on every page. Let's re
     ---
     import Navigation from '../components/Navigation.astro';
     import Footer from '../components/Footer.astro';
-    const pageTitle = "Home Page"
-    const { pageTitle } = Astro.props
+    const pageTitle = "Home Page";
+    const { pageTitle } = Astro.props;
     ---
     ```
 

--- a/src/pages/en/tutorial/4-layouts/2.md
+++ b/src/pages/en/tutorial/4-layouts/2.md
@@ -26,7 +26,7 @@ When you include the `layout` frontmatter property in an `.md` file, all of your
 
     ```astro title="src/layouts/MarkdownPostLayout.astro"
     ---
-    const { frontmatter } = Astro.props
+    const { frontmatter } = Astro.props;
     ---
     <h1>{frontmatter.title}</h1>
     <p>Written by {frontmatter.author}</p>
@@ -97,7 +97,7 @@ Welcome to my new blog about learning Astro! Here, I will share my learning jour
 
 ```astro title="src/layouts/MarkdownPostLayout.astro" ins={5}
 ---
-const { frontmatter } = Astro.props
+const { frontmatter } = Astro.props;
 ---
 <h1>{frontmatter.title}</h1>
 <p>Published on: {frontmatter.pubDate.slice(0,10)}</p>
@@ -112,7 +112,7 @@ Here is an example of a refactored layout that leaves only individual blog post 
 
 ```astro title="src/layouts/MarkdownPostLayout.astro"
 ---
-const { frontmatter } = Astro.props
+const { frontmatter } = Astro.props;
 ---
 <h1> {frontmatter.title}</h1>
 <p>{frontmatter.pubDate.slice(0,10)}</p>

--- a/src/pages/en/tutorial/5-astro-api/1.md
+++ b/src/pages/en/tutorial/5-astro-api/1.md
@@ -24,9 +24,9 @@ Now that you have a few blog posts to link to, let's configure the Blog page to 
   ---
   import BaseLayout from '../layouts/BaseLayout.astro'
   const allPosts = await Astro.glob('../pages/posts/*.md');
-  title = "My Astro Learning Blog"
+  const pageTitle = "My Astro Learning Blog";
   ---
-  <BaseLayout title={title}>
+  <BaseLayout pageTitle={pageTitle}>
     <p>This is where I will post about my journey learning Astro.</p>
     <ul>
       <li><a href="/posts/post-1/">Post 1</a></li>
@@ -43,7 +43,7 @@ Now that you have a few blog posts to link to, let's configure the Blog page to 
     ---
     import BaseLayout from '../layouts/BaseLayout.astro'
     const allPosts = await Astro.glob('../pages/posts/*.md');
-    pageTitle = "My Astro Learning Blog"
+    const pageTitle = "My Astro Learning Blog";
     ---
     <BaseLayout pageTitle={pageTitle}>
       <p>This is where I will post about my journey learning Astro.</p>
@@ -110,7 +110,7 @@ Try on your own to make the all necessary changes to your Astro project so that 
     ```astro
     ---
     // src/components/BlogPost.astro
-    const { title, url } = Astro.props
+    const { title, url } = Astro.props;
     ---
     ```
     </details>
@@ -131,10 +131,10 @@ Try on your own to make the all necessary changes to your Astro project so that 
     <summary>Show the code</summary>
     ```astro title="src/pages/blog.astro" ins={3}
     ---
-    import BaseLayout from '../layouts/BaseLayout.astro'
-    import BlogPost from '../components/BlogPost.astro'
+    import BaseLayout from '../layouts/BaseLayout.astro';
+    import BlogPost from '../components/BlogPost.astro';
     const allPosts = await Astro.glob('../pages/posts/*.md');
-    pageTitle = "My Astro Learning Blog"
+    const pageTitle = "My Astro Learning Blog";
     ---
     ```
     </details>
@@ -151,10 +151,10 @@ Try on your own to make the all necessary changes to your Astro project so that 
     ```
     ```astro title="src/pages/blog.astro" ins={3,10}
     ---
-    import BaseLayout from '../layouts/BaseLayout.astro'
-    import BlogPost from '../components/BlogPost.astro'
+    import BaseLayout from '../layouts/BaseLayout.astro';
+    import BlogPost from '../components/BlogPost.astro';
     const allPosts = await Astro.glob('../pages/posts/*.md');
-    pageTitle = "My Astro Learning Blog"
+    const pageTitle = "My Astro Learning Blog"
     ---
     <BaseLayout pageTitle={pageTitle}>
       <p>This is where I will post about my journey learning Astro.</p>

--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -36,7 +36,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
       ]
     }
 
-    const { tag } = Astro.params
+    const { tag } = Astro.params;
     ---
     <BaseLayout pageTitle={tag}>
       <p>Posts tagged with {tag}</p>    
@@ -71,8 +71,8 @@ You can create entire sets of pages dynamically using `.astro` files that export
       ]
     }
     
-    const { tag } = Astro.params
-    const { posts } = Astro.props
+    const { tag } = Astro.params;
+    const { posts } = Astro.props;
     ---
     ```
 
@@ -80,9 +80,9 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
     ```astro title="/src/pages/posts/tags/[tag]" ins={4}
     ---
-    const { tag } = Astro.params
-    const { posts } = Astro.props
-    const filteredPosts = posts.filter((post) => post.frontmatter.tags.includes(tag))
+    const { tag } = Astro.params;
+    const { posts } = Astro.props;
+    const filteredPosts = posts.filter((post) => post.frontmatter.tags.includes(tag));
     ---
     ```
 

--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -65,7 +65,7 @@ But, since you already have the directory `/tags/`, you can take advantage of an
           ```astro title="src/pages/tags/index.astro" ins={3} "pageTitle"
           ---
           import BaseLayout from '../../layouts/BaseLayout.astro';
-          const pageTitle = "Tag Index"
+          const pageTitle = "Tag Index";
           ---
           <BaseLayout pageTitle={pageTitle}></BaseLayout>
           ```
@@ -86,8 +86,8 @@ You have previously displayed items in a list from an array using `map()`. What 
     ```astro title="src/pages/tags/index.astro"
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const tags = ["astro","sucesses", "community", "setbacks", "learning in Public"]
-    const pageTitle = "Tag Index"
+    const tags = ["astro","sucesses", "community", "setbacks", "learning in Public"];
+    const pageTitle = "Tag Index";
     ---
     <BaseLayout pageTitle={pageTitle}>
       <ul>
@@ -111,7 +111,7 @@ Fortunately, you already know a way to grab the data from all your Markdown file
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
     const allPosts = await Astro.glob('../posts/*.md');
-    const pageTitle = "Tag Index"
+    const pageTitle = "Tag Index";
     ---
     ```
     </details>
@@ -123,7 +123,7 @@ Fortunately, you already know a way to grab the data from all your Markdown file
     import BaseLayout from '../../layouts/BaseLayout.astro';
     const allPosts = await Astro.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
-    const pageTitle = "Tag Index"
+    const pageTitle = "Tag Index";
     ---
     
     ```
@@ -203,7 +203,7 @@ Here is what your new page should look like:
 import BaseLayout from '../../layouts/BaseLayout.astro';
 const allPosts = await Astro.glob('../posts/*.md');
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
-const pageTitle = "Tag Index"
+const pageTitle = "Tag Index";
 ---
 <BaseLayout pageTitle={pageTitle}>
    <div class="tags">


### PR DESCRIPTION
One of our participants noticed that we had inconsistent semicolon usage. This PR adds missing semicolons, and also fixes the `title`/`pageTitle` inconsistency in Chapter 5.