### PR TITLE
fix:redirect to the new URL

### DIFF
--- a/src/pages/en/guides/integrations-guide/vue.md
+++ b/src/pages/en/guides/integrations-guide/vue.md
@@ -98,7 +98,7 @@ This package is maintained by Astro's Core team. You're welcome to submit an iss
 
 ## Options
 
-This integration is powered by `@vitejs/plugin-vue`. To customize the Vue compiler, options can be provided to the integration. See the `@vitejs/plugin-vue` [docs](https://github.com/vitejs/vite/tree/main/packages/plugin-vue) for more details.
+This integration is powered by `@vitejs/plugin-vue`. To customize the Vue compiler, options can be provided to the integration. See the `@vitejs/plugin-vue` [docs](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue) for more details.
 
 **`astro.config.mjs`**
 

--- a/src/pages/en/guides/integrations-guide/vue.md
+++ b/src/pages/en/guides/integrations-guide/vue.md
@@ -166,7 +166,7 @@ export default defineConfig({
 });
 ```
 
-This will enable rendering for both Vue and Vue JSX components. To customize the Vue JSX compiler, pass an options object instead of a boolean. See the `@vitejs/plugin-vue-jsx` [docs](https://github.com/vitejs/vite/tree/main/packages/plugin-vue-jsx) for more details.
+This will enable rendering for both Vue and Vue JSX components. To customize the Vue JSX compiler, pass an options object instead of a boolean. See the `@vitejs/plugin-vue-jsx` [docs](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx) for more details.
 
 **`astro.config.mjs`**
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- Changed the link to the new URL due to vitejs/vite has moved framework plugins out of core.
