### PR TITLE
Fix import route in the WordPress connection guide

### DIFF
--- a/src/pages/en/guides/cms/wordpress.md
+++ b/src/pages/en/guides/cms/wordpress.md
@@ -117,7 +117,7 @@ The page `src/pages/dinos/[slug].astro` [dynamically generates a page](/en/core-
 
 ```astro title="/src/pages/dinos/[slug].astro"
 ---
-import Layout from '../layouts/Layout.astro';
+import Layout from '../../layouts/Layout.astro';
 
 const { slug } = Astro.params;
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes the broken `Layout` component import route in the [Using the WordPress API to generate pages](https://docs.astro.build/en/guides/cms/wordpress/#using-the-wordpress-api-to-generate-pages) section's code example:

* Layout route: `src/layouts/Layout.astro`
* Dino page route: `src/pages/dinos/[slug].astro`

We need to go 2 directory levels up to be able to import the `Layout` in the `[slug].astro` file.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
