### PR TITLE
[proposal-draft] scaled-back MDX integration guide

### DIFF
--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -97,7 +97,7 @@ export default {
 }
 ```
 
-### rehypePlugins
+### `rehypePlugins`
 
  Browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a full curated list of [Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) to transform the HTML that your Markdown generates.
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -69,7 +69,6 @@ Finally, restart the dev server.
 
 ## Usage
 
-Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
 
 In Astro, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -114,6 +114,7 @@ export default {
     rehypePlugins: [rehypeAccessibleEmojis],
   })],
 }
+```
 
 
 ### remarkRehype

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -103,18 +103,17 @@ export default {
 
 We apply our own (non-removable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
 
-This example applies the [`rehype-minify`](https://github.com/rehypejs/rehype-minify) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](#extendplugins).
+This example applies the [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](#extendplugins).
 
 ```js
 // astro.config.mjs
-import rehypeMinifyHtml from 'rehype-minify';
+import rehypeAccessibleEmojis from 'rehype-accessible-emojis';
 
 export default {
   integrations: [mdx({
-    rehypePlugins: [rehypeMinifyHtml],
+    rehypePlugins: [rehypeAccessibleEmojis],
   })],
 }
-```
 
 
 ### `extendPlugins`

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -75,7 +75,7 @@ Astro's MDX integration adds extra features to standard MDX, including Markdown-
 
 See how MDX works in Astro with examples in our [MD/MDX guide](https://docs.astro.build/en/guides/markdown-content/).
 
-Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
+Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using standard MDX features.
 
 
 ## Configuration

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -117,6 +117,7 @@ export default {
 When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults in Markdown and MDX files with the `markdown.extendDefaultPlugins` flag.
 
 To control extending plugins only in MDX, you can configure `.extendPlugins` in your `mdx` integration directly.
+
 **Type:** `'markdown' | 'astroDefaults' | false`
 
 **Default:** `'markdown'`

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -80,7 +80,7 @@ Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using M
 
 Once the MDX integration is installed, no configuration is necessary to use `.mdx` files in your Astro project.
 
-### remarkPlugins
+### `remarkPlugins`
 
 Browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list of [remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) to extend your Markdown's capabilities.
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -119,7 +119,7 @@ export default {
 ```
 
 
-### remarkRehype
+### `remarkRehype`
 
 Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -171,7 +171,7 @@ export default {
 }
 ```
 
-### recmaPlugins
+### `recmaPlugins`
 
 These are plugins that modify the output [estree](https://github.com/estree/estree) directly. This is useful for modifying or injecting JavaScript variables in your MDX files.
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -140,8 +140,6 @@ This inherits the configuration of [`markdown.remarkRehype`](https://docs.astro.
 
 You can customize how MDX files inherit your project’s existing Markdown configuration using the `extendPlugins` option.
 
-
-
 #### `markdown` (default)
 
 Astro's MDX files will inherit all [`markdown` options](https://docs.astro.build/en/reference/configuration-reference/#markdown-options) in your Astro configuration file, which includes the [GitHub-Flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default.

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -138,9 +138,7 @@ This inherits the configuration of [`markdown.remarkRehype`](https://docs.astro.
 
 ### `extendPlugins`
 
-**Type:** `'markdown' | 'astroDefaults' | false`
-
-**Default:** `'markdown'`
+You can customize how MDX files inherit your project’s existing Markdown configuration using the `extendPlugins` option.
 
 
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -79,60 +79,65 @@ Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using M
 
 ## Configuration
 
-Once installed, no configuration is necessary to use `.mdx` files in your Astro project. You may choose to extend or transform your Markdown with plugins.
+Once the MDX integration is installed, no configuration is necessary to use `.mdx` files in your Astro project.
 
+### remarkPlugins
 
-### Markdown Plugins
+Browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list of [remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) to extend your Markdown's capabilities.
 
-#### Supported Plugins
-Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are applied by default. 
+This example applies the [`remark-toc`](https://github.com/remarkjs/remark-toc) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](#extendplugins).
 
-**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`markdown.extendDefaultPlugins` flag](https://docs.astro.build/en/reference/configuration-reference/#markdownextenddefaultplugins) or with [`extendPlugins`](#extendplugins) in your `mdx` integration config.
-
-You can browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins. See each plugin's own README for specific installation instructions.
-
-#### Inherited Plugins from `markdown` config
-
-By default, Astro's MDX integration inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins).
-
-Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins, and will apply only to `.mdx` files.
-
-This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) to Markdown *and* MDX, and [`rehype-minify`](https://github.com/rehypejs/rehype-minify) to MDX only:
-
-```js title="astro.config.mjs"
-import { defineConfig } from 'astro/config';
+```js
+// astro.config.mjs
 import remarkToc from 'remark-toc';
-import rehypeMinify from 'rehype-minify';
+
 export default {
-  markdown: {
-    // Applied to .md and .mdx files
-    remarkPlugins: [remarkToc],
-  },
   integrations: [mdx({
-    // Applied to .mdx files only
-    rehypePlugins: [rehypeMinify],
+    remarkPlugins: [remarkToc],
   })],
 }
 ```
 
+### rehypePlugins
+
+ Browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a full curated list of [Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) to transform the HTML that your Markdown generates.
+
+We apply our own (non-removable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
+
+This example applies the [`rehype-minify`](https://github.com/rehypejs/rehype-minify) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](#extendplugins).
+
+```js
+// astro.config.mjs
+import rehypeMinifyHtml from 'rehype-minify';
+
+export default {
+  integrations: [mdx({
+    rehypePlugins: [rehypeMinifyHtml],
+  })],
+}
+```
+
+
 ### extendPlugins
-
-When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults in Markdown and MDX files with the `markdown.extendDefaultPlugins` flag.
-
-To control extending plugins only in MDX, you can configure `.extendPlugins` in your `mdx` integration directly.
 
 **Type:** `'markdown' | 'astroDefaults' | false`
 
 **Default:** `'markdown'`
 
+
+
 #### `markdown` (default)
 
-By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/#markdownextenddefaultplugins) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
+Astro's MDX files will inherit all [`markdown` options](https://docs.astro.build/en/reference/configuration-reference/#markdown-options) in your Astro configuration file, which includes the [GitHub-Flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins by default.
+
+Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
 
 
 #### `astroDefaults`
 
-You may *only* want to extend [Astro's default plugins](/en/reference/configuration-reference/#markdownextenddefaultplugins) without inheriting your Markdown config. This example will apply the default [GitHub-Flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins alongside [`remark-toc`](https://github.com/remarkjs/remark-toc):
+Astro's MDX files will apply only [Astro's default plugins](/en/reference/configuration-reference/#markdownextenddefaultplugins), without inheriting the rest of your Markdown config. 
+
+This example will apply the default [GitHub-Flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins alongside [`remark-toc`](https://github.com/remarkjs/remark-toc) to your MDX files, while ignoring any `markdown.remarkPlugins` configuration:
 
 ```js "extendPlugins: 'astroDefaults'"
 // astro.config.mjs
@@ -152,7 +157,7 @@ export default {
 
 #### `false`
 
-If you don't want to extend any plugins, set `extendPlugins` to `false`:
+Astro's MDX files will not inherit any [`markdown` options](https://docs.astro.build/en/reference/configuration-reference/#markdown-options), nor will any Astro Markdown defaults be applied:
 
 ```js "extendPlugins: false"
 // astro.config.mjs

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -114,6 +114,7 @@ export default {
 ### extendPlugins
 
 When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults in Markdown and MDX files with the `markdown.extendDefaultPlugins` flag.
+
 To control extending plugins only in MDX, you can configure `.extendPlugins` in your `mdx` integration directly.
 **Type:** `'markdown' | 'astroDefaults' | false`
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -84,7 +84,7 @@ Once installed, no configuration is necessary to use `.mdx` files in your Astro 
 #### Supported Plugins
 Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are applied by default. 
 
-**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`extendDefaultPlugins` flag](#extendplugins).
+**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`markdown.extendDefaultPlugins` flag](#extendplugins) or with `extendPlugins` in your `mdx` integration config.
 
 You can browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins. See each plugin's own README for specific installation instructions.
 
@@ -110,12 +110,6 @@ export default {
     rehypePlugins: [rehypeMinify],
   })],
 }
-```
-
-### extendPlugins
-
-When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults with the `extendDefaultPlugins` flag.
-
 
 **Type:** `'markdown' | 'astroDefaults' | false`
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -71,7 +71,7 @@ export default defineConfig({
 
 With the Astro MDX integration, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
 
-Astro's MDX integration adds extra features to standard MDX, allowing you to use most of Astro's built-in Markdown features like a frontmatter `layout` property, a setting for draft pages, as well as default support for frontmatter variables.
+Astro's MDX integration adds extra features to standard MDX, including support for Markdown-style frontmatter. This allows you to use most of Astro's built-in Markdown features like a frontmatter `layout` property and a setting for draft pages.
 
 Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -117,7 +117,7 @@ export default {
 ```
 
 
-### extendPlugins
+### `extendPlugins`
 
 **Type:** `'markdown' | 'astroDefaults' | false`
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -70,7 +70,11 @@ Finally, restart the dev server.
 ## Usage
 
 
-In Astro, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
+With the Astro MDX integration, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
+
+Astro's MDX integration adds extra features to standard MDX, allowing you to use most of Astro's built-in Markdown features like a frontmatter `layout` property, a setting for draft pages, as well as default support for frontmatter variables.
+
+Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
 
 
 ## Configuration

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -84,7 +84,7 @@ Once installed, no configuration is necessary to use `.mdx` files in your Astro 
 #### Supported Plugins
 Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are applied by default. 
 
-**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`markdown.extendDefaultPlugins` flag](#extendplugins) or with `extendPlugins` in your `mdx` integration config.
+**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`markdown.extendDefaultPlugins` flag](https://docs.astro.build/en/reference/configuration-reference/#markdownextenddefaultplugins) or with [`extendPlugins`](#extendplugins) in your `mdx` integration config.
 
 You can browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins. See each plugin's own README for specific installation instructions.
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -1,0 +1,209 @@
+---
+layout: ~/layouts/IntegrationLayout.astro
+title: '@astrojs/mdx'
+description: Learn how to use the @astrojs/mdx integration in your Astro project.
+githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/mdx/'
+hasREADME: true
+category: other
+i18nReady: false
+setup: |
+  import Video from '~/components/Video.astro';
+  import DontEditWarning from '../../../../components/DontEditWarning.astro';
+---
+This **[Astro integration][astro-integration]** enables the usage of [MDX](https://mdxjs.com/) components and allows you to create pages as `.mdx` files.
+
+## Why MDX?
+
+MDX allows you to [use variables, JSX expressions and components within Markdown content](https://docs.astro.build/en/guides/markdown-content/#variables-and-components). If you have existing content authored in MDX, this integration allows you to bring those files to your Astro project.
+
+## Installation
+
+### Quick Install
+
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+
+```sh
+# Using NPM
+npx astro add mdx
+# Using Yarn
+yarn astro add mdx
+# Using PNPM
+pnpm astro add mdx
+```
+
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
+
+### Manual Install
+
+First, install the `@astrojs/mdx` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install @astrojs/mdx
+```
+
+Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+
+**`astro.config.mjs`**
+
+```js
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+
+export default defineConfig({
+  // ...
+  integrations: [mdx()],
+});
+```
+
+Finally, restart the dev server.
+
+### Editor Integration
+
+[VS Code](https://code.visualstudio.com/) supports Markdown by default. However, for MDX editor support, you may wish to add the following setting in your VSCode config. This ensures authoring MDX files provides a Markdown-like editor experience.
+
+```json title=".vscode/settings.json"
+"files.associations": {
+    "*.mdx": "markdown"
+}
+```
+
+## Usage
+
+You can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory.
+
+You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files.
+
+
+## Configuration
+
+Once installed, no configuration is necessary to use `.mdx` files in your Astro project. You may choose to extend extend your Markdown with plugins.
+
+### remarkPlugins
+
+[Remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) allow you to extend your Markdown with new capabilities. This includes [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list!
+
+This example applies the [`remark-toc`](https://github.com/remarkjs/remark-toc) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendplugins).
+
+```js
+// astro.config.mjs
+import remarkToc from 'remark-toc';
+
+export default {
+  integrations: [mdx({
+    remarkPlugins: [remarkToc],
+  })],
+}
+```
+
+### rehypePlugins
+
+[Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) allow you to transform the HTML that your Markdown generates. We encourage you to browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a full curated list of plugins!
+
+We apply our own (non-removable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
+
+This example applies the [`rehype-minify`](https://github.com/rehypejs/rehype-minify) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendplugins).
+
+```js
+// astro.config.mjs
+import rehypeMinifyHtml from 'rehype-minify';
+
+export default {
+  integrations: [mdx({
+    rehypePlugins: [rehypeMinifyHtml],
+  })],
+}
+```
+
+### extendPlugins
+
+**Type:** `'markdown' | 'astroDefaults' | false`
+
+**Default:** `'markdown'`
+
+#### `markdown` (default)
+
+By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/#markdownextenddefaultplugins) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
+
+This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) to Markdown *and* MDX, and [`rehype-minify`](https://github.com/rehypejs/rehype-minify) to MDX alone:
+
+```js
+// astro.config.mjs
+import remarkToc from 'remark-toc';
+import rehypeMinify from 'rehype-minify';
+
+export default {
+  markdown: {
+    // Applied to .md and .mdx files
+    remarkPlugins: [remarkToc],
+  },
+  integrations: [mdx({
+    // Applied to .mdx files only
+    rehypePlugins: [rehypeMinify],
+  })],
+}
+```
+
+#### `astroDefaults`
+
+You may *only* want to extend [Astro's default plugins](/en/reference/configuration-reference/#markdownextenddefaultplugins) without inheriting your Markdown config. This example will apply the default [GitHub-Flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) plugins alongside [`remark-toc`](https://github.com/remarkjs/remark-toc):
+
+```js "extendPlugins: 'astroDefaults'"
+// astro.config.mjs
+import remarkToc from 'remark-toc';
+
+export default {
+  markdown: {
+    remarkPlugins: [/** ignored */]
+  },
+  integrations: [mdx({
+    remarkPlugins: [remarkToc],
+    // Astro defaults applied
+    extendPlugins: 'astroDefaults',
+  })],
+}
+```
+
+#### `false`
+
+If you don't want to extend any plugins, set `extendPlugins` to `false`:
+
+```js "extendPlugins: false"
+// astro.config.mjs
+import remarkToc from 'remark-toc';
+
+export default {
+  integrations: [mdx({
+    remarkPlugins: [remarkToc],
+    // Astro defaults not applied
+    extendPlugins: false,
+  })],
+}
+```
+
+### recmaPlugins
+
+These are plugins that modify the output [estree](https://github.com/estree/estree) directly. This is useful for modifying or injecting JavaScript variables in your MDX files.
+
+We suggest [using AST Explorer](https://astexplorer.net/) to play with estree outputs, and trying [`estree-util-visit`](https://unifiedjs.com/explore/package/estree-util-visit/) for searching across JavaScript nodes.
+
+## Examples
+
+*   The [Astro MDX starter template](https://github.com/withastro/astro/tree/latest/examples/with-mdx) shows how to use MDX files in your Astro project.
+
+## Troubleshooting
+
+For help, check out the `#support` channel on [Discord](https://astro.build/chat). Our friendly Support Squad members are here to help!
+
+You can also check our [Astro Integration Documentation][astro-integration] for more on integrations.
+
+## Contributing
+
+This package is maintained by Astro's Core team. You're welcome to submit an issue or PR!
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: /en/guides/integrations-guide/
+
+[astro-ui-frameworks]: /en/core-concepts/framework-components/#using-framework-components

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -55,7 +55,6 @@ export default defineConfig({
 });
 ```
 
-Finally, restart the dev server.
 
 ### Editor Integration
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -111,6 +111,10 @@ export default {
   })],
 }
 
+### extendPlugins
+
+When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults in Markdown and MDX files with the `markdown.extendDefaultPlugins` flag.
+To control extending plugins only in MDX, you can configure `.extendPlugins` in your `mdx` integration directly.
 **Type:** `'markdown' | 'astroDefaults' | false`
 
 **Default:** `'markdown'`

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -14,7 +14,7 @@ This **[Astro integration][astro-integration]** enables the usage of [MDX](https
 
 ## Why MDX?
 
-MDX allows you to [use variables, JSX expressions and components within Markdown content](https://docs.astro.build/en/guides/markdown-content/#variables-and-components). If you have existing content authored in MDX, this integration allows you to bring those files to your Astro project.
+MDX allows you to [use variables, JSX expressions and components within Markdown content](https://docs.astro.build/en/guides/markdown-content/#variables-and-components) in Astro. If you have existing content authored in MDX, this integration allows you to bring those files to your Astro project.
 
 ## Installation
 
@@ -69,68 +69,37 @@ Finally, restart the dev server.
 
 ## Usage
 
-You can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory.
+Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
 
-You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files.
+In Astro, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
 
 
 ## Configuration
 
-Once installed, no configuration is necessary to use `.mdx` files in your Astro project. You may choose to extend extend your Markdown with plugins.
+Once installed, no configuration is necessary to use `.mdx` files in your Astro project. You may choose to extend or transform your Markdown with plugins.
 
-### remarkPlugins
 
-[Remark plugins](https://github.com/remarkjs/remark/blob/main/doc/plugins.md) allow you to extend your Markdown with new capabilities. This includes [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) for a full curated list!
+### Markdown Plugins
 
-This example applies the [`remark-toc`](https://github.com/remarkjs/remark-toc) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendplugins).
+#### Supported Plugins
+Astro supports third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are applied by default. 
 
-```js
-// astro.config.mjs
-import remarkToc from 'remark-toc';
+**When adding your own plugins, these two default plugins are removed.** You can preserve these defaults with the [`extendDefaultPlugins` flag](#extendplugins).
 
-export default {
-  integrations: [mdx({
-    remarkPlugins: [remarkToc],
-  })],
-}
-```
+You can browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins. See each plugin's own README for specific installation instructions.
 
-### rehypePlugins
+#### Inherited Plugins from `markdown` config
 
-[Rehype plugins](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md) allow you to transform the HTML that your Markdown generates. We encourage you to browse [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for a full curated list of plugins!
+By default, Astro's MDX integration inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins).
 
-We apply our own (non-removable) [`collect-headings`](https://github.com/withastro/astro/blob/main/packages/integrations/mdx/src/rehype-collect-headings.ts) plugin. This applies IDs to all headings (i.e. `h1 -> h6`) in your MDX files to [link to headings via anchor tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
+Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins, and will apply only to `.mdx` files.
 
-This example applies the [`rehype-minify`](https://github.com/rehypejs/rehype-minify) plugin to `.mdx` files. To customize plugin inheritance from your Markdown config or Astro's defaults, [see the `extendPlugins` option](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendplugins).
+This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) to Markdown *and* MDX, and [`rehype-minify`](https://github.com/rehypejs/rehype-minify) to MDX only:
 
-```js
-// astro.config.mjs
-import rehypeMinifyHtml from 'rehype-minify';
-
-export default {
-  integrations: [mdx({
-    rehypePlugins: [rehypeMinifyHtml],
-  })],
-}
-```
-
-### extendPlugins
-
-**Type:** `'markdown' | 'astroDefaults' | false`
-
-**Default:** `'markdown'`
-
-#### `markdown` (default)
-
-By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/#markdownextenddefaultplugins) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
-
-This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) to Markdown *and* MDX, and [`rehype-minify`](https://github.com/rehypejs/rehype-minify) to MDX alone:
-
-```js
-// astro.config.mjs
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
 import rehypeMinify from 'rehype-minify';
-
 export default {
   markdown: {
     // Applied to .md and .mdx files
@@ -142,6 +111,20 @@ export default {
   })],
 }
 ```
+
+### extendPlugins
+
+When adding your own plugins, [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [Smartypants](https://github.com/silvenon/remark-smartypants) are removed. You can preserve these defaults with the `extendDefaultPlugins` flag.
+
+
+**Type:** `'markdown' | 'astroDefaults' | false`
+
+**Default:** `'markdown'`
+
+#### `markdown` (default)
+
+By default, Astro inherits all [remark](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#remarkplugins) and [rehype](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#rehypeplugins) plugins from [the `markdown` option in your Astro config](/en/guides/markdown-content/#markdown-plugins). This also respects the [`markdown.extendDefaultPlugins`](/en/reference/configuration-reference/#markdownextenddefaultplugins) option to extend Astro's defaults. Any additional plugins you apply in your MDX config will be applied *after* your configured Markdown plugins.
+
 
 #### `astroDefaults`
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -110,6 +110,7 @@ export default {
     rehypePlugins: [rehypeMinify],
   })],
 }
+```
 
 ### extendPlugins
 

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -116,6 +116,25 @@ export default {
 }
 
 
+### remarkRehype
+
+Markdown content is transformed into HTML through remark-rehype which has [a number of options](https://github.com/remarkjs/remark-rehype#options).
+
+You can use remark-rehype options in your config file like so:
+
+```js
+// astro.config.mjs
+export default {
+  integrations: [mdx({
+    remarkRehype: {
+      footnoteLabel: 'Catatan kaki',
+      footnoteBackLabel: 'Kembali ke konten',
+    },
+  })],
+};
+```
+This inherits the configuration of [`markdown.remarkRehype`](https://docs.astro.build/en/reference/configuration-reference/#markdownremarkrehype). This behavior can be changed by configuring `extendPlugins`.
+
 ### `extendPlugins`
 
 **Type:** `'markdown' | 'astroDefaults' | false`

--- a/src/pages/en/integrations/mdx.md
+++ b/src/pages/en/integrations/mdx.md
@@ -71,7 +71,9 @@ export default defineConfig({
 
 With the Astro MDX integration, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](https://docs.astro.build/en/guides/markdown-content/#importing-markdown) into `.astro` files. 
 
-Astro's MDX integration adds extra features to standard MDX, including support for Markdown-style frontmatter. This allows you to use most of Astro's built-in Markdown features like a frontmatter `layout` property and a setting for draft pages.
+Astro's MDX integration adds extra features to standard MDX, including Markdown-style frontmatter. This allows you to use most of Astro's built-in Markdown features like a [special frontmatter `layout` property](https://docs.astro.build/en/guides/markdown-content/#frontmatter-layout) and a [property for marking a page as a draft](https://docs.astro.build/en/guides/markdown-content/#draft-pages).
+
+See how MDX works in Astro with examples in our [MD/MDX guide](https://docs.astro.build/en/guides/markdown-content/).
 
 Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using MDX as a content authoring solution.
 


### PR DESCRIPTION
- New or updated content

Not to actually be merged! For preview purposes only!

This is a WIP, new proposal to replace the MDX integrations guide, once most of the content is moved to Docs.

This retains the Integration Guide structure, and strips down the "Usage" section to links to our Markdown/MDX content. It therefore focuses on Installation and Configuration.

I think there's still some duplication/wording to hash out. But initial concerns are: is this "enough" to be a usable README to stand on its own, and point to docs for most things usage/layout etc.?

Eggregious use of `/integrations/` to host this not-intended-where-it-is preview:  https://deploy-preview-2060--astro-docs-2.netlify.app/en/integrations/mdx/