### PR TITLE
Add Imports section: Extending file type support

### DIFF
--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -242,7 +242,7 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.
     :::
 
-3. Finally, you can import YAML data using the `import` statement:
+3. Finally, you can import YAML data using an `import` statement:
 
 ```js
 import yml from './data.yml';

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -213,7 +213,7 @@ const data = JSON.parse(json);
 
 ## Extending file type support
 
-With **Vite** and compatible **Rollup** plugins, you can import file types which aren't natively supported by Astro. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
+With **Vite** and compatible **Rollup** plugins, you can import file types which aren't natively supported by Astro. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of the Vite Documentation.
 
 
  :::note[plugin configuration]

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -221,9 +221,9 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
 
 1. Install `@rollup/plugin-yaml`:
 
-```bash
-npm install @rollup/plugin-yaml --save-dev
-```
+    ```bash
+    npm install @rollup/plugin-yaml --save-dev
+    ```
 
 2. Import the plugin in your `astro.config.mjs` and add it to the plugins array:
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -243,9 +243,6 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     });
     ```
 
-    :::note[Using a different plugin?]
-    Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.
-    :::
 
 3. Finally, you can import YAML data using an `import` statement:
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -215,7 +215,7 @@ const data = JSON.parse(json);
 
 You can import file types which aren't natively supported by Astro. There are many **Vite** and compatible **Rollup** plugins you can use. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
 
-For example, the YAML data format isn't natively supported by Astro, but you can to add support for it by using a compatible Rollup plugin:
+For example, the YAML data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin:
 
 1. Install `@rollup/plugin-yaml`:
 
@@ -223,7 +223,7 @@ For example, the YAML data format isn't natively supported by Astro, but you can
 npm install @rollup/plugin-yaml --save-dev
 ```
 
-2. In your `astro.config.mjs` file, import it and add it to the plugins array:
+2. Import the plugin in your `astro.config.mjs` and add it to the plugins array:
 
 ```js title="astro.config.mjs" ins={2,6,7,8}
 import { defineConfig } from 'astro/config';

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -244,8 +244,10 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     ```
 
 
-3. Finally, you can import YAML data using an `import` statement:
+3. Finally, you can import YAML data into an Astro file using an `import` statement:
 
-    ```js
+    ```astro title="src/components/Component.astro"
+    ---
     import yml from './data.yml';
+    ---
     ```

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -222,7 +222,7 @@ Refer to your plugin's documentation for configuration options, and how to corre
 
 ### Example: YAML support
 
-The YAML (`.yml`) data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin:
+The YAML (`.yml`) data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin like [`@rollup/plugin-yaml`](https://www.npmjs.com/package/@rollup/plugin-yaml):
 
 1. Install `@rollup/plugin-yaml`:
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -213,7 +213,7 @@ const data = JSON.parse(json);
 
 ## Extending file type support
 
-You can import file types which aren't natively supported by Astro. There are many **Vite** and compatible **Rollup** plugins you can use. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
+With **Vite** and compatible **Rollup** plugins, you can import file types which aren't natively supported by Astro. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
 
 ### Example: YAML support
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -225,7 +225,7 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     npm install @rollup/plugin-yaml --save-dev
     ```
 
-2. Import the plugin in your `astro.config.mjs` and add it to the plugins array:
+2. Import the plugin in your `astro.config.mjs` and add it to the Vite plugins array:
 
 ```js title="astro.config.mjs" ins={2,6,7,8}
 import { defineConfig } from 'astro/config';

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -244,6 +244,6 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
 
 3. Finally, you can import YAML data using an `import` statement:
 
-```js
-import yml from './data.yml';
-```
+    ```js
+    import yml from './data.yml';
+    ```

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -244,7 +244,7 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     ```
 
 
-3. Finally, you can import YAML data into an Astro file using an `import` statement:
+3. Finally, you can import YAML data using an `import` statement:
 
     ```astro title="src/components/Component.astro"
     ---

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -215,7 +215,9 @@ const data = JSON.parse(json);
 
 You can import file types which aren't natively supported by Astro. There are many **Vite** and compatible **Rollup** plugins you can use. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
 
-For example, the YAML data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin:
+### Example: YAML support
+
+The YAML (`.yml`) data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin:
 
 1. Install `@rollup/plugin-yaml`:
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -246,8 +246,6 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
 
 3. Finally, you can import YAML data using an `import` statement:
 
-    ```astro title="src/components/Component.astro"
-    ---
+    ```js
     import yml from './data.yml';
-    ---
     ```

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -227,17 +227,16 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
 
 2. Import the plugin in your `astro.config.mjs` and add it to the Vite plugins array:
 
-```js title="astro.config.mjs" ins={2,6,7,8}
-import { defineConfig } from 'astro/config';
-import yaml from '@rollup/plugin-yaml';
+    ```js title="astro.config.mjs" ins={2,5-7}
+    import { defineConfig } from 'astro/config';
+    import yaml from '@rollup/plugin-yaml';
 
-export default defineConfig(
-{
-  vite: {
-    plugins: [yaml()]
-  }
-});
-```
+    export default defineConfig({
+      vite: {
+        plugins: [yaml()]
+      }
+    });
+    ```
 
 :::note
 Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -215,6 +215,11 @@ const data = JSON.parse(json);
 
 With **Vite** and compatible **Rollup** plugins, you can import file types which aren't natively supported by Astro. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
 
+
+ :::note[plugin configuration]
+Refer to your plugin's documentation for configuration options, and how to correctly install it.
+:::
+
 ### Example: YAML support
 
 The YAML (`.yml`) data format isn't natively supported by Astro, but you can add support for it by using a compatible Rollup plugin:

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -238,9 +238,9 @@ The YAML (`.yml`) data format isn't natively supported by Astro, but you can add
     });
     ```
 
-:::note
-Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.
-:::
+    :::note[Using a different plugin?]
+    Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.
+    :::
 
 3. Finally, you can import YAML data using the `import` statement:
 

--- a/src/pages/en/guides/imports.md
+++ b/src/pages/en/guides/imports.md
@@ -210,3 +210,39 @@ const data = JSON.parse(json);
 
 <span>Version: {data.version}</span>
 ```
+
+## Extending file type support
+
+You can import file types which aren't natively supported by Astro. There are many **Vite** and compatible **Rollup** plugins you can use. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of Vite Documentation.
+
+For example, the YAML data format isn't natively supported by Astro, but you can to add support for it by using a compatible Rollup plugin:
+
+1. Install `@rollup/plugin-yaml`:
+
+```bash
+npm install @rollup/plugin-yaml --save-dev
+```
+
+2. In your `astro.config.mjs` file, import it and add it to the plugins array:
+
+```js title="astro.config.mjs" ins={2,6,7,8}
+import { defineConfig } from 'astro/config';
+import yaml from '@rollup/plugin-yaml';
+
+export default defineConfig(
+{
+  vite: {
+    plugins: [yaml()]
+  }
+});
+```
+
+:::note
+Refer to your plugin's documentation to learn what configuration options it has, and how to correctly install it.
+:::
+
+3. Finally, you can import YAML data using the `import` statement:
+
+```js
+import yml from './data.yml';
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Closes #1274
Closes #1784

Adding a section on extending file support. Based on @delucis's recommendation, I tried to combine a generic "You can add any plugin you like" guide with a specific "YML import" guide.

1. I refer to https://vitejs.dev/guide/using-plugins.html#finding-plugins if users want to learn where to find plugins, as it mentions all the important parts:
	- where to find official plugins
	- where to find community created plugins
	- where to check for Rollup plugin compatibility

2. Also I felt it appropriate to note that you should...

	> Refer to your plugin's documentation to learn what configuration options it has

	...as many plugins seem to have additional config options, and some even have a slightly different installation process. Most however seem to be identical to the YAML Rollup plugin, so this note felt appropriate.

Let me know what you think. We can change anything and everything.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

4. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
