### PR TITLE
Fix `<FileTree>` overflow bug in Safari/iOS

### DIFF
--- a/src/components/FileTree.astro
+++ b/src/components/FileTree.astro
@@ -92,7 +92,7 @@ const processedContent = await fileTreeProcessor.process({
 		display: inline-flex;
 		align-items: flex-start;
 		flex-wrap: wrap;
-		max-width: calc(100% - 1em);
+		max-width: calc(100% - 1.25em);
 	}
 
 	@media (min-width: 30em) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fixes a bug where items in the FileTree could break to a new line inelegantly in Safari/iOS:

    <img alt="File tree component with items breaking onto new line" src="https://user-images.githubusercontent.com/357379/208200939-2bcf5c1e-2a49-41f2-9bb0-9542f46235ac.png" width="300">


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
