### PR TITLE
Fix: remove `pages` from quick reference

### DIFF
--- a/src/pages/en/reference/integrations-reference.mdx
+++ b/src/pages/en/reference/integrations-reference.mdx
@@ -42,7 +42,7 @@ interface AstroIntegration {
     }) => void | Promise<void>;
     'astro:build:generated'?: (options: { dir: URL }) => void | Promise<void>;
     'astro:build:ssr'?: (options: { manifest: SerializedSSRManifest }) => void | Promise<void>;
-    'astro:build:done'?: (options: { pages: { pathname: string }[]; dir: URL; routes: RouteData[] }) => void | Promise<void>;
+    'astro:build:done'?: (options: { dir: URL; routes: RouteData[] }) => void | Promise<void>;
   };
 }
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

`pages` is undocumented in the [`astro:build:done` hook reference](https://docs.astro.build/en/reference/integrations-reference/#astrobuilddone). This is being officially removed for Astro 2.0, so let's update the quick reference to match!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
