### PR TITLE
Move `src/content/config.ts` to `content.config.ts`

### DIFF
--- a/src/pages/en/guides/content-collections.mdx
+++ b/src/pages/en/guides/content-collections.mdx
@@ -121,7 +121,7 @@ For example, you can use this structure for internationalization:
 
 ## Configuring collections
 
-You can configure your content collections with an optional `src/content/config.ts` file (`.js` and `.mjs` extensions are also supported). 
+You can configure your content collections with an optional `content.config.ts` file. 
 
 This file currently allows you to [define a collection schema](#defining-a-collection-schema), and to [create custom slugs](#custom-entry-slugs) for your collections.
 
@@ -129,7 +129,7 @@ This file currently allows you to [define a collection schema](#defining-a-colle
 
 Schemas are an optional way to enforce frontmatter types in a collection. Astro uses [Zod](https://github.com/colinhacks/zod) to validate your frontmatter with schemas in the form of [Zod objects](https://github.com/colinhacks/zod#objects).
 
-To configure schemas, create a `src/content/config.ts` file (`.js` and `.mjs` extensions are also supported). This file should:
+To configure schemas, create a `content.config.ts` file at the base of your project. This file should:
 
 1. Import the `defineCollection` and `z` utilities from `astro:content`. 
 2. Define a `schema` for each collection.
@@ -140,7 +140,7 @@ For example, say you maintain two collections: one for release announcements and
 You can specify each expected property in the `schema` field of `defineCollection`:
 
 ```ts
-// src/content/config.ts
+// content.config.ts
 import { z, defineCollection } from 'astro:content';
 
 const releases = defineCollection({
@@ -219,7 +219,7 @@ If you want to generate custom slugs for each entry, you can provide a `slug()` 
 For example, to use a frontmatter `permalink` property as the slug for your blog pages instead of the file path, you can use the following `slug()` function. For extra safety, conditionally return the entry's `defaultSlug` as a fallback.
 
 ```ts {5-9}
-// src/content/config.ts
+// content.config.ts
 import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Move `src/content/config.ts` to a `content.config.ts` at the base of your project. [See the Astro core PR](https://github.com/withastro/astro/pull/5698) to understand the change!
- Remove callout that `.js` and `.mjs` are supported. This requires added `tsconfig` changes in order to work, and it feels premature to recommend this.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
