### PR TITLE
Fix mismatched quote in MDX docs

### DIFF
--- a/src/pages/en/guides/markdown-content.md
+++ b/src/pages/en/guides/markdown-content.md
@@ -218,7 +218,7 @@ With MDX, you can map Markdown syntax to custom components instead of their stan
 Import your custom component into your `.mdx` file, then export a `components` object that maps the standard HTML element to your custom component:
 
 ```mdx title="src/pages/about.mdx"
-import Blockquote from `../components/Blockquote.astro';
+import Blockquote from '../components/Blockquote.astro';
 export const components = {blockquote: Blockquote}
 
 > This quote will be a custom Blockquote


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
A mismatched backtick quote character broke syntax highlighting in the MDX box.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
