### PR TITLE
[troubleshooting] remove suggested workaround re: executing inline scripts

### DIFF
--- a/src/pages/en/guides/troubleshooting.mdx
+++ b/src/pages/en/guides/troubleshooting.mdx
@@ -54,22 +54,7 @@ You may see the following error logged in the browser console:
 
 This means that your site’s [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) disallows running inline `<script>` tags, which Astro outputs by default.
 
-**Solution:** To work around this, you can force Astro to bundle all styles and scripts into external assets using the [`vite.build.assetsInlineLimit`](https://vitejs.dev/config/build-options.html#build-assetsinlinelimit) setting in `astro.config.mjs`.
-
-```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-
-export default defineConfig({
-  vite: {
-    build: {
-      assetsInlineLimit: 0,
-    },
-  },
-});
-```
-
-Alternatively, you can update your CSP to include `script-src: 'unsafe-inline'` to allow inline scripts to run.
+**Solution:** Update your CSP to include `script-src: 'unsafe-inline'` to allow inline scripts to run.
 
 ## Common gotchas
 


### PR DESCRIPTION
- New or updated content

Closes #2150 (The documentation issue; the greater conversation is ongoing elsewhere.)

As per @delucis suggestion and @matthewp approval, removes a problematic workaround that does not work in every case, and instead just leaves the suggestion to update your CSP.

(Note: eventually error messages will make their way to the Error Reference page. But, at least this removes potentially harmful advice for now.)