### PR TITLE
Correct en-only typo in Contentful CMS Guide

### DIFF
--- a/src/pages/en/guides/cms/contentful.md
+++ b/src/pages/en/guides/cms/contentful.md
@@ -252,7 +252,7 @@ const entries = await contentfulClient.getEntries<BlogPost>({
 ---
 ```
 
-This fetch call will return an array of your blog posts at `entries.items`. Use can use `map()` to create a new array (`posts`)  that formats your returned data.
+This fetch call will return an array of your blog posts at `entries.items`. You can use `map()` to create a new array (`posts`)  that formats your returned data.
 
 The example below returns the `items.fields` properites from our Content model to create a blog post preview, and at the same time, reformats the date to a more readable format.
 


### PR DESCRIPTION
Correct en-only typo in Contentful CMS Guide from "Use can use" to "You can use"

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description

This changes a one word typo from "Use" to "You" in the Contentful CMS guide en version.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
