### PR TITLE
fix: capitalize the P in WordPress

### DIFF
--- a/src/pages/en/guides/cms/wordpress.md
+++ b/src/pages/en/guides/cms/wordpress.md
@@ -185,7 +185,7 @@ To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow 
 ## Community Resources 
 
 - [Building An Astro Website With WordPress As A Headless CMS](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/) by Chris Bongers.
-- [Building with Astro x Wordpress](https://www.youtube.com/watch?v=Jstqgklvfnc) on Ben Holmes's stream.
+- [Building with Astro x WordPress](https://www.youtube.com/watch?v=Jstqgklvfnc) on Ben Holmes's stream.
 - [Building a Headless WordPress Site with Astro](https://developers.wpengine.com/blog/building-a-headless-wordpress-site-with-astro) by Jeff Everhart
 
 ## Production Sites

--- a/src/pages/es/concepts/mpa-vs-spa.md
+++ b/src/pages/es/concepts/mpa-vs-spa.md
@@ -9,7 +9,7 @@ Comprender los beneficios de elegir entre la arquitectura de Aplicación de múl
 
 ## Terminología
 
-**Una Aplicación de múltiples páginas (MPA)** es un sitio web que consta de varias páginas HTML, en su mayoría renderizadas en el servidor. Cuando navegas a una nueva página, tu navegador solicita una nueva página de HTML al servidor. **Astro es un framework MPA.** Los frameworks MPA tradicionales también incluyen Ruby on Rails, Python Django, PHP Laravel, Wordpress, Joomla, Drupal y creadores de sitios estáticos como Eleventy o Hugo.
+**Una Aplicación de múltiples páginas (MPA)** es un sitio web que consta de varias páginas HTML, en su mayoría renderizadas en el servidor. Cuando navegas a una nueva página, tu navegador solicita una nueva página de HTML al servidor. **Astro es un framework MPA.** Los frameworks MPA tradicionales también incluyen Ruby on Rails, Python Django, PHP Laravel, WordPress, Joomla, Drupal y creadores de sitios estáticos como Eleventy o Hugo.
 
 **Una Aplicación de una sola página (SPA)** es un sitio web que consta de una sola aplicación de JavaScript que se carga en el navegador del usuario y luego muestra HTML localmente. Los SPA **también** pueden generar HTML en el servidor, pero los SPA son únicos en su capacidad de ejecutar tu sitio web como una aplicación de JavaScript dentro del navegador para renderizar modificaciones en el HTML a medida que navegas. Next.js, Nuxt, SvelteKit, Remix, Gatsby y Create React App son todos ejemplos de frameworks SPA.
 

--- a/src/pages/fr/concepts/mpa-vs-spa.md
+++ b/src/pages/fr/concepts/mpa-vs-spa.md
@@ -9,7 +9,7 @@ Il est essentiel de comprendre les compromis entre l'architecture d'une applicat
 
 ## Terminologie
 
-**Une application multi-pages (AMP)** est un site web composé de plusieurs pages HTML, dont la plupart sont rendues sur un serveur. Lorsque vous naviguez vers une nouvelle page, votre navigateur demande une nouvelle page de HTML au serveur. **Les cadres traditionnels d'AMP comprennent également Ruby on Rails, Python Django, PHP Laravel, Wordpress, Joomla, Drupal et les constructeurs de sites statiques comme Eleventy ou Hugo.
+**Une application multi-pages (AMP)** est un site web composé de plusieurs pages HTML, dont la plupart sont rendues sur un serveur. Lorsque vous naviguez vers une nouvelle page, votre navigateur demande une nouvelle page de HTML au serveur. **Les cadres traditionnels d'AMP comprennent également Ruby on Rails, Python Django, PHP Laravel, WordPress, Joomla, Drupal et les constructeurs de sites statiques comme Eleventy ou Hugo.
 
 **Une application monopage (SPA)** est un site Web composé d'une seule application JavaScript qui se charge dans le navigateur de l'utilisateur et rend ensuite le HTML localement. Les SPA peuvent *également* générer du HTML sur le serveur, mais les SPA sont uniques dans leur capacité à exécuter votre site Web en tant qu'application JavaScript dans le navigateur pour rendre une nouvelle page de HTML lorsque vous naviguez. Next.js, Nuxt, SvelteKit, Remix, Gatsby et Create React App sont tous des exemples de frameworks SPA.
 
@@ -70,4 +70,3 @@ Si vous connaissez une migration publique ou un benchmark et que vous ne le voye
 ## Ressources supplémentaires
 
 Si vous souhaitez en savoir plus, Surma (Google) et Jake Archibald (Google) ont enregistré un excellent échange de vues [sur ce sujet précis](https://www.youtube.com/watch?v=ivLhf3hq7eM).
-

--- a/src/pages/pt-br/integrations/integrations.md
+++ b/src/pages/pt-br/integrations/integrations.md
@@ -47,7 +47,7 @@ Apesar das descrições abaixo estarem traduzidas, o conteúdo dos links é em I
 
 [Learn With Jason](https://youtube.com/watch?v=FJOJmKFngLI) - **Vídeo**: Construindo um carrinho de compras customizado com Astro e a API Storefront da Shopify
 
-[Chris Bongers](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms) - **Postagem**: Construindo um site Astro com Wordpress como Headless CMS
+[Chris Bongers](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms) - **Postagem**: Construindo um site Astro com WordPress como Headless CMS
 
 [Front End Horse](https://www.youtube.com/watch?v=qFUfuDSLdxM) - **Vídeo**: Desenvolvendo com Astro & Prismic
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes

#### Description

Properly [capitalize](https://developer.wordpress.org/reference/functions/capital_p_dangit/
) the "p" in WordPress.
