### PR TITLE
Show Feedback Fish in left sidebar on narrower screens

### DIFF
--- a/src/components/RightSidebar/CommunityMenu.astro
+++ b/src/components/RightSidebar/CommunityMenu.astro
@@ -1,4 +1,5 @@
 ---
+import FeedbackButton from '../tutorial/FeedbackButton.astro';
 import UIString from '../UIString.astro';
 
 export interface Props {
@@ -123,6 +124,9 @@ const HeadingWrapper = hideOnLargerScreens ? 'summary' : 'div';
 			</a>
 		</li>
 	</ul>
+	<div class="feedback-section">
+		<FeedbackButton />
+	</div>
 </Wrapper>
 
 <style>
@@ -193,5 +197,16 @@ const HeadingWrapper = hideOnLargerScreens ? 'summary' : 'div';
 
 	svg path {
 		fill: currentColor;
+	}
+
+	.feedback-section {
+		margin-block: 2rem;
+		margin-inline-start: 2rem;
+	}
+
+	@media (min-width: 50em) {
+		.feedback-section {
+			margin-inline-start: 1rem;
+		}
 	}
 </style>

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -3,7 +3,6 @@ import TableOfContents from './TableOfContents';
 import ContributeMenu from './ContributeMenu.astro';
 import CommunityMenu from './CommunityMenu.astro';
 import { useTranslations } from '../../i18n/util';
-import FeedbackButton from '../tutorial/FeedbackButton.astro';
 
 const t = useTranslations(Astro);
 
@@ -24,9 +23,6 @@ const headings = content.astro?.headings;
 	}
 	<ContributeMenu i18nReady={content.i18nReady} editHref={githubEditUrl} />
 	<CommunityMenu />
-	<div class="feedback-section">
-		<FeedbackButton />
-	</div>
 </nav>
 
 <style>
@@ -35,9 +31,5 @@ const headings = content.astro?.headings;
 		padding: var(--doc-padding-block) 0;
 		overflow: auto;
 		font-size: var(--theme-text-xs);
-	}
-
-	.feedback-section {
-		margin: 2rem 0 2rem 1rem;
 	}
 </style>

--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -7,7 +7,12 @@ const currentUrl = Astro.url.pathname.replace(/\/$/, '');
 <button data-feedback-fish data-feedback-fish-url={currentUrl}>
 	<UIString key="feedback.button" />
 </button>
-<script defer src="https://feedback.fish/ff.js?pid=1b24b5d16c81bd"></script>
+<script>
+	const script = document.createElement('script');
+	script.setAttribute('defer', '');
+	script.setAttribute('src', 'https://feedback.fish/ff.js?pid=1b24b5d16c81bd');
+	document.body.append(script);
+</script>
 
 <style>
 	button {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

Realised this was easier than I expected!

- Moved the feedback button into the community menu so it moves just like the community menu does as @sarah11918 suggested.

- Tweaked how we load the Feedback Fish script so we only load it once.

One thing to consider: because we’re using the left sidebar, on tutorial pages we now have TWO feedback buttons on smaller screens:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/357379/203427655-68b12e11-1867-4f31-bdff-07870f313362.png">

Is that an issue? The left sidebar is usually scrolled up so most likely you wouldn’t see both at once.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
