### PR TITLE
Update typescript.md

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -85,11 +85,7 @@ import Layout from '@layouts/Layout.astro';
 
 ## Component Props
 
-Astro supports typing your component props via TypeScript. To enable, add a TypeScript `Props` interface to your component frontmatter. The [Astro VSCode Extension](/en/editor-setup/) will automatically look for the `Props` interface and give you proper TS support when you use that component inside another template.
-
-**Note**\
-Many of the themes and examples you will find still use `export` on `interface Props` as originally our docs said you needed to. However, this is *not* necessary unless you really want to import this into another file! (Which is probably not the case).
-
+Astro supports typing your component props via TypeScript. To enable, add a TypeScript `Props` interface to your component frontmatter. An `export` statement maybe be used, but is not necessary. The [Astro VSCode Extension](/en/editor-setup/) will automatically look for the `Props` interface and give you proper TS support when you use that component inside another template.
 ```astro title="src/components/HelloProps.astro" ins={2-5}
 ---
 interface Props {

--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -87,6 +87,9 @@ import Layout from '@layouts/Layout.astro';
 
 Astro supports typing your component props via TypeScript. To enable, add a TypeScript `Props` interface to your component frontmatter. The [Astro VSCode Extension](/en/editor-setup/) will automatically look for the `Props` interface and give you proper TS support when you use that component inside another template.
 
+**Note**\
+Many of the themes and examples you will find still use `export` on `interface Props` as originally our docs said you needed to. However, this is *not* necessary unless you really want to import this into another file! (Which is probably not the case).
+
 ```astro title="src/components/HelloProps.astro" ins={2-5}
 ---
 interface Props {


### PR DESCRIPTION
There are tons of examples of `export` being used on  `interface Props` out in the wild so I think it would be good to make clear this is not necessary in the docs.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
- Changes to the docs site code


#### Description
Added a note stating you don't need `export` on `interface Props`.