### PR TITLE
Improve documentation around setting up ambient types

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -34,16 +34,6 @@ Additionally, our templates include an `env.d.ts` file inside the `src` folder t
 /// <reference types="astro/client" />
 ```
 
-Optionally, you can delete this file and instead add the [`types` setting](https://www.typescriptlang.org/tsconfig#types) to your `tsconfig.json`:
-
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "types": ["astro/client"]
-  }
-}
-```
-
 ### UI Frameworks
 
 If your project uses a [UI framework](/en/core-concepts/framework-components/), additional settings depending on the framework might be needed. Please see your framework's TypeScript documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://reactjs.org/docs/static-type-checking.html), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -146,7 +146,7 @@ If you want to include [UI framework components](/en/core-concepts/framework-com
 
 📚 Read Astro's [API configuration reference](/en/reference/configuration-reference/) for more information.
 
-## 6. Create `tsconfig.json`
+## 6. Add TypeScript support
 
 Typescript is configured using `tsconfig.json`. Even if you don’t write TypeScript code, this file is important so that tools like Astro and VS Code know how to understand your project. Some features (like npm package imports) aren’t fully supported in the editor without a `tsconfig.json` file. 
 
@@ -157,10 +157,13 @@ Create `tsconfig.json` at the root of your project, and copy the code below into
 ```json title="tsconfig.json" "base"
 {
   "extends": "astro/tsconfigs/base",
-  "compilerOptions": {
-    "types": ["astro/client"]
-  }
 }
+```
+
+Finally, create `src/env.d.ts` to let TypeScript know about ambient types available in an Astro project:
+
+```ts title="src/env.d.ts"
+/// <reference types="astro/client" />
 ```
 
 📚 Read Astro's [TypeScript setup guide](/en/guides/typescript/#setup) for more information.

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -148,7 +148,7 @@ If you want to include [UI framework components](/en/core-concepts/framework-com
 
 ## 6. Add TypeScript support
 
-Typescript is configured using `tsconfig.json`. Even if you don’t write TypeScript code, this file is important so that tools like Astro and VS Code know how to understand your project. Some features (like npm package imports) aren’t fully supported in the editor without a `tsconfig.json` file. 
+TypeScript is configured using `tsconfig.json`. Even if you don’t write TypeScript code, this file is important so that tools like Astro and VS Code know how to understand your project. Some features (like npm package imports) aren’t fully supported in the editor without a `tsconfig.json` file. 
 
 If you do intend to write TypeScript code, using Astro's `strict` or `strictest` template is recommended. You can view and compare the three template configurations at [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #1607 <!-- Add an issue number if this PR will close it. -->
- Remove the suggestion to use `"types"` in the TypeScript guide.
- Update the manual installation guide to advise users to create `src/env.d.ts` like our starter projects instead of setting `"types"` in `tsconfig.json`

#### Jump to preview

- [Manual install guide: TS set up](https://deploy-preview-2026--astro-docs-2.netlify.app/en/install/manual/#6-add-typescript-support)
- [TS guide](https://deploy-preview-2026--astro-docs-2.netlify.app/en/guides/typescript/#setup) (removed content only)

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
