### PR TITLE
#2077 `/routing/#rest-parameters` Minor update + link to MDN docs.

### DIFF
--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -102,13 +102,9 @@ const { path } = Astro.params;
 ...
 ```
 
-:::tip
-The name of the rest parameter can be anything as long as it matches the name returned in `getStaticPaths`. For example, `[...cats].astro` should return `[{ params: { cats: 'path/to/cat' } }]`.
-:::
-
 This will generate `/sequences/one/two/three`, `/sequences/four`, and `/sequences`. (Setting the rest parameter to `undefined` allows it to match the top level page.)
 
-Rest parameters can be used with other named parameters. For example, we could represent GitHub's file viewer with a dynamic route like this:
+Rest parameters can be used with **other named parameters**. For example, we could represent GitHub's file viewer with a dynamic route like this:
 
 ```
 /[org]/[repo]/tree/[branch]/[...file]

--- a/src/pages/en/core-concepts/routing.md
+++ b/src/pages/en/core-concepts/routing.md
@@ -85,7 +85,7 @@ Parameters can be included in separate parts of the path, so we could use `src/p
 
 #### Rest parameters
 
-If you need more flexibility in your URL routing, you can use a rest parameter (`[...param]`) in your `.astro` filename to match file paths of any depth:
+If you need more flexibility in your URL routing, you can use a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) (`[...path]`) in your `.astro` filename to match file paths of any depth:
 
 ```astro title="src/pages/sequences/[...path].astro"
 ---
@@ -101,6 +101,10 @@ const { path } = Astro.params;
 ---
 ...
 ```
+
+:::tip
+The name of the rest parameter can be anything as long as it matches the name returned in `getStaticPaths`. For example, `[...cats].astro` should return `[{ params: { cats: 'path/to/cat' } }]`.
+:::
 
 This will generate `/sequences/one/two/three`, `/sequences/four`, and `/sequences`. (Setting the rest parameter to `undefined` allows it to match the top level page.)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

### What kind of changes does this PR include?
-  New or updated content

### Description

- Closes #2077 

Originally, I got confused about because the [Rest Parameters](http://localhost:3000/en/core-concepts/routing/#rest-parameters) docs used the word `...params` in the description, but `...path` in the code example. 

I was also going to add [this tip](https://user-images.githubusercontent.com/17516559/204306968-1d587030-e2f4-4172-ba98-cda55fe183cb.png), but I decided to bold something else, instead.



### Screenshots

#### Before 

<img width="756" alt="Screen Shot 2022-11-28 at 9 50 31 AM" src="https://user-images.githubusercontent.com/17516559/204307668-79bcd4ca-608e-40dc-a3f0-ab86f0d4955f.png">

#### After

<img width="756" alt="Screen Shot 2022-11-28 at 9 49 03 AM" src="https://user-images.githubusercontent.com/17516559/204307376-7913ad85-ec45-43e4-ba29-d241beb70d73.png">


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
