### PR TITLE
Fix dynamic redirect route

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,7 +3,7 @@ import type { MarkdownInstance } from 'astro';
 
 export async function getStaticPaths() {
 	// get english pages that moved from `/` to `/en/`
-	const englishPages = await Astro.glob<MarkdownInstance<{}>>('./en/**.{md,mdx}');
+	const englishPages = await Astro.glob<MarkdownInstance<{}>>('./en/**/*.{md,mdx}');
 
 	return englishPages.map((page) => ({
 		params: {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

While updating an `Astro.glob()` call as part of #2133, I messed up one of the patterns so that a dynamic route we use to redirect from routes like `/reference/configuration-reference` to `/en/reference/configuration-reference` wasn’t working properly. Noticed it today after spotting an increase in docs 404s since #2133 merged. This PR fixes the glob pattern.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
