### PR TITLE
Use type import in “Built-in HTML attributes” example

### DIFF
--- a/src/pages/en/guides/typescript.md
+++ b/src/pages/en/guides/typescript.md
@@ -117,7 +117,7 @@ For example, if you were building a `<Link>` component, you could do the followi
 
 ```astro title="src/components/Link.astro" ins="HTMLAttributes" ins="HTMLAttributes<'a'>"
 ---
-import { HTMLAttributes } from 'astro/types'
+import type { HTMLAttributes } from 'astro/types'
 // use a `type`
 type Props = HTMLAttributes<'a'>;
 // or extend with an `interface`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change?
The PR adds 'type' to the `import { HTMLAttributes } from 'astro/types'` from `Built-in HTML attributes` section.



<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
