### PR TITLE
Update `astro preview` docs after 1.5

### DIFF
--- a/src/pages/en/reference/cli-reference.md
+++ b/src/pages/en/reference/cli-reference.md
@@ -92,14 +92,14 @@ Includes [Markdown draft pages](/en/guides/markdown-content/#markdown-drafts) in
 
 ## `astro preview`
 
-Starts a local file server to serve your static `dist/` directory.
+Starts a local server to serve your `dist/` directory.
 
-This command is useful for previewing your static build locally, before deploying it. It is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy/).
+This command is useful for previewing your build locally, before deploying it. It is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy/).
 
 Can be combined with the [common flags](#common-flags) documented below.
 
 :::caution
-`astro preview` does not work for SSR builds, which require the server runtime that corresponds to your adapter.
+`astro preview` does not work for SSR builds unless you use an adapter that supports it. Currently, only the Node adapter supports `astro preview`.
 :::
 
 ## `astro check`


### PR DESCRIPTION

- New or updated content

As of 1.5, `astro preview` doesn't just work in static mode. This PR removes the "static" qualifier from our description of `astro preview`, and updates the caution to explain when it works in SSR.