### PR TITLE
Hot fix to make Prettier happy

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -28,10 +28,12 @@ const direction = rtlLanguages.has(lang) ? 'rtl' : 'ltr';
 		// inside elements that hide any overflow axis. The article hides `overflow-x`,
 		// so we must place fixed UI elements like the mobile TOC here.
 		Astro.slots.has('before-article') && (
-			<div class="fixed-mobile-bar" dir={direction}>
-				<slot name="before-article" />
-			</div>
-			<div class="spacer" />
+			<>
+				<div class="fixed-mobile-bar" dir={direction}>
+					<slot name="before-article" />
+				</div>
+				<div class="spacer" />
+			</>
 		)
 	}
 	<article id="article" class="content">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description
This is a small formatting fix to make our format CI task happy. Wrapping with `<>...</>` Shouldn’t strictly speaking be necessary in `.astro` but looks like Prettier is confused in this context without it and wrapping with a fragment is harmless, so I’m adding this to get CI passing.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
