### PR TITLE
Fix integrations absolute links and changelog generation errors

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -170,7 +170,11 @@ function absoluteLinks({ base }: { base: string }) {
 		function visitor(node: Link | Definition) {
 			// Sanitize URL by removing leading `/`
 			const relativeUrl = node.url.replace(/^.?\//, '');
-			node.url = new URL(relativeUrl, base).href;
+			// Don't add absolute path to local and docs links.
+			node.url =
+				node.url.startsWith('#') || node.url.startsWith('/')
+					? node.url
+					: new URL(relativeUrl, base).href;
 		}
 		visit(tree, 'link', visitor);
 		visit(tree, 'definition', visitor);
@@ -262,7 +266,7 @@ function removeTOC() {
 			const firstItemContent = node.children[0].children[0];
 			if (firstItemContent.type !== 'paragraph') return;
 			return firstItemContent.children.some(
-				(child) => child.type === 'link' && child.url.startsWith('#why')
+				(child) => child.type === 'link' && (child.url.startsWith('#why') || child.url.startsWith('#installation'))
 			);
 		});
 	};

--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -171,10 +171,7 @@ function absoluteLinks({ base }: { base: string }) {
 			// Sanitize URL by removing leading `/`
 			const relativeUrl = node.url.replace(/^.?\//, '');
 			// Don't add absolute path to local and docs links.
-			node.url =
-				node.url.startsWith('#') || node.url.startsWith('/')
-					? node.url
-					: new URL(relativeUrl, base).href;
+			node.url = node.url.startsWith('#') ? node.url : new URL(relativeUrl, base).href;
 		}
 		visit(tree, 'link', visitor);
 		visit(tree, 'definition', visitor);

--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -170,7 +170,7 @@ function absoluteLinks({ base }: { base: string }) {
 		function visitor(node: Link | Definition) {
 			// Sanitize URL by removing leading `/`
 			const relativeUrl = node.url.replace(/^.?\//, '');
-			// Don't add absolute path to local and docs links.
+			// Don't add absolute path to local links.
 			node.url = node.url.startsWith('#') ? node.url : new URL(relativeUrl, base).href;
 		}
 		visit(tree, 'link', visitor);

--- a/src/pages/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/pages/en/guides/integrations-guide/alpinejs.mdx
@@ -23,14 +23,6 @@ import DontEditWarning from '../../../../components/DontEditWarning.astro';
 
 This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinejs.dev/) to your project so that you can use Alpine.js anywhere on your page.
 
-*   <strong>[Installation](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#installation)</strong>
-*   <strong>[Usage](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#usage)</strong>
-*   <strong>[Configuration](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#configuration)</strong>
-*   <strong>[Examples](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#examples)</strong>
-*   <strong>[Troubleshooting](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#troubleshooting)</strong>
-*   <strong>[Contributing](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#contributing)</strong>
-*   <strong>[Changelog](https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/#changelog)</strong>
-
 ## Installation
 
 ### Quick Install

--- a/src/pages/en/guides/integrations-guide/image.mdx
+++ b/src/pages/en/guides/integrations-guide/image.mdx
@@ -255,7 +255,7 @@ A `number` can also be provided, useful when the aspect ratio is calculated at b
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 The background color is used to fill the remaining background when using `contain` for the `fit` property.
 
@@ -278,7 +278,7 @@ color representation with 3 or 6 hexadecimal characters in the form `#123[abc]`,
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 How the image should be resized to fit both `height` and `width`.
 
@@ -291,7 +291,7 @@ How the image should be resized to fit both `height` and `width`.
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 Position of the crop when fit is `cover` or `contain`.
 
@@ -399,7 +399,7 @@ For remote images, the original image format is unknown. If not provided, only `
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 The background color to use for replacing the alpha channel with `sharp`'s `flatten` method. In case the output format
 doesn't support transparency (i.e. `jpeg`), it's advisable to include a background color, otherwise black will be used
@@ -420,7 +420,7 @@ color representation with 3 or 6 hexadecimal characters in the form `#123[abc]`,
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 How the image should be resized to fit both `height` and `width`.
 
@@ -435,7 +435,7 @@ How the image should be resized to fit both `height` and `width`.
 
 </p>
 
-> This is not supported by the default Squoosh service. See the [installation section](https://github.com/withastro/astro/tree/main/packages/integrations/image/#installing-sharp-optional) for details on using the `sharp` service instead.
+> This is not supported by the default Squoosh service. See the [installation section](#installing-sharp-optional) for details on using the `sharp` service instead.
 
 Position of the crop when fit is `cover` or `contain`.
 

--- a/src/pages/en/guides/integrations-guide/mdx.mdx
+++ b/src/pages/en/guides/integrations-guide/mdx.mdx
@@ -78,7 +78,7 @@ export default defineConfig({
 
 ## Usage
 
-With the Astro MDX integration, you can [add MDX pages to your project](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](/en/guides/markdown-content/#importing-markdown) into `.astro` files.
+With the Astro MDX integration, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](/en/guides/markdown-content/#importing-markdown) into `.astro` files.
 
 Astro's MDX integration adds extra features to standard MDX, including Markdown-style frontmatter. This allows you to use most of Astro's built-in Markdown features like a [special frontmatter `layout` property](/en/guides/markdown-content/#frontmatter-layout) and a [property for marking a page as a draft](/en/guides/markdown-content/#draft-pages).
 
@@ -92,13 +92,13 @@ Once the MDX integration is installed, no configuration is necessary to use `.md
 
 You can configure how your MDX is rendered with the following options:
 
-*   [Options inherited from Markdown config](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#options-inherited-from-markdown-config)
-*   [`extendMarkdownConfig`](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendmarkdownconfig)
-*   [`recmaPlugins`](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#recmaplugins)
+*   [Options inherited from Markdown config](#options-inherited-from-markdown-config)
+*   [`extendMarkdownConfig`](#extendmarkdownconfig)
+*   [`recmaPlugins`](#recmaplugins)
 
 ### Options inherited from Markdown config
 
-All [`markdown` configuration options](/en/reference/configuration-reference/#markdown-options) except `drafts` can be configured separately in the MDX integration. This includes remark and rehype plugins, syntax highlighting, and more. Options will default to those in your Markdown config ([see the `extendMarkdownConfig` option](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/#extendmarkdownconfig) to modify this).
+All [`markdown` configuration options](/en/reference/configuration-reference/#markdown-options) except `drafts` can be configured separately in the MDX integration. This includes remark and rehype plugins, syntax highlighting, and more. Options will default to those in your Markdown config ([see the `extendMarkdownConfig` option](#extendmarkdownconfig) to modify this).
 
 :::note
 There is no separate MDX configuration for [including pages marked as draft in the build](/en/reference/configuration-reference/#markdowndrafts). This Markdown setting will be respected by both Markdown and MDX files and cannot be overriden for MDX files specifically.
@@ -210,6 +210,6 @@ This package is maintained by Astro's Core team. You're welcome to submit an iss
 
 See [CHANGELOG.md](https://github.com/withastro/astro/tree/main/packages/integrations/mdx/CHANGELOG.md) for a history of changes to this integration.
 
-[astro-integration]: https://github.com/withastro/astro/tree/main/packages/integrations/mdx/en/guides/integrations-guide/
+[astro-integration]: /en/guides/integrations-guide/
 
-[astro-ui-frameworks]: https://github.com/withastro/astro/tree/main/packages/integrations/mdx/en/core-concepts/framework-components/#using-framework-components
+[astro-ui-frameworks]: /en/core-concepts/framework-components/#using-framework-components


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description

Lots of links to other docs pages and local links (those starting with `#`) were being wrongly prepended by the `absoluteLinks` remark plugin. I couldn't find a reason as to why the `absoluteLinks` remark plugin exists in the first place, taking a look at #954, I guess it was fixing something related to Markdown footnotes (maybe we can remove it?). Changed a line to make it ignore the links I didn't want it to change, but perhaps this can cause another problem. - I did some tests and couldn't find any broken links from the change in the remark plugin.

Additionally, I found out the Alpine.js integration changelog wasn't being deleted, so I made a small change to ensure its deletion as well.