### PR TITLE
Set up redirects based on 404 data & filter sitemap

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,20 +1,17 @@
-import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 
 import { toString } from 'hast-util-to-string';
 import { h } from 'hastscript';
 import { escape } from 'html-escaper';
 
-import { tokens, foregroundPrimary, backgroundPrimary } from './syntax-highlighting-theme';
 import { astroAsides } from './integrations/astro-asides';
-import { astroSpoilers } from './integrations/astro-spoilers';
 import { astroCodeSnippets } from './integrations/astro-code-snippets';
-import { remarkFallbackLang } from './plugins/remark-fallback-lang';
+import { astroSpoilers } from './integrations/astro-spoilers';
+import { sitemap } from './integrations/sitemap';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
-
-import languages from './src/i18n/languages';
-import { normalizeLangTag } from './src/i18n/bcp-normalize';
+import { remarkFallbackLang } from './plugins/remark-fallback-lang';
+import { backgroundPrimary, foregroundPrimary, tokens } from './syntax-highlighting-theme';
 
 const AnchorLinkIcon = h(
 	'svg',
@@ -38,12 +35,6 @@ const createSROnlyLabel = (text: string) => {
 	return node;
 };
 
-const sitemapBlocklist = new Set([
-	...Object.keys(languages).map((lang) => `/${lang}/`),
-	...Object.keys(languages).map((lang) => `/${lang}/install/`),
-	...Object.keys(languages).map((lang) => `/${lang}/tutorial/`),
-]);
-
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://docs.astro.build/',
@@ -52,15 +43,7 @@ export default defineConfig({
 	},
 	integrations: [
 		preact({ compat: true }),
-		sitemap({
-			filter: (page) => !sitemapBlocklist.has(new URL(page).pathname),
-			i18n: {
-				defaultLocale: 'en',
-				locales: Object.fromEntries(
-					Object.keys(languages).map((lang) => [lang, normalizeLangTag(lang)])
-				),
-			},
-		}),
+		sitemap(),
 		astroAsides(),
 		astroSpoilers(),
 		astroCodeSnippets(),

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -38,6 +38,12 @@ const createSROnlyLabel = (text: string) => {
 	return node;
 };
 
+const sitemapBlocklist = new Set([
+	...Object.keys(languages).map((lang) => `/${lang}/`),
+	...Object.keys(languages).map((lang) => `/${lang}/install/`),
+	...Object.keys(languages).map((lang) => `/${lang}/tutorial/`),
+]);
+
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://docs.astro.build/',
@@ -47,6 +53,7 @@ export default defineConfig({
 	integrations: [
 		preact({ compat: true }),
 		sitemap({
+			filter: (page) => sitemapBlocklist.has(new URL(page).pathname),
 			i18n: {
 				defaultLocale: 'en',
 				locales: Object.fromEntries(

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
 	integrations: [
 		preact({ compat: true }),
 		sitemap({
-			filter: (page) => sitemapBlocklist.has(new URL(page).pathname),
+			filter: (page) => !sitemapBlocklist.has(new URL(page).pathname),
 			i18n: {
 				defaultLocale: 'en',
 				locales: Object.fromEntries(

--- a/integrations/sitemap.ts
+++ b/integrations/sitemap.ts
@@ -1,0 +1,30 @@
+import AstroSitemap from '@astrojs/sitemap';
+import type { AstroIntegration } from 'astro';
+import { normalizeLangTag } from '../src/i18n/bcp-normalize';
+import languages from '../src/i18n/languages';
+
+const langTags = Object.keys(languages);
+
+/** Set matching our `/[lang]/something.astro` redirect routes. */
+const blocklist = new Set([
+	...langTags.map((lang) => `/${lang}/`),
+	...langTags.map((lang) => `/${lang}/install/`),
+	...langTags.map((lang) => `/${lang}/tutorial/`),
+]);
+
+/** Match a pathname starting with “lighthouse” or one of our language tags. */
+const ValidRouteRE = new RegExp(`^/(lighthouse|${langTags.join('|')})/`);
+
+/** Test a pathname is not in our blocklist and starts with a valid prefix. */
+const isValidPath = (path: string) => !blocklist.has(path) && ValidRouteRE.test(path);
+
+/** Get a preconfigured instance of the `@astrojs/sitemap` integration. */
+export function sitemap(): AstroIntegration {
+	return AstroSitemap({
+		filter: (page) => isValidPath(new URL(page).pathname),
+		i18n: {
+			defaultLocale: 'en',
+			locales: Object.fromEntries(langTags.map((lang) => [lang, normalizeLangTag(lang)])),
+		},
+	});
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,10 @@
   ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- /"
 
   [[redirects]]
+    from = "/reference/renderer-reference"
+    to = "/en/reference/integrations-reference"
+
+  [[redirects]]
     from = "/en/reference/renderer-reference"
     to = "/en/reference/integrations-reference"
 

--- a/src/pages/[lang]/tutorial.astro
+++ b/src/pages/[lang]/tutorial.astro
@@ -1,0 +1,9 @@
+---
+import languages from '../../i18n/languages';
+
+export const getStaticPaths = () => Object.keys(languages).map((lang) => ({ params: { lang } }));
+
+const { lang } = Astro.params;
+---
+
+<meta http-equiv="refresh" content={`0;url=/${lang}/tutorial/0-introduction/`} />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- [x] Changes to the docs site code


#### Description

- Add a Netlify redirect for an old `renderer-reference` URL

- Add a route with a `<meta>` refresh redirect for `/[lang]/tutorial`

    We may one day _have_ an actual `/tutorial` landing page potentially, so using a `.astro` route with `<meta>` seemed safer than configuring a Netlify redirect we’d be more likely to forget to remove.

#### Testing

These URLs were 404s but should now work:

- https://deploy-preview-1976--astro-docs-2.netlify.app/reference/renderer-reference/
- https://deploy-preview-1976--astro-docs-2.netlify.app/en/tutorial/