### PR TITLE
Document custom slugs for content collection entries

### DIFF
--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -173,7 +173,11 @@ You can use all of Zod’s properties and methods with content schemas. This inc
 
 ### Custom entry slugs
 
-By default, Astro will generate a `slug` for each content entry based on its file path. If you want to generate custom slugs for each entry, you can provide a `slug()` function in `defineCollection()`. A custom `slug()` function will be passed the entry ID, default slug, parsed frontmatter (as `data`), and the raw body of the entry.
+By default, Astro will generate a `slug` for each content entry based on its file path.
+
+If you want to generate custom slugs for each entry, you can provide a `slug()` function in `defineCollection()`. Your `slug()` function can use the entry ID, default slug, parsed frontmatter (as `data`), and the raw body of the entry to generate the slug.
+
+For example, to use a frontmatter `permalink` property as the slug for your blog pages instead of the file path, you can use the following `slug()` function. For extra safety, conditionally return the entry's `defaultSlug` as a fallback.
 
 ```ts {5-9}
 // src/content/config.ts

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -80,7 +80,13 @@ For example, you can use this structure for internationalization:
     - ...
 </FileTree>
 
-## Defining a collection schema
+## Configuring collections
+
+You can configure your content collections with an optional `src/content/config.ts` file (`.js` and `.mjs` extensions are also supported). 
+
+This file currently allows you to [define a collection schema](#defining-a-collection-schema), and to [create custom slugs]((#custom-entry-slugs)) for your collections.
+
+### Defining a collection schema
 
 Schemas are an optional way to enforce frontmatter types in a collection. Astro uses [Zod](https://github.com/colinhacks/zod) to validate your frontmatter with schemas in the form of [Zod objects](https://github.com/colinhacks/zod#objects).
 
@@ -120,7 +126,7 @@ export const collections = {
 };
 ```
 
-### Schema data types with Zod
+#### Schema data types with Zod
 
 Markdown and MDX frontmatter can contain booleans, strings, numbers, objects, and arrays. When defining a schema, you must include every frontmatter property along with its data type. To define and validate this schema, we use a library called [Zod](https://github.com/colinhacks/zod), which is available via the `z` import.
 
@@ -148,7 +154,7 @@ defineCollection({
 })
 ```
 
-### Advanced schema features
+#### Advanced schema features
 
 You can use all of Zod’s properties and methods with content schemas. This includes transforming a frontmatter value into another value, checking the shape of string values with built-in regexes, and more.
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -165,7 +165,7 @@ You can use all of Zod’s properties and methods with content schemas. This inc
 
 📚 See [Zod’s documentation](https://github.com/colinhacks/zod) for a complete list of features.
 
-### Customizing collection slugs
+### Custom entry slugs
 
 By default, Astro will generate a `slug` for each content entry based on its file path. If you want to generate custom slugs for each entry, you can provide a `slug()` function in `defineCollection()`. A custom `slug()` function will be passed the entry ID, default slug, parsed frontmatter (as `data`), and the raw body of the entry.
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -175,7 +175,7 @@ import { defineCollection } from 'astro:content';
 
 const blog = defineCollection({
   slug: ({ id, defaultSlug, data, body }) => {
-    // If set, use `permalink` from the entry’s frontmatter as the slug.
+    // Use `permalink` from the entry’s frontmatter as the slug, if it exists.
     // Otherwise, fall back to the default slug.
     return data.permalink || defaultSlug;
   },

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -84,7 +84,7 @@ For example, you can use this structure for internationalization:
 
 You can configure your content collections with an optional `src/content/config.ts` file (`.js` and `.mjs` extensions are also supported). 
 
-This file currently allows you to [define a collection schema](#defining-a-collection-schema), and to [create custom slugs]((#custom-entry-slugs)) for your collections.
+This file currently allows you to [define a collection schema](#defining-a-collection-schema), and to [create custom slugs](#custom-entry-slugs) for your collections.
 
 ### Defining a collection schema
 

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -165,6 +165,28 @@ You can use all of Zod’s properties and methods with content schemas. This inc
 
 📚 See [Zod’s documentation](https://github.com/colinhacks/zod) for a complete list of features.
 
+### Customizing collection slugs
+
+By default, Astro will generate a `slug` for each content entry based on its file path. If you want to generate custom slugs for each entry, you can provide a `slug()` function in `defineCollection()`. A custom `slug()` function will be passed the entry ID, default slug, parsed frontmatter (as `data`), and the raw body of the entry.
+
+```ts {5-9}
+// src/content/config.ts
+import { defineCollection } from 'astro:content';
+
+const blog = defineCollection({
+  slug: ({ id, defaultSlug, data, body }) => {
+    // If set, use `permalink` from the entry’s frontmatter as the slug.
+    // Otherwise, fall back to the default slug.
+    return data.permalink || defaultSlug;
+  },
+  schema: {
+    permalink: z.string().optional(),
+  },
+});
+
+export const collections = { blog };
+```
+
 ## Querying content collections
 
 Astro provides two functions to query collections:

--- a/src/pages/en/guides/content-collections.md
+++ b/src/pages/en/guides/content-collections.md
@@ -171,7 +171,7 @@ By default, Astro will generate a `slug` for each content entry based on its fil
 
 ```ts {5-9}
 // src/content/config.ts
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
   slug: ({ id, defaultSlug, data, body }) => {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->


- New or updated content

#### Description

- Documents that you can provide a function to customize how slugs are generated for each entry in a content collection.
- [Relevant RFC section for reference](https://github.com/withastro/rfcs/blob/main/proposals/0027-content-collections.md#custom-slugs)

Deploy preview: https://deploy-preview-2214--astro-docs-2.netlify.app/en/guides/content-collections/#custom-entry-slugs

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
