### PR TITLE
Update `Importing layouts manually (MDX)` subtitle to be title case

### DIFF
--- a/src/pages/en/core-concepts/layouts.md
+++ b/src/pages/en/core-concepts/layouts.md
@@ -194,7 +194,7 @@ A Markdown/MDX layout will have access to all its file's [exported properties](/
 *   Values defined outside of frontmatter (e.g. `export` statements in MDX) are not available. Consider [importing a layout](#importing-layouts-manually-mdx) instead.
 :::
 
-### Importing layouts manually (MDX)
+### Importing Layouts Manually (MDX)
 
 You may need to pass information to your MDX layout that does not (or cannot) exist in your frontmatter. In this case, you can instead import and use a [`<Layout />` component](/en/core-concepts/layouts/) and pass it props like any other component:
 


### PR DESCRIPTION

## What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

## Description

First PR. I am going through all the docs. I really like them :) 

It looks like all of the titles and subtitles are written in **title case**. [This](https://docs.astro.build/en/core-concepts/layouts/#importing-layouts-manually-mdx) one was not. 

I updated it to be title case :) 

#### Related Notes:
- There is no Issue Number. I just directly made a PR.

## Screenshots:

<img width="1138" alt="screenshot of the non title case title" src="https://user-images.githubusercontent.com/17516559/202921062-2cd65fc0-7232-4ba9-a30b-a36cd0c50695.png">

> Screenshot of the "Importing layouts manually (MDX)" section written in the "non-title case" format.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
