### PR TITLE
updated highlighted insert range

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -186,7 +186,7 @@ You now have an array `uniqueTags` with element items `"astro"`, `"successes"`, 
 
 ### 2. Replace the `return` value of the `getStaticPaths` function
 
-```js title="src/pages/tags/[tag].astro" del={1-8} ins={10-15}
+```js title="src/pages/tags/[tag].astro" del={1-8} ins={10-16}
   return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
         {params: {tag: "sucesses"}, props: {posts: allPosts}},


### PR DESCRIPTION
to remove error generated when copy and pasting tutorial code

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
Updates the highlighted insert range of the Advanced JavaScript: Generate pages from existing tags's second list item to remove error generated when copy and pasting tutorial code.
- Did you change something visual? A before/after screenshot can be helpful.
No.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
