### PR TITLE
Fix typo in markdown-content.mdx

### DIFF
--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -584,7 +584,7 @@ The following example disables GitHub-Flavored Markdown and applies a different 
 
 ```ts
 // astro.config.mjs
-import { defineConfig } froAm 'astro/config';
+import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({


### PR DESCRIPTION
Minor content fixes (broken links, typos, etc.)
