### PR TITLE
[tutorial] Added step: checking for tags

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -158,9 +158,11 @@ The following example shows how to replace your code on this page with code that
 Even if it looks challenging, you can try following along with the steps to build this function yourself! If you don't want to walk through the JavaScript required right now, you can skip ahead to the [finished version of the code](#final-code-sample) and use it directly in your project, replacing the existing content.
 :::
 
+### 1. Check that all your blog posts contain tags
 
+Revisit each of your existing Markdown pages and ensure that every post contains a `tags` array in its frontmatter. Even if you only have one tag, it should still be written as an array, e.g. `tags: ["blogging"]`. 
 
-### 1. Create an array of all your existing tags
+### 2. Create an array of all your existing tags
 
 Add the following code to provide you with a list of every tag used in your blog posts.
 
@@ -184,7 +186,7 @@ Add the following code to provide you with a list of every tag used in your blog
 
 You now have an array `uniqueTags` with element items `"astro"`, `"successes"`, `"community"`, `"blogging"`, `"setbacks"`, `"learning in public"` 
 
-### 2. Replace the `return` value of the `getStaticPaths` function
+### 3. Replace the `return` value of the `getStaticPaths` function
 
 ```js title="src/pages/tags/[tag].astro" del={1-8} ins={10-16}
   return [


### PR DESCRIPTION
Makes a clear instruction to ensure that every Markdown blot post written includes tags by adding a new Step 1 to the instructions for generating tag pages. 

In order to keep the code as simple as possible for generating tag pages, I did not include any conditional (if no tag) logic. Some readers are encountering errors in this line, that is likely caused by having created their own content for blog posts that does not include a `tags` array. (I suspect this is why only *some* people are encountering this error.)

There is a line in the previous section that says "make sure to include all these front matter properties" but that might not be strong enough, and I'll consider revisiting that page, too.