### PR TITLE
Fix categorisation of error reference pages for Algolia

### DIFF
--- a/src/util/getPageCategory.ts
+++ b/src/util/getPageCategory.ts
@@ -1,11 +1,15 @@
 // TODO: Move this data to our i18n system to support localized category labels.
 const defaultCategory = 'Learn';
+
+// Order is important here. Pages are tested to see if they *start* with one of
+// these paths and will return early when one matches. This means more specific
+// paths need to be earlier in the array, e.g. `reference/errors/` before `reference/`.
 const categories = [
-	['tutorial/', 'Tutorials'],
-	['reference/', 'Reference'],
 	['guides/deploy/', 'Deploy Guides'],
 	['guides/integrations-guide/', 'Integration Guides'],
 	['reference/errors/', 'Error Reference'],
+	['reference/', 'Reference'],
+	['tutorial/', 'Tutorials'],
 ] as const;
 
 /**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

Addresses some recent poor search results reported in #2042 

We add a hidden element to pages that Algolia picks up and uses to extract that page’s category, e.g.

```html
<span id="docsearch-lvl0" hidden>Learn</span>
```

Due to a bug in our category utility, we were categorising error reference pages as “Reference”. This PR fixes that so that these pages now contain:

```html
<span id="docsearch-lvl0" hidden>Error Reference</span>
```

Will still need to reevaluate these search terms (`getStaticPaths` and `slots` are current known issues) once this is live to see if the “Error Reference” category needs demoting in Algolia’s crawler logic.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
