### PR TITLE
[i18nIgnore] Prep to remove `astroFlavoredMarkdown` in reference

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -153,5 +153,4 @@ This will bring up a "patchfile" containing all of the information about the com
 
 Currently there are dependencies installed that are not directly used, but should not be removed:
 
-- `github-slugger`: Required for `legacy.astroFlavoredMarkdown: true`
 - `canvaskit-wasm`: Dependency of `astro-og-canvas` which doesn't bundle well as it uses `__dirname` that doesn't exist in ESM. Install as direct dependency so it can be imported by Astro's intermediary SSR build process.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint": "^8.29.0",
     "eslint-plugin-astro": "^0.21.0",
     "fast-glob": "^3.2.11",
-    "github-slugger": "^1.5.0",
     "gray-matter": "^4.0.3",
     "hast-util-from-html": "^1.0.0",
     "hast-util-to-string": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,6 @@ specifiers:
   eslint: ^8.29.0
   eslint-plugin-astro: ^0.21.0
   fast-glob: ^3.2.11
-  github-slugger: ^1.5.0
   gray-matter: ^4.0.3
   hast-util-from-html: ^1.0.0
   hast-util-to-string: ^2.0.0
@@ -113,7 +112,6 @@ devDependencies:
   eslint: 8.29.0
   eslint-plugin-astro: 0.21.0_eslint@8.29.0
   fast-glob: 3.2.11
-  github-slugger: 1.5.0
   gray-matter: 4.0.3
   hast-util-from-html: 1.0.0
   hast-util-to-string: 2.0.0

--- a/src/pages/en/migrate.mdx
+++ b/src/pages/en/migrate.mdx
@@ -2,7 +2,7 @@
 layout: ~/layouts/MainLayout.astro
 title: Migration Guide
 description: How to migrate your project to latest version of Astro.
-i18nReady: true
+i18nReady: false
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 

--- a/src/pages/en/migrate.mdx
+++ b/src/pages/en/migrate.mdx
@@ -153,7 +153,7 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
     ```
 
 :::tip
-While you are transitioning to MDX, you may wish to enable the `legacy.astroFlavoredMarkdown` flag and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
+While you are transitioning to MDX, you may wish to enable the `legacy.astroFlavoredMarkdown` flag (removed in v2.0) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
 
 ```astro
 ---

--- a/src/pages/en/migrate.mdx
+++ b/src/pages/en/migrate.mdx
@@ -95,7 +95,7 @@ When upgrading, please visually inspect your site output to make sure everything
 
 Astro no longer supports components or JSX expressions in Markdown pages by default. For long-term support you should migrate to the [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration.
 
-To make migrating easier, a new [legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) can be used to re-enable previous Markdown features.
+To make migrating easier, a new `legacy.astroFlavoredMarkdown` flag can be used to re-enable previous Markdown features.
 
 ### Converting existing `.md` files to `.mdx`
 
@@ -153,7 +153,7 @@ If you're not familiar with MDX, here are some steps you can follow to quickly c
     ```
 
 :::tip
-While you are transitioning to MDX, you may wish to [enable the legacy flag](/en/reference/configuration-reference/#legacyastroflavoredmarkdown) and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
+While you are transitioning to MDX, you may wish to enable the `legacy.astroFlavoredMarkdown` flag and include both **`.md` and `.mdx`** files, so that your site continues to function normally even before all your files have been converted. Here is one way you can do that:
 
 ```astro
 ---

--- a/src/pages/en/migrate.mdx
+++ b/src/pages/en/migrate.mdx
@@ -95,7 +95,7 @@ When upgrading, please visually inspect your site output to make sure everything
 
 Astro no longer supports components or JSX expressions in Markdown pages by default. For long-term support you should migrate to the [`@astrojs/mdx`](/en/guides/integrations-guide/mdx/) integration.
 
-To make migrating easier, a new `legacy.astroFlavoredMarkdown` flag can be used to re-enable previous Markdown features.
+To make migrating easier, a new `legacy.astroFlavoredMarkdown` flag (removed in v2.0) can be used to re-enable previous Markdown features.
 
 ### Converting existing `.md` files to `.mdx`
 

--- a/src/pages/ru/guides/markdown-content.mdx
+++ b/src/pages/ru/guides/markdown-content.mdx
@@ -257,7 +257,7 @@ Astro v1.0 **поддерживает только стандартный Markdo
 Возможность использовать [компоненты или JSX в Markdown страницах более не включен по умолчанию](/ru/migrate/#deprecated-components-and-jsx-in-markdown)
 и поддержка в конечном итоге будет полностью удалена. 
 
-Конфиг Astro поддерживает [устаревший флаг](/ru/reference/configuration-reference/#legacyastroflavoredmarkdown), который
+Конфиг Astro поддерживает устаревший флаг `legacy.astroFlavoredMarkdown`, который
 повторно включит эти функции на страницах Markdown, пока вы не сможете перейти на MDX в Astro.
 Интеграция MDX в Astro - рекомендуемый вариант, если вам нужно больше возможностей, чем предоставляет стандартный Markdown.
 :::
@@ -366,7 +366,7 @@ If you plan to use `rawContent` for calculating values like "reading time," we s
 Только сам документ markdown будет возвращен в формате HTML.
 
 :::caution
-**[Для пользователей `legacy.astroFlavoredMarkdown`](/ru/reference/configuration-reference/#legacyastroflavoredmarkdown):** 
+**Для пользователей `legacy.astroFlavoredMarkdown`:** 
 Это не парсит `{jsx выражения}` или `<Components />`.
 Только стандартные Markdown блоки, такие как `## headings` и `- lists`, будут спарсены в HTML.
 :::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Removes links to the AFMD config entry in the `/en/` migration guide.
- Mark the migration guide as `i18nReady: false` — we’ll change this once the v1 -> v2 guide replaces this
- Removes links to the AFMD config entry in the `/ru/` Markdown Content guide.
- Uninstalls a direct dependency `MAINTAINERS.md` said was only needed for AFMD and updated that note

Does _not_ change Spanish, Portuguese, French, and Chinese pages as these should not cause any broken links. I think it’s safe to leave these as is until they get a proper refresh.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
