### PR TITLE
[Content collections] `z.object` wrapper for schemas

### DIFF
--- a/src/pages/en/guides/content-collections.mdx
+++ b/src/pages/en/guides/content-collections.mdx
@@ -198,14 +198,12 @@ defineCollection({
 You can use all of Zod’s properties and methods with content schemas. This includes transforming a frontmatter value into another value, checking the shape of string values with built-in regexes, and more.
 
 ```ts
-{
-  // Allow only strings representing email addresses
-  authorContact: z.string().email(),
-  // Allow URL strings only (e.g. `https://example.com`)
-  canonicalURL: z.string().url(),
-  // Parse publishDate as a browser-standard `Date` object
-  publishDate: z.string().transform(str => new Date(str)),
-}
+// Allow only strings representing email addresses
+authorContact: z.string().email(),
+// Allow URL strings only (e.g. `https://example.com`)
+canonicalURL: z.string().url(),
+// Parse publishDate as a browser-standard `Date` object
+publishDate: z.string().transform(str => new Date(str)),
 ```
 
 📚 See [Zod’s documentation](https://github.com/colinhacks/zod) for a complete list of features.

--- a/src/pages/en/guides/content-collections.mdx
+++ b/src/pages/en/guides/content-collections.mdx
@@ -144,18 +144,18 @@ You can specify each expected property in the `schema` field of `defineCollectio
 import { z, defineCollection } from 'astro:content';
 
 const releases = defineCollection({
-  schema: {
+  schema: z.object({
     title: z.string(),
     version: z.number(),
-  },
+  }),
 });
 
 const engineeringBlog = defineCollection({
-  schema: {
+  schema: z.object({
     title: z.string(),
     tags: z.array(z.string()),
     image: z.string().optional(),
-  },
+  }),
 });
 
 export const collections = {
@@ -177,7 +177,7 @@ The following schema illustrates each of these data types in use:
 import { z, defineCollection } from 'astro:content';
 
 defineCollection({
-  schema: {
+  schema: z.object({
     isDraft: z.boolean(),
     title: z.string(),
     sortOrder: z.number(),
@@ -189,7 +189,7 @@ defineCollection({
     footnote: z.string().optional(),
     author: z.string().default('Anonymous'),
     language: z.enum(['en', 'es']),
-  }
+  })
 })
 ```
 
@@ -228,9 +228,9 @@ const blog = defineCollection({
     // Otherwise, fall back to the default slug.
     return data.permalink || defaultSlug;
   },
-  schema: {
+  schema: z.object({
     permalink: z.string().optional(),
-  },
+  }),
 });
 
 export const collections = { blog };

--- a/src/pages/en/guides/content-collections.mdx
+++ b/src/pages/en/guides/content-collections.mdx
@@ -137,7 +137,7 @@ To configure schemas, create a `src/content/config.ts` file (`.js` and `.mjs` ex
 
 For example, say you maintain two collections: one for release announcements and one for blog content. Your entries at `src/content/releases/` should include a `title` and `version`.  Your `src/content/engineering-blog/` collection entries should have a `title`, list of `tags`, and an optional `image` URL. 
 
-You can specify each expected property in the `schema` field of `defineCollection`:
+You can specify the expected shape of your frontmatter with the `schema` field of `defineCollection`:
 
 ```ts
 // src/content/config.ts

--- a/src/pages/en/reference/api-reference.mdx
+++ b/src/pages/en/reference/api-reference.mdx
@@ -718,10 +718,10 @@ Content collections offer APIs to configure and query your Markdown or MDX docum
 // src/content/config.ts
 import { z, defineCollection } from 'astro:content';
 const blog = defineCollection({
-  schema: {
+  schema: z.object({
     title: z.string(),
     permalink: z.string().optional(),
-  },
+  }),
   slug({ id, data, defaultSlug, body }) {
     return data.permalink ?? defaultSlug;
   }
@@ -736,9 +736,9 @@ This function accepts the following properties:
 
 #### `schema`
 
-**Type:** `TSchema extends ZodAnyObject | undefined`
+**Type:** `TSchema extends ZodType`
 
-`schema` is an optional object to configure the type and shape of document frontmatter for a collection. Each object value must use [a Zod validator](https://github.com/colinhacks/zod).
+`schema` is an optional Zod object to configure the type and shape of document frontmatter for a collection. Each object value must use [a Zod validator](https://github.com/colinhacks/zod).
 
 #### `slug()`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Add `z.object` wrapper around schema definitions. This is now a required wrapper!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
