### PR TITLE
Add `class:list` example to styling docs

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -70,6 +70,25 @@ This is a great way to style things like blog posts, or documents with CMS-power
 
 Scoped styles should be used as often as possible. Global styles should be used only as-needed.
 
+### Combining classes with `class:list`
+
+If you need to combine classes on an element dynamically, you can use the `class:list` utility attribute in `.astro` files.
+
+```astro title="src/components/ClassList.astro" /class:list={.*}/
+---
+const { isRed } = Astro.props;
+---
+<!-- If `isRed` is truthy, class will be "box red". Otherwise, class will be "box". -->
+<div class:list={['box', { red: isRed }]}><slot /></div>
+
+<style>
+  .box { border: 1px solid blue; }
+  .red { border-color: red; }
+</style>
+```
+
+📚 See our [directives reference](/en/reference/directives-reference/#classlist) page to learn more about `class:list`.
+
 ### CSS Variables
 
 <Since v="0.21.0" />

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -78,7 +78,8 @@ If you need to combine classes on an element dynamically, you can use the `class
 ---
 const { isRed } = Astro.props;
 ---
-<!-- If `isRed` is truthy, class will be "box red". Otherwise, class will be "box". -->
+<!-- If `isRed` is truthy, class will be "box red". -->
+<!-- If `isRed` is falsy, class will be "box". -->
 <div class:list={['box', { red: isRed }]}><slot /></div>
 
 <style>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

After seeing [this tweet](https://twitter.com/simonswiss/status/1594986667747659777), I was thinking about how we don’t really surface `class:list` outside of reference. There’s one line in [an example in the component docs](https://docs.astro.build/en/core-concepts/astro-components/#the-component-template) but nothing in the styling docs.

Tried adding an example to “Styling & CSS”:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/357379/203285656-b6226e89-9308-4c05-8144-fed1133735c9.png">

Maybe feels a bit like duplication of our reference entry of this and there‘s also an argument this belongs to the component docs rather than styling docs but we’re already showing `is:global` and `define:vars` on this page, so I think this is a reasonable fit.


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
