### PR TITLE
Make stub note translatable in CMS guide layout

### DIFF
--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -47,6 +47,9 @@ export default {
 	'deploy.staticTag': 'Static',
 	// CMS Guides vocabulary
 	'cms.navTitle': 'More CMS guides',
+	'cms.stubNoteTitle': 'Expand this stub!',
+	'cms.stubNoteExplanation': 'This guide is a stub.',
+	'cms.stubNoteQuestion': 'Know more about how to use this CMS with Astro?',
 	// `<ContributorList>` fallback text
 	'contributors.seeAll': 'See all contributors',
 	// Fallback content notice shown when a page is not yet translated

--- a/src/layouts/CMSLayout.astro
+++ b/src/layouts/CMSLayout.astro
@@ -2,9 +2,11 @@
 import Aside from '~/components/Aside.astro';
 import CMSGuidesNav from '~/components/CMSGuidesNav.astro';
 import UIString from '~/components/UIString.astro';
+import { useTranslations } from '~/i18n/util';
 import { getGithubEditUrl } from '~/util/getGithubEditUrl';
 import MainLayout from './MainLayout.astro';
 
+const t = useTranslations(Astro);
 const githubEditUrl = getGithubEditUrl(Astro);
 const {
 	content: { stub },
@@ -15,9 +17,10 @@ const {
 	<slot />
 	{
 		stub && (
-			<Aside title="Expand this stub!">
-				This guide is a stub. <br />
-				Know more about how to use this CMS with Astro?{' '}
+			<Aside title={t('cms.stubNoteTitle')}>
+				{t('cms.stubNoteExplanation')}
+				<br />
+				{t('cms.stubNoteQuestion')}{' '}
 				<a href={githubEditUrl} target="_blank">
 					<UIString key="rightSidebar.editPage" />
 				</a>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

Makes it possible to translate the copy in our note soliciting contributions to our stub CMS guides. Relevant now we have translations (#2096)!