### PR TITLE
i18n Status Issue design refresh

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -373,15 +373,15 @@ class GitHubTranslationStatus {
 	 * @param {{ size?: number }} [opts]
 	 */
 	renderProgressBar(total, outdated, missing, { size = 20 } = {}) {
-		const doneFraction = (total - missing - outdated) / total;
-		const outdatedFraction = outdated / total;
-		const missingFraction = missing / total;
+		const outdatedLength = Math.round((outdated / total) * size);
+		const missingLength = Math.round((missing / total) * size);
+		const doneLength = size - outdatedLength - missingLength;
 		return [
-			[doneFraction, '🟪'],
-			[outdatedFraction, '🟧'],
-			[missingFraction, '⬜'],
+			[doneLength, '🟪'],
+			[outdatedLength, '🟧'],
+			[missingLength, '⬜'],
 		]
-			.map(([fraction, icon]) => Array.from({ length: Math.round(fraction * size) }, () => icon))
+			.map(([length, icon]) => Array.from({ length }, () => icon))
 			.flat()
 			.join('');
 	}

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -365,6 +365,23 @@ class GitHubTranslationStatus {
 		return lines.join('\n');
 	}
 
+	/**
+	 * Render a progress bar with emoji.
+	 * @param {number} total
+	 * @param {number} outdated
+	 * @param {number} missing
+	 * @param {{ size?: number }} [opts]
+	 */
+	renderProgressBar(total, outdated, missing, { size = 20 } = {}) {
+		const doneFraction = (total - missing - outdated) / total;
+		const outdatedFraction = outdated / total;
+		const missingFraction = missing / total;
+		return [[doneFraction, '🟪'], [outdatedFraction, '🟧'], missingFraction, '⬜']
+			.map(([fraction, icon]) => Array.from({ length: fraction * size }, () => icon))
+			.flat()
+			.join('');
+	}
+
 	renderTranslationTodosByLanguage({ pages }) {
 		const arrContent = this.getTranslationStatusByContent({ pages });
 		const lines = [];
@@ -375,11 +392,16 @@ class GitHubTranslationStatus {
 			lines.push('<details>');
 			lines.push(
 				`<summary><strong>` +
-					`${this.languageLabels[lang]} (${lang}): ` +
-					`${missing.length} missing, ${outdated.length} need${
-						outdated.length === 1 ? 's' : ''
-					} updating` +
-					`</strong></summary>`
+					`${this.languageLabels[lang]} (${lang})` +
+					`</strong><br>` +
+					`<sup>` +
+					`${arrContent.length - outdated.length - missing.length} done,` +
+					`${outdated.length} need${outdated.length === 1 ? 's' : ''} updating,` +
+					`${missing.length} missing` +
+					'<br><sup>' +
+					this.renderProgressBar(arrContent.length, outdated.length, missing.length) +
+					`</sup></sup>` +
+					`</summary>`
 			);
 			lines.push(``);
 			if (outdated.length > 0) {

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -103,10 +103,10 @@ class GitHubTranslationStatus {
 		let humanFriendlySummary = dedent`
 			${intro}
 
-			### Translation progress by language
+			## Translation progress by language
 			${this.renderTranslationTodosByLanguage(state)}
 
-			### Translation status by content
+			## Translation status by content
 			${this.renderTranslationStatusByContent(state)}
 		`;
 

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -382,6 +382,18 @@ class GitHubTranslationStatus {
 					`</strong></summary>`
 			);
 			lines.push(``);
+			if (outdated.length > 0) {
+				lines.push(`##### 🔄&nbsp; Needs updating`);
+				lines.push(
+					...outdated.map(
+						(content) =>
+							`- [${content.subpath}](${content.githubUrl}) ` +
+							`([outdated translation](${content.translations[lang].githubUrl}), ` +
+							`[source change history](${content.translations[lang].sourceHistoryUrl}))`
+					)
+				);
+				lines.push(``);
+			}
 			if (missing.length > 0) {
 				lines.push(`##### ❌&nbsp; Missing`);
 				lines.push(
@@ -391,18 +403,6 @@ class GitHubTranslationStatus {
 								lang,
 								content.subpath
 							)}`
-					)
-				);
-				lines.push(``);
-			}
-			if (outdated.length > 0) {
-				lines.push(`##### 🔄&nbsp; Needs updating`);
-				lines.push(
-					...outdated.map(
-						(content) =>
-							`- [${content.subpath}](${content.githubUrl}) ` +
-							`([outdated translation](${content.translations[lang].githubUrl}), ` +
-							`[source change history](${content.translations[lang].sourceHistoryUrl}))`
 					)
 				);
 				lines.push(``);

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -381,7 +381,7 @@ class GitHubTranslationStatus {
 			[outdatedFraction, '🟧'],
 			[missingFraction, '⬜'],
 		]
-			.map(([fraction, icon]) => Array.from({ length: fraction * size }, () => icon))
+			.map(([fraction, icon]) => Array.from({ length: Math.round(fraction * size) }, () => icon))
 			.flat()
 			.join('');
 	}

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -103,11 +103,11 @@ class GitHubTranslationStatus {
 		let humanFriendlySummary = dedent`
 			${intro}
 
+			### Translation progress by language
+			${this.renderTranslationTodosByLanguage(state)}
+
 			### Translation status by content
 			${this.renderTranslationStatusByContent(state)}
-
-			### Translation todos by language
-			${this.renderTranslationTodosByLanguage(state)}
 		`;
 
 		// Build a new issue body with the new human-friendly summary and JSON metadata

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -399,8 +399,8 @@ class GitHubTranslationStatus {
 					`${this.languageLabels[lang]} (${lang})` +
 					`</strong><br>` +
 					`<sup>` +
-					`${arrContent.length - outdated.length - missing.length} done,` +
-					`${outdated.length} need${outdated.length === 1 ? 's' : ''} updating,` +
+					`${arrContent.length - outdated.length - missing.length} done, ` +
+					`${outdated.length} need${outdated.length === 1 ? 's' : ''} updating, ` +
 					`${missing.length} missing` +
 					'<br><sup>' +
 					this.renderProgressBar(arrContent.length, outdated.length, missing.length) +

--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -376,7 +376,11 @@ class GitHubTranslationStatus {
 		const doneFraction = (total - missing - outdated) / total;
 		const outdatedFraction = outdated / total;
 		const missingFraction = missing / total;
-		return [[doneFraction, '🟪'], [outdatedFraction, '🟧'], missingFraction, '⬜']
+		return [
+			[doneFraction, '🟪'],
+			[outdatedFraction, '🟧'],
+			[missingFraction, '⬜'],
+		]
 			.map(([fraction, icon]) => Array.from({ length: fraction * size }, () => icon))
 			.flat()
 			.join('');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

This PR gives the i18n status issue a light refresh now we have so much more content than when we first started.

- Show the breakdown by language first, before the table of by-page data
- Inside a language’s details, show “Needs updating” pages ahead of “Missing”
- `<h2>` instead of `<h3>` for the section headings
- Show a progress bar made of emoji in each language’s header & include the done count

Here’s how the new by-language section looks:

<img width="868" alt="image" src="https://user-images.githubusercontent.com/357379/206865596-28254344-8300-4534-a286-a76b70448cab.png">
