### PR TITLE
i18n(es): add multiple error pages

### DIFF
--- a/src/pages/es/reference/errors/config-legacy-key.md
+++ b/src/pages/es/reference/errors/config-legacy-key.md
@@ -1,0 +1,23 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Legacy configuration detected
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ConfigLegacyKey**: Configuración antigua detectada: `LEGACY_CONFIG_KEY`. (E07002)
+
+## ¿Qué salió mal?
+
+Astro detectó una opción de configuración antigua en tu archivo de configuración.
+
+**Ver también:**
+
+-  [Referencia de configuración](/es/reference/configuration-reference/)
+-  [Guía de migración](/es/migrate/)
+

--- a/src/pages/es/reference/errors/config-not-found.md
+++ b/src/pages/es/reference/errors/config-not-found.md
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Specified configuration file not found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ConfigNotFound**: No se puede resolver `--config "CONFIG_FILE"`. ¿Existe este archivo? (E07001)
+
+## ¿Qué salió mal?
+
+No se pudo encontrar el archivo de configuración especificado usando `--config`. Asegúrate que este existe o que la ruta es correcta.
+
+**Ver también:**
+
+-  [--config](/es/reference/cli-reference/#--config-path)
+

--- a/src/pages/es/reference/errors/csssyntax-error.md
+++ b/src/pages/es/reference/errors/csssyntax-error.md
@@ -1,0 +1,21 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: CSS Syntax Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Ejemplos de mensajes de error:**<br/>
+CSSSyntaxError: Missed semicolon<br/>
+CSSSyntaxError: Unclosed string<br/> (E05001)
+
+## ¿Qué salió mal?
+
+Astro encontró un error al analizar el CSS debido a un error de sintaxis. Esto a menudo es causado por la falta de un punto y coma.
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Translated content

#### Description

- add `reference/errors/config-legacy-key.md`
- add `reference/errors/config-not-found.md`
- add `reference/errors/csssyntax-error.md`

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
