### PR TITLE
Add "document is not defined" troubleshooting entry

### DIFF
--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -87,7 +87,7 @@ import { Icon } from 'astro-icon';
 If you've installed an NPM package, you can import it in Astro. Even if a package was published using a legacy format, Astro will convert the package to ESM so that `import` statements work.
 
 :::warning
-Some packages rely on a browser environment. Astro components runs on the server, so importing these packages in the frontmatter may lead to errors.
+Some packages rely on a browser environment. Astro components runs on the server, so importing these packages in the frontmatter may [lead to errors](/en/guides/troubleshooting/#document-or-window-is-not-defined).
 :::
 
 ### JSON

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -34,7 +34,7 @@ Framework components run on the server by default, so this error can occur when 
 
 - If the code is in an Astro component, move it to a `<script>` tag outside of the frontmatter. This tells Astro to run this code on the client, where `document` and `window` are available.
 
-- If the code is in a framework component, try to access these objects after rendering using lifecycle methods (e.g. [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React, [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue, and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte). You can also prevent the component from rendering on the server at by adding the [`client:only`](https://docs.astro.build/en/reference/directives-reference/#clientonly) directive.
+- If the code is in a framework component, try to access these objects after rendering using lifecycle methods (e.g. [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React, [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue, and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte). You can also prevent the component from rendering on the server at all by adding the [`client:only`](/en/reference/directives-reference/#clientonly) directive.
 
 ### Expected a default export
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -34,7 +34,7 @@ Framework components run on the server by default, so this error can occur when 
 
 - If the code is in an Astro component, move it to a `<script>` tag outside of the frontmatter. This tells Astro to run this code on the client, where `document` and `window` are available.
 
-- If the code is in a framework component, try to access these objects after rendering using lifecycle methods (ex: [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React or [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte).
+- If the code is in a framework component, try to access these objects after rendering using lifecycle methods (e.g. [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React, [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue, and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte). You can also prevent the component from rendering on the server at by adding the [`client:only`](https://docs.astro.build/en/reference/directives-reference/#clientonly) directive.
 
 ### Expected a default export
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -22,25 +22,19 @@ In Astro components, `<script>` tags are hoisted and loaded as [JS modules](http
 **Not sure that this is your problem?**  
 Check to see if anyone else has reported [this issue](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Cannot+use+import+statement)!
 
-### Unable to render component
+### `document` (or `window`) is not defined
 
-This indicates an error in a component you have imported and are using in your Astro template.
+This error occurs when trying to access `document` or `window` on the server.
 
-#### Common cause
+Astro components run on the server, so you can't access these browser-specific objects within the frontmatter.
 
-This can be caused by attempting to access the `window` or `document` object at render time. By default, Astro will render your component [isomorphically](https://en.wikipedia.org/wiki/Isomorphic_JavaScript), meaning it runs on the server where the browser runtime is not available. You can disable this pre-render step using [the `client:only` directive](/en/reference/directives-reference/#clientonly).
+Framework components run on the server by default, so this error can occur when accessing `document` or `window` during rendering. 
 
-**Solution**: Try to access those objects after rendering (ex: [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React or [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte).
+**Solution**: Determine the code that calls `document` or `window`. If you aren't using `document` or `window` directly and still getting this error, check to see if any packages you're importing are meant to run on the client. 
 
-**Status**: Expected Astro behavior, as intended.
+- If the code is in an Astro component, move it to a `<script>` tag outside of the frontmatter. This tells Astro to run this code on the client, where `document` and `window` are available.
 
-#### Not that?
-
-**Solution**: Check the appropriate documentation for your [Astro](/en/core-concepts/astro-components/) or [UI framework](/en/core-concepts/framework-components/) component. Consider opening an Astro starter template from [astro.new](https://astro.new) and troubleshooting just your component in a minimal Astro project.
-
-**Not sure that this is your problem?**  
-Check to see if anyone else has reported [this issue](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Unable+to+render+Component)!
-
+- If the code is in a framework component, try to access these objects after rendering using lifecycle methods (ex: [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React or [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte).
 
 ### Expected a default export
 

--- a/src/pages/en/guides/troubleshooting.md
+++ b/src/pages/en/guides/troubleshooting.md
@@ -36,6 +36,8 @@ Framework components run on the server by default, so this error can occur when 
 
 - If the code is in a framework component, try to access these objects after rendering using lifecycle methods (e.g. [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect) in React, [`onMounted()`](https://vuejs.org/api/composition-api-lifecycle.html#onmounted) in Vue, and [`onMount()`](https://svelte.dev/docs#run-time-svelte-onmount) in Svelte). You can also prevent the component from rendering on the server at all by adding the [`client:only`](/en/reference/directives-reference/#clientonly) directive.
 
+**Status**: Expected Astro behavior, as intended.
+
 ### Expected a default export
 
 This error can be thrown when trying to import or render an invalid component, or one that is not working properly. (This particular message occurs because of the way importing a UI component works in Astro.)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
- New or updated content
#### Description

- Closes #1959
- Adds a _`document` (or `window`) is not defined_ common error, describing the possibility of the error in both Astro components and framework components
- Combines the new content with the "unable to render component" entry, and removes that entry. (In my testing, using `document` or `window` in a framework component would give you the "_ is not defined" error, not the "unable to render component" error)

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
