### PR TITLE
[tutorial] Fix code sample typo in 5-3

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/3.mdx
+++ b/src/pages/en/tutorial/5-astro-api/3.mdx
@@ -276,7 +276,7 @@ Follow the steps below, then check your work by comparing it to the [final code 
 
     <p>Written by: {frontmatter.author}</p>
 
-    <img src={frontmatter.postImage} width="300" alt={frontmatter.image.alt} /> 
+    <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} /> 
 
     <div class="tags">
       {tags.map((tag) => (


### PR DESCRIPTION
`BlogPostLayout.astro` included `src={frontmater.postImage}`. Corrected to `src={frontmatter.image.url}`