### PR TITLE
add env.d.ts to project directory tree in manual install

### DIFF
--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -177,7 +177,7 @@ If you have followed the steps above, your project directory should now look lik
 ├── public/
 │   └── robots.txt
 ├── src/
-│   └── pages/
+│   ├── pages/
 │       └── index.astro
 │   └── env.d.ts
 ├── astro.config.mjs

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -178,7 +178,7 @@ If you have followed the steps above, your project directory should now look lik
 │   └── robots.txt
 ├── src/
 │   ├── pages/
-│       └── index.astro
+│   │   └── index.astro
 │   └── env.d.ts
 ├── astro.config.mjs
 ├── package-lock.json (or: yarn.lock, pnpm-lock.yaml, etc.)

--- a/src/pages/en/install/manual.md
+++ b/src/pages/en/install/manual.md
@@ -179,6 +179,7 @@ If you have followed the steps above, your project directory should now look lik
 ├── src/
 │   └── pages/
 │       └── index.astro
+│   └── env.d.ts
 ├── astro.config.mjs
 ├── package-lock.json (or: yarn.lock, pnpm-lock.yaml, etc.)
 ├── package.json


### PR DESCRIPTION
- New or updated content

The example file structure shown as the last step in the manual install instructions was missing `env.d.ts`. This adds that.
