### PR TITLE
Align left edge of Tabs and TabGroup

### DIFF
--- a/src/components/TabGroup/InstallGuideTabGroup.astro
+++ b/src/components/TabGroup/InstallGuideTabGroup.astro
@@ -8,7 +8,7 @@ const lang = getLanguageFromURL(currentPage);
 const segments = currentPage.split('/');
 ---
 
-<div class="TabGroup no-flex pull-wide">
+<div class="TabGroup no-flex">
 	<a href={`/${lang}/install/auto/`} class={segments.includes('auto') ? 'active' : ''}>
 		<UIString key="install.autoTab" />
 	</a>

--- a/src/components/TabGroup/TabGroup.css
+++ b/src/components/TabGroup/TabGroup.css
@@ -45,8 +45,3 @@
 .TabGroup.no-flex a {
 	flex: 0;
 }
-
-/* Align tab text with block edges. */
-.TabGroup.pull-wide {
-	margin-inline-start: -1rem;
-}

--- a/src/components/tabs/Tabs.module.css
+++ b/src/components/tabs/Tabs.module.css
@@ -4,7 +4,6 @@
 }
 
 .tab-scroll-overflow {
-	margin-inline-start: -1rem;
 	overflow-x: scroll;
 	/* Hide scrollbar on firefox */
 	scrollbar-width: none;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Tweaks the design of the Tabs and TabGroup components to align their left edge.
  - Sorry if this was intentional😅, but only the left side of the Tabs component was outside of the container, which was a bit odd to me, so I created this PR to fix that.
  - (Update) Found that TabGroup had the same style, so I updated it as well for consistency.
  - This may be a PR based on my personal preference, so feel free to close it if it is inappropriate🙏

##### Mobile view

Tabs

| Before | After |
| --- | --- |
| ![mobile-before](https://user-images.githubusercontent.com/7889778/210168598-8fdf1edb-8b26-441b-b948-0da9c1f3b920.png) | ![mobile-after](https://user-images.githubusercontent.com/7889778/210168611-419065b2-0eb8-4d00-80dd-b4dbe20595b1.png) |

TabGroup

| Before | After |
| --- | --- |
| ![mobile-before](https://user-images.githubusercontent.com/7889778/210242308-ff2b25dc-3665-439e-ad94-24dd495718f2.png) | ![mobile-after](https://user-images.githubusercontent.com/7889778/210242345-038e10c1-e729-469f-9359-c3a22116d7d5.png) |

##### Desktop view

Tabs

| Before | After |
| --- | --- |
| ![desktop-before](https://user-images.githubusercontent.com/7889778/210168736-9b7286a2-09de-4e9a-9cd4-60df9de97753.png) | ![desktop-after](https://user-images.githubusercontent.com/7889778/210168751-78b7791b-ad85-408f-9b0b-71728ba9818e.png) |

TabGroup

| Before | After |
| --- | --- |
| ![desktop-before](https://user-images.githubusercontent.com/7889778/210243549-435242bb-3df0-46fd-96b6-c1ed74795f05.png) | ![desktop-after](https://user-images.githubusercontent.com/7889778/210243573-1c7b3056-4a53-435f-b5d2-57360b6b1fca.png) |

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
