### PR TITLE
Ignore commits containing `i18nIgnore` in i18n status tracker

### DIFF
--- a/scripts/github-translation-status.mjs
+++ b/scripts/github-translation-status.mjs
@@ -323,7 +323,7 @@ class GitHubTranslationStatus {
 		// usually do not require translations to be updated
 		const lastMajorCommit =
 			gitLog.all.find((logEntry) => {
-				return !logEntry.message.match(/(en-only|typo|broken link|i18nReady)/i);
+				return !logEntry.message.match(/(en-only|typo|broken link|i18nReady|i18nIgnore)/i);
 			}) || lastCommit;
 
 		return {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
- Something else!

#### Description

Adds a new keyword for ignoring commits in our i18n status tracker: commits containing `i18nIgnore` will be now also be ignored. Allows us to stop abusing other keywords like `typo` or `en-only`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
