### PR TITLE
[tutorial] fixes closing tag notation

### DIFF
--- a/src/pages/en/tutorial/6-islands/2.md
+++ b/src/pages/en/tutorial/6-islands/2.md
@@ -57,7 +57,7 @@ Let's build a clickable icon to let your users toggle between light or dark mode
         <ThemeIcon />
         <Navigation />
       </nav>
-    <header>
+    </header>
     ```
 
 3. Visit your browser preview at `localhost:3000` to see the icon now on all your pages. You can try clicking it, but you have not written a script to make it interactive yet.


### PR DESCRIPTION
- Minor content fixes (broken links, typos, etc.)

Adds a missing `/` in a closing `<header>` tag in `6-islands-2`