### PR TITLE
Add Changelog link to integration pages & tweak styles

### DIFF
--- a/src/components/IntegrationsNav.astro
+++ b/src/components/IntegrationsNav.astro
@@ -18,7 +18,11 @@ function categoryLinksFromPages(pages: MarkdownInstance<Frontmatter>[], category
 			const [scope, name] = page.frontmatter.title.split(' ').shift()!.split('/');
 			const pageUrl = page.url.replace('/en/', `/${lang}/`) + '/';
 			return {
-				title: '<span class="scope">' + scope + '/&#8203;</span>' + name,
+				title:
+					'<span class="scope">' +
+					scope +
+					'/</span><wbr>' +
+					name.replaceAll('-', '&#8288;-&#8288;'),
 				href: pageUrl,
 				logo: name as any,
 			};

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -13,7 +13,9 @@ export interface Props {
 
 const { content, previous, next } = Astro.props;
 // We wrap `@astrojs/` in a span to style it separately on integration pages.
-const title = content.title.replace('@astrojs/', '<span class="scope">@astrojs/</span>');
+const title = content.title
+	.replace('@astrojs/', '<span class="scope">@astrojs/</span><wbr>')
+	.replaceAll('-', '&#8288;-&#8288;');
 const isFallback = !!Astro.params.fallback || undefined;
 const lang = getLanguageFromURL(Astro.url.pathname);
 const bcpLang = normalizeLangTag(lang);

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -60,6 +60,7 @@ export default {
 	'aside.caution': 'Caution',
 	'aside.danger': 'Danger',
 	// Integrations vocabulary
+	'integrations.changelog': 'Changelog',
 	'integrations.footerTitle': 'More Integrations',
 	'integrations.renderers': 'UI Frameworks',
 	'integrations.adapters': 'SSR Adapters',

--- a/src/layouts/IntegrationLayout.astro
+++ b/src/layouts/IntegrationLayout.astro
@@ -38,6 +38,21 @@ const { title, githubURL } = Astro.props.content;
 				></path>
 			</svg>npm
 		</a>
+		<a href={githubURL + 'CHANGELOG.md'}>
+			<svg
+				aria-hidden="true"
+				viewBox="0 0 16 16"
+				height="1em"
+				width="1em"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fill="currentColor"
+					fill-rule="evenodd"
+					d="M2.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .14.11.25.25.25h10.5a.25.25 0 0 0 .25-.25V4.66a.25.25 0 0 0-.07-.17L10.5 1.57a.25.25 0 0 0-.17-.07H2.75zM1 1.75C1 .78 1.78 0 2.75 0h7.59c.46 0 .9.18 1.23.51l2.92 2.92c.33.32.51.77.51 1.23v9.59A1.75 1.75 0 0 1 13.25 16H2.75A1.75 1.75 0 0 1 1 14.25V1.75zm7 1.5a.75.75 0 0 1 .75.75v1.5h1.5a.75.75 0 0 1 0 1.5h-1.5v1.5a.75.75 0 0 1-1.5 0V7h-1.5a.75.75 0 0 1 0-1.5h1.5V4A.75.75 0 0 1 8 3.25zm-3 8a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75z"
+				></path>
+			</svg><UIString key="integrations.changelog" />
+		</a>
 	</aside>
 	<slot />
 	<h2>
@@ -56,21 +71,27 @@ const { title, githubURL } = Astro.props.content;
 		color: var(--theme-text-lighter);
 		margin-top: 0;
 		margin-bottom: 3rem;
-		gap: 0.5rem 1.5rem;
-	}
-
-	@media (min-width: 50em) {
-		.pkg-info {
-			gap: 0.5rem 2rem;
-		}
+		gap: 0.5rem 1rem;
+		font-size: var(--theme-text-sm);
 	}
 
 	.pkg-info a {
 		display: inline-flex;
+		gap: 0.25rem;
 		align-items: center;
 		color: var(--theme-text-lighter);
 		text-decoration: none;
 		font-weight: bold;
+	}
+
+	@media (min-width: 37.75em) {
+		.pkg-info {
+			gap: 0.5rem 2rem;
+			font-size: var(--theme-text-base);
+		}
+		.pkg-info a {
+			gap: 0.5rem;
+		}
 	}
 
 	.pkg-info a:hover {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

I found myself needing to consult the changelogs for several Astro integrations over the weekend and realised they are not always easy to find: some integrations include a link at the bottom of the README, some don’t.

This PR adds a Changelog link as part of the header section in the integration guide layout:

<img width="803" alt="image" src="https://user-images.githubusercontent.com/357379/197497834-a47b1dd8-0feb-49bf-95e4-7e59c05e5128.png">

I also tweaked how we format the integration names subtly to improve how they break in narrower spaces.

| Before | After |
|--------|-------|
| <img width="324" alt="image" src="https://user-images.githubusercontent.com/357379/197498551-2674a63d-a1e5-4ae3-b5f7-07a29630c28a.png"> | <img width="323" alt="image" src="https://user-images.githubusercontent.com/357379/197498489-d8490b42-c831-4f38-8f95-6cb98d4fcd2f.png"> |