### PR TITLE
[content collections] added typescript settings guidance via tabs

### DIFF
--- a/src/components/tabs/TypeScriptSettingTabs.astro
+++ b/src/components/tabs/TypeScriptSettingTabs.astro
@@ -3,17 +3,17 @@ import Tabs from './Tabs';
 ---
 
 <Tabs client:visible sharedStore="typescript-settings">
-	<Fragment slot="tab.arelaxed">base ("relaxed")</Fragment>
-	<Fragment slot="tab.bstrict">strict or strictest</Fragment>
-  <Fragment slot="tab.custom">custom</Fragment>
+	<Fragment slot="tab.1.relaxed">base ("relaxed")</Fragment>
+	<Fragment slot="tab.2.strict">strict or strictest</Fragment>
+  <Fragment slot="tab.3.custom">custom</Fragment>
 
-	<Fragment slot="panel.arelaxed">
+	<Fragment slot="panel.1.relaxed">
 		<slot name="relaxed" />
 	</Fragment>
-	<Fragment slot="panel.bstrict">
+	<Fragment slot="panel.2.strict">
 		<slot name="strict" />
 	</Fragment>
-  <Fragment slot="panel.custom">
+  <Fragment slot="panel.3.custom">
 		<slot name="custom" />
 	</Fragment>
 </Tabs>

--- a/src/components/tabs/TypeScriptSettingTabs.astro
+++ b/src/components/tabs/TypeScriptSettingTabs.astro
@@ -1,0 +1,19 @@
+---
+import Tabs from './Tabs';
+---
+
+<Tabs client:visible sharedStore="typescript-settings">
+	<Fragment slot="tab.relaxed">Astro base ("relaxed")</Fragment>
+	<Fragment slot="tab.strict">Astro strict or strictest</Fragment>
+  <Fragment slot="tab.custom">A custom configuration</Fragment>
+
+	<Fragment slot="panel.relaxed">
+		<slot name="relaxed" />
+	</Fragment>
+	<Fragment slot="panel.strict">
+		<slot name="strict" />
+	</Fragment>
+  <Fragment slot="panel.custom">
+		<slot name="custom" />
+	</Fragment>
+</Tabs>

--- a/src/components/tabs/TypeScriptSettingTabs.astro
+++ b/src/components/tabs/TypeScriptSettingTabs.astro
@@ -3,14 +3,14 @@ import Tabs from './Tabs';
 ---
 
 <Tabs client:visible sharedStore="typescript-settings">
-	<Fragment slot="tab.relaxed">Astro base ("relaxed")</Fragment>
-	<Fragment slot="tab.strict">Astro strict or strictest</Fragment>
-  <Fragment slot="tab.custom">A custom configuration</Fragment>
+	<Fragment slot="tab.arelaxed">base ("relaxed")</Fragment>
+	<Fragment slot="tab.bstrict">strict or strictest</Fragment>
+  <Fragment slot="tab.custom">custom</Fragment>
 
-	<Fragment slot="panel.relaxed">
+	<Fragment slot="panel.arelaxed">
 		<slot name="relaxed" />
 	</Fragment>
-	<Fragment slot="panel.strict">
+	<Fragment slot="panel.bstrict">
 		<slot name="strict" />
 	</Fragment>
   <Fragment slot="panel.custom">

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -66,7 +66,7 @@ Follow the instructions below based on your Astro project's TypeScript configura
   ```
   </Fragment>
   <Fragment slot="custom">
-  If you have a custom TypeScript configuration that does not include `strict: true`, add`"strictNullChecks": true` under `compilerOptions` if it does not already exist.
+  If you have a custom TypeScript configuration that does not include `strict: true`, add `"strictNullChecks": true` under `compilerOptions` if it does not already exist.
 
   ```json title="tsconfig.json" ins={3}
   {

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -37,7 +37,7 @@ export default defineConfig({
 
 To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](en/guides/content-collections/#defining-a-collection-schema).
 
-Follow the instructions below based on your Astro project's TypeScript configuration.
+To enable the setting necessary for schemas, follow the instructions below based on your Astro project's current [TypeScript configuration](/en/guides/typescript/#setup). 
 
 <TypeScriptSettingTabs>
   <Fragment slot="relaxed">

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -41,7 +41,7 @@ To benefit from the full TypeScript and autocompletion features of [using schema
   <Fragment slot="relaxed">
   If you are extending Astro's `base` TypeScript config (e.g. you chose "relaxed" TypeScript when creating your project with `create astro`), add `"strictNullChecks": true` under `compilerOptions`.
   
-  Or, you can change your `base` TypeScript setting to `strict` or `strictest` to use TypeScript's features throughout your entire Astro project.
+  Or, you can change your `base` TypeScript config to `strict` or `strictest` to use a broader set of stricter type-checks in your project.
 
   ```json title="tsconfig.json" ins={3-5} "base"
   {

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -39,7 +39,7 @@ To benefit from the full TypeScript and autocompletion features of [using schema
 
 <TypeScriptSettingTabs>
   <Fragment slot="relaxed">
-  If you are using Astro's `base` setting (e.g. you set up your project with "relaxed" TypeScript), add `"strictNullChecks": true` under `compilerOptions`. 
+  If you are extending Astro's `base` TypeScript config (e.g. you chose "relaxed" TypeScript when creating your project with `create astro`), add `"strictNullChecks": true` under `compilerOptions`.
   
   Or, you can change your `base` TypeScript setting to `strict` or `strictest` to use TypeScript's features throughout your entire Astro project.
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -35,7 +35,7 @@ export default defineConfig({
 
 ### Update TypeScript configuration
 
-To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. This is optional, but recommended.
+To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](en/guides/content-collections/#defining-a-collection-schema).
 
 Follow the instructions below based on your Astro project's TypeScript configuration.
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -66,7 +66,7 @@ Follow the instructions below based on your Astro project's TypeScript configura
   ```
   </Fragment>
   <Fragment slot="custom">
-  If you have a custom TypeScript configuration, add`"strictNullChecks": true` under `compilerOptions` if it does not already exist.
+  If you have a custom TypeScript configuration that does not include `strict: true`, add`"strictNullChecks": true` under `compilerOptions` if it does not already exist.
 
   ```json title="tsconfig.json" ins={3}
   {

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -35,7 +35,7 @@ export default defineConfig({
 
 ### Update TypeScript configuration
 
-To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](en/guides/content-collections/#defining-a-collection-schema).
+To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](/en/guides/content-collections/#defining-a-collection-schema).
 
 To enable the setting necessary for schemas, follow the instructions below based on your Astro project's current [TypeScript configuration](/en/guides/typescript/#setup). 
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -6,6 +6,7 @@ i18nReady: false
 setup: |
   import FileTree from '~/components/FileTree.astro'
   import Since from '~/components/Since.astro'
+  import TypeScriptSettingTabs from '~/components/tabs/TypeScriptSettingTabs.astro'
 ---
 
 <p>
@@ -32,15 +33,52 @@ export default defineConfig({
 });
 ```
 
-You will also need to update `tsconfig.json`. Add `"strictNullChecks": true` under `compilerOptions`.
+### Update TypeScript configuration
 
-```json title="tsconfig.json" ins={3}
-{
-  "compilerOptions": {
-    "strictNullChecks": true
+To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. This is optional, but recommended.
+
+Follow the instructions below based on your Astro project's TypeScript configuration.
+
+<TypeScriptSettingTabs>
+  <Fragment slot="relaxed">
+  If you are using Astro's `base` setting (e.g. you set up your project with "relaxed" TypeScript), add `"strictNullChecks": true` under `compilerOptions`. 
+  
+  Or, you can change your `base` TypeScript setting to `strict` or `strictest` to use TypeScript's features throughout your entire Astro project.
+
+  ```json title="tsconfig.json" ins={3-5} "base"
+  {
+    "extends": "astro/tsconfigs/base"
+    "compilerOptions": {
+      "strictNullChecks": true
+    }
   }
-}
-```
+  ```
+  </Fragment>
+  <Fragment slot="strict">
+  No update necessary! 
+  
+  `"strictNullChecks": true` is already enabled in your `strict` or `strictest` configuration.
+
+  ```json title="tsconfig.json" "strict" "strictest"
+  {
+    "extends": "astro/tsconfigs/strict" // or `strictest`
+  }
+  ```
+  </Fragment>
+  <Fragment slot="custom">
+  If you have a custom TypeScript configuration, add`"strictNullChecks": true` under `compilerOptions` if it does not already exist.
+
+  ```json title="tsconfig.json" ins={3}
+  {
+    "compilerOptions": {
+      "strictNullChecks": true
+    }
+  }
+  ```
+  </Fragment>
+</TypeScriptSettingTabs>
+
+
 
 ## The content directory
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -35,9 +35,7 @@ export default defineConfig({
 
 ### Update TypeScript configuration
 
-To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](#defining-a-collection-schema).
-
-To enable the setting necessary for schemas, follow the instructions below based on your Astro project's current [TypeScript configuration](/en/guides/typescript/#setup). 
+To benefit from the full TypeScript and autocompletion features of [using schemas with your collections](#defining-a-collection-schema), you may also need to update `tsconfig.json`. Follow the instructions below based on your Astro project's current [TypeScript configuration](/en/guides/typescript/#setup). 
 
 <TypeScriptSettingTabs>
   <Fragment slot="relaxed">

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -35,7 +35,7 @@ export default defineConfig({
 
 ### Update TypeScript configuration
 
-To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](/en/guides/content-collections/#defining-a-collection-schema).
+To benefit from the full TypeScript and autocompletion features of content collections, you may also need to update `tsconfig.json`. Proper TypeScript configuration is required to [use schemas with your collections](#defining-a-collection-schema).
 
 To enable the setting necessary for schemas, follow the instructions below based on your Astro project's current [TypeScript configuration](/en/guides/typescript/#setup). 
 


### PR DESCRIPTION
- New or updated content

Choose your own TypeScript adventure!

Added more specific advice for configuring TypeScript based on one's current Astro project's existing `tsconfig`. For example, the existing guidance to add `strictNullChecks: true` wasn't applicable if a project was already using Astro's `strict` or `strictest` setting.

Also includes a new tab component, but not in the order I want?  😅  PR'ing to get help correcting the tab order, and so we can work on the wording!

Deploy preview: https://deploy-preview-2209--astro-docs-2.netlify.app/en/guides/content-collections/ 



