### PR TITLE
Add new “Scripts and Event Handling” guide

### DIFF
--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -55,6 +55,11 @@ export default [
 		slug: 'guides/server-side-rendering',
 		key: 'guides/server-side-rendering',
 	},
+	{
+		text: 'Scripts & Event Handling',
+		slug: 'guides/client-side-scripts',
+		key: 'guides/client-side-scripts',
+	},
 	{ text: 'CSS & Styling', slug: 'guides/styling', key: 'guides/styling' },
 	{ text: 'Authoring Content', slug: 'guides/content', key: 'guides/content' },
 	{ text: 'Connecting a CMS', slug: 'guides/cms', key: 'guides/cms' },

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -51,16 +51,16 @@ export default [
 		key: 'core-concepts/framework-components',
 	},
 	{
-		text: 'Server-side Rendering (SSR)',
-		slug: 'guides/server-side-rendering',
-		key: 'guides/server-side-rendering',
-	},
-	{
 		text: 'Scripts & Event Handling',
 		slug: 'guides/client-side-scripts',
 		key: 'guides/client-side-scripts',
 	},
 	{ text: 'CSS & Styling', slug: 'guides/styling', key: 'guides/styling' },
+	{
+		text: 'Server-side Rendering (SSR)',
+		slug: 'guides/server-side-rendering',
+		key: 'guides/server-side-rendering',
+	},
 	{ text: 'Authoring Content', slug: 'guides/content', key: 'guides/content' },
 	{ text: 'Connecting a CMS', slug: 'guides/cms', key: 'guides/cms' },
 	{ text: 'Images', slug: 'guides/images', key: 'guides/images' },

--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -470,60 +470,31 @@ The styles defined here apply only to content written directly in the component'
 
 ## Client-Side Scripts
 
-To send JavaScript to the browser without [using a framework component](/en/core-concepts/framework-components/) (React, Svelte, Vue, Preact, SolidJS, AlpineJS, Lit) or an [Astro integration](https://astro.build/integrations/) (e.g. astro-XElement), you can use a `<script>` tag in your Astro component template and send JavaScript to the browser that executes in the global scope.
+Astro components support adding client-side interactivity using standard HTML `<script>` tags.
 
-By default, `<script>` tags are processed by Astro.
-
-- Any imports will be bundled, allowing you to import local files or Node modules.
-- The processed script will be injected into your page’s `<head>` with [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
-- TypeScript is fully supported, including importing TypeScript files
-- If your component is used several times on a page, the script tag will only be included once.
+Scripts can be used to add event listeners, send analytics data, play animations, and everything else JavaScript can do on the web.
 
 ```astro
+// src/components/ConfettiButton.astro
+<button data-confetti-button>Celebrate!</button>
+
 <script>
-  // Processed! Bundled! TypeScript-supported! ESM imports work, even to npm packages.
+  // Import npm modules.
+  import confetti from 'canvas-confetti';
+
+  // Find our component DOM on the page.
+  const buttons = document.querySelectorAll('[data-confetti-button]');
+
+  // Add event listeners to fire confetti when a button is clicked.
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => confetti());
+  });
 </script>
 ```
 
-To avoid bundling the script, you can use the `is:inline` attribute.
+By default, Astro processes and bundles `<script>` tags, adding support for importing npm modules, writing TypeScript, and more.
 
-```astro "is:inline"
-<script is:inline>
-  // Will be rendered into the HTML exactly as written!
-  // ESM imports will not be resolved relative to the file.
-</script>
-```
-
-Multiple `<script>` tags can be used in the same `.astro` file using any combination of the methods above.
-
-:::note
-Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
-:::
-
-📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.
-
-### Loading External Scripts
-
-**When to use this:** If your JavaScript file lives inside of `public/`.
-
-Note that this approach skips the JavaScript processing, bundling and optimizations that are provided by Astro when you use the `import` method described below.
-
-```astro
-// absolute URL path
-<script is:inline src="/some-external-script.js"></script>
-```
-### Using Hoisted Scripts
-
-**When to use this:** If your external script lives inside of `src/` _and_ it supports the ESM module type.
-
-Astro detects these JavaScript client-side imports and then builds, optimizes, and adds the JS to the page automatically.
-
-```astro
-// ESM import
-<script>
-  import './some-external-script.js';
-</script>
-```
+📚 See our [Scripting Guide](/en/guides/client-side-scripts/) for more details.
 
 ## HTML Components
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -74,7 +74,7 @@ Astro will build, optimize, and add these scripts to the page for you, following
 
 **When to use this:** If your JavaScript file lives inside of `public/` or on a CDN.
 
-This approach skips the JavaScript processing, bundling, and optimizations that are provided by Astro when you import scripts as described above.
+To load scripts outside of your project's `src/` folder, include the `is:inline` directive. This approach skips the JavaScript processing, bundling, and optimizations that are provided by Astro when you import scripts as described above.
 
 ```astro title="src/components/ExternalScripts.astro" "is:inline"
 <!-- absolute path to a script at `public/my-script.js` in your project -->

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -43,6 +43,7 @@ To avoid bundling the script, you can use the `is:inline` directive.
 <script is:inline>
   // Will be rendered into the HTML exactly as written!
   // Local imports are not resolved and will not work.
+  // If in a component, will repeat each time the component is used.
 </script>
 ```
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -88,7 +88,9 @@ To load scripts outside of your project's `src/` folder, include the `is:inline`
 
 ### Handle `onclick` and other events
 
-Some UI frameworks use custom syntax for event handling like `onclick={...}` (React/Preact) or `@click="..."` (Vue). Astro components follow web standards and recommend using [`addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) in a `<script>` tag to handle user interactions.
+Some UI frameworks use custom syntax for event handling like `onClick={...}` (React/Preact) or `@click="..."` (Vue). This is not possible in Astro components, which follow standard HTML syntax more closely.
+
+Instead, you can use [`addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) in a `<script>` tag to handle user interactions.
 
 ```astro title="src/components/AlertButton.astro"
 <button class="alert">Click me!</button>

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -109,7 +109,7 @@ Instead, you can use [`addEventListener`](https://developer.mozilla.org/en-US/do
 ```
 
 :::note
-If you have multiple `<AlertButton />` components on a page, Astro will not run the component's script multiple times. Scripts are bundled and run only once. Using `querySelectorAll` ensures that this script attaches the event listener to every button with the `alert` class found on the page.
+If you have multiple `<AlertButton />` components on a page, Astro will not run the script multiple times. Scripts are bundled and only included once per page. Using `querySelectorAll` ensures that this script attaches the event listener to every button with the `alert` class found on the page.
 :::
 
 ### Web components with custom elements

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -37,7 +37,7 @@ By default, `<script>` tags are processed by Astro.
 </script>
 ```
 
-To avoid bundling the script, you can use the `is:inline` attribute.
+To avoid bundling the script, you can use the `is:inline` directive.
 
 ```astro title="src/components/InlineScript.astro" "is:inline"
 <script is:inline>

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -1,0 +1,73 @@
+---
+title: Scripts and Event Handling
+description: How to add client-side interactivity to Astro components using native browser JavaScript APIs.
+layout: ~/layouts/MainLayout.astro
+i18nReady: false
+---
+
+You can add client interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to the browser to add functionality to your components.
+
+## Script bundling in Astro
+
+By default, `<script>` tags are processed by Astro.
+
+- Any imports will be bundled, allowing you to import local files or Node modules.
+- The processed script will be injected into your page’s `<head>` with [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+- TypeScript is fully supported, including importing TypeScript files
+- If your component is used several times on a page, the script tag will only be included once.
+
+```astro title="src/components/Example.astro"
+<script>
+  // Processed! Bundled! TypeScript-supported!
+  // ESM imports work, even to npm packages.
+</script>
+```
+
+To avoid bundling the script, you can use the `is:inline` attribute.
+
+```astro title="src/components/InlineScript.astro" "is:inline"
+<script is:inline>
+  // Will be rendered into the HTML exactly as written!
+  // ESM imports will not be resolved relative to the file.
+</script>
+```
+
+Multiple `<script>` tags can be used in the same `.astro` file using any combination of the methods above.
+
+:::note
+Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
+:::
+
+📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.
+
+## Loading scripts
+
+Sometimes it’s useful to write your scripts as separate `.js`/`.ts` file or you may need to reference an external script on another server. You can do this by referencing these in a `<script>` tag’s `src` attribute.
+
+### Import local scripts
+
+**When to use this:** If your script lives inside of `src/`.
+
+Astro will build, optimize, and add these scripts to the page for you, following its [script bundling rules](#script-bundling-in-astro).
+
+```astro title="src/components/LocalScripts.astro"
+<!-- relative path to script in `src/` -->
+<script src="./local-script.js"></script>
+
+<!-- also works for local TypeScript files -->
+<script src="./script-with-types.ts"></script>
+```
+
+### Load external scripts
+
+**When to use this:** If your JavaScript file lives inside of `public/` or on a CDN.
+
+This approach skips the JavaScript processing, bundling, and optimizations that are provided by Astro when you import scripts as described above.
+
+```astro title="src/components/ExternalScripts.astro"
+<!-- absolute path to a script at `public/my-script.js` in your project -->
+<script is:inline src="/my-script.js"></script>
+
+<!-- full URL to a script on a remote server -->
+<script is:inline src="https://analytics.example.com/script.js"></script>
+```

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -88,7 +88,7 @@ To load scripts outside of your project's `src/` folder, include the `is:inline`
 
 ### Handle `onclick` and other events
 
-Some UI frameworks use custom syntax for event handling like `onClick={...}` (React/Preact) or `@click="..."` (Vue). This is not possible in Astro components, which follow standard HTML syntax more closely.
+Some UI frameworks use custom syntax for event handling like `onClick={...}` (React/Preact) or `@click="..."` (Vue). Astro follows standard HTML more closely and does not use custom syntax for events.
 
 Instead, you can use [`addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) in a `<script>` tag to handle user interactions.
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -147,7 +147,11 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
 </script>
 ```
 
-This is similar to how you might handle user input without a custom element. But, instead of using `document.querySelector()`, we used `this.querySelector()` to get DOM elements. `this.querySelector()` only searches within the current custom element instance, so it’s easier to work with the children of one component instance at a time. Because the browser understands that this code is for a custom element, it will automatically run it for you each time it finds `<astro-heart>` on the page.
+There are two advantages to using a custom element here:
+
+1. You can use `this.querySelector()` to get DOM elements instead of searching the whole page using `document.querySelector()`. `this.querySelector()` only searches within the current custom element instance, making it easier to work with the children of one component instance at a time.
+
+2. The browser will run our custom element’s `constructor()` method each time it finds `<astro-heart>` on the page. This means your code only needs to handle one component at a time instead of setting up all components on the page at once.
 
 📚 You can learn more about custom elements in [web.dev’s Reusable Web Components guide](https://web.dev/custom-elements-v1/) and [MDN’s introduction to custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements).
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -149,7 +149,7 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
 
 There are two advantages to using a custom element here:
 
-1. You can use `this.querySelector()` to get DOM elements instead of searching the whole page using `document.querySelector()`. `this.querySelector()` only searches within the current custom element instance, making it easier to work with the children of one component instance at a time.
+1. Instead of searching the whole page using `document.querySelector()`, you can use `this.querySelector()`, which only searches within the current custom element instance. This makes it easier to work with only the children of one component instance at a time.
 
 2. Although a `<script>` only runs once, the browser will run our custom element’s `constructor()` method each time it finds `<astro-heart>` on the page. This means you can safely write code for one component at a time, even if you intend to use this component multiple times on a page.
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -5,16 +5,30 @@ layout: ~/layouts/MainLayout.astro
 i18nReady: false
 ---
 
-You can add client interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to the browser to add functionality to your components.
+You can add client interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to run in the browser and add functionality to your components.
 
-## Script bundling in Astro
+## Using `<script>` in Astro
+
+In `.astro` files, you can add client-side JavaScript by adding one (or more) `<script>` tags.
+
+In this example, adding the `<Hello />` component to a page will log a message to the browser console.
+
+```astro title="src/components/Hello.astro"
+<h1>Welcome, world!</h1>
+
+<script>
+  console.log('Welcome, browser console!');
+</script>
+```
+
+### Script bundling
 
 By default, `<script>` tags are processed by Astro.
 
 - Any imports will be bundled, allowing you to import local files or Node modules.
 - The processed script will be injected into your page’s `<head>` with [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 - TypeScript is fully supported, including importing TypeScript files
-- If your component is used several times on a page, the script tag will only be included once.
+- If your component is used several times on a page, the script will only be included once.
 
 ```astro title="src/components/Example.astro"
 <script>
@@ -32,19 +46,17 @@ To avoid bundling the script, you can use the `is:inline` attribute.
 </script>
 ```
 
-Multiple `<script>` tags can be used in the same `.astro` file using any combination of the methods above.
-
 :::note
 Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
 :::
 
 📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.
 
-## Loading scripts
+### Script loading
 
-Sometimes it’s useful to write your scripts as separate `.js`/`.ts` file or you may need to reference an external script on another server. You can do this by referencing these in a `<script>` tag’s `src` attribute.
+You may want to write your scripts as separate `.js`/`.ts` files or need to reference an external script on another server. You can do this by referencing these in a `<script>` tag’s `src` attribute.
 
-### Import local scripts
+#### Import local scripts
 
 **When to use this:** If your script lives inside of `src/`.
 
@@ -58,13 +70,13 @@ Astro will build, optimize, and add these scripts to the page for you, following
 <script src="./script-with-types.ts"></script>
 ```
 
-### Load external scripts
+#### Load external scripts
 
 **When to use this:** If your JavaScript file lives inside of `public/` or on a CDN.
 
 This approach skips the JavaScript processing, bundling, and optimizations that are provided by Astro when you import scripts as described above.
 
-```astro title="src/components/ExternalScripts.astro"
+```astro title="src/components/ExternalScripts.astro" "is:inline"
 <!-- absolute path to a script at `public/my-script.js` in your project -->
 <script is:inline src="/my-script.js"></script>
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -159,7 +159,7 @@ There are two advantages to using a custom element here:
 
 In Astro components, the code in [the frontmatter](/en/core-concepts/astro-components/#the-component-script) between the `---` fences runs on the server and is not available in the browser. To send variables from the server to the client, we need a way to store our variables and then read them when JavaScript runs in the browser.
 
-One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store the value of variables in your HTML output. Scripts, including custom elements, can then read these using an element’s `dataset` property once your HTML loads in the browser.
+One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store the value of variables in your HTML output. Scripts, including custom elements, can then read these attributes using an element’s `dataset` property once your HTML loads in the browser.
 
 In this example component, a `message` prop is stored in a `data-message` attribute, so the custom element can read `this.dataset.message` and get the value of the prop in the browser.
 
@@ -198,7 +198,7 @@ Now we can use our component multiple times and be greeted by a different messag
 import AstroGreet from '../components/AstroGreet.astro';
 ---
 
-<!-- Uses the default message: “Welcome, world!” -->
+<!-- Use the default message: “Welcome, world!” -->
 <AstroGreet />
 
 <!-- Use custom messages passed as a props. -->
@@ -207,5 +207,5 @@ import AstroGreet from '../components/AstroGreet.astro';
 ```
 
 :::tip[Did you know?]
-This is actually what Astro does behind the scenes when you pass props to a component written using a UI framework like React! For components with a `client:*` directive, it creates an `<astro-island>` custom element with a `props` attribute that stores your server-side props in the HTML output.
+This is actually what Astro does behind the scenes when you pass props to a component written using a UI framework like React! For components with a `client:*` directive, Astro creates an `<astro-island>` custom element with a `props` attribute that stores your server-side props in the HTML output.
 :::

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -112,7 +112,7 @@ If you have multiple `<AlertButton />` components on a page, Astro will not run 
 
 ### Web components with custom elements
 
-[Custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) provide a standard API that allows you to define your own HTML elements with custom behavior. Defining a custom element in a `.astro` component can be a good way to build interactivity without reaching for a UI framework library.
+You can create your own HTML elements with custom behavior using the Web Components standard. Defining a [custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) in a `.astro` component allows you to build interactive components without needing a UI framework library.
 
 In this example, we define a new `<astro-heart>` HTML element that tracks how many times you click the heart button and updates the `<span>` with the latest count.
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -47,7 +47,7 @@ To avoid bundling the script, you can use the `is:inline` directive.
 ```
 
 :::note
-Adding `type="module"` or any other attribute to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
+Adding `type="module"` or any attribute other than `src` to a `<script>` tag will disable Astro's default bundling behavior, treating the tag as if it had an `is:inline` directive.
 :::
 
 📚 See our [directives reference](/en/reference/directives-reference/#script--style-directives) page for more information about the directives available on `<script>` tags.

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -63,8 +63,8 @@ You may want to write your scripts as separate `.js`/`.ts` files or need to refe
 Astro will build, optimize, and add these scripts to the page for you, following its [script bundling rules](#script-bundling).
 
 ```astro title="src/components/LocalScripts.astro"
-<!-- relative path to script in `src/` -->
-<script src="./local-script.js"></script>
+<!-- relative path to script at `src/scripts/local.js` -->
+<script src="../scripts/local.js"></script>
 
 <!-- also works for local TypeScript files -->
 <script src="./script-with-types.ts"></script>

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -151,7 +151,7 @@ There are two advantages to using a custom element here:
 
 1. You can use `this.querySelector()` to get DOM elements instead of searching the whole page using `document.querySelector()`. `this.querySelector()` only searches within the current custom element instance, making it easier to work with the children of one component instance at a time.
 
-2. The browser will run our custom element’s `constructor()` method each time it finds `<astro-heart>` on the page. This means your code only needs to handle one component at a time instead of setting up all components on the page at once.
+2. Although a `<script>` only runs once, the browser will run our custom element’s `constructor()` method each time it finds `<astro-heart>` on the page. This means you can safely write code for one component at a time, even if you intend to use this component multiple times on a page.
 
 📚 You can learn more about custom elements in [web.dev’s Reusable Web Components guide](https://web.dev/custom-elements-v1/) and [MDN’s introduction to custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements).
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -2,7 +2,7 @@
 title: Scripts and Event Handling
 description: How to add client-side interactivity to Astro components using native browser JavaScript APIs.
 layout: ~/layouts/MainLayout.astro
-i18nReady: false
+i18nReady: true
 ---
 
 You can add interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to run in the browser and add functionality to your Astro components.

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -91,11 +91,11 @@ To load scripts outside of your project's `src/` folder, include the `is:inline`
 Some UI frameworks use custom syntax for event handling like `onclick={...}` (React/Preact) or `@click="..."` (Vue). Astro components follow web standards and recommend using [`addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) in a `<script>` tag to handle user interactions.
 
 ```astro title="src/components/AlertButton.astro"
-<button data-alert>Click me!</button>
+<button class="alert">Click me!</button>
 
 <script>
-  // Find all buttons with the `data-alert` attribute on the page.
-  const buttons = document.querySelectorAll('button[data-alert]');
+  // Find all buttons with the `alert` class on the page.
+  const buttons = document.querySelectorAll('button.alert');
 
   // Handle clicks on each button.
   buttons.forEach((button) => {

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -107,7 +107,7 @@ Some UI frameworks use custom syntax for event handling like `onclick={...}` (Re
 ```
 
 :::note
-Because this script will run once even if we add many instances of `<AlertButton />` to a page, we use `querySelectorAll` to get all instances of our component and add listeners to each one instead of using `querySelector`, which would only return the first button it found.
+If you have multiple `<AlertButton />` components on a page, Astro will not run the component's script multiple times. Scripts are bundled and run only once. Using `querySelectorAll` ensures that this script attaches the event listener to every button with the `alert` class found on the page.
 :::
 
 ### Web components with custom elements

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -5,7 +5,7 @@ layout: ~/layouts/MainLayout.astro
 i18nReady: false
 ---
 
-You can add client interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to run in the browser and add functionality to your components.
+You can add interactivity to your Astro components without [using a UI framework](/en/core-concepts/framework-components/) like React, Svelte, Vue, etc. using standard HTML `<script>` tags. This allows you to send JavaScript to run in the browser and add functionality to your Astro components.
 
 ## Using `<script>` in Astro
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -43,7 +43,7 @@ To avoid bundling the script, you can use the `is:inline` directive.
 <script is:inline>
   // Will be rendered into the HTML exactly as written!
   // Local imports are not resolved and will not work.
-  // If in a component, will repeat each time the component is used.
+  // If in a component, repeats each time the component is used.
 </script>
 ```
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -149,12 +149,11 @@ This is similar to how you might handle user input without a custom element. But
 
 📚 You can learn more about custom elements in [web.dev’s Reusable Web Components guide](https://web.dev/custom-elements-v1/) and [MDN’s introduction to custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements).
 
-### Pass component props to scripts
+### Pass frontmatter variables to scripts
 
-In Astro components, the code in [the frontmatter](/en/core-concepts/astro-components/#the-component-script) between the `---` fences runs on the server and is not available in the browser. To send props from the server to the client, we need a way to store our values and then read them when JavaScript runs in the browser.
+In Astro components, the code in [the frontmatter](/en/core-concepts/astro-components/#the-component-script) between the `---` fences runs on the server and is not available in the browser. To send variables from the server to the client, we need a way to store our variables and then read them when JavaScript runs in the browser.
 
-One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store component props in your HTML output.
-Scripts, including custom elements, can then read these once your HTML loads in the browser.
+One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store the value of variables in your HTML output. Scripts, including custom elements, can then read these once your HTML loads in the browser.
 
 In this example component, a `message` prop is stored in a `data-message` attribute. Data attributes are available in JavaScript using an element’s `dataset` property, so the custom element logic can read `this.dataset.message` and get the value of the prop in the browser.
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -159,9 +159,9 @@ There are two advantages to using a custom element here:
 
 In Astro components, the code in [the frontmatter](/en/core-concepts/astro-components/#the-component-script) between the `---` fences runs on the server and is not available in the browser. To send variables from the server to the client, we need a way to store our variables and then read them when JavaScript runs in the browser.
 
-One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store the value of variables in your HTML output. Scripts, including custom elements, can then read these once your HTML loads in the browser.
+One way to do this is to use [`data-*` attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to store the value of variables in your HTML output. Scripts, including custom elements, can then read these using an element’s `dataset` property once your HTML loads in the browser.
 
-In this example component, a `message` prop is stored in a `data-message` attribute. Data attributes are available in JavaScript using an element’s `dataset` property, so the custom element logic can read `this.dataset.message` and get the value of the prop in the browser.
+In this example component, a `message` prop is stored in a `data-message` attribute, so the custom element can read `this.dataset.message` and get the value of the prop in the browser.
 
 ```astro title="src/components/AstroGreet.astro" {2} /data-message={.+}/ "this.dataset.message"
 ---

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -27,7 +27,7 @@ By default, `<script>` tags are processed by Astro.
 
 - Any imports will be bundled, allowing you to import local files or Node modules.
 - The processed script will be injected into your page’s `<head>` with [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
-- TypeScript is fully supported, including importing TypeScript files
+- TypeScript is fully supported, including importing TypeScript files.
 - If your component is used several times on a page, the script will only be included once.
 
 ```astro title="src/components/Example.astro"

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -77,11 +77,11 @@ Astro will build, optimize, and add these scripts to the page for you, following
 To load scripts outside of your project's `src/` folder, include the `is:inline` directive. This approach skips the JavaScript processing, bundling, and optimizations that are provided by Astro when you import scripts as described above.
 
 ```astro title="src/components/ExternalScripts.astro" "is:inline"
-<!-- absolute path to a script at `public/my-script.js` in your project -->
+<!-- absolute path to a script at `public/my-script.js` -->
 <script is:inline src="/my-script.js"></script>
 
 <!-- full URL to a script on a remote server -->
-<script is:inline src="https://analytics.example.com/script.js"></script>
+<script is:inline src="https://my-analytics.com/script.js"></script>
 ```
 
 ## Common script patterns

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -33,7 +33,7 @@ By default, `<script>` tags are processed by Astro.
 ```astro title="src/components/Example.astro"
 <script>
   // Processed! Bundled! TypeScript-supported!
-  // ESM imports work, even to npm packages.
+  // Importing local scripts and Node modules works.
 </script>
 ```
 
@@ -42,7 +42,7 @@ To avoid bundling the script, you can use the `is:inline` directive.
 ```astro title="src/components/InlineScript.astro" "is:inline"
 <script is:inline>
   // Will be rendered into the HTML exactly as written!
-  // ESM imports will not be resolved relative to the file.
+  // Local imports are not resolved and will not work.
 </script>
 ```
 

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -60,7 +60,7 @@ You may want to write your scripts as separate `.js`/`.ts` files or need to refe
 
 **When to use this:** If your script lives inside of `src/`.
 
-Astro will build, optimize, and add these scripts to the page for you, following its [script bundling rules](#script-bundling-in-astro).
+Astro will build, optimize, and add these scripts to the page for you, following its [script bundling rules](#script-bundling).
 
 ```astro title="src/components/LocalScripts.astro"
 <!-- relative path to script in `src/` -->

--- a/src/pages/en/guides/client-side-scripts.md
+++ b/src/pages/en/guides/client-side-scripts.md
@@ -201,5 +201,5 @@ import AstroGreet from '../components/AstroGreet.astro';
 ```
 
 :::tip[Did you know?]
-This is actually what Astro does behind the scenes when you pass props to a component written using a UI framework like React! It creates an `<astro-island>` custom element with a `props` attribute that stores your server-side props in the HTML output.
+This is actually what Astro does behind the scenes when you pass props to a component written using a UI framework like React! For components with a `client:*` directive, it creates an `<astro-island>` custom element with a `props` attribute that stores your server-side props in the HTML output.
 :::

--- a/src/pages/en/reference/directives-reference.md
+++ b/src/pages/en/reference/directives-reference.md
@@ -234,6 +234,8 @@ const message = "Astro is awesome!";
 Using `define:vars` on a `<script>` or `<style>` tag implies the [`is:inline` directive](#isinline), which means your scripts or styles won't be bundled and will be inlined directly into the HTML. 
 
 This is because when Astro bundles a script, it includes and runs the script once even if you include the component containing the script multiple times on one page. `define:vars` requires a script to rerun with each set of values, so Astro creates an inline script instead.
+
+For scripts, try [passing variables to scripts manually](/en/guides/client-side-scripts/#pass-frontmatter-variables-to-scripts) instead.
 :::
 
 ## Advanced Directives


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Simplifies the [“Client-side scripts” section](https://deploy-preview-2102--astro-docs-2.netlify.app/en/core-concepts/astro-components/#client-side-scripts) of the Components guide
- Adds a new guide to writing `<scripts>` — https://deploy-preview-2102--astro-docs-2.netlify.app/en/guides/client-side-scripts/

    Includes guidance on:
  - Adding event listeners from a `<script>`
  - Writing a custom element
  - Passing variables from component frontmatter to a script (_without_ `define:vars`)
- Moves detailed content on script bundling and loading out of the Components guide to the new page
- Closes #2100

#### Useful things to answer

How does this feel? It’s a slightly 50-50 page with a reference-y first half and guide-y second half. 

Are the examples clear and helpful? I tried to pick things I could distil down but also chose not to dive too deep into custom element syntax etc. as I think that probably is out of scope for the Astro docs.

Given that, are the _links_ helpful? Can people find what they need to know by following them?

Nav bar position? I feel grouping this with both styling & UI frameworks makes sense. Does SSR need to move up/down?