### PR TITLE
chore: bump `actions/checkout` in deno deploy guide

### DIFF
--- a/src/pages/en/guides/deploy/deno.md
+++ b/src/pages/en/guides/deploy/deno.md
@@ -100,7 +100,7 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           # Not using npm? Change `npm ci` to `yarn install` or `pnpm i`
           - name: Install dependencies

--- a/src/pages/es/guides/deploy/deno.md
+++ b/src/pages/es/guides/deploy/deno.md
@@ -101,7 +101,7 @@ Si tu proyecto está almacenado en GitHub, la [página web de Deno Deploy](https
 
         steps:
           - name: Clonar el repositorio
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           # ¿No usas npm? Cambia `npm ci` por `yarn install` o `pnpm i`.
           - name: Instalar las dependencias


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description

- Bumps the `actions/checkout` version for the deno deploy guide