### PR TITLE
Reduce i18n metadata stored to try to fix our i18n status issue

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -108,10 +108,8 @@ The JSON object will look something like this:
 "zh-cn": {
       "comparing-astro-vs-other-tools.md": {
         "lastChange": "2022-07-27T19:08:40.000Z",
-        "lastCommitMsg": "Core Concepts PR follow-up (#1126)",
         // This property below is the one you should change!
         "lastMajorChange": "2022-07-27T19:08:40.000Z", 
-        "lastMajorCommitMsg": "Core Concepts PR follow-up (#1126)"
       },
       // (other pages...)
   }

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -215,6 +215,15 @@ class GitHubTranslationStatus {
 		const payload = matches[1].trim();
 		try {
 			const state = JSON.parse(payload);
+			// TODO: Migration step to remove excess keys in existing payload. Can be removed later.
+			for (const lang in state.pages) {
+				const langPages = state.pages[lang];
+				for (const slug in langPages) {
+					const { lastChange, lastMajorChange, i18nReady } = langPages[slug];
+					langPages[slug] = { lastChange, lastMajorChange };
+					if (i18nReady) langPages[slug].i18nReady = i18nReady;
+				}
+			}
 			return state;
 		} catch (error) {
 			output.warning(`Failed to parse JSON payload in issue body: ${error.message}`);

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -289,18 +289,12 @@ class GitHubTranslationStatus {
 		const i18nReady = /^\s*i18nReady:\s*true\s*$/m.test(frontMatterBlock);
 		if (i18nReady) {
 			pageData.i18nReady = true;
-			// If the page was i18nReady before, keep the old i18nReadyDate (if any),
-			// or use the last commit date as a fallback
-			pageData.i18nReadyDate =
-				(oldPageData.i18nReady && oldPageData.i18nReadyDate) || gitHistory.lastCommitDate;
 		}
 
 		// Use the most recent dates (which allows us to manually set future dates
 		// if we do not want a translated page to become outdated) and the actual commit messages
 		pageData.lastChange = latest(oldPageData.lastChange, gitHistory.lastCommitDate);
-		pageData.lastCommitMsg = gitHistory.lastCommitMessage;
 		pageData.lastMajorChange = latest(oldPageData.lastMajorChange, gitHistory.lastMajorCommitDate);
-		pageData.lastMajorCommitMsg = gitHistory.lastMajorCommitMessage;
 
 		return pageData;
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Attempt to fix #438 which hasn’t been updated for ~3 weeks.

If the issue is that we’re hitting size limits on the issue body, it might help not to include extra metadata which can be helpful for manual debugging but is not actually used by the action to update the dashboard. I’ve removed the `i18nReadyDate`, `lastCommitMsg`, and `lastMajorCommitMsg` metadata which is stored for each page. `lastChange` is also not used for functionality but I decided to leave that in for now as the most helpful of the surplus metadata.

This PR also adds a bit of code when loading the existing, stored metadata from the issue body to actively strip out those extra properties.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
