### PR TITLE
Add Feedback Fish across whole docs site

### DIFF
--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -3,6 +3,7 @@ import TableOfContents from './TableOfContents';
 import ContributeMenu from './ContributeMenu.astro';
 import CommunityMenu from './CommunityMenu.astro';
 import { useTranslations } from '../../i18n/util';
+import FeedbackButton from '../tutorial/FeedbackButton.astro';
 
 const t = useTranslations(Astro);
 
@@ -23,6 +24,9 @@ const headings = content.astro?.headings;
 	}
 	<ContributeMenu i18nReady={content.i18nReady} editHref={githubEditUrl} />
 	<CommunityMenu />
+	<div class="feedback-section">
+		<FeedbackButton />
+	</div>
 </nav>
 
 <style>
@@ -31,5 +35,9 @@ const headings = content.astro?.headings;
 		padding: var(--doc-padding-block) 0;
 		overflow: auto;
 		font-size: var(--theme-text-xs);
+	}
+
+	.feedback-section {
+		margin: 2rem 0 2rem 1rem;
 	}
 </style>

--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -1,11 +1,15 @@
 ---
+import UIString from '../UIString.astro';
+
 const isTutorial = /\/[\w-]+\/tutorial\//.test(Astro.url.pathname);
 const pid = isTutorial ? '1b24b5d16c81bd' : '1fe455fdbf9ac5';
 
 const currentUrl = Astro.url.pathname.replace(/\/$/, '');
 ---
 
-<button data-feedback-fish data-feedback-fish-url={currentUrl}>Give us feedback</button>
+<button data-feedback-fish data-feedback-fish-url={currentUrl}>
+	<UIString key="feedback.button" />
+</button>
 <script defer src={`https://feedback.fish/ff.js?pid=${pid}`}></script>
 
 <style>

--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -1,16 +1,13 @@
 ---
 import UIString from '../UIString.astro';
 
-const isTutorial = /\/[\w-]+\/tutorial\//.test(Astro.url.pathname);
-const pid = isTutorial ? '1b24b5d16c81bd' : '1fe455fdbf9ac5';
-
 const currentUrl = Astro.url.pathname.replace(/\/$/, '');
 ---
 
 <button data-feedback-fish data-feedback-fish-url={currentUrl}>
 	<UIString key="feedback.button" />
 </button>
-<script defer src={`https://feedback.fish/ff.js?pid=${pid}`}></script>
+<script defer src="https://feedback.fish/ff.js?pid=1b24b5d16c81bd"></script>
 
 <style>
 	button {

--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -1,9 +1,12 @@
 ---
+const isTutorial = /\/[\w-]+\/tutorial\//.test(Astro.url.pathname);
+const pid = isTutorial ? '1b24b5d16c81bd' : '1fe455fdbf9ac5';
+
 const currentUrl = Astro.url.pathname.replace(/\/$/, '');
 ---
 
 <button data-feedback-fish data-feedback-fish-url={currentUrl}>Give us feedback</button>
-<script defer src="https://feedback.fish/ff.js?pid=1b24b5d16c81bd"></script>
+<script defer src={`https://feedback.fish/ff.js?pid=${pid}`}></script>
 
 <style>
 	button {

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -82,4 +82,6 @@ export default {
 	'tutorial.unit': 'Unit',
 	// Tutorial
 	'tutorial.getReady': 'Get ready to…',
+	// Feedback Fish widget
+	'feedback.button': 'Give us feedback',
 };


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Add the Feedback Fish button to the right sidebar across the whole site
- Make the “Give us feedback” label translatable

Example of location:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/357379/203394510-fc2fa9d1-d153-4486-83af-a062026ee9cd.png">

Worth noting that this sidebar is not visible at narrower viewport widths. We don’t show any of the “extra” (non-ToC) stuff on smaller screens and the approach I took for small screens in the tutorial isn’t an option because that space is used by the current heading text next to “On this page”.

My take is that gathering feedback outside of the tutorial is slightly less crucial, so maybe only showing on wider screens is OK and NWTWWHB? Otherwise, we may need to spend more time thinking. One option could be to move the entire “extra” sidebar stuff to the bottom of each page.


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
