### PR TITLE
Add i18n for screen reader section labels

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,9 +9,12 @@ import { astroAsides } from './integrations/astro-asides';
 import { astroCodeSnippets } from './integrations/astro-code-snippets';
 import { astroSpoilers } from './integrations/astro-spoilers';
 import { sitemap } from './integrations/sitemap';
+import { rehypei18nAutolinkHeadings } from './plugins/rehype-i18n-autolink-headings';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
 import { remarkFallbackLang } from './plugins/remark-fallback-lang';
 import { backgroundPrimary, foregroundPrimary, tokens } from './syntax-highlighting-theme';
+
+import { useTranslationsFromString } from "./src/i18n/util";
 
 const AnchorLinkIcon = h(
 	'svg',
@@ -30,7 +33,8 @@ const AnchorLinkIcon = h(
 );
 
 const createSROnlyLabel = (text: string) => {
-	const node = h('span.sr-only', `Section titled ${escape(text)}`);
+	const t = useTranslationsFromString("en");
+	const node = h('span.sr-only', `${t("a11y.sectionLink")} ${escape(text)}`);
 	node.properties!['is:raw'] = true;
 	return node;
 };
@@ -94,6 +98,8 @@ export default defineConfig({
 			],
 			// Tweak GFM task list syntax
 			rehypeTasklistEnhancer(),
+			// Translates the autolink headings anchors
+			rehypei18nAutolinkHeadings(),
 		],
 	},
 });

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,7 +14,7 @@ import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
 import { remarkFallbackLang } from './plugins/remark-fallback-lang';
 import { backgroundPrimary, foregroundPrimary, tokens } from './syntax-highlighting-theme';
 
-import { useTranslationsFromString } from "./src/i18n/util";
+import { useTranslationsForLang } from "./src/i18n/util";
 
 const AnchorLinkIcon = h(
 	'svg',
@@ -33,7 +33,7 @@ const AnchorLinkIcon = h(
 );
 
 const createSROnlyLabel = (text: string) => {
-	const t = useTranslationsFromString("en");
+	const t = useTranslationsForLang("en");
 	const node = h('span.sr-only', `${t("a11y.sectionLink")} ${escape(text)}`);
 	node.properties!['is:raw'] = true;
 	return node;

--- a/plugins/rehype-i18n-autolink-headings.ts
+++ b/plugins/rehype-i18n-autolink-headings.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import type { Root } from 'hast';
+import type { Transformer } from 'unified';
+import { visit } from 'unist-util-visit';
+
+import { mdFilePathToUrl, getLanguageCodeFromPathname } from './remark-fallback-lang';
+import { useTranslationsFromString } from '../src/i18n/util';
+import type { UILanguageKeys } from '../src/i18n/translation-checkers';
+
+/**
+ * Rehype plugin to translate the headings' anchors according to the currently selected language.
+ */
+export function rehypei18nAutolinkHeadings() {
+	const pageSourceDir = path.resolve('./src/pages');
+	const baseUrl = 'https://docs.astro.build/';
+
+	const transformer: Transformer<Root> = (tree, file) => {
+		const pageUrl = mdFilePathToUrl(file.path, pageSourceDir, baseUrl);
+		const pageLang = getLanguageCodeFromPathname(pageUrl.pathname);
+		const englishText = useTranslationsFromString('en')('a11y.sectionLink') as string;
+
+		// Find anchor links
+		visit(tree, 'element', (node) => {
+			if (node.tagName === 'a' && node.properties?.class === 'anchor-link') {
+
+				// Find a11y text labels
+				visit(node, 'text', (text) => {
+						const heading = text.value.replace(englishText, '');
+						const t = useTranslationsFromString(pageLang as UILanguageKeys);
+						const title = t('a11y.sectionLink') || englishText;
+
+						text.value = title + heading;
+				});
+			}
+		});
+	};
+
+	return function attacher() {
+		return transformer;
+	};
+}

--- a/plugins/rehype-i18n-autolink-headings.ts
+++ b/plugins/rehype-i18n-autolink-headings.ts
@@ -4,7 +4,7 @@ import type { Transformer } from 'unified';
 import { visit } from 'unist-util-visit';
 
 import { mdFilePathToUrl, getLanguageCodeFromPathname } from './remark-fallback-lang';
-import { useTranslationsFromString } from '../src/i18n/util';
+import { useTranslationsForLang } from '../src/i18n/util';
 import type { UILanguageKeys } from '../src/i18n/translation-checkers';
 
 /**
@@ -17,7 +17,7 @@ export function rehypei18nAutolinkHeadings() {
 	const transformer: Transformer<Root> = (tree, file) => {
 		const pageUrl = mdFilePathToUrl(file.path, pageSourceDir, baseUrl);
 		const pageLang = getLanguageCodeFromPathname(pageUrl.pathname);
-		const englishText = useTranslationsFromString('en')('a11y.sectionLink') as string;
+		const englishText = useTranslationsForLang('en')('a11y.sectionLink');
 
 		// Find anchor links
 		visit(tree, 'element', (node) => {
@@ -25,8 +25,8 @@ export function rehypei18nAutolinkHeadings() {
 
 				// Find a11y text labels
 				visit(node, 'text', (text) => {
-						const heading = text.value.replace(englishText, '');
-						const t = useTranslationsFromString(pageLang as UILanguageKeys);
+						const heading = text.value.replace(englishText!, '');
+						const t = useTranslationsForLang(pageLang as UILanguageKeys);
 						const title = t('a11y.sectionLink') || englishText;
 
 						text.value = title + heading;

--- a/plugins/remark-fallback-lang.ts
+++ b/plugins/remark-fallback-lang.ts
@@ -41,14 +41,14 @@ export function remarkFallbackLang(): Plugin<[], Root> {
 	};
 }
 
-function mdFilePathToUrl(mdFilePath: string, pageSourceDir: string, baseUrl: string) {
+export function mdFilePathToUrl(mdFilePath: string, pageSourceDir: string, baseUrl: string) {
 	const pathBelowRoot = path.relative(pageSourceDir, mdFilePath);
 	const pathname = pathBelowRoot.replace(/\\/g, '/').replace(/\.md$/i, '/');
 
 	return new URL(pathname, baseUrl);
 }
 
-function getLanguageCodeFromPathname(pathname: string) {
+export function getLanguageCodeFromPathname(pathname: string) {
 	// Assuming that `pathname` always starts with a `/`, retrieve the first path part,
 	// which is usually the language code
 	const firstPathPart = pathname.split('/')[1];

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -1,5 +1,6 @@
 export default {
 	'a11y.skipLink': 'Skip to Content',
+	'a11y.sectionLink': 'Section titled',
 	'navbar.a11yTitle': 'Top',
 	// Site settings
 	'site.title': 'Astro Documentation',

--- a/src/i18n/pt-br/ui.ts
+++ b/src/i18n/pt-br/ui.ts
@@ -2,6 +2,7 @@ import { UIDictionary } from '../translation-checkers';
 
 export default UIDictionary({
 	'a11y.skipLink': 'Pular para o Conteúdo',
+	'a11y.sectionLink': 'Seção intitulada',
 	'navbar.a11yTitle': 'Superior',
 	'site.title': 'Documentação do Astro',
 	'site.description': 'Construa websites mais rápidos com menos Javascript no lado do cliente.',

--- a/src/i18n/translation-checkers.ts
+++ b/src/i18n/translation-checkers.ts
@@ -1,9 +1,11 @@
 import type { ModalTranslations } from '@docsearch/react';
 import enNav from './en/nav';
 import type enUI from './en/ui';
+import languages from './languages';
 
 export type UIDictionaryKeys = keyof typeof enUI;
 export type UIDict = Partial<typeof enUI>;
+export type UILanguageKeys = keyof typeof languages;
 
 /** Helper to type check a dictionary of UI string translations. */
 export const UIDictionary = (dict: Partial<typeof enUI>) => dict;

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -98,14 +98,10 @@ export function useTranslations(
 	Astro: Readonly<AstroGlobal>
 ): (key: UIDictionaryKeys) => string | undefined {
 	const lang = getLanguageFromURL(Astro.url.pathname) || 'en';
-	return function getTranslation(key: UIDictionaryKeys) {
-		const str = translations[lang]?.[key] || translations[fallbackLang][key];
-		if (str === undefined) console.error(`Missing translation for “${key}” in “${lang}”.`);
-		return str;
-	};
+	return useTranslationsForLang(lang as UILanguageKeys);
 }
 
-export function useTranslationsFromString(
+export function useTranslationsForLang(
 	lang: UILanguageKeys
 ): (key: UIDictionaryKeys) => string | undefined {
 	return function getTranslation(key: UIDictionaryKeys) {

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -1,7 +1,7 @@
 import type { AstroGlobal } from 'astro';
 import { readdir } from 'node:fs/promises';
 import { getLanguageFromURL } from '../util';
-import { DocSearchTranslation, NavDict, UIDict, UIDictionaryKeys } from './translation-checkers';
+import { DocSearchTranslation, NavDict, UIDict, UIDictionaryKeys, UILanguageKeys } from './translation-checkers';
 
 /**
  * Convert the map of modules returned by `import.meta.globEager` to an object
@@ -98,6 +98,16 @@ export function useTranslations(
 	Astro: Readonly<AstroGlobal>
 ): (key: UIDictionaryKeys) => string | undefined {
 	const lang = getLanguageFromURL(Astro.url.pathname) || 'en';
+	return function getTranslation(key: UIDictionaryKeys) {
+		const str = translations[lang]?.[key] || translations[fallbackLang][key];
+		if (str === undefined) console.error(`Missing translation for “${key}” in “${lang}”.`);
+		return str;
+	};
+}
+
+export function useTranslationsFromString(
+	lang: UILanguageKeys
+): (key: UIDictionaryKeys) => string | undefined {
 	return function getTranslation(key: UIDictionaryKeys) {
 		const str = translations[lang]?.[key] || translations[fallbackLang][key];
 		if (str === undefined) console.error(`Missing translation for “${key}” in “${lang}”.`);


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content
- Changes to the docs site code

#### Description

- Closes #1586 

This PR adds a new rehype plugin to translate the screen reader anchor labels injected by `rehype-autolink-headings`. If the current language doesn't have a translation yet, it will fallback to English.

| PT-BR (translated)  | ES (fallback) |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/209818306-455fcc49-ea36-477f-bfed-8296bb707084.png) | ![image](https://user-images.githubusercontent.com/61414485/209818386-eb7c836b-4892-42ce-b330-19fa1fad0d24.png) |
