### PR TITLE
[tutorial] Pull out and simplify Stackblitz instructions

### DIFF
--- a/src/pages/en/tutorial/1-setup/1.md
+++ b/src/pages/en/tutorial/1-setup/1.md
@@ -16,22 +16,6 @@ setup: |
 
 ## Get the dev tools you need
 
-
-    
-:::tip[using stackblitz]
-
-Want to complete this tutorial in an online code editor instead? There's no local development environment to set up!
-
-<details>
-<summary>
-Follow these instructions and then skip ahead to [Create your first Astro project](/en/tutorial/1-setup/2/)!
-</summary>
-1. Sign in to [StackBlitz](https://stackblitz.com) using your GitHub credentials. This site will provide you with two different software tools that you will need to build your site:
- - A **code editor** (an alternative to locally-installed software like VS Code) where you will edit your files.
- - A **terminal pane** for running server commands.
-</details>
-:::
-
 ### Terminal
 
 You will use a **command line (terminal)** to create your Astro project and to run key commands to build, develop, and test your site.

--- a/src/pages/en/tutorial/1-setup/2.md
+++ b/src/pages/en/tutorial/1-setup/2.md
@@ -17,19 +17,6 @@ setup: |
   - View a live preview of your website in your browser
 </PreCheck>
 
-:::tip[using stackblitz]
-Instead of using the setup wizard, you will open a new project in your browser. Your project will automatically run in development mode and display a website preview.
-
-<details>
-<summary>**Follow these steps, then skip ahead directly to ["Write your first line of Astro"](/en/tutorial/1-setup/4/)**</summary>
-1. Visit [stackblitz.com](https://stackblitz.com) and sign in with your GitHub account.
-2. Visit [astro.new](https://astro.new) and click the button to open the "Empty Project" template in StackBlitz. (This will launch in StackBlitz.)
-3. In the upper left of the StackBlitz editor window, click to "fork" the template (save to your own account dashboard).
-4. Wait for the project to load, and you will see a live preview of the "Empty Project" starter.
-</details>
-:::
-
-
 ## Launch the Astro setup wizard
 
 The preferred way to create a new Astro site is through our `create astro` setup wizard.

--- a/src/pages/en/tutorial/1-setup/4.md
+++ b/src/pages/en/tutorial/1-setup/4.md
@@ -19,17 +19,6 @@ This tutorial will use GitHub to store our repository and connect to a web host.
 If you are already familiar with git, and have your own workflow, then create a new GitHub repository for your project using your preferred method. Skip ahead to the next page: ["Deploy your Site to the Web"](/en/tutorial/1-setup/5/).
 :::
 
-:::tip[using stackblitz]
-You will be able to create a new GitHub repository right from your StackBlitz workspace.
-<details>
-<summary>Follow these instructions, then skip ahead to ["Deploy your site to the web."](/en/tutorial/1-setup/5/)</summary>
-
-1. Press the <kbd>Connect Repository</kbd> button at the top of your list of files, enter a new name for your repository, and click <kbd>Create repo & push</kbd>. 
-
-2. When you have changes to be committed back to GitHub, a "Commit" button will appear at the top left of your workspace. Clicking on this will allow you to enter a commit message, and update your repository.
-</details>
-:::
-
 ## Create a repository on GitHub
 
 Although there are a few ways to get your local code stored in GitHub, this tutorial will guide you through a method that does not require using git in the command line. 

--- a/src/pages/en/tutorial/1-setup/5.md
+++ b/src/pages/en/tutorial/1-setup/5.md
@@ -20,7 +20,6 @@ Here, you will connect your GitHub repository to Netlify. Netlify will use that 
 This tutorial will use **Netlify**, but you are welcome to use your preferred hosting service for deploying your site to the internet.
 :::
 
-
 ## Create a new Netlify site
 
 1. Create a free account at [Netlify](https://netlify.com) if you do not already have one.

--- a/src/pages/en/tutorial/1-setup/index.md
+++ b/src/pages/en/tutorial/1-setup/index.md
@@ -30,7 +30,7 @@ Want to complete this tutorial in an online code editor instead?
 
 **Make a Change**
 
-In the file pane, you should see `src/pages/index.astro`. Click to open it, and follow [Write your first line of Astro](/en/tutorial/1-setup/3) to make a change to this file.
+In the file pane, you should see `src/pages/index.astro`. Click to open it, and follow [Write your first line of Astro](/en/tutorial/1-setup/3/) to make a change to this file.
 
 **Create a GitHub Repository**
 
@@ -40,7 +40,7 @@ In the file pane, you should see `src/pages/index.astro`. Click to open it, and 
 
 **Deploy your Site**
 
-If you'd like to deploy to Netlify, skip to [Deploy your site to the web](/en/tutorial/1-setup/5).
+If you'd like to deploy to Netlify, skip to [Deploy your site to the web](/en/tutorial/1-setup/5/).
 Otherwise, skip to [Unit 2](/en/tutorial/2-pages/) to start building with Astro!
 
 </details>

--- a/src/pages/en/tutorial/1-setup/index.md
+++ b/src/pages/en/tutorial/1-setup/index.md
@@ -17,7 +17,7 @@ Skip ahead to [Unit 2](/en/tutorial/2-pages/) if you already have a working deve
 
 Want to complete this tutorial in an online code editor instead?
 <details>
-<summary>Follow these instructions!</summary>
+<summary>Follow these instructions, then go directly to Unit 2!</summary>
 
 **Set up StackBlitz**
 1. Visit [astro.new](https://astro.new) and click the button to open the "Empty Project" template in StackBlitz. 

--- a/src/pages/en/tutorial/1-setup/index.md
+++ b/src/pages/en/tutorial/1-setup/index.md
@@ -13,6 +13,39 @@ Now that you know what you're going to build, let's set up all the tools and acc
 
 Skip ahead to [Unit 2](/en/tutorial/2-pages/) if you already have a working development environment, and can [create](/en/install/auto/) and deploy the [Astro minimal starter template](https://github.com/withastro/astro/tree/main/examples/minimal) to the web on your own.
 
+:::tip[using stackblitz]
+
+Want to complete this tutorial in an online code editor instead?
+<details>
+<summary>Follow these instructions!</summary>
+
+**Set up StackBlitz**
+1. Visit [astro.new](https://astro.new) and click the button to open the "Empty Project" template in StackBlitz. 
+
+2. Click "Sign in" on the top right to log in using your GitHub credentials.
+
+3. In the upper left of the StackBlitz editor window, click to "fork" the template (save to your own account dashboard).
+
+4. Wait for the project to load, and you will see a live preview of the "Empty Project" starter.
+
+**Make a Change**
+
+In the file pane, you should see `src/pages/index.astro`. Click to open it, and follow [Write your first line of Astro](/en/tutorial/1-setup/3) to make a change to this file.
+
+**Create a GitHub Repository**
+
+1. Press the <kbd>Connect Repository</kbd> button at the top of your list of files, enter a new name for your repository, and click <kbd>Create repo & push</kbd>. 
+
+2. When you have changes to be committed back to GitHub, a "Commit" button will appear at the top left of your workspace. Clicking on this will allow you to enter a commit message, and update your repository.
+
+**Deploy your Site**
+
+If you'd like to deploy to Netlify, skip to [Deploy your site to the web](/en/tutorial/1-setup/5).
+Otherwise, skip to [Unit 2](/en/tutorial/2-pages/) to start building with Astro!
+
+</details>
+:::
+
 ### Where are we going?
 
 In this unit, you will **create a new project** that is **stored online in GitHub** and **connected to Netlify**. 


### PR DESCRIPTION
This addresses the feedback that the interleaved Stackblitz instructions were confusing. It pulls out the Stackblitz instructions into a single `<details>` on the Check In page. It also tells the user to log in _after_ opening Stackblitz with `astro.new`, instead of before.