### PR TITLE
Use unique class name in tutorial nav tabs

### DIFF
--- a/src/components/tabs/TabbedContent.astro
+++ b/src/components/tabs/TabbedContent.astro
@@ -27,7 +27,7 @@ const { tabs } = Astro.props as Props;
 		</slot>
 	</ul>
 
-	<div class="content">
+	<div class="panels">
 		<slot />
 	</div>
 </tabbed-content>
@@ -51,7 +51,7 @@ const { tabs } = Astro.props as Props;
 			super();
 
 			// Get relevant elements and collections
-			const panels = this.querySelectorAll<HTMLElement>('.content > section');
+			const panels = this.querySelectorAll<HTMLElement>('.panels > section');
 			const tablist = this.querySelector('.tab-list')!;
 			const tabs = tablist.querySelectorAll('a');
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

We use a `.content` class on our main page content and instruct DocSearch to use this to find content. We don’t want to include the tutorial navigation tabs in search results and also don’t want styles from the global `.content` bleeding into them, so this renames `.content` to `.panels`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
