### PR TITLE
chore: change mention of Nuxt's framework from React to Vue

### DIFF
--- a/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -26,7 +26,7 @@ Nuxt and Astro share some similarities that will help you migrate your project:
 
 When you rebuild your Nuxt site in Astro, you will notice some important differences:
 
-- [MPA vs SPA](/en/concepts/mpa-vs-spa/): Nuxt is a React-based SPA (single-page application). Astro sites are multi-page apps built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
+- [MPA vs SPA](/en/concepts/mpa-vs-spa/): Nuxt is a Vue-based SPA (single-page application). Astro sites are multi-page apps built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 
 - [Page Routing](/en/core-concepts/astro-pages/#file-based-routing): Nuxt uses `vue-router` for SPA routing, and `vue-meta` for managing `<head>`. In Astro, you will create separate HTML page routes and control your page `<head>` directly, or in a layout component.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.

This PR changes a mention of React in the Nuxt guide to more accurately say "Vue", since Nuxt is the Vue meta-framework.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
