### PR TITLE
Fix highlight regex for `CollectionEntry` code example

### DIFF
--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -253,7 +253,7 @@ const blogPosts = await getCollection('blog', ({ data }) => {
 
 If a page or component uses content from a `getCollection()` or `getEntry()` query, you can use the `CollectionEntry` utility to type its props:
 
-```astro /CollectionEntry([<.+>])?/
+```astro /CollectionEntry(?:<.+>)?/
 ---
 // src/components/BlogCard.astro
 import type { CollectionEntry } from 'astro:content';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

Old: 
<img width="490" alt="image" src="https://user-images.githubusercontent.com/74938858/208539379-a41880ed-31e7-4690-8351-edb6e4489172.png">
New:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/74938858/208540433-c32c8d62-d40a-42a6-9846-123d403b92ed.png">

#### Description

Fixes a broken code highlight regex.

I'm not sure what exactly the cause of the issue was - it might have been a typo (the square brackets), or depending on how the code that tests the regex works, it might have been the use of a capturing group instead of a non-capturing group (a group that starts with `?:`).

