### PR TITLE
Fix a typo in "About this Tutorial" page: a URL to the GitHub repo

### DIFF
--- a/src/pages/en/tutorial/0-introduction/1.mdx
+++ b/src/pages/en/tutorial/0-introduction/1.mdx
@@ -43,7 +43,7 @@ Hop into the support forum channel to ask questions, or say hi and chat in `#gen
 <details>
 <summary>Where can I leave feedback about this tutorial?</summary>
 
-This tutorial is a project of our Docs team. You can find us on Discord in the `#docs` channel, or file issues to the [Docs repo on GitHub](https://github.com/withastro/astro/docs/issues). 
+This tutorial is a project of our Docs team. You can find us on Discord in the `#docs` channel, or file issues to the [Docs repo on GitHub](https://github.com/withastro/docs/issues). 
 </details>
 
 <Box icon="check-list">


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Fix a typo in "About this Tutorial" page: a URL to the GitHub repo
  - before: https://github.com/withastro/astro/docs/issues (404)
  - after: https://github.com/withastro/docs/issues