### PR TITLE
chore: bump actions/checkout in GitHub deploy guide 

### DIFF
--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -44,8 +44,8 @@ Astro maintains the official `withastro/action` to deploy your project with very
 2. Create a new file in your project at `.github/workflows/deploy.yml` and paste in the YAML below.
 
     ```yaml title="deploy.yml"
-    name: Github Pages Astro CI
-
+    name: Deploy to GitHub Pages
+    
     on:
       # Trigger the workflow every time you push to the `main` branch
       # Using a different branch name? Replace `main` with your branch’s name
@@ -59,21 +59,20 @@ Astro maintains the official `withastro/action` to deploy your project with very
       contents: read
       pages: write
       id-token: write
-
+    
     jobs:
       build:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v2          
-          - name: Install, build, and upload your site
+            uses: actions/checkout@v3
+          - name: Install, build, and upload your site output
             uses: withastro/action@v0
             # with:
                 # path: . # The root location of your Astro project inside the repository. (optional)
                 # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
                 # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-
-
+    
       deploy:
         needs: build
         runs-on: ubuntu-latest

--- a/src/pages/en/guides/deploy/github.md
+++ b/src/pages/en/guides/deploy/github.md
@@ -45,7 +45,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
     ```yaml title="deploy.yml"
     name: Deploy to GitHub Pages
-    
+
     on:
       # Trigger the workflow every time you push to the `main` branch
       # Using a different branch name? Replace `main` with your branch’s name
@@ -59,20 +59,20 @@ Astro maintains the official `withastro/action` to deploy your project with very
       contents: read
       pages: write
       id-token: write
-    
+
     jobs:
       build:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
             uses: actions/checkout@v3
-          - name: Install, build, and upload your site output
+          - name: Install, build, and upload your site
             uses: withastro/action@v0
             # with:
                 # path: . # The root location of your Astro project inside the repository. (optional)
                 # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
                 # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-    
+
       deploy:
         needs: build
         runs-on: ubuntu-latest

--- a/src/pages/es/guides/deploy/github.md
+++ b/src/pages/es/guides/deploy/github.md
@@ -65,7 +65,7 @@ Astro mantiene la acción oficial `withastro/action` para desplegar tu proyecto 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v2          
+            uses: actions/checkout@v3
           - name: Install, build, and upload your site
             uses: withastro/action@v0
             # with:

--- a/src/pages/pt-br/guides/deploy/github.md
+++ b/src/pages/pt-br/guides/deploy/github.md
@@ -66,7 +66,7 @@ O Astro mantém oficialmente o `withastro/action` para fazer o deploy do seu pro
        runs-on: ubuntu-latest
        steps:
          - name: Checkout your repository using git
-           uses: actions/checkout@v2
+           uses: actions/checkout@v3
          - name: Install, build, and upload your site
            uses: withastro/action@v0
             # with:

--- a/src/pages/zh-cn/guides/deploy/github.md
+++ b/src/pages/zh-cn/guides/deploy/github.md
@@ -66,7 +66,7 @@ Astro 维护了一个官方的 GitHub Action `withastro/action` 来帮助你部�
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v2          
+            uses: actions/checkout@v3
           - name: Install, build, and upload your site
             uses: withastro/action@v0
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Primarily, update the script so it reflects that users should now use actions/checkout@v3 instead of v2, which was recently merged in https://github.com/withastro/action/pull/17
- Script is now a 1:1 match with the one found in [withastro/action](https://github.com/withastro/action) repository

Thanks!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
