### PR TITLE
Tweaks to improve “link” search results

### DIFF
--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -24,7 +24,7 @@ Astro leverages a routing strategy called **file-based routing**. Each file in y
 
 ### Link between pages
 
-Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your component template to link between pages.
+Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your Astro components to link to other pages on your site.
 
 ## Astro Pages
 

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -24,7 +24,7 @@ Astro leverages a routing strategy called **file-based routing**. Each file in y
 
 ### Link between pages
 
-Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your Astro components to link to other pages on your site.
+Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your Astro pages to link to other pages on your site.
 
 ## Astro Pages
 

--- a/src/pages/en/core-concepts/astro-pages.md
+++ b/src/pages/en/core-concepts/astro-pages.md
@@ -20,9 +20,11 @@ Astro supports the following file types in the `src/pages/` directory:
 
 Astro leverages a routing strategy called **file-based routing**. Each file in your `src/pages/` directory becomes an endpoint on your site based on its file path.
 
-Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your component template to link between pages.
-
 📚 Read more about [Routing in Astro](/en/core-concepts/routing/).
+
+### Link between pages
+
+Write standard HTML [`<a>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) in your component template to link between pages.
 
 ## Astro Pages
 

--- a/src/pages/en/tutorial/3-components/1.md
+++ b/src/pages/en/tutorial/3-components/1.md
@@ -1,6 +1,6 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
-title: Refactor page links into a Navigation component
+title: Make a reusable Navigation component
 description: "Tutorial: Build your first Astro blog —\nReplace elements repeated on multiple pages with a reusable component"
 setup: |
   import Badge from '~/components/Badge.astro';

--- a/src/pages/en/tutorial/3-components/2.md
+++ b/src/pages/en/tutorial/3-components/2.md
@@ -1,6 +1,6 @@
 ---
 layout: ~/layouts/TutorialLayout.astro
-title: Create a Footer with social media links
+title: Create a social media footer
 description: "Tutorial: Build your first Astro blog —\nBuild a new component from scratch, then add it to your pages"
 setup: |
   import Checklist from '~/components/Checklist.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Remove “link” from page titles in tutorial lessons
- Add a “Link between pages” subheading to our “Pages” page to help that content stand out

Probably not a silver bullet because “Link between pages” is `<h3>` and there are some `<h2>`s containing “link” in the tutorial, but should be a start. We can re-evaluate if we want to do more after re-crawling.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
