### PR TITLE
[tutorial] remove backticks inside spoiler text

### DIFF
--- a/src/pages/en/tutorial/2-pages/5.mdx
+++ b/src/pages/en/tutorial/2-pages/5.mdx
@@ -112,15 +112,15 @@ Your About page is now styled using *both* the imported `global.css` file *and* 
 
 - Are there any conflicting styles, and if so, which are applied?
 
-    || Yes, `h1` has a size of `2.5rem` globally, but `4rem` locally in the `<style>` tag. The local `4rem` rule is applied on the About page. ||
+    || Yes, h1 has a size of 2.5rem globally, but 4rem locally in the <style> tag. The local 4rem rule is applied on the About page. ||
 
 - Describe how `global.css` and `<style>` work together.
 
-    || When conflicting styles are defined both globally and in a page's local `<style>` tag, the local styles should overwrite any global styles. (But, there can be other factors involved, so always visually inspect your site to make sure your styles are properly applied!)  ||
+    || When conflicting styles are defined both globally and in a page's local <style> tag, the local styles should overwrite any global styles. (But, there can be other factors involved, so always visually inspect your site to make sure your styles are properly applied!)  ||
 
 - How would you choose whether to declare a style in a `global.css` file or a `<style>` tag?
 
-    || If you want a style to be applied site-wide, you would choose to use a `global.css` file. However, if you want styles to apply to only the HTML content in a single `.astro` file, and not affect other elements on your site, you would choose a `<style>` tag. ||
+    || If you want a style to be applied site-wide, you would choose to use a global.css file. However, if you want styles to apply to only the HTML content in a single Astro file, and not affect other elements on your site, you would choose a <style> tag. ||
 
 </Box>
 


### PR DESCRIPTION
Quick fix because `code styling` doesn't seem to work inside our spoiler text for Analyze the Pattern in our tutorial.

![spoiler](https://user-images.githubusercontent.com/5098874/210905252-aeb73636-5f6c-4d40-ad26-005cb6d86cc8.png)

Without backticks:
![spoilerfix](https://user-images.githubusercontent.com/5098874/210906017-0ae471b9-da3e-4933-8855-6855116d0dca.png)

