### PR TITLE
[tutorial] Fix typo in Test your knowledge option

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -282,7 +282,7 @@ Choose the term that matches the description.
 2. The process of creating multiple page routes from one file in Astro.
 
     <MultipleChoice>
-      <Option>parames</Option>
+      <Option>params</Option>
       <Option isCorrect>dynamic routing</Option>
       <Option>`getStaticPaths()`</Option>
       <Option>props</Option>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes a small typo in the last `Test your knowledge` section in the tutorial - [Generate tag pages](https://docs.astro.build/en/tutorial/5-astro-api/2/), specifically the second question in that knowledge section. The `params` option had a typo, it was spelled `parames` and not `params`.