### PR TITLE
[i18nIgnore] Delete outdated content with broken link in es/ja

### DIFF
--- a/src/pages/es/guides/markdown-content.mdx
+++ b/src/pages/es/guides/markdown-content.mdx
@@ -430,14 +430,6 @@ Astro es compatible con plugins externos de [remark](https://github.com/remarkjs
 
 ¡Te invitamos a darle un vistazo a las listas [awesome-remark](https://github.com/remarkjs/awesome-remark) y [awesome-rehype](https://github.com/rehypejs/awesome-rehype) para ver más plugins populares! Puedes leer sus README para seguir las instrucciones de instalación de cada uno.
 
-:::tip
-Cuando agregas tus propios plugins, los plugins predeterminados de Astro son removidos. Puedes mantener los agregados por defecto usando la [flag `markdown.extendDefaultPlugins`](/es/reference/configuration-reference/#markdownextenddefaultplugins).
-:::
-
-De forma predeterminada, la intregración de MDX de Astro hereda todos los plugins de rehype y remark de tus opciones de configuración de `markdown` de Astro. Para alterar este comportamiento, configura [`extendPlugins`](/es/guides/integrations-guide/mdx/#extendplugins) en tu integración `mdx`.
-
-Cualquier plugin adicional que apliques en tu configuración de MDX serán aplicados *luego* de tus plugins de Markdown configurados y solamente se aplicarán a archivos `.mdx`.
-
 En este ejemplo aplicamos los plugins [remark-toc](https://github.com/remarkjs/remark-toc) a Markdown *y* MDX, y [rehype-accessible-emojis](https://www.npmjs.com/package/rehype-accessible-emojis) a MDX únicamente, mientras preservamos los plugins predeterminados de Astro:
 
 ```js title="astro.config.mjs"

--- a/src/pages/ja/guides/markdown-content.mdx
+++ b/src/pages/ja/guides/markdown-content.mdx
@@ -432,16 +432,6 @@ Astroは、MarkdownおよびMDXのためのサードパーティの[remark](http
 
 人気のあるプラグインは[awesome-remark](https://github.com/remarkjs/awesome-remark)と[awesome-rehype](https://github.com/rehypejs/awesome-rehype)を参照するのがおすすめです。具体的なインストール方法については、各プラグインのREADMEをご覧ください。
 
-:::tip
-独自のプラグインを追加する場合、Astroのデフォルトプラグインは削除されます。[`markdown.extendDefaultPlugins` フラグ](/ja/reference/configuration-reference/#マークダウンのオプション)でこれらのデフォルトを維持できます。
-{/* TODO: リファレンスページが更新されたら /ja/reference/configuration-reference/#markdownextenddefaultplugins にリンク先を更新する */}
-:::
-
-
-デフォルトでは、AstroのMDXインテグレーションは、Astro設定の`markdown`オプションからすべてのremarkとrehypeのプラグインを継承します。この動作を変更するには、`mdx`インテグレーションで[`extendPlugins`](/ja/guides/integrations-guide/mdx/#extendplugins)を設定します。
-
-MDXの設定で適用する追加のプラグインは、設定されたMarkdownプラグインの**後に**適用され、`.mdx`ファイルのみに適用されます。
-
 この例では、Astroのデフォルトプラグインを維持したまま、MarkdownとMDXに[`remark-toc`](https://github.com/remarkjs/remark-toc)を適用し、MDXのみに[`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis)を適用しています。
 
 ```js title="astro.config.mjs"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Spanish & Japanese translations of the Markdown content include text linking to a MDX subheading which no longer exists.

These paragraphs were wholesale removed here: https://github.com/withastro/docs/pull/2280/files#diff-5aa3990791d164a679ef35f083c2cc0e6afb3d4b007445fba1ee0d5adf9df89dL434-L442

So I think we can do the same here, fixing the broken link, but using the new `i18nIgnore` keyword to avoid marking these pages as updated as they do still need some work.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
