### PR TITLE
[tutorial] adds alt text to image in code sample

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -270,7 +270,6 @@ Follow the steps below, then check your work by comparing it to the [final code 
   <BaseLayout pageTitle={frontmatter.title}>
     <p><em>{frontmatter.description}</em></p>
     <p>{frontmatter.pubDate.slice(0,10)}</p>
-    <h1>{frontmatter.title}</h1>
 
     <p>Written by: {frontmatter.author}</p>
 
@@ -346,7 +345,6 @@ const { frontmatter } = Astro.props;
 <BaseLayout pageTitle={frontmatter.title}>
   <p><em>{frontmatter.description}</em></p>
   <p>{frontmatter.pubDate.slice(0,10)}</p>
-  <h1>{frontmatter.title}</h1>
 
   <p>Written by: {frontmatter.author}</p>
 

--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -274,7 +274,7 @@ Follow the steps below, then check your work by comparing it to the [final code 
 
     <p>Written by: {frontmatter.author}</p>
 
-    <img src={frontmatter.postImage} width="300" /> 
+    <img src={frontmatter.postImage} width="300" alt={frontmatter.image.alt} /> 
 
     <div class="tags">
       {tags.map((tag) => (
@@ -350,7 +350,7 @@ const { frontmatter } = Astro.props;
 
   <p>Written by: {frontmatter.author}</p>
 
-  <img src={frontmatter.postImage} width="300" /> 
+  <img src={frontmatter.postImage} width="300" alt={frontmatter.image.alt} /> 
 
   <div class="tags">
     {frontmatter.tags.map((tag) => (


### PR DESCRIPTION
- New or updated content

The tutorial code snippet was missing an `alt` attribute for the image in `5-astro-api/3`. This adds `alt={frontmatter.image.alt}` in both places the code is shown.

Also removes the `<h1>` because it is being provided by `<BaseLayout>`