### PR TITLE
[tutorial] remove unnecessary {}

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/2.mdx
+++ b/src/pages/en/tutorial/5-astro-api/2.mdx
@@ -67,7 +67,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
-    export async function getStaticPaths({ }) {
+    export async function getStaticPaths() {
       const allPosts = await Astro.glob('../posts/*.md');
 
       return [
@@ -177,7 +177,7 @@ Add the following code to provide you with a list of every tag used in your blog
   ---
   import BaseLayout from '../../layouts/BaseLayout.astro';
 
-  export async function getStaticPaths({ }) {
+  export async function getStaticPaths() {
     const allPosts = await Astro.glob('../posts/*.md');
 
     const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];


### PR DESCRIPTION
Removes some empty `{ }` from `getStaticPaths()` function in a couple of places.