### PR TITLE
fix: misaligned code block diff markings in the tutorial

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/3.md
+++ b/src/pages/en/tutorial/5-astro-api/3.md
@@ -262,7 +262,7 @@ Follow the steps below, then check your work by comparing it to the [final code 
 
 1. Copy the `<div class="tags">`... `</div>` and `<style>...</style>` from `src/pages/tags/index.astro` and reuse it inside `MarkdownLayoutPost.astro`: 
 
-  ```astro title="src/layouts/MarkdownPostLayout.astro" ins={14-18, 22-41}
+  ```astro title="src/layouts/MarkdownPostLayout.astro" ins={13-17, 21-40}
   ---
   import BaseLayout from './BaseLayout.astro';
   const { frontmatter } = Astro.props;


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes the misaligned code block diff markings to cover the entirety of `div` and `style` tags in unit 5 section 3 of the tutorial:
https://docs.astro.build/en/tutorial/5-astro-api/3/#challenge-include-tags-in-your-blog-post-layout

_Before_:
<img src="https://user-images.githubusercontent.com/45052145/209032447-91b241bb-11d4-4486-a3db-760d0722ad90.png" width=50% height=50%>

_After_:
<img src="https://user-images.githubusercontent.com/45052145/209032456-dfc502df-5a62-411f-a314-cae1dedbff68.png" width=50% height=50%>
