### PR TITLE
[tutorial] quick fixes from Hippo feedback

### DIFF
--- a/src/pages/en/tutorial/0-introduction/1.mdx
+++ b/src/pages/en/tutorial/0-introduction/1.mdx
@@ -21,13 +21,15 @@ You check them off!
 
 At the end of each page, you'll find a clickable checklist of tasks you should now be able to do. Check these items off to see your progress in the Tutorial Tracker.
 
+Using the tracker is optional, but it can help you remember your place if you complete the tutorial over multiple visits. You can also leave some checklists blank as a reminder of units that you want to revisit later.
+
 (This data is only saved to your browser's local storage, and is not available elsewhere. No data is sent to, nor stored by Astro.)
 </details>
 
 <details>
 <summary>Unit 1 is things I already know how to do. Can I skip it?</summary>
 
-You can use [Unit 1](/en/tutorial/1-setup/) to make sure you have the development tools and online accounts you'll need to complete the tutorial. It will walk you through creating a new Astro project, storing it on GitHub and deploying to Netlify.
+You can use the lessons inside [Unit 1](/en/tutorial/1-setup/) to make sure you have the development tools and online accounts you'll need to complete the tutorial. It will walk you through creating a new Astro project, storing it on GitHub and deploying to Netlify.
 
 If you [create a new, empty Astro project](/en/install/auto/) and are comfortable with your setup, you can safely skip ahead to [Unit 2](/en/tutorial/2-pages/) where you will start making new pages in your project.
 </details>

--- a/src/pages/en/tutorial/1-setup/2.mdx
+++ b/src/pages/en/tutorial/1-setup/2.mdx
@@ -119,7 +119,7 @@ Your project files contain all the code necessary to display an Astro website, b
 
 1. Click on the `localhost` link in your terminal window to see a live preview of your new Astro website! 
 
-    (Astro uses `https://localhost:3000` by default if port 3000 is available.)
+    (Astro uses `http://localhost:3000` by default if port 3000 is available.)
 
     Here's what the Astro "Empty Project" starter website should look like in the browser preview:
 

--- a/src/pages/en/tutorial/1-setup/4.mdx
+++ b/src/pages/en/tutorial/1-setup/4.mdx
@@ -37,10 +37,10 @@ Although there are a few ways to get your local code stored in GitHub, this tuto
 
 ## Commit your local code to GitHub
 
-In the last section, you made a change to your page's content. This means that your project files have changed, and VS Code should show a number on top of the "Source" menu icon. This source tab is where you will regularly go to update your files on GitHub. 
+In the last section, you made a change to your page's content. This means that your project files have changed, and VS Code should show a number on top of the "Source" menu icon. This source tab is where you will regularly go to update your files on GitHub.
 
 
-1. Click the Source Control tab in your VS Code to see a list of files that have changed. 
+1. Click the Source Control tab in your VS Code to see a list of files that have changed. If you see a message that you need to install `git`, follow the instructions provided, then reload VS Code.
 
 2. Click the <kbd>•••</kbd> "3 dots" menu above the commit message and choose <kbd>Remote</kbd> > <kbd>Add Remote</kbd>.
 

--- a/src/pages/en/tutorial/1-setup/index.mdx
+++ b/src/pages/en/tutorial/1-setup/index.mdx
@@ -57,7 +57,7 @@ In this unit, you will **create a new project** that is **stored online in GitHu
 
 As you write code, you will periodically commit your changes to GitHub. Netlify will use the files in your GitHub repository to build your website, and then publish it on the internet at a unique address where anyone can view it.
 
-Netlify will continuously monitor your GitHub repository for any committed changes, and will rebuild and republish your site to reflect those changes.
+Every time you commit a change to GitHub, a notification will be sent to Netlify. Then, Netlify will automatically rebuild and republish your live site to reflect those changes.
 
 
 

--- a/src/pages/en/tutorial/2-pages/1.mdx
+++ b/src/pages/en/tutorial/2-pages/1.mdx
@@ -31,7 +31,7 @@ Now that you know that `.astro` files are responsible for pages on your website,
     Your editor might show a solid white circle on the tab label for this file. This means that the file is not yet saved. Under the File menu in VS Code, enable "Auto Save" and you should no longer need to save any files manually.
     :::
 
-4. Add `/about` to the end of your website preview's URL in the address bar and check that you can see a page load there. (e.g. `https://localhost:3000/about`)
+4. Add `/about` to the end of your website preview's URL in the address bar and check that you can see a page load there. (e.g. `http://localhost:3000/about`)
 
 Right now, your "About" page should look exactly the same as the first page, but we're going to change that!
 


### PR DESCRIPTION
- Minor content fixes (broken links, typos, etc.)

This applies the "quick wins" feedback from @hippotastic after taking the tutorial.

Specifically:
- Fixes `localhost:3000` to no longer be `https:` 
- Gives a little more context re: WHY you might want to use the checklists/tutorial tracker.
- Correctly states the cause/effect of the GitHub/Netlify deployment relationship
- Minimally refers to "lessons" inside of "Unit 1" since, as Hippo points out, we use numbers for both Units and pages inside units. This provides at least a vocab early on to distinguish. (*Not sure I'm entirely happy yet, since Unit 0 is not named as such, so Hippo's totally right, when you're IN Unit 0, you only see a 0 and a 1 for those current lesson pages. You don't know that you aren't IN unit 1 when you're on Unit 0-lesson 1.*)

- Does NOT address the "on the first page, I completed the checkbox and "Build a blog" was marked completed. So, where's my blog??" totally valid comment!  :sweat_smile: This turned out to ***not*** be a "quick win" because with our infrastruture, the title of the page is the item that's checked off. As our main landing/index page, we WANT a generic "Build a blog!" statement. But, agreed that it might look strange to see "build a blog" marked as completed. 