### PR TITLE
`docgen:integrations`: don't strip hashes from links

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -92,7 +92,7 @@ class IntegrationPagesBuilder {
 	 */
 	async #processReadme({ name, readme, srcdir, category }: IntegrationData): Promise<string> {
 		// Remove title from body
-		readme = readme.replace(/# (.+)/, '');
+		readme = readme.replace(/^# (.+)/, '');
 		const githubLink = `https://github.com/${this.#sourceRepo}/tree/${
 			this.#sourceBranch
 		}/packages/integrations/${srcdir}/`;
@@ -183,7 +183,8 @@ function relativeLinks({ base }: { base: string }) {
 	return function transform(tree: Root) {
 		function visitor(node: Link | Definition) {
 			if (!node.url.startsWith(base)) return;
-			node.url = new URL(node.url).pathname;
+			const url = new URL(node.url);
+			node.url = url.pathname + url.search + url.hash;
 		}
 		visit(tree, 'link', visitor);
 		visit(tree, 'definition', visitor);


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code (specifically to `scripts/generate-integration-pages.ts`, which is called by `pnpm run docgen:integrations`)

#### Description

- [I noticed](https://github.com/withastro/docs/pull/1886#issuecomment-1290997156) that a link hash was disappearing somewhere between `withastro/astro` and `withastro`docs`:
    ```diff
    - https://docs.astro.build/en/reference/configuration-reference/#markdownextenddefaultplugins
    +                         /en/reference/configuration-reference/
    ```
- Tracked down the source of the issue, this PR fixes it (confirmed locally).
- Also made a very minor change to an unrelated regex in the same script, to reduce the chance of it erroneously matching in the future.
- Tempting to figure out how to test this script, but I gather it will be retired sometime in the next few months.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
