### PR TITLE
Improve DocSearch modal

### DIFF
--- a/public/theme.css
+++ b/public/theme.css
@@ -193,29 +193,6 @@
 
 	--theme-glow-highlight: hsla(var(--color-base-purple), 50%, 1);
 	--theme-glow-diffuse: hsla(var(--color-base-purple), 35%, 0.4);
-
-	/* DocSearch [Algolia] */
-	--docsearch-primary-color: var(--theme-accent);
-	--docsearch-modal-background: var(--theme-bg-gradient-top);
-	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
-	--docsearch-footer-background: var(--theme-bg-gradient-bottom);
-	--docsearch-text-color: var(--theme-text);
-	--docsearch-hit-background: var(--theme-bg-offset);
-	--docsearch-hit-shadow: none;
-	--docsearch-hit-color: var(--theme-text);
-	--docsearch-footer-shadow: inset 0 -1px 0 var(--theme-glow-highlight),
-		inset 1px 0px 0 var(--theme-glow-highlight), inset -1px 0px 0 var(--theme-glow-highlight),
-		inset 0 calc(-1 * var(--theme-glow-blur)) var(--theme-glow-blur)
-			calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
-		inset calc(-1 * var(--theme-glow-blur)) 0 var(--theme-glow-blur)
-			calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
-		inset var(--theme-glow-blur) 0 var(--theme-glow-blur) calc(-1 * var(--theme-glow-blur))
-			var(--theme-glow-diffuse);
-	--docsearch-modal-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse),
-		inset 0 0 0 1px var(--theme-glow-highlight),
-		inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
-	--docsearch-container-background: hsla(var(--color-gray-10), 0.8);
-	--docsearch-hit-active-color: hsla(var(--color-gray-10), 1);
 }
 
 ::selection {

--- a/src/components/Header/DocSearch.css
+++ b/src/components/Header/DocSearch.css
@@ -4,6 +4,30 @@
 	--docsearch-logo-color: var(--theme-text);
 }
 
+:root.theme-dark {
+	--docsearch-primary-color: var(--theme-accent);
+	--docsearch-modal-background: var(--theme-bg-gradient-top);
+	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
+	--docsearch-footer-background: var(--theme-bg-gradient-bottom);
+	--docsearch-text-color: var(--theme-text);
+	--docsearch-hit-background: var(--theme-bg-offset);
+	--docsearch-hit-shadow: none;
+	--docsearch-hit-color: var(--theme-text);
+	--docsearch-footer-shadow: inset 0 -1px 0 var(--theme-glow-highlight),
+		inset 1px 0px 0 var(--theme-glow-highlight), inset -1px 0px 0 var(--theme-glow-highlight),
+		inset 0 calc(-1 * var(--theme-glow-blur)) var(--theme-glow-blur)
+			calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
+		inset calc(-1 * var(--theme-glow-blur)) 0 var(--theme-glow-blur)
+			calc(-1 * var(--theme-glow-blur)) var(--theme-glow-diffuse),
+		inset var(--theme-glow-blur) 0 var(--theme-glow-blur) calc(-1 * var(--theme-glow-blur))
+			var(--theme-glow-diffuse);
+	--docsearch-modal-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse),
+		inset 0 0 0 1px var(--theme-glow-highlight),
+		inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
+	--docsearch-container-background: hsla(var(--color-gray-10), 0.8);
+	--docsearch-hit-active-color: hsla(var(--color-gray-10), 1);
+}
+
 .DocSearch-Modal .DocSearch-Hit a {
 	box-shadow: none;
 	border: 1px solid var(--theme-glow-diffuse);

--- a/src/components/Header/DocSearch.css
+++ b/src/components/Header/DocSearch.css
@@ -1,18 +1,17 @@
 :root {
-	--docsearch-hit-active-color: var(--theme-text);
-	--docsearch-primary-color: var(--theme-text-accent);
+	--docsearch-primary-color: var(--theme-accent-secondary);
+	--docsearch-modal-background: var(--theme-bg);
+	--docsearch-footer-background: var(--theme-bg-gradient-bottom);
 	--docsearch-logo-color: var(--theme-text);
+	--docsearch-text-color: var(--theme-text);
+	--docsearch-hit-color: var(--theme-text);
+	--docsearch-muted-color: var(--theme-text-lighter);
+	--docsearch-hit-shadow: none;
 }
 
 :root.theme-dark {
-	--docsearch-primary-color: var(--theme-accent);
-	--docsearch-modal-background: var(--theme-bg-gradient-top);
 	--docsearch-searchbox-focus-background: var(--theme-bg-offset);
-	--docsearch-footer-background: var(--theme-bg-gradient-bottom);
-	--docsearch-text-color: var(--theme-text);
 	--docsearch-hit-background: var(--theme-bg-offset);
-	--docsearch-hit-shadow: none;
-	--docsearch-hit-color: var(--theme-text);
 	--docsearch-footer-shadow: inset 0 -1px 0 var(--theme-glow-highlight),
 		inset 1px 0px 0 var(--theme-glow-highlight), inset -1px 0px 0 var(--theme-glow-highlight),
 		inset 0 calc(-1 * var(--theme-glow-blur)) var(--theme-glow-blur)
@@ -26,11 +25,9 @@
 		inset 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
 	--docsearch-container-background: hsla(var(--color-gray-10), 0.8);
 	--docsearch-hit-active-color: hsla(var(--color-gray-10), 1);
-}
-
-.DocSearch-Modal .DocSearch-Hit a {
-	box-shadow: none;
-	border: 1px solid var(--theme-glow-diffuse);
+	--docsearch-key-gradient: linear-gradient(-225deg, #2b2d2f, #151515);
+	--docsearch-key-shadow: inset 0 -2px 0 0 #0d0d11, inset 0 0 1px 1px #000,
+		0 1px 2px 1px rgba(0, 0, 0, 0.4);
 }
 
 /* This query matches the upstream media query for mobile devices */

--- a/src/components/Header/DocSearch.tsx
+++ b/src/components/Header/DocSearch.tsx
@@ -72,6 +72,22 @@ export default function Search({ lang = 'en', labels }: Props) {
 			}}
 			placeholder={labels.placeholder}
 			translations={labels.modal}
+			resultsFooterComponent={() => (
+				<div style={{ marginBlock: '2em' }}>
+					<p>Looking for an Astro integration or theme? Need more help?</p>
+					<ul style={{ display: 'flex', gap: '1em', marginBlock: '0.5em', flexWrap: 'wrap' }}>
+						<li>
+							<a href="https://astro.build/integrations/">Astro Integrations catalog</a>
+						</li>
+						<li>
+							<a href="https://astro.build/integrations/">Astro Themes catalog</a>
+						</li>
+						<li>
+							<a href="https://astro.build/chat">Join us on Discord</a>
+						</li>
+					</ul>
+				</div>
+			)}
 		/>,
 		document.body
 	);

--- a/src/components/Header/DocSearch.tsx
+++ b/src/components/Header/DocSearch.tsx
@@ -5,7 +5,7 @@ import type { DocSearchTranslation } from '../../i18n/translation-checkers';
 
 interface Props {
 	lang?: string;
-	labels: Pick<DocSearchTranslation, 'modal' | 'placeholder'>;
+	labels: Omit<DocSearchTranslation, 'button' | 'shortcutLabel'>;
 }
 
 export default function Search({ lang = 'en', labels }: Props) {
@@ -74,16 +74,16 @@ export default function Search({ lang = 'en', labels }: Props) {
 			translations={labels.modal}
 			resultsFooterComponent={() => (
 				<div style={{ marginBlock: '2em' }}>
-					<p>Looking for an Astro integration or theme? Need more help?</p>
+					<p>{labels.resultsFooterLede}</p>
 					<ul style={{ display: 'flex', gap: '1em', marginBlock: '0.5em', flexWrap: 'wrap' }}>
 						<li>
-							<a href="https://astro.build/integrations/">Astro Integrations catalog</a>
+							<a href="https://astro.build/integrations/">{labels.resultsFooterIntegrations}</a>
 						</li>
 						<li>
-							<a href="https://astro.build/themes/">Astro Themes catalog</a>
+							<a href="https://astro.build/themes/">{labels.resultsFooterThemes}</a>
 						</li>
 						<li>
-							<a href="https://astro.build/chat">Join us on Discord</a>
+							<a href="https://astro.build/chat">{labels.resultsFooterDiscord}</a>
 						</li>
 					</ul>
 				</div>

--- a/src/components/Header/DocSearch.tsx
+++ b/src/components/Header/DocSearch.tsx
@@ -80,7 +80,7 @@ export default function Search({ lang = 'en', labels }: Props) {
 							<a href="https://astro.build/integrations/">Astro Integrations catalog</a>
 						</li>
 						<li>
-							<a href="https://astro.build/integrations/">Astro Themes catalog</a>
+							<a href="https://astro.build/themes/">Astro Themes catalog</a>
 						</li>
 						<li>
 							<a href="https://astro.build/chat">Join us on Discord</a>

--- a/src/components/Header/Search.astro
+++ b/src/components/Header/Search.astro
@@ -11,7 +11,7 @@ export interface Props {
 }
 
 const { lang, labels } = Astro.props as Props;
-const { button, shortcutLabel, modal, placeholder } = labels;
+const { button, shortcutLabel, ...modalLabels } = labels;
 ---
 
 <button
@@ -45,7 +45,7 @@ const { button, shortcutLabel, modal, placeholder } = labels;
 		<kbd aria-hidden="true">/</kbd>
 	</span>
 </button>
-<DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />
+<DocSearch {...{ lang, labels: modalLabels }} client:only="preact" />
 
 <style>
 	/** Style search header button */

--- a/src/i18n/en/docsearch.ts
+++ b/src/i18n/en/docsearch.ts
@@ -4,5 +4,9 @@ export default DocSearchDictionary({
 	button: 'Search',
 	placeholder: 'Search docs',
 	shortcutLabel: 'Press / to search',
+	resultsFooterLede: 'Looking for an Astro integration or theme? Need more help?',
+	resultsFooterIntegrations: 'Astro Integrations catalog',
+	resultsFooterThemes: 'Astro Themes catalog',
+	resultsFooterDiscord: 'Join us on Discord',
 	modal: {},
 });

--- a/src/i18n/en/docsearch.ts
+++ b/src/i18n/en/docsearch.ts
@@ -5,8 +5,8 @@ export default DocSearchDictionary({
 	placeholder: 'Search docs',
 	shortcutLabel: 'Press / to search',
 	resultsFooterLede: 'Looking for an Astro integration or theme? Need more help?',
-	resultsFooterIntegrations: 'Astro Integrations directory',
-	resultsFooterThemes: 'Astro Themes showcase',
+	resultsFooterIntegrations: 'Astro integrations directory',
+	resultsFooterThemes: 'Astro themes showcase',
 	resultsFooterDiscord: 'Join us on Discord',
 	modal: {},
 });

--- a/src/i18n/en/docsearch.ts
+++ b/src/i18n/en/docsearch.ts
@@ -5,8 +5,8 @@ export default DocSearchDictionary({
 	placeholder: 'Search docs',
 	shortcutLabel: 'Press / to search',
 	resultsFooterLede: 'Looking for an Astro integration or theme? Need more help?',
-	resultsFooterIntegrations: 'Astro Integrations catalog',
-	resultsFooterThemes: 'Astro Themes catalog',
+	resultsFooterIntegrations: 'Astro Integrations directory',
+	resultsFooterThemes: 'Astro Themes showcase',
 	resultsFooterDiscord: 'Join us on Discord',
 	modal: {},
 });

--- a/src/i18n/translation-checkers.ts
+++ b/src/i18n/translation-checkers.ts
@@ -34,6 +34,11 @@ export interface DocSearchTranslation {
 	// These two keys are Astro-specific and apply to the search box in the header.
 	button?: string;
 	shortcutLabel?: string;
+	// Astro-specific labels for the custom `resultsFooterComponent`.
+	resultsFooterLede?: string;
+	resultsFooterIntegrations?: string;
+	resultsFooterThemes?: string;
+	resultsFooterDiscord?: string;
 	// Search box placeholder text within the DocSearch modal.
 	placeholder?: string;
 	// This object follows DocSearch's translation.modal format.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

1. Adds a small component with useful links to the bottom of search results:

    <img width="460" alt="Screenshot of the bottom of the search modal showing newly added links" src="https://user-images.githubusercontent.com/357379/203137839-0200f019-4a93-4d22-ad7d-27d68b7773aa.png">

2. Refreshes the theming inside the search modal to improve several details:
    - In light mode, highlight the portion of text matching the search query like we do in dark mode
    - In dark mode, style the keyboard shortcut buttons appropriately
    - Tweak the style of individual search results
    - Fix contrast issues with muted secondary text in the modal
  
    Here are some before/after screenshots:
    
    | Before (light) | After (light) | Before (dark) | After (dark) |
    |----------------|---------------|---------------|--------------|
    | ![image](https://user-images.githubusercontent.com/357379/203138823-919e7f88-d33a-4d5a-b8a0-4e664e1da8c8.png) | ![image](https://user-images.githubusercontent.com/357379/203138971-5ff2e03f-9ad9-431d-a6b2-979c23cacf41.png) | ![image](https://user-images.githubusercontent.com/357379/203139130-515f7893-493d-4e8d-bde1-04fbaae12343.png) | ![image](https://user-images.githubusercontent.com/357379/203139255-72835020-df96-4008-b935-b369b5925baa.png) |
