### PR TITLE
[tutorial] use PackageManagerTabs in 1-2 and 5-4

### DIFF
--- a/src/pages/en/tutorial/1-setup/2.md
+++ b/src/pages/en/tutorial/1-setup/2.md
@@ -90,9 +90,23 @@ In order to preview your project files _as a website_ while you work, you will n
 
 1. Run the command to start the Astro dev server by typing into VS Code's terminal:
 
-    ```sh
-    npm run dev
-    ```
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run dev
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm run dev
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn run dev
+      ```
+      </Fragment>
+    </PackageManagerTabs>
 
     Now you should see confirmation in the terminal that Astro is running in dev mode. 🚀
 

--- a/src/pages/en/tutorial/5-astro-api/4.md
+++ b/src/pages/en/tutorial/5-astro-api/4.md
@@ -6,6 +6,7 @@ setup: |
   import Box from '~/components/tutorial/Box.astro';
   import Checklist from '~/components/Checklist.astro';
   import PreCheck from '~/components/tutorial/PreCheck.astro';
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 ---
 
 <PreCheck>
@@ -23,15 +24,43 @@ Individuals can subscribe to your feed in a feed reader, and receive notificatio
 
 1. Quit the Astro development server and run the following command in the terminal to install Astro's RSS package.
 
-    ```shell
-    npm install @astrojs/rss
-    ```
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm install @astrojs/rss
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm install @astrojs/rss
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn add @astrojs/rss
+      ```
+      </Fragment>
+    </PackageManagerTabs>
 
-3. Restart the dev server to begin working on your Astro project again.
+2. Restart the dev server to begin working on your Astro project again.
 
-    ```shell
-    npm run dev
-    ```
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run dev
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm run dev
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn run dev
+      ```
+      </Fragment>
+    </PackageManagerTabs>
 
 ## Create an `.xml` feed document
 
@@ -54,11 +83,29 @@ Individuals can subscribe to your feed in a feed reader, and receive notificatio
 
 3. This `rss.xml` document is only created when your site is built, so you won't be able to see this page in your browser during development. Quit the dev server and run the following commands to first, build your site locally and then, view a preview of your build:
 
-```sh
-npm run build
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run build
 
-npm run preview
-```
+      npm run preview
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm run build
+
+      pnpm run preview
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn run build
+
+      yarn run preview
+      ```
+      </Fragment>
+    </PackageManagerTabs>
 
 4. Visit `localhost:3000/rss.xml` and verify that you can see (unformatted) text on the page with an `item` for each of your `.md` files. Each item should contain blog post information such as `title`, `url` and `description`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

I noticed that PackageManagerTabs component is used for the first command in 1-2, but not where the other npm commands are used. So, for consistency, I've updated 1-2 and 5-4 to use this component.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
