### PR TITLE
update create astro and template flag instructions

### DIFF
--- a/src/pages/en/core-concepts/project-structure.mdx
+++ b/src/pages/en/core-concepts/project-structure.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 ---
 import FileTree from '~/components/FileTree.astro'
 
-Your new Astro project generated from the `create-astro` CLI wizard already includes some files and folders. Others, you will create yourself and add to Astro's existing file structure.
+Your new Astro project generated from the `create astro` CLI wizard already includes some files and folders. Others, you will create yourself and add to Astro's existing file structure.
 
 Here's how an Astro project is organized, and some files you will find in your new project.
 

--- a/src/pages/en/getting-started.mdx
+++ b/src/pages/en/getting-started.mdx
@@ -37,7 +37,7 @@ Visit [astro.new](https://astro.new/) and choose from a variety of templates to 
 
 ## Start your first project
 
-Get a new Astro project up and running locally with our helpful `create-astro` CLI wizard!
+Get a new Astro project up and running locally with our helpful `create astro` CLI wizard!
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -60,9 +60,7 @@ Get a new Astro project up and running locally with our helpful `create-astro` C
   </Fragment>
 </PackageManagerTabs>
 
-Our [Installation Guide](/en/install/auto/) has full, step-by-step instructions for installing Astro using your favorite package manager.
-
-
+Our [Installation Guide](/en/install/auto/) has full, step-by-step instructions for installing Astro using our CLI wizard, creating a new project from an existing Astro GitHub repository, and for installing Astro manually.
 
 
 ## Learn Astro

--- a/src/pages/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -43,22 +43,22 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 To convert a Docusaurus documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes/docs/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/docs
+    npm create astro@latest -- --template docs
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/docs
+    pnpm create astro@latest --template docs
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/docs
+    yarn create astro --template docs
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -43,7 +43,7 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 To convert a Docusaurus documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes/docs/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-eleventy.mdx
@@ -36,7 +36,7 @@ When you rebuild your Eleventy (11ty) site in Astro, you will notice some import
 
 To convert an Eleventy blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-eleventy.mdx
@@ -36,22 +36,22 @@ When you rebuild your Eleventy (11ty) site in Astro, you will notice some import
 
 To convert an Eleventy blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -38,7 +38,7 @@ When you rebuild your Gatsby site in Astro, you will notice some important diffe
 
 To convert a Gatsby blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -38,22 +38,22 @@ When you rebuild your Gatsby site in Astro, you will notice some important diffe
 
 To convert a Gatsby blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-gridsome.mdx
@@ -36,7 +36,7 @@ When you rebuild your Gridsome site in Astro, you will notice some important dif
 
 To convert a Gridsome blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-gridsome.mdx
@@ -36,22 +36,22 @@ When you rebuild your Gridsome site in Astro, you will notice some important dif
 
 To convert a Gridsome blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-hugo.mdx
@@ -36,7 +36,7 @@ When you rebuild your Hugo site in Astro, you will notice some important differe
 
 To convert a Hugo blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-hugo.mdx
@@ -36,22 +36,22 @@ When you rebuild your Hugo site in Astro, you will notice some important differe
 
 To convert a Hugo blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-jekyll.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-jekyll.mdx
@@ -34,7 +34,7 @@ When you rebuild your Jekyll site in Astro, you will notice some important diffe
 
 To convert a Jekyll blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-jekyll.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-jekyll.mdx
@@ -34,22 +34,22 @@ When you rebuild your Jekyll site in Astro, you will notice some important diffe
 
 To convert a Jekyll blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -41,7 +41,7 @@ When you rebuild your Next.js site in Astro, you will notice some important diff
 
 To convert a Next.js blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -41,22 +41,22 @@ When you rebuild your Next.js site in Astro, you will notice some important diff
 
 To convert a Next.js blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -36,7 +36,7 @@ When you rebuild your Nuxt site in Astro, you will notice some important differe
 
 To convert a Nuxt blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -36,22 +36,22 @@ When you rebuild your Nuxt site in Astro, you will notice some important differe
 
 To convert a Nuxt blog to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-pelican.mdx
@@ -32,7 +32,7 @@ When you rebuild your Pelican site in Astro, you will notice some important diff
 
 To convert a Pelican documentation site to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-pelican.mdx
@@ -32,22 +32,22 @@ When you rebuild your Pelican site in Astro, you will notice some important diff
 
 To convert a Pelican documentation site to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/docs
+    npm create astro@latest -- --template docs
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/docs
+    pnpm create astro@latest --template docs
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/docs
+    yarn create astro --template docs
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -37,7 +37,7 @@ When you rebuild your SvelteKit site in Astro, you will notice some important di
 
 To convert a SvelteKit blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -37,22 +37,22 @@ When you rebuild your SvelteKit site in Astro, you will notice some important di
 
 To convert a SvelteKit blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/).
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-vuepress.mdx
@@ -34,22 +34,22 @@ When you rebuild your VuePress site in Astro, you will notice some important dif
 
 To convert a VuePress documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes/docs/). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/docs
+    npm create astro@latest -- --template docs
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/docs
+    pnpm create astro@latest --template docs
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/docs
+    yarn create astro --template docs
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-vuepress.mdx
@@ -34,7 +34,7 @@ When you rebuild your VuePress site in Astro, you will notice some important dif
 
 To convert a VuePress documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes/docs/). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-wordpress.mdx
@@ -36,22 +36,22 @@ When you rebuild your WordPress site in Astro, you will notice some important di
 
 To convert a WordPress blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes). 
 
-You can pass a `--template` argument to the `create-astro` command to start a new Astro project from any existing Astro repository on GitHub:
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro -- --template withastro/blog
+    npm create astro@latest -- --template blog
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro --template withastro/blog
+    pnpm create astro@latest --template blog
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template withastro/blog
+    yarn create astro --template blog
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/pages/en/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-wordpress.mdx
@@ -36,7 +36,7 @@ When you rebuild your WordPress site in Astro, you will notice some important di
 
 To convert a WordPress blog to Astro, start with our blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes). 
 
-You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our offiicial starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
+You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">

--- a/src/pages/en/guides/troubleshooting.mdx
+++ b/src/pages/en/guides/troubleshooting.mdx
@@ -127,7 +127,7 @@ const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPos
 
 ### Using Astro with Yarn 2+ (Berry)
 
-Yarn 2+, a.k.a. Berry, uses a technique called [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) to store and manage Node modules, which can [cause problems](https://github.com/withastro/astro/issues/3450) while initializing a new Astro project using `create-astro` or while working with Astro. A workaround is to set the [`nodeLinker` property](https://yarnpkg.com/configuration/yarnrc#nodeLinker) in `.yarnrc.yml` to `node-modules`:
+Yarn 2+, a.k.a. Berry, uses a technique called [Plug'n'Play (PnP)](https://yarnpkg.com/features/pnp) to store and manage Node modules, which can [cause problems](https://github.com/withastro/astro/issues/3450) while initializing a new Astro project using `create astro` or while working with Astro. A workaround is to set the [`nodeLinker` property](https://yarnpkg.com/configuration/yarnrc#nodeLinker) in `.yarnrc.yml` to `node-modules`:
 
 ```yaml title=".yarnrc.yml"
 nodeLinker: "node-modules"

--- a/src/pages/en/install/auto.mdx
+++ b/src/pages/en/install/auto.mdx
@@ -8,7 +8,7 @@ import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.ast
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-Ready to install Astro? Follow our automatic or manual set-up guide to get started.
+Ready to install Astro? Follow our automatic or manual setup guide to get started.
 
 #### Prerequisites
 
@@ -20,7 +20,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Installation
 
-`create-astro` is the fastest way to start a new Astro project from scratch. It will walk you through every step of setting up your new Astro project. It allows you to choose from a few different starter templates or provide your own using the `--template` argument.
+`create astro` is the fastest way to start a new Astro project from scratch. It will walk you through every step of setting up your new Astro project. It allows you to choose from a few different official starter templates or you can [use any existing project on GitHub with the `--template` argument](#starter-templates).
 
 :::tip[Online previews]
 Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to browse our starter templates and spin up a new Astro project without ever leaving your browser.
@@ -28,7 +28,7 @@ Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to br
 
 ## 1. Run the Setup Wizard
 
-Run the following command in your terminal to start our handy install wizard, `create-astro`.
+Run the following command in your terminal to start our handy install wizard:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -51,11 +51,11 @@ Run the following command in your terminal to start our handy install wizard, `c
   </Fragment>
 </PackageManagerTabs>
 
-You can run `create-astro` anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
+You can run `create astro` anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
 
 If all goes well, you should see a "Ready for liftoff!" message followed by some recommended "Next steps". `cd` into your new project directory to begin using Astro. 
 
-If you skipped the `npm install` step during the `create-astro` wizard, then be sure to install your dependencies before continuing.
+If you skipped the `npm install` step during the CLI wizard, then be sure to install your dependencies before continuing.
 
 ## 2. Start Astro ✨
 
@@ -87,6 +87,30 @@ If all goes well, Astro should now be serving your project on [http://localhost:
 Astro will listen for live file changes in your `src/` directory, so you will not need to restart the server as you make changes during development.
 
 If you aren't able to open your project in the browser, go back to the terminal where you ran the `dev` command and look to see if an error occurred, or if your project is being served at a different URL than the one linked to above.
+
+## Starter Templates
+
+You can also start a new astro project based on an existing GitHub repostory by passing a `--template` argument to the `create astro` command.
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro@latest -- --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro@latest --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn create astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Explore our [themes and starters showcase](https://astro.build/themes/) where you can browse themes for blogs, portfolios, documentation, landing pages, and more! Or, [search on GitHub](https://github.com/search?o=desc&q=astro+starter&s=stars&type=Repositories) for even more starter projects.
 
 ## Next Steps
 

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -21,7 +21,7 @@ Ready to install Astro? Follow our automatic or manual set-up guide to get start
 
 #### Installation
 
-If you prefer not to use our automatic `create-astro` CLI tool, you can set up your project yourself by following the guide below.
+If you prefer not to use our automatic `create astro` CLI tool, you can set up your project yourself by following the guide below.
 
 ## 1. Create your directory
 

--- a/src/pages/en/integrations/integrations.mdx
+++ b/src/pages/en/integrations/integrations.mdx
@@ -50,17 +50,17 @@ Check out our new [integrations library](https://astro.build/integrations/), and
 
 ## Repositories / Starter Templates
 
-You can start a new astro project based on an existing github repostory by passing a `--template` argument to the `create-astro` command.
+You can start a new astro project based on an existing github repostory by passing a `--template` argument to the `create astro` command.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  npm create astro -- --template <github-username>/<github-repo>
+  npm create astro@latest -- --template <github-username>/<github-repo>
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm create astro --template <github-username>/<github-repo>
+  pnpm create astro@latest --template <github-username>/<github-repo>
   ```
   </Fragment>
   <Fragment slot="yarn">


### PR DESCRIPTION
This fixes the instructions for running create astro with a template flag in the migration guides.

It also adds the example we have for starting a new project from any GitHub template from the hidden `integrations/integrations` page to Auto install, to better surface these instructions.

Lastly, it changes *most* instances of `create-astro` to `create astro`, since we are usually referring to the command to run, not the name of the package itself. (This has caused confusion in the past, so doing this while I'm here, but can be talked out of that change.) Admittedly, some of these occurances (both changed, and not changed) were judgment calls. Mostly based on what I thought might be least confusing to the reader. e.g. If the name of the wizard shows up JUST BEFORE they need to run the command, then I removed the hyphen so the reader is not seeing two conflicting things together.