### PR TITLE
Remove Netlify pnpm workaround that is no longer needed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,5 @@
-[build.environment]
-  NPM_FLAGS = "--version"
-
 [build]
-  command = "npx pnpm install --store=node_modules/.pnpm-store && npx pnpm build"
+  command = "pnpm build"
   ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- /"
 
   [[redirects]]


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

Netlify recently [introduced out-of-the-box support for deploying with `pnpm`](https://www.netlify.com/blog/how-to-use-pnpm-with-netlify-build/), so we no longer need our workaround in `netlify.toml`.