### PR TITLE
Note scoped classes passed to child components

### DIFF
--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -143,7 +143,7 @@ import MyComponent from "../components/MyComponent.astro"
 This pattern lets you style child components directly. Astro will pass the parent’s scoped class name (e.g. `astro-HHNQFKH6`) through the `class` prop automatically, including the child in its parent’s scope.
 
 :::note[Scoped classes from parent components]
-As the `class` prop contains scoped classes from the parent, it's recommended to create unique class names in the child component to prevent unintended style cascading from the parent component.
+Because the `class` prop includes the child in its parent’s scope, it is possible for styles to cascade from parent to child. To avoid this having unintended side effects, ensure you use unique class names in the child component.
 :::
 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -132,7 +132,7 @@ const { class: className } = Astro.props;
 ---
 import MyComponent from "../components/MyComponent.astro"
 ---
-<style is:global>
+<style>
   .red {
     color: red;
   }
@@ -140,8 +140,10 @@ import MyComponent from "../components/MyComponent.astro"
 <MyComponent class="red">This will be red!</MyComponent>
 ```
 
+With this pattern, parents can style children components directly! Scoped styles can also be passed through the `class` prop as Astro attaches scoped classes like `astro-HHNQFKH6` internally.
+
 :::note[Scoped classes from parent components]
-If the parent component uses scoped styles, Astro scoped classes like `astro-HHNQFKH6` will also be passed to the `class` prop. This may cause scoped styles from the parent to leak into child components if they have the same CSS selectors. If you encounter this issue, you can prevent it by filtering out the class before passing it down to an element.
+As the `class` prop contains scoped classes from the parent, it's recommended to create unique class names in the child component to prevent unintended style cascading from the parent component.
 :::
 
 

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -140,7 +140,7 @@ import MyComponent from "../components/MyComponent.astro"
 <MyComponent class="red">This will be red!</MyComponent>
 ```
 
-With this pattern, parents can style children components directly! Scoped styles can also be passed through the `class` prop as Astro attaches scoped classes like `astro-HHNQFKH6` internally.
+This pattern lets you style child components directly. Astro will pass the parent’s scoped class name (e.g. `astro-HHNQFKH6`) through the `class` prop automatically, including the child in its parent’s scope.
 
 :::note[Scoped classes from parent components]
 As the `class` prop contains scoped classes from the parent, it's recommended to create unique class names in the child component to prevent unintended style cascading from the parent component.

--- a/src/pages/en/guides/styling.md
+++ b/src/pages/en/guides/styling.md
@@ -140,6 +140,9 @@ import MyComponent from "../components/MyComponent.astro"
 <MyComponent class="red">This will be red!</MyComponent>
 ```
 
+:::note[Scoped classes from parent components]
+If the parent component uses scoped styles, Astro scoped classes like `astro-HHNQFKH6` will also be passed to the `class` prop. This may cause scoped styles from the parent to leak into child components if they have the same CSS selectors. If you encounter this issue, you can prevent it by filtering out the class before passing it down to an element.
+:::
 
 
 ## External Styles


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Close https://github.com/withastro/astro/issues/5112

Clarify that the issue is expected behaviour and how to prevent it if it happens.

Question: Should we show the user how to filter out the scoped class? It might involve regex replace that maybe even make sense to export out from Astro as an API, but it also feels like a bandaid API to the problem. I'm slightly leaning to not for now unless more people hit this edge case.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
