### PR TITLE
Initial work overhauling styles for the tutorial project

### DIFF
--- a/src/pages/en/tutorial/2-pages/4.md
+++ b/src/pages/en/tutorial/2-pages/4.md
@@ -71,7 +71,7 @@ Using Astro's own `<style></style>` tags, you can style items on your page. Addi
 ## Use your first CSS variable
 The Astro `<style>` tag can also reference any variables from your frontmatter script using the `define:vars={ {...} }` directive. You can **define variables within your code fence**, then **use them as CSS variables in your style tag**.
 
-1. Add the following code into the frontmatter script of `src/pages/about.astro`
+1. Define a `skillColor` variable by adding it to the frontmatter script of `src/pages/about.astro` like this:
 
     ```astro title="src/pages/about.astro" ins={17}
     ---
@@ -90,7 +90,7 @@ The Astro `<style>` tag can also reference any variables from your frontmatter s
     const finished = false;
     const goal = 3;
   
-    const skillColor = "green";
+    const skillColor = "navy";
     ---
     ```
 
@@ -109,7 +109,7 @@ The Astro `<style>` tag can also reference any variables from your frontmatter s
     </style>
     ```
 
-3. Check your About page in your browser preview, and once again, you should not notice any changes! The color green is still being applied, but now through the `define:vars` directive.
+3. Check your About page in your browser preview. You should see that the skills are now navy blue, as set by the `skillColor` variable passed to the `define:vars` directive.
 
 <Box icon="puzzle-piece">
 
@@ -131,7 +131,7 @@ The Astro `<style>` tag can also reference any variables from your frontmatter s
     ```
  
  2. Add any missing variable definitions in your frontmatter script so that your new `<style>` tag successfully applies these styles to your list of skills:
-    - The text color is green
+    - The text color is navy blue
     - The text is bold
     - The list items are in all-caps (all uppercase letters)
 
@@ -155,7 +155,7 @@ const happy = true;
 const finished = false;
 const goal = 3;
 
-const skillColor = "green";
+const skillColor = "navy";
 const fontWeight = "bold";
 const textCase = "uppercase";
 ---

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -26,22 +26,25 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
 
     ```css title="src/styles/global.css"
     html {
-      background-color: #00539F;
+      background-color: #f1f5f9;
+      font-family: sans-serif;
     }
+
     body {
-      background-color: #E2CAF1;
       margin: 0 auto;
-      width: 80%;
+      width: 100%;
       max-width: 80ch;
-      padding: 1em;
-      border: 5px solid black;
+      padding: 1rem;
+      line-height: 1.5;
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     h1 {
       margin: 0;
-      padding: 20px 0;
-      color: #00539F;
-      text-shadow: 3px 3px 1px grey;
+      padding: 1.25rem 0;
     }
     ```
 3. In `about.astro`, add the following import statement anywhere in your frontmatter: 

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -47,10 +47,13 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
       padding: 1.25rem 0;
     }
     ```
-3. In `about.astro`, add the following import statement anywhere in your frontmatter: 
 
-    ```astro title="src/pages/about.astro" ins={21}
+3. In `about.astro`, add the following import statement to your frontmatter: 
+
+    ```astro title="src/pages/about.astro" ins={2}
     ---
+    import '../styles/global.css';
+
     const pageTitle = "About Me";
 
     const identity = {
@@ -69,8 +72,6 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
     const skillColor = "green";
     const fontWeight = "bold";
     const textCase = "uppercase";
-
-    import '../styles/global.css';
     ---
     ```
 

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -69,7 +69,7 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
     const finished = false;
     const goal = 3;
 
-    const skillColor = "green";
+    const skillColor = "navy";
     const fontWeight = "bold";
     const textCase = "uppercase";
     ---

--- a/src/pages/en/tutorial/3-components/2.md
+++ b/src/pages/en/tutorial/3-components/2.md
@@ -28,22 +28,23 @@ Now that you have used Astro components on a page, let's use a component within 
     const platform = "github";
     const username = "withastro";
     ---
-    <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
+
+    <footer>
+      <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
+    </footer>
     ```
 
-### Import and Use Footer.astro
+### Import and use `Footer.astro`
 
-1. Add the following import statement anywhere in the frontmatter in each of your three Astro pages (`index.astro`, `about.astro`, and `blog.astro`):
+1. Add the following import statement to the frontmatter in each of your three Astro pages (`index.astro`, `about.astro`, and `blog.astro`):
 
-    ```astro title="src/components/Footer.astro" ins={2}
-    ---
+    ```js
     import Footer from '../components/Footer.astro';
-    ---
     ```
 
 2. Add a new `<Footer />` component in your Astro template on each page, just before the closing `</body>` tag to display your footer at the bottom of the page. 
 
-    ```astro title="src/pages/index.astro" ins={1}
+    ```astro ins={1}
        <Footer />
       </body>
     </html>
@@ -64,10 +65,11 @@ If you've been following along with each step in the tutorial, your `index.astro
 
 ```astro title="src/pages/index.astro"
 ---
-const pageTitle = "Home Page";
 import Navigation from '../components/Navigation.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
+
+const pageTitle = 'Home Page';
 ---
 
 <html lang="en">
@@ -96,69 +98,71 @@ import '../styles/global.css';
 
     ```astro title="src/components/Social.astro"
     ---
-    const {platform, username} = Astro.props;
+    const { platform, username } = Astro.props;
     ---
-    <span><a href={`https://www.${platform}.com/${username}`}>{platform}</a></span>
+    <a href={`https://www.${platform}.com/${username}`}>{platform}</a>
     ```
 
 ### Import and use `Social.astro` in your Footer
 
 1. Change the code in `src/components/Footer.astro` to import, then use this new component three times, passing different **component attributes** as props each time:
 
-    ```astro title="src/components/Footer.astro" del={2,3,6} ins={4,7-9}
+    ```astro title="src/components/Footer.astro" del={2,3,8} ins={4,9-11}
     ---
     const platform = "github";
     const username = "withastro";
     import Social from './Social.astro';
     ---
-    <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
-    <Social platform="twitter" username="astrodotbuild" />
-    <Social platform="github" username="withastro" />
-    <Social platform="youtube" username="astrodotbuild" />
+
+    <footer>
+      <p>Learn more about my projects on <a href={`https://www.${platform}.com/${username}`}>{platform}</a>!</p>
+      <Social platform="twitter" username="astrodotbuild" />
+      <Social platform="github" username="withastro" />
+      <Social platform="youtube" username="astrodotbuild" />
+    </footer>
     ```
 
 2. Check your browser preview, and you should see your new footer displaying links to these three platforms on each page.
 
 ## Style your Social Media Component
 
-1. Add the following `<style>` tag to `src/components/Social.astro` and corresponding `class` to the `<span>` element:
+1. Customize the appearance of your links by adding a `<style>` tag to `src/components/Social.astro`.
 
-    ```astro title="src/components/social.astro" ins={6-17} 'class="social-platform'
+    ```astro title="src/components/Social.astro" ins={6-17} 'class="social-platform'
     ---
-    const {platform, username} = Astro.props;
+    const { platform, username } = Astro.props;
     ---
-    <span class="social-platform"><a href={`https://www.${platform}.com/${username}`}>{platform}</a></span>
+    <a href={`https://www.${platform}.com/${username}`}>{platform}</a>
 
     <style>
-      .social-platform {
-        margin: 0.4em;
-        padding: 1em;
-        background-color: #ff9776;
-        border-radius: 3px;
-      }
       a {
-        color: #00539F;
+        padding: 0.5rem 1rem;
+        color: white;
+        background-color: #4c1d95;
         text-decoration: none;
       }
     </style>
     ```
 
-2. Add the following HTML element with a corresponding `<style>` tag to `src/components/footer.astro` to separate your footer from the rest of the page content. 
+2. Let’s add a `<style>` tag to `src/components/Footer.astro` as well to improve the layout of its contents.
 
-    ```astro title="src/components/footer.astro" ins={4-8,10}
+    ```astro title="src/components/Footer.astro" ins={4-10}
     ---
     import Social from './Social.astro';
     ---
     <style>
-       .spacer {
-           height: 2em;
-       }
+      footer {
+        display: flex;
+        gap: 1rem;
+        margin-top: 2rem;
+      }
     </style>
 
-    <div class="spacer"></div>
-    <Social platform="twitter" username="astrodotbuild" />
-    <Social platform="github" username="withastro" />
-    <Social platform="youtube" username="astrodotbuild" />
+    <footer>
+      <Social platform="twitter" username="astrodotbuild" />
+      <Social platform="github" username="withastro" />
+      <Social platform="youtube" username="astrodotbuild" />
+    </footer>
     ```
 
 3. Check your browser preview again and confirm that each page shows an updated footer.

--- a/src/pages/en/tutorial/3-components/2.md
+++ b/src/pages/en/tutorial/3-components/2.md
@@ -144,7 +144,7 @@ const pageTitle = 'Home Page';
     </style>
     ```
 
-2. Let’s add a `<style>` tag to `src/components/Footer.astro` as well to improve the layout of its contents.
+2. Add a `<style>` tag to `src/components/Footer.astro` to improve the layout of its contents.
 
     ```astro title="src/components/Footer.astro" ins={4-10}
     ---


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Updates the styling used in the tutorial project up to and including lesson 3.2
- Main aim is to make things look a little more minimal while still preserving the same basic learning flow
- I have tweaked a few bits of markup too where it seemed we could do better: use `<footer>` in the footer component for example.

I have been updating the example repo as I go, so you can get a glimpse by looking at the `unit-4/start` branch on StackBlitz: https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/unit-4/start (N.B. this does still include the hamburger/nav styles, which I haven’t tackled yet)

Here’s a taste:

<img width="481" alt="image" src="https://user-images.githubusercontent.com/357379/197876207-3c4ce771-99c6-4208-b9d2-2961c54575fb.png">
