### PR TITLE
Include `pointer` style for tutorial radio button on hover

### DIFF
--- a/src/components/tutorial/Option.astro
+++ b/src/components/tutorial/Option.astro
@@ -40,6 +40,10 @@ const { isCorrect } = Astro.props as Props;
 		appearance: none;
 	}
 
+	input[type='radio']:hover {
+		cursor: pointer;
+	}
+
 	input[type='radio'] ~ * {
 		color: var(--theme-text-light);
 	}


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This fix the cursor being the default style when hovering over the radio button for tutorial questions.
With this code, the mouse style will be `pointer` in all the clickable areas for the radio button. 
