### PR TITLE
More `<MultipleChoice>` polish

### DIFF
--- a/public/theme.css
+++ b/public/theme.css
@@ -19,6 +19,8 @@
 	--theme-text-base: 1rem;
 	--theme-text-sm: 0.9375rem;
 	--theme-text-xs: 0.875rem;
+	/* Animation helpers */
+	--theme-ease-bounce: cubic-bezier(0.4, 2.5, 0.6, 1);
 }
 
 @media (min-width: 50em) {

--- a/src/components/Checklist.astro
+++ b/src/components/Checklist.astro
@@ -81,7 +81,7 @@ const { key = 'default' } = Astro.props as Props;
 	@media (prefers-reduced-motion: no-preference) {
 		check-list :global(input[type='checkbox']::after) {
 			transition-property: transform, box-shadow;
-			transition-timing-function: cubic-bezier(0.4, 2.5, 0.6, 1);
+			transition-timing-function: var(--theme-ease-bounce);
 			transition-duration: 0.15s;
 		}
 	}

--- a/src/components/tutorial/MultipleChoice.astro
+++ b/src/components/tutorial/MultipleChoice.astro
@@ -52,8 +52,8 @@ const t = useTranslations(Astro);
 		cursor: pointer;
 		box-shadow: -0.25rem 0.25rem var(--theme-shade-subtle);
 		transition-property: box-shadow, transform;
-		transition-duration: 50ms;
-		transition-timing-function: ease-out;
+		transition-duration: 0.15s;
+		transition-timing-function: var(--theme-ease-bounce);
 		color: var(--theme-text-light);
 		background-color: transparent;
 	}

--- a/src/components/tutorial/MultipleChoice.astro
+++ b/src/components/tutorial/MultipleChoice.astro
@@ -51,9 +51,6 @@ const t = useTranslations(Astro);
 	.submit {
 		cursor: pointer;
 		box-shadow: -0.25rem 0.25rem var(--theme-shade-subtle);
-		transition-property: box-shadow, transform;
-		transition-duration: 0.15s;
-		transition-timing-function: var(--theme-ease-bounce);
 		color: var(--theme-text-light);
 		background-color: transparent;
 	}
@@ -112,6 +109,12 @@ const t = useTranslations(Astro);
 	}
 
 	@media (prefers-reduced-motion: no-preference) {
+		.submit {
+			transition-property: box-shadow, transform;
+			transition-duration: 0.15s;
+			transition-timing-function: var(--theme-ease-bounce);
+		}
+
 		.correct,
 		.wrong {
 			animation-iteration-count: 1;

--- a/src/components/tutorial/MultipleChoice.astro
+++ b/src/components/tutorial/MultipleChoice.astro
@@ -76,7 +76,7 @@ const t = useTranslations(Astro);
 	.submit:disabled,
 	.submit:active {
 		box-shadow: 0 0 var(--theme-shade-subtle);
-		transform: translate3d(0.25rem, 0.25rem, 0);
+		transform: translate3d(-0.25rem, 0.25rem, 0);
 	}
 
 	.submit:disabled {

--- a/src/components/tutorial/Option.astro
+++ b/src/components/tutorial/Option.astro
@@ -77,7 +77,7 @@ const { isCorrect } = Astro.props as Props;
 	@media (prefers-reduced-motion: no-preference) {
 		input[type='radio']::after {
 			transition-property: transform, box-shadow;
-			transition-timing-function: cubic-bezier(0.4, 2.5, 0.6, 1);
+			transition-timing-function: var(--theme-ease-bounce);
 			transition-duration: 0.15s;
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- I forgot to make the `<MultipleChoice>` submit button “pop” in the right direction as part of #1908 — this PR fixes that.
- I’ve also switched up the transition style so it uses the same “bounce” easing as our other buttons for consistency.
- These transitions were active even for users who prefer reduced motion, so I’ve fixed that, disabling animations when appropriate.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
