### PR TITLE
[tutorial] Use GitHub branches to generate StackBlitz links

### DIFF
--- a/src/components/tutorial/StackblitzIntro.astro
+++ b/src/components/tutorial/StackblitzIntro.astro
@@ -1,17 +1,18 @@
 ---
 interface Props {
-	slug: string;
+	tree: string;
 }
 
-const { slug } = Astro.props as Props;
+const { tree } = Astro.props as Props;
 
 const file = 'src/pages/index.astro';
-const url = `https://stackblitz.com/edit/${slug}?file=${file}`;
+const github = `https://github.com/${tree}`;
+const stackblitz = `https://stackblitz.com/github/${tree}?file=${file}`;
 ---
 
 <p>
-	You can find a working version of the code at this point in the tutorial <a href={url}
-		>on StackBlitz.</a
+	You can find the code at this point in the tutorial on <a href={github}>GitHub</a> or <a href={stackblitz}
+		>StackBlitz.</a
 	>
 </p>
 <p>

--- a/src/pages/en/tutorial/0-introduction/index.md
+++ b/src/pages/en/tutorial/0-introduction/index.md
@@ -19,10 +19,9 @@ Along the way, you'll:
 - Query and work with local files
 - Add interactivity to your site 
 
-
-You can view the finished code with a live preview [on StackBlitz](https://stackblitz.com/edit/astro-tutorial-completed?file=src%2Fpages%2Findex.astro).
-
 The finished blog will be **deployed to the web**, and can even be used as a personal website once you have completed this tutorial.
+
+You can view the code on [GitHub](https://github.com/withastro/blog-tutorial-demo) or [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro).
 
 :::note
 If you would rather start exploring Astro with a pre-built Astro site, you can visit https://astro.new and choose a starter template to open and edit in an online editor.

--- a/src/pages/en/tutorial/2-pages/index.md
+++ b/src/pages/en/tutorial/2-pages/index.md
@@ -13,7 +13,7 @@ Now that you have a working site on the web, let's add pages and posts!
 
 ## Where are we now?
 
-<StackblitzIntro slug="astro-tutorial-1"/>
+<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-2/start"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/3-components/index.md
+++ b/src/pages/en/tutorial/3-components/index.md
@@ -15,7 +15,7 @@ Now that you have `.astro` and `.md` files generating entire pages on your websi
 
 ## Where are we now?
 
-<StackblitzIntro slug="astro-tutorial-2"/>
+<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-3/start"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/4-layouts/index.md
+++ b/src/pages/en/tutorial/4-layouts/index.md
@@ -13,7 +13,7 @@ Now that you can build with components, let's create some custom layouts!
 
 ## Where are we now?
 
-<StackblitzIntro slug="astro-tutorial-3"/>
+<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-4/start"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/5-astro-api/index.md
+++ b/src/pages/en/tutorial/5-astro-api/index.md
@@ -16,7 +16,7 @@ Now that you have some blog posts, let's use Astro's API to work with your files
 
 ## Where are we now?
 
-<StackblitzIntro slug="astro-tutorial-4"/>
+<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-5/start"/>
 
 ## Where are we going?
 

--- a/src/pages/en/tutorial/6-islands/index.md
+++ b/src/pages/en/tutorial/6-islands/index.md
@@ -15,7 +15,7 @@ Now that you have a fully functioning blog, let's add some interactive islands t
 
 ## Where are we now?
 
-<StackblitzIntro slug="astro-tutorial-5"/>
+<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-6/start"/>
 
 ## Where are we going?
 


### PR DESCRIPTION
Changes the `StackblitzIntro` component to take a GitHub tree branch and generate both a GitHub and StackBlitz link from it.