### PR TITLE
[tutorial] 0-1 Correct link to docs repo issues

### DIFF
--- a/src/pages/en/tutorial/0-introduction/1.md
+++ b/src/pages/en/tutorial/0-introduction/1.md
@@ -42,7 +42,7 @@ Hop into the support forum channel to ask questions, or say hi and chat in `#gen
 <details>
 <summary>Where can I leave feedback about this tutorial?</summary>
 
-This tutorial is a project of our Docs team. You can find us on Discord in the `#docs` channel, or file issues to the [Docs repo on GitHub](https://withastro/astro/docs/issues). 
+This tutorial is a project of our Docs team. You can find us on Discord in the `#docs` channel, or file issues to the [Docs repo on GitHub](https://github.com/withastro/astro/docs/issues). 
 </details>
 
 <Box icon="check-list">


### PR DESCRIPTION
- Minor content fixes (broken links, typos, etc.)

Fixes link on 0-1. Was missing the `github.com`