### PR TITLE
Show tutorial navigation on smaller screens

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -23,7 +23,17 @@ const direction = rtlLanguages.has(lang) ? 'rtl' : 'ltr';
 ---
 
 <div dir={isFallback ? 'ltr' : direction} lang={isFallback && 'en'}>
-	<slot name="before-article" />
+	{
+		// For best cross-browser support of sticky or fixed elements, they must not be nested
+		// inside elements that hide any overflow axis. The article hides `overflow-x`,
+		// so we must place fixed UI elements like the mobile TOC here.
+		Astro.slots.has('before-article') && (
+			<div class="fixed-mobile-bar" dir={direction}>
+				<slot name="before-article" />
+				<div class="spacer" />
+			</div>
+		)
+	}
 	<article id="article" class="content">
 		<section class="main-section">
 			<header>
@@ -52,6 +62,34 @@ const direction = rtlLanguages.has(lang) ? 'rtl' : 'ltr';
 </div>
 
 <style>
+	.fixed-mobile-bar {
+		display: block;
+		position: fixed;
+		inset-inline: 0;
+		top: calc(var(--theme-navbar-height));
+		z-index: 2;
+	}
+
+	.spacer {
+		height: var(--theme-mobile-toc-height);
+	}
+
+	@media (min-width: 50em) {
+		.fixed-mobile-bar {
+			inset-inline-start: var(--theme-left-sidebar-width);
+			margin-top: 0;
+		}
+	}
+
+	@media (min-width: 72em) {
+		.fixed-mobile-bar {
+			display: none;
+		}
+		.spacer {
+			height: 0;
+		}
+	}
+
 	.content-title :global(.scope) {
 		font-weight: 300;
 		color: var(--theme-text-lighter);

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -30,8 +30,8 @@ const direction = rtlLanguages.has(lang) ? 'rtl' : 'ltr';
 		Astro.slots.has('before-article') && (
 			<div class="fixed-mobile-bar" dir={direction}>
 				<slot name="before-article" />
-				<div class="spacer" />
 			</div>
+			<div class="spacer" />
 		)
 	}
 	<article id="article" class="content">

--- a/src/components/tabs/TabbedContent.astro
+++ b/src/components/tabs/TabbedContent.astro
@@ -42,6 +42,7 @@ const { tabs } = Astro.props as Props;
 
 <script>
 	class Tabs extends HTMLElement {
+		readonly id = Math.floor(Math.random() * 10e10).toString(32);
 		count = 0;
 		TabStore: Set<HTMLElement>[] = [];
 		PanelStore: Set<HTMLElement>[] = [];
@@ -62,7 +63,7 @@ const { tabs } = Astro.props as Props;
 			// Add semantics are remove user focusability for each tab
 			Array.prototype.forEach.call(tabs, (tab: HTMLElement, i: number) => {
 				tab.setAttribute('role', 'tab');
-				tab.setAttribute('id', 'tab' + this.count++);
+				tab.setAttribute('id', this.id + 'tab' + this.count++);
 				tab.setAttribute('tabindex', '-1');
 				tab.parentNode.setAttribute('role', 'presentation');
 				if (!this.TabStore[i]) this.TabStore.push(new Set());

--- a/src/components/tutorial/MobileTutorialNav.astro
+++ b/src/components/tutorial/MobileTutorialNav.astro
@@ -27,7 +27,7 @@ import TutorialNav from './TutorialNav.astro';
 			</div>
 		</summary>
 		<div class="tut-nav-content">
-			<TutorialNav />
+			<TutorialNav id="mobile" />
 		</div>
 	</details>
 </nav>

--- a/src/components/tutorial/MobileTutorialNav.astro
+++ b/src/components/tutorial/MobileTutorialNav.astro
@@ -1,0 +1,133 @@
+---
+import UIString from '../UIString.astro';
+import TutorialNav from './TutorialNav.astro';
+---
+
+<nav>
+	<details class="tut-mobile-container">
+		<summary class="tut-mobile-header">
+			<div class="tut-mobile-header-content">
+				<div class="tut-toggle">
+					<h2 class="heading">
+						<UIString key="tutorial.trackerLabel" />
+					</h2>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 1 16 16"
+						width="16"
+						height="16"
+						aria-hidden="true"
+					>
+						<path
+							fill-rule="evenodd"
+							d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"
+						></path>
+					</svg>
+				</div>
+			</div>
+		</summary>
+		<div class="tut-nav-content">
+			<TutorialNav />
+		</div>
+	</details>
+</nav>
+
+<style>
+	/* The mobile container is a <details> element wrapping the mobile TOC */
+	.tut-mobile-container > .tut-mobile-header::marker,
+	.tut-mobile-container > .tut-mobile-header::-webkit-details-marker {
+		display: none;
+	}
+
+	.tut-mobile-container[open] .tut-toggle svg {
+		transform: rotate(90deg);
+	}
+
+	.tut-mobile-container {
+		--header-bottom-padding: 1.5rem;
+	}
+
+	@media (min-width: 50em) {
+		/* Improve toggle & title alignment with left sidebar */
+		.tut-mobile-container {
+			--header-bottom-padding: 0.5rem;
+		}
+	}
+
+	/*
+	The mobile header is the clickable <summary> heading.
+
+	It has a opaque background and covers the entire viewport width
+	to ensure that page content scrolling underneath is hidden.
+*/
+	.tut-mobile-header {
+		display: block;
+		cursor: pointer;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		background: var(--theme-bg-gradient-top);
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.tut-mobile-header-content {
+		display: flex;
+		align-items: center;
+		height: var(--theme-mobile-toc-height);
+		max-width: 80ch;
+		margin-inline: auto;
+		padding-bottom: var(--header-bottom-padding);
+		padding-inline: var(--min-spacing-inline);
+	}
+
+	.tut-toggle {
+		margin-inline-end: 0.5rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--theme-shade-subtle);
+		padding: 0.25rem 0.75rem;
+		padding-inline-end: 0.5rem;
+		font-size: var(--theme-text-sm);
+	}
+
+	.tut-toggle svg {
+		margin-inline-start: 0.25rem;
+	}
+
+	.tut-mobile-header h2 {
+		margin: 0;
+		display: inline;
+	}
+
+	.tut-mobile-container[open] .tut-toggle {
+		background-color: var(--theme-bg-offset);
+	}
+
+	.tut-toggle svg {
+		transform: rotate(0);
+		transition: 0.15s transform ease;
+		vertical-align: middle;
+		fill: var(--theme-accent-secondary);
+		stroke: var(--theme-accent-secondary);
+	}
+
+	@media (forced-colors: active) {
+		.tut-toggle svg {
+			fill: Highlight;
+			stroke: Highlight;
+		}
+	}
+
+	.tut-nav-content {
+		margin-inline: var(--min-spacing-inline);
+		max-height: calc(
+			var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-mobile-toc-height) -
+				1rem
+		);
+		overflow-y: auto;
+		border: 1px solid var(--theme-shade-subtle);
+		border-radius: 0.5rem;
+		font-size: var(--theme-text-sm);
+		background: var(--theme-bg-gradient);
+		transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
+	}
+</style>

--- a/src/components/tutorial/MobileTutorialNav.astro
+++ b/src/components/tutorial/MobileTutorialNav.astro
@@ -127,7 +127,7 @@ import TutorialNav from './TutorialNav.astro';
 		border: 1px solid var(--theme-shade-subtle);
 		border-radius: 0.5rem;
 		font-size: var(--theme-text-sm);
-		background: var(--theme-bg-gradient);
+		background: var(--theme-bg);
 		transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
 	}
 </style>

--- a/src/components/tutorial/RightSidebar.astro
+++ b/src/components/tutorial/RightSidebar.astro
@@ -5,7 +5,7 @@ import TutorialNav from './TutorialNav.astro';
 
 <nav class="right-sidebar">
 	<h1><UIString key="tutorial.trackerLabel" /></h1>
-	<TutorialNav />
+	<TutorialNav id="sidebar" />
 </nav>
 
 <style>

--- a/src/components/tutorial/RightSidebar.astro
+++ b/src/components/tutorial/RightSidebar.astro
@@ -1,0 +1,21 @@
+---
+import UIString from '../UIString.astro';
+import TutorialNav from './TutorialNav.astro';
+---
+
+<div class="right-sidebar">
+	<h1><UIString key="tutorial.trackerLabel" /></h1>
+	<TutorialNav />
+</div>
+
+<style>
+	.right-sidebar {
+		overflow: auto;
+		padding-inline-end: 0.5rem;
+	}
+
+	h1 {
+		font-size: var(--theme-text-base);
+		font-weight: 700;
+	}
+</style>

--- a/src/components/tutorial/RightSidebar.astro
+++ b/src/components/tutorial/RightSidebar.astro
@@ -3,10 +3,10 @@ import UIString from '../UIString.astro';
 import TutorialNav from './TutorialNav.astro';
 ---
 
-<div class="right-sidebar">
+<nav class="right-sidebar">
 	<h1><UIString key="tutorial.trackerLabel" /></h1>
 	<TutorialNav />
-</div>
+</nav>
 
 <style>
 	.right-sidebar {

--- a/src/components/tutorial/TutorialNav.astro
+++ b/src/components/tutorial/TutorialNav.astro
@@ -17,7 +17,7 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 	unit.lessons.some((lesson) => currentUrl.endsWith(lesson.slug));
 ---
 
-<nav>
+<div class="tutorial-nav">
 	<TabbedContent>
 		<Fragment slot="tab-list">
 			{
@@ -64,10 +64,10 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 			))
 		}
 	</TabbedContent>
-</nav>
+</div>
 
 <style>
-	nav {
+	.tutorial-nav {
 		width: 100%;
 		font-size: var(--theme-text-xs);
 	}
@@ -77,7 +77,7 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 		background-color: var(--theme-bg-offset);
 	}
 
-	nav ol.lessons {
+	.tutorial-nav ol.lessons {
 		margin: 0;
 		padding-inline-start: 0;
 		list-style: none;

--- a/src/components/tutorial/TutorialNav.astro
+++ b/src/components/tutorial/TutorialNav.astro
@@ -7,12 +7,16 @@ import TabPanel from '../tabs/TabPanel.astro';
 import Progress from './Progress.astro';
 import UnitProgressIcon from './UnitProgressIcon.astro';
 
+export interface Props {
+	id: string;
+}
+
 const currentUrl = Astro.url.pathname.replace(/\/$/, '');
 const lang = getLanguageFromURL(Astro.url.pathname);
 const tutorialPages = getTutorialPages(await Astro.glob(`../../pages/*/tutorial/**/*.md`), lang);
 const units = getTutorialUnits(tutorialPages);
 
-const makeUnitId = (index: number) => `tutorial-unit-nav-panel-${index}`;
+const makeUnitId = (index: number) => `${Astro.props.id}__tutorial-unit-nav-panel-${index}`;
 const isCurrentUnit = (unit: typeof units[number]) =>
 	unit.lessons.some((lesson) => currentUrl.endsWith(lesson.slug));
 ---

--- a/src/components/tutorial/TutorialNav.astro
+++ b/src/components/tutorial/TutorialNav.astro
@@ -18,7 +18,6 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 ---
 
 <nav>
-	<h1>Tutorial Tracker</h1>
 	<TabbedContent>
 		<Fragment slot="tab-list">
 			{
@@ -70,14 +69,7 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 <style>
 	nav {
 		width: 100%;
-		padding: var(--doc-padding-block) 0.5rem 0 0;
-		overflow: auto;
 		font-size: var(--theme-text-xs);
-	}
-
-	h1 {
-		font-size: var(--theme-text-base);
-		font-weight: 700;
 	}
 
 	.unit {

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -76,6 +76,7 @@ export default {
 	'progress.todo': 'To-do',
 	'progress.done': 'Complete',
 	// Tutorial Navigation
+	'tutorial.trackerLabel': 'Tutorial Tracker',
 	'tutorial.unit': 'Unit',
 	// Tutorial
 	'tutorial.getReady': 'Get ready to…',

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -2,7 +2,6 @@
 import PageContent from '../components/PageContent/PageContent.astro';
 import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
 import TableOfContents from '../components/RightSidebar/TableOfContents';
-import { rtlLanguages } from '../i18n/languages';
 import { useTranslations } from '../i18n/util';
 import { getLanguageFromURL } from '../util';
 import { getNavLinks } from '../util/getNavLinks';
@@ -13,7 +12,6 @@ const headings = content.astro?.headings;
 const isFallback = !!Astro.params.fallback;
 const currentPage = Astro.url.pathname;
 const lang = getLanguageFromURL(currentPage);
-const direction = rtlLanguages.has(lang) ? 'rtl' : 'ltr';
 const t = useTranslations(Astro);
 const { previous, next } = await getNavLinks(Astro);
 const filePath = `src/pages${currentPage.replace(/\/$/, '')}.md`;
@@ -28,12 +26,9 @@ const githubEditUrl =
 	<RightSidebar slot="secondary-sidebar" content={content} githubEditUrl={githubEditUrl} />
 	<PageContent {...{content, previous, next}}>
 		{
-			// For best cross-browser support of sticky or fixed elements, they must not be nested
-			// inside elements that hide any overflow axis. The article content hides `overflow-x`,
-			// so we must place the mobile TOC here.
 			headings && (
 				<Fragment slot="before-article">
-					<nav class="mobile-toc" dir={direction}>
+					<nav>
 						<TableOfContents
 							client:media="(max-width: 72em)"
 							headings={headings}
@@ -44,7 +39,6 @@ const githubEditUrl =
 							isMobile={true}
 						/>
 					</nav>
-					<div class="spacer" />
 				</Fragment>
 			)
 		}
@@ -52,33 +46,3 @@ const githubEditUrl =
 		<slot />
 	</PageContent>
 </BaseLayout>
-
-<style>
-	.mobile-toc {
-		display: block;
-		position: fixed;
-		inset-inline: 0;
-		top: calc(var(--theme-navbar-height));
-		z-index: 2;
-	}
-	@media (min-width: 50em) {
-		.mobile-toc {
-			inset-inline-start: var(--theme-left-sidebar-width);
-			margin-top: 0;
-		}
-	}
-
-	.spacer {
-		height: var(--theme-mobile-toc-height);
-	}
-
-	@media (min-width: 72em) {
-		.mobile-toc {
-			display: none;
-		}
-
-		.spacer {
-			height: 0;
-		}
-	}
-</style>

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -1,6 +1,7 @@
 ---
 import PageContent from '../components/PageContent/PageContent.astro';
-import TutorialNav from '../components/tutorial/TutorialNav.astro';
+import MobileTutorialNav from '../components/tutorial/MobileTutorialNav.astro';
+import RightSidebar from '../components/tutorial/RightSidebar.astro';
 import { getLanguageFromURL } from '../util';
 import { getPreviousAndNext } from '../util/getNavLinks';
 import { getTutorialPages, getTutorialUnits } from '../util/getTutorialPages';
@@ -22,8 +23,9 @@ const { next } = getPreviousAndNext(
 ---
 
 <BaseLayout {...Astro.props}>
-	<TutorialNav slot="secondary-sidebar" />
+	<RightSidebar slot="secondary-sidebar" />
 	<PageContent content={Astro.props.content} {...{ next }}>
+		<MobileTutorialNav slot="before-article" />
 		<p class="unit" slot="before-title">
 			{currentUnitIndex} • {currentUnit.title}
 		</p>

--- a/src/pages/en/tutorial/0-introduction/1.md
+++ b/src/pages/en/tutorial/0-introduction/1.md
@@ -18,9 +18,9 @@ You will also need a [GitHub](https://github.com) (or similar) account for publi
 
 You check them off!
 
-At the end of each page, you'll find a clickable checklist of tasks you should now be able to do.
+At the end of each page, you'll find a clickable checklist of tasks you should now be able to do. Check these items off to see your progress in the Tutorial Tracker.
 
-Check these items off to see your progress in the tutorial navigation sidebar. (This is only set in your browser's local storage, and is not available elsewhere. No data is sent to, nor stored by Astro.) 
+(This data is only saved to your browser's local storage, and is not available elsewhere. No data is sent to, nor stored by Astro.)
 </details>
 
 <details>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- Adds a collapsible menu similar to our existing “On this page” component on smaller screens to show the tutorial tracker
    <img width="592" alt="image" src="https://user-images.githubusercontent.com/357379/197642841-6ccd8be8-5f46-4426-8d20-56bd11460a00.png">


<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
