### PR TITLE
Update 5.3 tags styles & markup

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -262,49 +262,46 @@ Follow the steps below, then check your work by comparing it to the [final code 
 
 1. Copy the `<div class="tags">`... `</div>` and `<style>...</style>` from `src/pages/tags/index.astro` and reuse it inside `MarkdownLayoutPost.astro`: 
 
-  ```astro title="src/layouts/MarkdownPostLayout.astro" ins={14-18, 22-41}
-  ---
-  import BaseLayout from './BaseLayout.astro';
-  const { frontmatter } = Astro.props;
-  --- 
-  <BaseLayout pageTitle={frontmatter.title}>
-    <p><em>{frontmatter.description}</em></p>
-    <p>{frontmatter.pubDate.slice(0,10)}</p>
-    <h1>{frontmatter.title}</h1>
+    ```astro title="src/layouts/MarkdownPostLayout.astro" ins={14-18, 23-38}
+    ---
+    import BaseLayout from './BaseLayout.astro';
+    const { frontmatter } = Astro.props;
+    --- 
+    <BaseLayout pageTitle={frontmatter.title}>
+      <p><em>{frontmatter.description}</em></p>
+      <p>{frontmatter.pubDate.slice(0,10)}</p>
+      <h1>{frontmatter.title}</h1>
 
-    <p>Written by: {frontmatter.author}</p>
+      <p>Written by: {frontmatter.author}</p>
 
-    <img src={frontmatter.postImage} width="300" /> 
+      <img src={frontmatter.postImage} width="300" /> 
 
-    <div class="tags">
-      {tags.map((tag) => (
-        <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
-      ))}
-    </div>
+      <p class="tags">
+        {tags.map((tag) => (
+          <a class="tag" href={`/tags/${tag}`}>{tag}</a>
+        ))}
+      </p>
 
-    <slot />
-  </BaseLayout>
-  <style>
-    a {
-      color: #00539F;
-    }
-              
+      <slot />
+    </BaseLayout>
+
+    <style>
     .tags {
-      display: flex; 
-      flex-wrap: wrap; 
-      margin: 0 auto;  
+      margin: 1em 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5em;
     }
 
     .tag {
-      margin: 0.25em;
-      border: dotted 1px #a1a1a1;
-      border-radius: .5em;
-      padding: .5em 1em;
-      font-size: 1.15em;
-      background-color: #F8FCFD;
+      border-radius: 1.5em;
+      padding: 0.25em 1em;
+      color: #fff;
+      background-color: #581c87;
+      text-decoration: none;
     }
-  </style>
-```
+    </style>
+    ```
 
 Before this code will work, you need to make **one small edit** to the code you pasted into `MarkdownPostLayout.astro`. Can you figure out what it is?
 
@@ -323,11 +320,11 @@ In order to use props (values passed) from a `.md` blog post in your layout, lik
 <summary>Show me the code!</summary>
 
 ```astro title="src/layouts/MarkdownPostLayout.astro" "frontmatter"
-    <div class="tags">
+    <p class="tags">
       {frontmatter.tags.map((tag) => (
-        <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
+        <a class="tag" href={`/tags/${tag}`}>{tag}</a>
       ))}
-    </div>
+    </p>
 ```
 </details>
 </details>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Updates HTML markup and styles used in the code challenge in tutorial unit 5.3:
- It’s now just a paragraph containing links
- Styles updated to look like this:
    <img width="690" alt="image" src="https://user-images.githubusercontent.com/357379/200701942-956e5479-1fd5-42c6-a44a-a8a1a8d51443.png">

- Also checked with later changes and seems to play well when we add dark mode:
   <img width="514" alt="image" src="https://user-images.githubusercontent.com/357379/200702142-f23af738-0382-46d5-b8a2-01ce050911de.png">

I _might_ have opted for an unordered list for this, but list styles complicate things a bit, so this markup keeps things simple.

I have the equivalent changes cued up to push to https://github.com/withastro/blog-tutorial-demo when we’re ready (@sarah11918 noticed we missed this bit of tags code entirely there).

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
