### PR TITLE
Fix out-of-memory Netlify deploys for external contributors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm build"
+  command = "NODE_OPTIONS=--max_old_space_size=4096 pnpm build"
   ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- /"
 
   [[redirects]]


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

To solve out-of-memory issues when building docs we set a `NODE_OPTIONS` environment variable in Netlify’s dashboard to increase the default memory limit. This worked fine in internal tests because those of us trying it out are included in the Netlify team. Now that external contributors are triggering deploys, Netlify is not using the environment variable for those builds because it considers all environment variables as “sensitive” (which some are, like our GitHub API key). Without `NODE_OPTIONS` the build fails (see #2251 for example).

This fix moves where we set the variable directly into the build command specified in `netlify.toml`. I would expect Netlify to then use `NODE_OPTIONS` correctly for all PRs.