### PR TITLE
Fix search result links by reintroducing URL hash

### DIFF
--- a/src/components/Header/DocSearch.tsx
+++ b/src/components/Header/DocSearch.tsx
@@ -66,7 +66,7 @@ export default function Search({ lang = 'en', labels }: Props) {
 					if (url.hash === '#overview') url.hash = '';
 					return {
 						...item,
-						url: url.pathname,
+						url: url.href.replace(url.origin, ''),
 					};
 				});
 			}}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

#2071 introduced a bug where the hashes in links to search results were lost, meaning you’d always just jump to the top of pages. This fixes that!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
