### PR TITLE
Add component usage example in the MDX docs

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -273,6 +273,22 @@ With the `@astrojs/mdx` integration, you can use Astro or UI framework component
 
 Don't forget to include a `client:directive` if necessary!
 
+```astro title="src/pages/about.mdx"
+---
+layout: ../layouts/BaseLayout.astro
+title: About me
+---
+import Button from '../components/Button.astro';
+import ReactCounter from '../components/ReactCounter.jsx';
+
+I live on **Mars** but feel free to <Button title="Contact me" />.
+
+Here is my counter component, working in MDX:
+
+<ReactCounter client:load />
+```
+
+
 ## Importing Markdown
 
 You can import Markdown and MDX files directly into your Astro files! You can import one specific page with `import` or multiple pages with `Astro.glob()`.

--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -273,7 +273,7 @@ With the `@astrojs/mdx` integration, you can use Astro or UI framework component
 
 Don't forget to include a `client:directive` if necessary!
 
-```astro title="src/pages/about.mdx"
+```astro title="src/pages/about.mdx" {5-6} /<.+\/>/
 ---
 layout: ../layouts/BaseLayout.astro
 title: About me


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->




#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Add Astro and React component usage example in the MDX docs. This was pretty hard to figure out even though the docs say it's possible. And there is confusion with the old `setup: |` syntax that is [spread](https://github.com/snowpackjs/astro/issues/491) [across](https://craigglennie.com/posts/2021/rewriting-in-astro) the internet already.

The only component usage example I could find in the existing docs comes from the migration guide converting an old React `.md` to `.mdx` in https://docs.astro.build/en/migrate/#converting-existing-md-files-to-mdx

Relevant docs:

 - https://docs.astro.build/en/guides/markdown-content/#using-components-in-mdx
    - This PR adds an example here
 - https://docs.astro.build/en/guides/integrations-guide/mdx/#components
    - It would be nice to cross-link or have an example here too (suggestion welcome)
    - Update: it looks like we sorta have an example in https://docs.astro.build/en/guides/integrations-guide/mdx/#custom-components but this is a little different for overriding existing components. And I completely missed this when Googling and trying to figure this out.


Update: Or perhaps link to https://github.com/withastro/astro/blob/latest/examples/with-mdx/src/pages/index.mdx?plain=1 which I just found from https://docs.astro.build/en/guides/integrations-guide/mdx/#examples

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
