### PR TITLE
Re-revert "Consistent installation title"

### DIFF
--- a/src/pages/en/install/auto.mdx
+++ b/src/pages/en/install/auto.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install Astro with the Automatic CLI
+title: Installation (Automatic CLI)
 description: 'How to install Astro with NPM, PNPM, or Yarn via the create-astro CLI tool.'
 layout: ~/layouts/MainLayout.astro
 i18nReady: true

--- a/src/pages/en/install/auto.mdx
+++ b/src/pages/en/install/auto.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation (Automatic CLI)
+title: Install Astro with the Automatic CLI
 description: 'How to install Astro with NPM, PNPM, or Yarn via the create-astro CLI tool.'
 layout: ~/layouts/MainLayout.astro
 i18nReady: true

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation (Manual Setup)
+title: Install Astro with manual setup
 description: 'How to install Astro manually with NPM, PNPM, or Yarn.'
 layout: ~/layouts/MainLayout.astro
 i18nReady: true

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install Astro manually
+title: Installation (Manual Setup)
 description: 'How to install Astro manually with NPM, PNPM, or Yarn.'
 layout: ~/layouts/MainLayout.astro
 i18nReady: true


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

My second shot at this PR, for context see #2262 and #2265 

The titles now are:
- Installation (Automatic CLI)
- Installation (Manual Setup)

I am using the tab names, so it should still be consistent, they also have around the same breakpoint so the line amount should match on most screen sizes

cc @delucis, let me know if this works for you

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
