### PR TITLE
[tutorial] added extra note to check tags, update manually

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -27,15 +27,15 @@ You can create entire sets of pages dynamically using `.astro` files that export
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
-    export async function getStaticPaths({ }) {
-      return[
-        {params: {tag: "astro"}},
-        {params: {tag: "successes"}},
-        {params: {tag: "community"}},
-        {params: {tag: "blogging"}},
-        {params: {tag: "setbacks"}},
-        {params: {tag: "learning in public"}}
-      ]
+    export async function getStaticPaths() {
+      return [
+        { params: { tag: "astro" } },
+        { params: { tag: "successes" } },
+        { params: { tag: "community" } },
+        { params: { tag: "blogging" } },
+        { params: { tag: "setbacks" } },
+        { params: { tag: "learning in public" } },
+      ];
     }
 
     const { tag } = Astro.params;

--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -21,7 +21,9 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
 ## Create pages dynamically
 
-1. Create a new file at `src/pages/tags/[tag].astro`. (You will have to create a new folder.) Notice that the file name (`[tag].astro`) uses square brackets. Paste the following code into the file:
+1. Create a new file at `src/pages/tags/[tag].astro`. (You will have to create a new folder.) Notice that the file name (`[tag].astro`) uses square brackets. Paste the following code into the file. 
+
+    If you have customized your blog posts, then replace the individual tag items (e.g. "astro", "successes", "community", etc.) with the tags used in your own posts. **Make sure at this time that every blog post contains at least one tag, written as an array, e.g. `tags: ["blogging"]`.**
 
     ```astro title="src/pages/tags/[tag].astro"
     ---

--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -21,9 +21,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
 ## Create pages dynamically
 
-1. Create a new file at `src/pages/tags/[tag].astro`. (You will have to create a new folder.) Notice that the file name (`[tag].astro`) uses square brackets. Paste the following code into the file. 
-
-    If you have customized your blog posts, then replace the individual tag items (e.g. "astro", "successes", "community", etc.) with the tags used in your own posts. **Make sure at this time that every blog post contains at least one tag, written as an array, e.g. `tags: ["blogging"]`.**
+1. Create a new file at `src/pages/tags/[tag].astro`. (You will have to create a new folder.) Notice that the file name (`[tag].astro`) uses square brackets. Paste the following code into the file:
 
     ```astro title="src/pages/tags/[tag].astro"
     ---
@@ -49,7 +47,11 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
     The `getStaticPaths` function returns an array of page routes, and all of the pages at those routes will use the same template defined in the file.
 
-2. Visit `localhost:3000/tags/astro` in your browser preview and you should see a page, generated dynamically from `[tag].astro`. Check that you also have pages created at `/tags/successes`, `/tags/community`, and `/tags/learning%20in%20public`. You may need to first quit and restart the dev server to see these new pages.
+2. If you have customized your blog posts, then replace the individual tag values (e.g. "astro", "successes", "community", etc.) with the tags used in your own posts.
+
+3. Make sure that every blog post contains at least one tag, written as an array, e.g. `tags: ["blogging"]`.
+
+4. Visit `localhost:3000/tags/astro` in your browser preview and you should see a page, generated dynamically from `[tag].astro`. Check that you also have pages created at `/tags/successes`, `/tags/community`, and `/tags/learning%20in%20public`. You may need to first quit and restart the dev server to see these new pages.
 
 
 ## Use props in dynamic routes

--- a/src/pages/en/tutorial/5-astro-api/2.md
+++ b/src/pages/en/tutorial/5-astro-api/2.md
@@ -51,7 +51,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
 3. Make sure that every blog post contains at least one tag, written as an array, e.g. `tags: ["blogging"]`.
 
-4. Visit `localhost:3000/tags/astro` in your browser preview and you should see a page, generated dynamically from `[tag].astro`. Check that you also have pages created at `/tags/successes`, `/tags/community`, and `/tags/learning%20in%20public`. You may need to first quit and restart the dev server to see these new pages.
+4. Visit `localhost:3000/tags/astro` in your browser preview and you should see a page, generated dynamically from `[tag].astro`. Check that you also have pages created for each of your tags at `/tags/successes`, `/tags/community`, and `/tags/learning%20in%20public`, etc., or at each of your custom tags. You may need to first quit and restart the dev server to see these new pages.
 
 
 ## Use props in dynamic routes


### PR DESCRIPTION
- New or updated content

Adds an extra paragraph to step 1 to:
- customize the tags listed out manually, if you have customized your posts and do not have the example Markdown files
- check manually that every post does have at least one tag, written as an array

This makes the manual step more illustrative if the reader has chosen their own Markdown content for their tutorial blog posts. And, following this extra step prevents errors occuring because the code itself is not (yet!) forgiving about posts that do not contain tags. 

(Follow up task will be to make the code handle posts without tags, but that also requires updating the project code repo on GitHub and rebasing, so this is the quicker, immediate fix.)

![Screenshot 2022-11-15 08 42 16](https://user-images.githubusercontent.com/5098874/201922481-b5be7645-9293-4dd9-bd27-d7e617457612.png)
