### PR TITLE
Tutorial: Ensure style conflict for a teachable moment!

### DIFF
--- a/src/pages/en/tutorial/2-pages/4.md
+++ b/src/pages/en/tutorial/2-pages/4.md
@@ -27,15 +27,20 @@ Using Astro's own `<style></style>` tags, you can style items on your page. Addi
     <style>
       h1 {
         color: purple;
+        font-size: 4rem;
       }
     </style>
     ```
 
-    Check all three pages in your browser preview. Which color is the page title of:
+    Check all three pages in your browser preview.
+    
+    - Which color is the page title of:
 
-    - Your Home page?  || _black_ ||
-    - Your About page? || _purple_ ||
-    - Your Blog page? || _black_ ||
+        - Your Home page?  ||black||
+        - Your About page? ||purple||
+        - Your Blog page? ||black||
+
+    - The page with the biggest title text is? ||Your About page||
 
     :::tip
     If you are unable to determine colors visually, you can use the dev tools in your browser to inspect the `<h1>` title elements and verify the text color applied.

--- a/src/pages/en/tutorial/2-pages/5.md
+++ b/src/pages/en/tutorial/2-pages/5.md
@@ -43,8 +43,8 @@ There are a few ways to define styles **globally** in Astro, but in this tutoria
     }
 
     h1 {
-      margin: 0;
-      padding: 1.25rem 0;
+      margin: 1rem 0;
+      font-size: 2.5rem;
     }
     ```
 
@@ -109,7 +109,7 @@ Your About page is now styled using *both* the imported `global.css` file *and* 
 
 - Are there any conflicting styles, and if so, which are applied?
 
-    || Yes, `h1` is defined as blue globally, but purple locally in the `<style>` tag. The purple color is applied.  ||
+    || Yes, `h1` has a size of `2.5rem` globally, but `4rem` locally in the `<style>` tag. The local `4rem` rule is applied on the About page. ||
 
 - Describe how `global.css` and `<style>` work together.
 

--- a/src/pages/en/tutorial/3-components/3.md
+++ b/src/pages/en/tutorial/3-components/3.md
@@ -87,7 +87,7 @@ Since your site will be viewed on different devices, let's create a page navigat
 
 ## Add responsive styles
 
-1. Update `Navigation.astro` with the a CSS class to control your navigation links. Wrap the existing navigation links in a `<div> ` with the class `nav-links`.
+1. Update `Navigation.astro` with the a CSS class to control your navigation links. Wrap the existing navigation links in a `<div>` with the class `nav-links`.
 
     ```astro title="src/components/Navigation.astro" ins={3,7}
     ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

#1921 reported we were still talking about `<h1>`s being blue in the tutorial and I’d missed this “Analyze the pattern” where we show that a local `<style>` tag on the About page overrides `global.css` in #1920. This PR patches that up by setting an extra big font-size on the about page and pointing out to the reader that _that_ overrides the smaller font-size in the global styles.

I have the equivalent changes to https://github.com/withastro/blog-tutorial-demo cued up ready to go.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
