### PR TITLE
i18n(es): Update of `api-reference.md`, `configuration-reference.md`, `directives-reference.md` & `publish-to-npm.md`

### DIFF
--- a/src/pages/es/guides/rss.md
+++ b/src/pages/es/guides/rss.md
@@ -3,7 +3,9 @@ layout: ~/layouts/MainLayout.astro
 title: RSS
 description: Introducción a RSS en Astro
 i18nReady: true
-setup: import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+setup: |
+  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+  import Since from '~/components/Since.astro';
 ---
 
 Astro proporciona una generación rápida y automática de RSS feeds para blogs u otros sitios web con mucho contenido. Para más información acerca de RSS feeds en general, visita [aboutfeeds.com](https://aboutfeeds.com/).
@@ -111,6 +113,32 @@ export const get = () => rss({
     link: post.url,
     title: post.frontmatter.title,
     pubDate: post.frontmatter.pubDate,
+  }))
+});
+```
+### Incluyendo contenido completo de un artículo
+
+<Since v="1.6.14" />
+
+Por defecto, la integración Astro RSS no tiene soporte para incluir el contenido de cada uno de tus artículos en el feed por si mismo. 
+
+Sin embargo, si tu mismo creas una lista con objetos RSS feed, puedes pasar el contenido de los archivos Markdown (no MDX), a la llave `content` usando la propiedad [`compiledContent()`](/es/guides/markdown-content/#propiedades-exportadas). Te recomendamos usar un paquete como [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) para asegurarse de que tu contenido está correctamente desinfectado, escapado y codificado para su uso en el feed XML.
+
+```js ins={2, 16} title={src/pages/rss.xml.js}
+import rss from '@astrojs/rss';
+import sanitizeHtml from 'sanitize-html';
+// ¡Funciona con archivos Markdown únicamente!
+const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true }); 
+const posts = Object.values(postImportResult);
+export const get = () => rss({
+  title: 'El Blog de Buzz',
+  description: 'Guía para las estrellas de un humilde astronauta',
+  site: import.meta.env.SITE,
+  items: posts.map((post) => ({
+    link: post.url,
+    title: post.frontmatter.title,
+    pubDate: post.frontmatter.pubDate,
+    content: sanitizeHtml(post.compiledContent()),
   }))
 });
 ```

--- a/src/pages/es/guides/styling.md
+++ b/src/pages/es/guides/styling.md
@@ -1,7 +1,7 @@
 ---
 layout: ~/layouts/MainLayout.astro
 title: Estilos & CSS
-description: Aprende a estilar componentes de Astro.
+description: Aprende a diseñar componentes en Astro con estilos locales, CSS externo y herramientas Sass y PostCSS
 i18nReady: true
 setup: |
   import Since from '../../../components/Since.astro';
@@ -70,6 +70,25 @@ Esta es una excelente manera de estilar cosas como artículos de blog o document
 
 Los estilos locales deben usarse con la mayor frecuencia posible. Los estilos globales deben usarse solo cuando sea necesario.
 
+### Combinando clases con `class:list`
+
+Si necesitas combinar clases sobre un elemento dinámicamente, puedes usar el atributo `class:list` en archivos `.astro`.
+
+```astro title="src/components/ClassList.astro" /class:list={.*}/
+---
+const { isRed } = Astro.props;
+---
+<!-- Si `isRed` es verdadero, la clase será "box red". -->
+<!-- Si `isRed` es falso, la clase será "box". -->
+<div class:list={['box', { red: isRed }]}><slot /></div>
+<style>
+  .box { border: 1px solid blue; }
+  .red { border-color: red; }
+</style>
+```
+
+📚 Visita nuestra página [referencia de directivas](/es/reference/directives-reference/#classlist) para aprender más sobre `class:list`.
+
 ### Variables de CSS
 
 <Since v="0.21.0" />
@@ -112,7 +131,7 @@ const { class: className } = Astro.props;
 ---
 import MyComponent from "../components/MyComponent.astro"
 ---
-<style is:global>
+<styl>
   .red {
     color: red;
   }
@@ -120,6 +139,11 @@ import MyComponent from "../components/MyComponent.astro"
 <MyComponent class="red">¡Esto será rojo!</MyComponent>
 ```
 
+Este patrón te permite estilar componentes hijos directamente. Astro pasará el nombre de la clase local del padre (por ejemplo `astro-HHNQFKH6`) por la propiedad `class` automaticamente, incluyendo el hijo en ámbito del componente padre.
+
+:::note[Clases globales de componentes padre]
+Debido a que la propiedad `clase` incluye al hijo en el ámbito de su padre, es posible que los estilos caigan en cascada de padre a hijo. Para evitar que esto tenga efectos secundarios no deseados, asegúrese de usar nombres de clase únicos en el componente secundario.
+:::
 
 
 ## Estilos externos
@@ -385,7 +409,7 @@ import "../components/hazlo-morado.css"
 
 Astro es compatible con preprocesadores de CSS como [Sass][sass], [Stylus][stylus] y [Less][less] usando [Vite][vite-preprocessors].
 
-### Sass
+### Sass y SCSS
 
 ```shell
 npm install -D sass

--- a/src/pages/es/guides/typescript.md
+++ b/src/pages/es/guides/typescript.md
@@ -116,7 +116,7 @@ Por ejemplo, si estuvieras construyendo un componente `<Link>`, podrías hacer l
 
 ```astro title="src/components/Link.astro" ins="HTMLAttributes" ins="HTMLAttributes<'a'>"
 ---
-import { HTMLAttributes } from 'astro/types'
+import type { HTMLAttributes } from 'astro/types'
 // usa un `type`
 type Props = HTMLAttributes<'a'>;
 // o extiendelo con una `interface`

--- a/src/pages/es/install/manual.md
+++ b/src/pages/es/install/manual.md
@@ -171,18 +171,19 @@ Lee nuestra [guía para configurar TypeScript](/es/guides/typescript/#configurac
 
 Si has seguido las instrucciones anteriores, el proyecto debe lucir así:
 
-```
-├── node_modules/
-├── public/
-│   └── robots.txt
-├── src/
-│   └── pages/
-│       └── index.astro
-├── astro.config.mjs
-├── package-lock.json (o: yarn.lock, pnpm-lock.yaml, etc.)
-├── package.json
-└── tsconfig.json
-```
+<FileTree>
+- node_modules/
+- public/
+  - robots.txt
+- src/
+  - pages/
+    - index.astro
+  - env.d.ts
+- astro.config.mjs
+- package-lock.json or `yarn.lock`, `pnpm-lock.yaml`, etc.
+- package.json
+- tsconfig.json
+</FileTree>
 
 ¡Felicidades, estás listo para empezar a usar Astro!
 

--- a/src/pages/es/install/manual.md
+++ b/src/pages/es/install/manual.md
@@ -3,6 +3,7 @@ title: Instala Astro manualmente
 description: Cómo instalar Astro manualmente con NPM, PNPM, o Yarn.
 layout: ~/layouts/MainLayout.astro
 setup: |
+  import FileTree from '~/components/FileTree.astro';
   import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
   import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 i18nReady: true

--- a/src/pages/es/reference/api-reference.md
+++ b/src/pages/es/reference/api-reference.md
@@ -202,7 +202,7 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 | `get`          | `(key: string) => AstroCookie`                       | Obtiene la cookie como un objeto [`AstroCookie`](#astrocookie), el cual contiene el `value` y funciones utilitarias para convertir la cookie en tipos no-string.          |
 | `has`          | `(key: string) => boolean`                       | Indica si esta cookie existe. Si la cookie se ha establecido a través de `Astro.cookies.set()` esto retornará _true_, de lo contrario, comprobará las cookies en `Astro.request`.          |
 | `set`       | `(key: string, value: string \| number \| boolean \| object, options?: CookieOptions) => void` | Establece el `key` de la cookie al valor dado. Esto intentará convertir el valor de la cookie en un _string_. _Options_ provee formas de establecer [características de la cookie](https://www.npmjs.com/package/cookie#options-1), como el `maxAge` o `httpOnly`.   |
-| `delete`       | `(key: string) => void` | Marca la cookie como eliminada. Una vez que se elimina una cookie `Astro.cookies.has()` retornará `false` y `Astro.cookies.get()` retornará [`AstroCookie`](#astrocookie) con un `value` de `undefined`.   |
+| `delete`       | `(key: string, options?: CookieDeleteOptions) => void` | Marca la cookie como eliminada. Una vez que se elimina una cookie `Astro.cookies.has()` retornará `false` y `Astro.cookies.get()` retornará [`AstroCookie`](#astrocookie) con un `value` de `undefined`. Options permite configurar el `domain` y el `path` de la cookie para borrar. |
 | `headers`       | `() => Iterator<string>` | Obtiene los valores de _headers_ para `Set-Cookie` que se enviarán con la respuesta.   |
 
 
@@ -269,7 +269,9 @@ const ip = Astro.clientAddress;
 
 ### `Astro.site`
 
-`Astro.site` devuelve una `URL` generada desde `site` en su configuración de Astro. Si no está definido, devolverá una URL generada desde `localhost`.
+`Astro.site` devuelve una `URL` generada desde `site` en su configuración de Astro. Si `site`no esta definido en tu configuración Astro, `Astro.site` no estará definido.
+
+```astro
 
 ### `Astro.generator`
 

--- a/src/pages/es/reference/configuration-reference.md
+++ b/src/pages/es/reference/configuration-reference.md
@@ -127,6 +127,8 @@ La URL final donde se desplegará. Astro usa esta URL completa para generar el s
 
 La ruta base en la que se desplegará. Astro compilará tus páginas y recursos usando esta ruta como la raíz. En este momento, esta configuración no tiene efecto durante el modo de desarrollo.
 
+Puedes acceder a este valor en tu aplicación usando `import.meta.env.BASE_URL`.
+
 ```js
 {
   base: '/docs',

--- a/src/pages/es/reference/directives-reference.md
+++ b/src/pages/es/reference/directives-reference.md
@@ -221,7 +221,10 @@ const message = "¡Astro es espectacular!";
 :::caution
 El uso de `define:vars` en una etiqueta `<script>` o `<style>` implica la directiva [`is:inline`](#isinline), lo que significa que los scripts o estilos no se empaquetarán y serán incluidos inline directamente en el HTML.
 
-Esto se debe a que cuando Astro empaqueta los scripts, Astro incluye y ejecuta los scripts una sola vez, aun si incluyes el componente que contiene el script múltiples veces en una página. `define:vars` requiere que un script se re-ejecute con los valores asignados, luego Astro crea, en su lugar, un script inline.:::
+Esto se debe a que cuando Astro empaqueta los scripts, Astro incluye y ejecuta los scripts una sola vez, aun si incluyes el componente que contiene el script múltiples veces en una página. `define:vars` requiere que un script se re-ejecute con los valores asignados, luego Astro crea, en su lugar, un script inline.
+
+Para scripts, intenta [pasar variables a los scripts manualmente](/es/guides/client-side-scripts/#pass-frontmatter-variables-to-scripts) en su lugar.
+:::
 
 ## Directivas avanzadas
 

--- a/src/pages/es/reference/publish-to-npm.md
+++ b/src/pages/es/reference/publish-to-npm.md
@@ -3,6 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: Publica en NPM
 description: Aprende a publicar componentes de Astro en NPM
 i18nReady: true
+setup: |
+  import FileTree from '~/components/FileTree.astro'
 ---
 
 ¿Construyendo un nuevo componente Astro? **¡Publícalo en [npm](https://npmjs.com/)!**
@@ -41,17 +43,17 @@ Antes de empezar, será útil tener una comprensión básica de:
 
 Para crear un nuevo paquete, recomendamos configurar tu entorno de desarrollo para utilizar **Workspaces** dentro de tu proyecto. Esto te permitirá desarrollar tu componente junto con una copia funcional de Astro.
 
-```
-mi-nueva-carpeta-de-componentes/
-├─ demo/
-| └─ ... para pruebas y demostraciones
-├─ package.json
-└─ packages/
-  └─ my-component/
-      ├─ index.js
-      ├─ package.json
-      └─ ... archivos adicionales utilizados por el paquete
-```
+<FileTree>
+- my-new-component-directory/
+  - demo/
+    - ... for testing and demonstration
+  - package.json
+  - packages/
+    - my-component/
+      - index.js
+      - package.json
+      - ... additional files used by the package
+</FileTree>
 
 En este ejemplo, llamado `mi-proyecto`, creamos un proyecto con un solo paquete, llamado `mi-componente`, y un directorio `demo/` para probar y demostrar el componente.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
This is an update of the markdown files previously mentioned and were updated as follows:
- `api-reference.md` based on these commits eb0657de3fff32d7e4550960f448ad558145a21a and eafcf6cf64990783c6ce0b1c075a169e980e27f1
- `configuration-reference.md` based on this commit 28b0cf427643f7cc6d85a97dead20cc7bed52be2
- `directives-reference.md` based on this commit 77d098d089b65f8ddc21038d8bd17ca76f5de420
- `publish-to-npm.md` based on this commit 79bdbb9ff909981606a62e276922a16bcd74e47c