### PR TITLE
i18n(es): Improve translations

### DIFF
--- a/src/pages/es/guides/markdown-content.md
+++ b/src/pages/es/guides/markdown-content.md
@@ -282,7 +282,7 @@ import ReactCounter from '../components/ReactCounter.jsx';
 
 Yo vivo en **Marte** pero siéntete libre de <Button title="Contactarme" />.
 
-Aqui está mi componente contador, funcionando en MDX:
+Aquí está mi componente contador, funcionando en MDX:
 
 <ReactCounter client:load />
 ```

--- a/src/pages/es/guides/troubleshooting.md
+++ b/src/pages/es/guides/troubleshooting.md
@@ -19,7 +19,7 @@ En componentes de Astro, las etiquetas `<script>` son elevadas (hoisted) y carga
 
 **Estado**: Comportamiento esperado de Astro.
 
-**¿No estás seguro de que este sea tu problema?**  
+**¿No estás seguro de que este sea tu problema?**
 ¡Puedes ver si alguien ya ha reportado [este error](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+Cannot+use+import+statement)!
 
 ### `document` (or `window`) is not defined
@@ -48,16 +48,15 @@ Este error puede ser lanzado cuando intentas importar o renderizar un componente
 
 **Estado**: Comportamiento esperado de Astro.
 
-### Negado a ejecutar script en línea
+### Refused to execute inline script
 
-You may see the following error logged in the browser console:
-Puedes ver el siguiente error en la consola del navegador:
+Es posible que veas el siguiente error en la consola del navegador:
 
 > Refused to execute inline script because it violates the following Content Security Policy directive: …
 
 Esto significa que la [política de seguridad de contenido](https://developer.mozilla.org/es/docs/Web/HTTP/CSP) (CSP) de tu sitio web no permite ejecutar etiquetas `<script>` en línea, las cuales Astro genera por defecto.
 
-**Solución** Para solucionar esto, puedes forzar a Astro a empaquetar todos los estilos y scripts en assets externos usando la configuración [`vite.build.assetsInlineLimit`](https://vitejs.dev/config/build-options.html#build-assetsinlinelimit) en `astro.config.mjs`.
+**Solución**: Para solucionar esto, puedes forzar a Astro a empaquetar todos los estilos y scripts en recursos externos usando la configuración [`vite.build.assetsInlineLimit`](https://vitejs.dev/config/build-options.html#build-assetsinlinelimit) en `astro.config.mjs`.
 
 ```js
 // astro.config.mjs

--- a/src/pages/es/guides/typescript.md
+++ b/src/pages/es/guides/typescript.md
@@ -86,7 +86,7 @@ import Layout from '@layouts/Layout.astro';
 
 ## Props de componentes
 
-Astro soporta escribir los tipos de las propiedades de tus componentes usando TypeScript. Para habilitar esto, agrega una interfaz `Props` a tu componente en el frontmatter. Una declaración `export` puede ser usada, pero no es necesaria. La [Extensión de Astro para VSCode](/es/editor-setup/) buscará automáticamente la interfaz `Props` y te dará soporte de TS cuando uses ese componente en otra plantilla.
+Astro soporta escribir los tipos de las propiedades de tus componentes usando TypeScript. Para habilitar esto, agrega una interfaz `Props` a tu componente en el frontmatter. Puedes usar una declaración `export`, pero no es necesaria. La [Extensión de Astro para VSCode](/es/editor-setup/) buscará automáticamente la interfaz `Props` y te dará soporte de TS cuando uses ese componente en otra plantilla.
 ```astro title="src/components/HelloProps.astro" ins={2-5}
 ---
 interface Props {

--- a/src/pages/es/reference/api-reference.md
+++ b/src/pages/es/reference/api-reference.md
@@ -298,7 +298,7 @@ const ip = Astro.clientAddress;
 
 **Tipo:** `(slotName: string) => boolean`
 
-Puedes verificar si el contenido para un slot específico existe usando `Astro.slots.has()`. Esto puede ser útil cuando quieres envolver el contenido del slot, pero solo quieres renderizar los elementos del envoltorio cuando se está usando el slot.
+Puedes verificar si el contenido para un slot específico existe usando `Astro.slots.has()`. Esto puede ser útil cuando quieres envolver el contenido del slot, pero solo quieres renderizar los elementos envueltos cuando se esté usando el slot.
 
 ```astro
 ---
@@ -317,7 +317,7 @@ Puedes verificar si el contenido para un slot específico existe usando `Astro.s
 
 **Tipo:** `(slotName: string, args?: any[]) => Promise<string>`
 
-Puedes renderizar de forma asíncrona el contenido de un slot a una cadena de HTML usando `Astro.slots.render()`.
+Puedes renderizar de forma asíncrona el contenido de un slot a un string de HTML usando `Astro.slots.render()`.
 
 ```astro
 ---
@@ -327,10 +327,10 @@ const html = await Astro.slots.render('default');
 ```
 
 :::note
-Esta nota es para casos de uso avanzados! En la mayoría de los casos, es más simple renderizar el contenido del slot con [el elemento `<slot />`](/es/core-concepts/astro-components/#slots).
+¡Esta nota es para casos de uso avanzados! En la mayoría de los casos, es más simple renderizar el contenido del slot con [el elemento `<slot />`](/es/core-concepts/astro-components/#slots).
 :::
 
-`Astro.slots.render()` opcionalmente acepta un segundo argumento: una array de parámetros que se enviarán a cualquier función hija. Esto puede ser útil para componentes de utilidad personalizados.
+`Astro.slots.render()` opcionalmente acepta un segundo argumento: un array de parámetros que se enviarán a cualquier función hija. Esto puede ser útil para componentes de utilidad personalizados.
 
 Por ejemplo, este componente `<Shout />` convierte su prop `message` en mayúsculas y la pasa al slot predeterminado:
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Improves spanish translation for `markdown-content.md`, `troubleshooting.md`, `typescript.md` and `api-reference.md`