### PR TITLE
i18n(de): add `fonts.md` translation

### DIFF
--- a/src/i18n/de/nav.ts
+++ b/src/i18n/de/nav.ts
@@ -36,6 +36,7 @@ export default NavDictionary({
 	'guides/environment-variables': 'Umgebungsvariablen',
 	'guides/aliases': 'Import-Aliasnamen',
 	'guides/integrations-guide': 'Integrationen',
+	'guides/fonts': 'Schriftarten',
 	'guides/rss': 'RSS',
 	'guides/server-side-rendering': 'Serverseitiges Rendern (SSR)',
 	'guides/typescript': 'TypeScript',

--- a/src/pages/de/guides/fonts.md
+++ b/src/pages/de/guides/fonts.md
@@ -1,6 +1,6 @@
 ---
-title: Verwendung von benutzerdefinierten Schriftarten
-description: Möchtest du einem Astro-Projekt einige benutzerdefinierte Schriftarten hinzufügen? Verwende dafür Google Fonts mit Fontsource oder füge eine Schriftart deiner wahl hinzu.
+title: Eigene Schriftarten verwenden
+description: Möchtest du einem Astro-Projekt einige benutzerdefinierte Schriftarten hinzufügen? Verwende dafür Google Fonts mit Fontsource oder füge eine Schriftart deiner Wahl hinzu.
 i18nReady: true
 layout: ~/layouts/MainLayout.astro
 setup: |
@@ -11,18 +11,18 @@ Astro unterstützt alle gängigen möglichkeiten zum Hinzufügen benutzerdefinie
 
 ## Verwenden einer lokalen Schriftdatei
 
-Wenn du Schriftdateien zu deinem Projekt hinzufügen möchtest, empfehlen wir, sie in deinem [`public/`-Verzeichniss](/de/core-concepts/project-structure/#public) zu plazieren. In deiner CSS datei können die Schriftarten dann mit einer [`@font-face`-Regel](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) registriert und mit einer `font -family`-Anweisung verwendet werden, um deine Website zu gestalten.
+Wenn du Schriftdateien zu deinem Projekt hinzufügen möchtest, empfehlen wir, sie in deinem [`public/`-Verzeichnis](/de/core-concepts/project-structure/#public) zu platzieren. In deinem CSS-Code können die Schriftarten dann mit einer [`@font-face`-Regel](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) registriert und mit einer `font-family`-Eigenschaft verwendet werden, um deine Website zu gestalten.
 
 ## Beispiel
 
-Angenommen du hast die Font-Datei `DistantGalaxy.woff`
+Nehmen wir an, du hast eine Schriftdatei namens `DistantGalaxy.woff`.
 
-1. Plaziere die Font-Datei im `public/fonts/`-Verzeichniss.
+1. Platziere die Schriftdatei im `public/fonts/`-Verzeichnis.
 
-2. Füge eine `@font-face`-Regel in deiner CSS hinzu. Das kann eine Globale `.css`-Datei sein oder in einem `<style>` Block innerhalb deines Layouts oder Komponente sein.
+2. Füge deinem CSS-Code eine `@font-face`-Regel hinzu. Du kannst dazu entweder eine global importierte `.css`-Datei verwenden, oder sie in einem `<style>`-Block innerhalb des Layouts oder der Komponente platzieren, in der du die Schriftart verwenden möchtest.
 
     ```css
-    /* Registriere deine Benutzerdefinierte Schriftart und teile dem Browser mit, wo er sie finden kann */
+    /* Registriere deine benutzerdefinierte Schriftart und teile dem Browser mit, wo sie zu finden ist. */
     @font-face {
       font-family: 'DistantGalaxy';
       src: url('/fonts/DistantGalaxy.woff') format('woff');
@@ -33,10 +33,10 @@ Angenommen du hast die Font-Datei `DistantGalaxy.woff`
     ```
 
     :::note
-    Wir fügen das `public`-Verzeichniss nicht in die Quell-URL hinzu, denn alle Dateien im `public`-Verzeichniss werden dem Projektstamm-­verzeichnis deiner Website hinzugefügt.
+    Wir lassen `public` bei der Quell-URL der Schriftart weg, denn alle Dateien im `public`-Verzeichnis werden dem Stammverzeichnis deiner Website hinzugefügt.
     :::
 
-3. Benutze die `font-family`-Anweisung von der `@font-face`-Regel um Komponente oder das Layout zu gestalten. In diesem Beispiel wird, das `<h1>` Element die Benutzerdefinierte Schriftart erhalten, während der Paragraph `<p>` sie nicht besitzt.
+3. Benutze den `font-family`-Wert aus deiner `@font-face`-Regel, um Elemente innerhalb deiner Komponente oder deines Layouts zu gestalten. Im folgenden Beispiel wird die benutzerdefinierte Schriftart auf das `<h1>`-Element angewendet, aber nicht auf den Absatz `<p>`.
 
     ```astro {10-12}
     ---
@@ -54,11 +54,11 @@ Angenommen du hast die Font-Datei `DistantGalaxy.woff`
     </style>
     ```
 
-## Fontsource Verwenden
+## Verwenden von Fontsource
 
-Das [Fontsource](https://fontsource.org/) Projekt ermöglicht die Verwendung von Google Fonts und anderen Open Source Schriftarten. Es stellt npm Pakete bereit um die gewünschten Schriftarten zu Installieren.
+Das [Fontsource](https://fontsource.org/)-Projekt ermöglicht die Verwendung von Google Fonts und anderen Open Source-Schriftarten. Es stellt npm-Pakete bereit, um die gewünschten Schriftarten zu installieren.
 
-1. Finde die Schriftart die du benutzen möchtest im [Fontsource Katalog](https://fontsource.org/fonts). Für dieses Beispiel werden wir [Twinkle Star](https://fontsource.org/fonts/twinkle-star) nutzen.
+1. Finde die Schriftart, die du benutzen möchtest, im [Fontsource-Katalog](https://fontsource.org/fonts). Für dieses Beispiel werden wir [Twinkle Star](https://fontsource.org/fonts/twinkle-star) nutzen.
 
 2. Installiere das Paket deiner gewählten Schriftart. 
 
@@ -81,10 +81,10 @@ Das [Fontsource](https://fontsource.org/) Projekt ermöglicht die Verwendung von
     </PackageManagerTabs>
 
     :::tip
-    Du findest den Korrekten Paket-Namen in der “Quick Installation” Sektion bei jeder Schriftart Seite von der Fontsource’s Website. Er startet immer mit `@fontsource/` gefolgt von Namen der Schriftart.
+    Du findest den korrekten Paketnamen im Abschnitt "Quick Installation" jeder Schriftarten-Seite auf der Fontsource-Website. Er beginnt immer mit `@fontsource/`, gefolgt vom Namen der Schriftart.
     :::
 
-3. Importiere das Schriftarten Paket in dein Layout oder Komponente wo du sie benutzen möchtest. Normalerweise solltest du dies in einer gemeinsamen Layoutkomponente tun, um sicherzustellen, dass die Schriftart überall auf deiner Website verfügbar ist.
+3. Importiere das Schriftarten-Paket in dein Layout oder die Komponente, in der du sie benutzen möchtest. Normalerweise solltest du dies in einer gemeinsamen Layoutkomponente tun, um sicherzustellen, dass die Schriftart überall auf deiner Website verfügbar ist.
 
     Der Import fügt automatisch die erforderliche `@font-face`-Regel hinzu, die zum Einrichten der Schriftart benötigt wird.
 
@@ -95,7 +95,7 @@ Das [Fontsource](https://fontsource.org/) Projekt ermöglicht die Verwendung von
     ---
     ```
 
-4. Benutze die `font-family`-Anweisung wie es auf der jeweiligen Schriftarten Fontsource Seite beschrieben ist. Das funktioniert überall wo CSS geschrieben werden kann in deinem Astro-Projekt.
+4. Benutze die `font-family`-Eigenschaft so, wie es auf der jeweiligen Schriftarten-Seite der Fontsource-Website beschrieben ist. Du kannst sie überall dort verwenden, wo du CSS-Code in deinem Astro-Projekt schreiben kannst.
 
     ```css
     h1 {
@@ -103,16 +103,16 @@ Das [Fontsource](https://fontsource.org/) Projekt ermöglicht die Verwendung von
     }
     ```
 
-## Mehr Ressourcen
+## Weitere Ressourcen
 
 ### Schriftarten mit Tailwind hinzufügen
 
-Falls du die [Tailwind-Integration](/de/guides/integrations-guide/tailwind/) verwendest,kannst du entweder eine `@font-face`-Regel für eine lokale Schriftart hinzufügen oder die `Import`-Strategie von Fontsource verwenden, um die Schriftart zu registrieren. Folge dann [Tailwinds Dokumentation zum Hinzufügen benutzerdefinierter Schriftfamilien](https://tailwindcss.com/docs/font-family#using-custom-values).
+Falls du die [Tailwind-Integration](/de/guides/integrations-guide/tailwind/) verwendest, kannst du entweder eine `@font-face`-Regel für eine lokale Schriftart hinzufügen oder die `Import`-Strategie von Fontsource verwenden, um die Schriftart zu registrieren. Folge dann [Tailwinds Dokumentation zum Hinzufügen benutzerdefinierter Schriftfamilien](https://tailwindcss.com/docs/font-family#using-custom-values).
 
-### Erfahre wie Web-Schriftarten funktionieren
+### Erfahre, wie Web-Schriftarten funktionieren
 
-Der [MDN’s web fonts guide](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts) erklärt mehr zu dem Thema.
+Die [Web Fonts-Anleitung von MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts) bietet eine Einführung in das Thema.
 
 ### Generiere CSS für deine Schriftart
 
-Der [Font Squirrel Webfont Generator](https://www.fontsquirrel.com/tools/webfont-generator) kann dabei helfen, deine Schriftarten vorzubereiten.
+Der [Font Squirrel Webfont Generator](https://www.fontsquirrel.com/tools/webfont-generator) kann dir dabei helfen, deine Schriftarten vorzubereiten.

--- a/src/pages/de/guides/fonts.md
+++ b/src/pages/de/guides/fonts.md
@@ -7,7 +7,7 @@ setup: |
     import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 ---
 
-Astro unterstützt alle gängigen möglichkeiten zum Hinzufügen benutzerdefinierter Schriftarten zu deinem Website-Design. Diese Anleitung zeigt zwei verschiedene Möglichkeiten, Webfonts in dein Projekt einzubinden.
+Astro unterstützt alle gängigen Möglichkeiten zum Hinzufügen benutzerdefinierter Schriftarten zu deinem Website-Design. Diese Anleitung zeigt zwei verschiedene Möglichkeiten, Webfonts in dein Projekt einzubinden.
 
 ## Verwenden einer lokalen Schriftdatei
 
@@ -84,7 +84,7 @@ Das [Fontsource](https://fontsource.org/)-Projekt ermöglicht die Verwendung von
     Du findest den korrekten Paketnamen im Abschnitt "Quick Installation" jeder Schriftarten-Seite auf der Fontsource-Website. Er beginnt immer mit `@fontsource/`, gefolgt vom Namen der Schriftart.
     :::
 
-3. Importiere das Schriftarten-Paket in dein Layout oder die Komponente, in der du sie benutzen möchtest. Normalerweise solltest du dies in einer gemeinsamen Layoutkomponente tun, um sicherzustellen, dass die Schriftart überall auf deiner Website verfügbar ist.
+3. Importiere das Schriftarten-Paket in dein Layout oder die Komponente, in der du es benutzen möchtest. Normalerweise solltest du dies in einer gemeinsamen Layoutkomponente tun, um sicherzustellen, dass die Schriftart überall auf deiner Website verfügbar ist.
 
     Der Import fügt automatisch die erforderliche `@font-face`-Regel hinzu, die zum Einrichten der Schriftart benötigt wird.
 

--- a/src/pages/de/guides/fonts.md
+++ b/src/pages/de/guides/fonts.md
@@ -1,0 +1,118 @@
+---
+title: Verwendung von benutzerdefinierten Schriftarten
+description: Möchtest du einem Astro-Projekt einige benutzerdefinierte Schriftarten hinzufügen? Verwende dafür Google Fonts mit Fontsource oder füge eine Schriftart deiner wahl hinzu.
+i18nReady: true
+layout: ~/layouts/MainLayout.astro
+setup: |
+    import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+---
+
+Astro unterstützt alle gängigen möglichkeiten zum Hinzufügen benutzerdefinierter Schriftarten zu deinem Website-Design. Diese Anleitung zeigt zwei verschiedene Möglichkeiten, Webfonts in dein Projekt einzubinden.
+
+## Verwenden einer lokalen Schriftdatei
+
+Wenn du Schriftdateien zu deinem Projekt hinzufügen möchtest, empfehlen wir, sie in deinem [`public/`-Verzeichniss](/de/core-concepts/project-structure/#public) zu plazieren. In deiner CSS datei können die Schriftarten dann mit einer [`@font-face`-Regel](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) registriert und mit einer `font -family`-Anweisung verwendet werden, um deine Website zu gestalten.
+
+## Beispiel
+
+Angenommen du hast die Font-Datei `DistantGalaxy.woff`
+
+1. Plaziere die Font-Datei im `public/fonts/`-Verzeichniss.
+
+2. Füge eine `@font-face`-Regel in deiner CSS hinzu. Das kann eine Globale `.css`-Datei sein oder in einem `<style>` Block innerhalb deines Layouts oder Komponente sein.
+
+    ```css
+    /* Registriere deine Benutzerdefinierte Schriftart und teile dem Browser mit, wo er sie finden kann */
+    @font-face {
+      font-family: 'DistantGalaxy';
+      src: url('/fonts/DistantGalaxy.woff') format('woff');
+      font-weight: normal;
+      font-style: normal;
+      font-display: swap;
+    }
+    ```
+
+    :::note
+    Wir fügen das `public`-Verzeichniss nicht in die Quell-URL hinzu, denn alle Dateien im `public`-Verzeichniss werden dem Projektstamm-­verzeichnis deiner Website hinzugefügt.
+    :::
+
+3. Benutze die `font-family`-Anweisung von der `@font-face`-Regel um Komponente oder das Layout zu gestalten. In diesem Beispiel wird, das `<h1>` Element die Benutzerdefinierte Schriftart erhalten, während der Paragraph `<p>` sie nicht besitzt.
+
+    ```astro {10-12}
+    ---
+    // src/pages/example.astro
+    ---
+
+    <h1>In einer Galaxie weit, weit entfernt...</h1>
+
+    <p>Benutzerdefinierte Schriftarten machen meine Überschriften viel cooler!</p>
+
+    <style>
+    h1 {
+      font-family: 'DistantGalaxy', sans-serif;
+    }
+    </style>
+    ```
+
+## Fontsource Verwenden
+
+Das [Fontsource](https://fontsource.org/) Projekt ermöglicht die Verwendung von Google Fonts und anderen Open Source Schriftarten. Es stellt npm Pakete bereit um die gewünschten Schriftarten zu Installieren.
+
+1. Finde die Schriftart die du benutzen möchtest im [Fontsource Katalog](https://fontsource.org/fonts). Für dieses Beispiel werden wir [Twinkle Star](https://fontsource.org/fonts/twinkle-star) nutzen.
+
+2. Installiere das Paket deiner gewählten Schriftart. 
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm install @fontsource/twinkle-star
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm install @fontsource/twinkle-star
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn add @fontsource/twinkle-star
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+    :::tip
+    Du findest den Korrekten Paket-Namen in der “Quick Installation” Sektion bei jeder Schriftart Seite von der Fontsource’s Website. Er startet immer mit `@fontsource/` gefolgt von Namen der Schriftart.
+    :::
+
+3. Importiere das Schriftarten Paket in dein Layout oder Komponente wo du sie benutzen möchtest. Normalerweise solltest du dies in einer gemeinsamen Layoutkomponente tun, um sicherzustellen, dass die Schriftart überall auf deiner Website verfügbar ist.
+
+    Der Import fügt automatisch die erforderliche `@font-face`-Regel hinzu, die zum Einrichten der Schriftart benötigt wird.
+
+    ```astro
+    ---
+    // src/layouts/BaseLayout.astro
+    import '@fontsource/twinkle-star';
+    ---
+    ```
+
+4. Benutze die `font-family`-Anweisung wie es auf der jeweiligen Schriftarten Fontsource Seite beschrieben ist. Das funktioniert überall wo CSS geschrieben werden kann in deinem Astro-Projekt.
+
+    ```css
+    h1 {
+      font-family: "Twinkle Star", cursive;
+    }
+    ```
+
+## Mehr Ressourcen
+
+### Schriftarten mit Tailwind hinzufügen
+
+Falls du die [Tailwind-Integration](/de/guides/integrations-guide/tailwind/) verwendest,kannst du entweder eine `@font-face`-Regel für eine lokale Schriftart hinzufügen oder die `Import`-Strategie von Fontsource verwenden, um die Schriftart zu registrieren. Folge dann [Tailwinds Dokumentation zum Hinzufügen benutzerdefinierter Schriftfamilien](https://tailwindcss.com/docs/font-family#using-custom-values).
+
+### Erfahre wie Web-Schriftarten funktionieren
+
+Der [MDN’s web fonts guide](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts) erklärt mehr zu dem Thema.
+
+### Generiere CSS für deine Schriftart
+
+Der [Font Squirrel Webfont Generator](https://www.fontsquirrel.com/tools/webfont-generator) kann dabei helfen, deine Schriftarten vorzubereiten.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content `/de/fonts.md`
- Translated content

#### Description

- What does this PR change? Give us a brief description.
The PR adds the German Translation for the missing [Fonts](https://docs.astro.build/de/guides/fonts/) Page

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->
<!-- Yes -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
