### PR TITLE
i18n(pt-BR): Update `framework-components.mdx` and +9 translations

### DIFF
--- a/src/pages/pt-br/core-concepts/framework-components.mdx
+++ b/src/pages/pt-br/core-concepts/framework-components.mdx
@@ -58,32 +58,32 @@ import MeuComponenteReact from '../components/MeuComponenteReact.jsx';
 </html>
 ```
 
-Por padrão, seus componentes de frameworks serão renderizados como HTML estático. Isso é útil para fazer o template de componentes que não são interativos e evita mandar qualquer JavaScript desnecessário ao cliente.
+Por padrão, seus componentes de frameworks serão renderizados apenas no servidor, como HTML estático. Isso é útil para fazer o template de componentes que não são interativos e evita mandar qualquer JavaScript desnecessário ao cliente.
 
 ## Hidratando Componentes Interativos
 
-Um componente de framework pode ser tornar interativo (hidratado) utilizando uma das diretivas `client:*`. Isso é um atributo de componente que define como seu componente deve ser **renderizado** e **hidratado**.
+Um componente de framework pode se tornar interativo (hidratado) utilizando uma [diretiva `client:*`](/pt-br/reference/directives-reference/#diretivas-de-cliente). Elas são atributos de componente que determinam quando o JavaScript do seu componente deve ser enviado ao navegador.
 
-Uma [diretiva de cliente](/pt-br/reference/directives-reference/#diretivas-de-cliente) descreve se o seu componente deve ou não ser renderizado no momento de build e quando o JavaScript do seu componente deve ser carregado pelo navegador, no lado do cliente.
-
-A maioria das diretivas irá renderizar o componente no servidor no momento de build. O JavaScript do componente será enviado ao cliente de acordo com a diretiva especificada. O componente será hidratado quando o seu JS terminar de ser importado.
+Com todas as diretivas de cliente exceto `client:only`, seu componente será primeiro renderizado no servidor para gerar HTML estático. JavaScript do componente será enviado ao navegador de acordo com a diretiva que você escolheu. O componente será então hidratado e se tornará interativo.
 
 ```astro title="src/pages/componentes-interativos.astro" /client:\S+/
 ---
 // Exemplo: hidratando componentes de frameworks no navegador.
 import BotaoInterativo from '../components/BotaoInterativo.jsx';
 import ContadorInterativo from '../components/ContadorInterativo.jsx';
+import ModalInterativo from "../components/InteractiveModal.svelte"
 ---
 <!-- O JS desse componente começará a ser importado quando a página carregar -->
 <BotaoInterativo client:load />
 
 <!-- O JS desse componente não será enviado ao cliente até que o usuário role a tela até o componente estar visível na página -->
 <ContadorInterativo client:visible />
+
+<!-- Este componente não será renderizado no servidor, mas será renderizado no cliente quando a página carregar -->
+<ModalInterativo client:only="svelte" />
 ```
 
-:::caution
-Qualquer JS de renderização necessário para o framework do componente (e.x. React, Svelte) é baixado com a página. As diretivas `client:*` apenas ditam quando o _JS do componente_ é importado e quando o _componente_ é hidratado.
-::: 
+O framework JavaScript (React, Svelte, etc) necessário para renderizar o componente será enviado ao navegador junto do JavaScript do próprio componente. Se dois ou mais componentes em uma página usam o mesmo framework, o framework será enviado apenas uma vez.
 
 :::note[Acessibilidade]
 A maioria dos padrões de acessibilidade específicos de frameworks devem funcionar da mesma forma ao serem utilizados no Astro. Certifique-se de utilizar uma diretiva de cliente que irá garantir que qualquer JavaScript relacionado à acessibilidade seja propriamente carregado e executado na hora certa!
@@ -115,6 +115,27 @@ import MeuComponenteVue from '../components/MeuComponenteVue.vue';
 
 :::caution
 Apenas componentes **Astro** (`.astro`) podem conter componentes de múltiplos frameworks.
+:::
+
+## Passando Props Para Componentes de Frameworks
+
+Você pode passar props de componentes Astro para componentes de frameworks:
+
+```astro title="src/pages/props-frameworks.astro"
+---
+import ListaDeFazeres from '../components/ListaDeFazeres.jsx';
+import Contador from '../components/Contador.svelte';
+---
+<div>
+  <ListaDeFazeres fazeresIniciais={["aprender Astro", "revisar PRs"]} />
+  <Contador contagemInicial={1} />
+</div>
+```
+
+:::caution[passando funções como props]
+Você pode passar uma função como prop para um componente de framework, mas ela apenas funciona durante renderização no servidor. Se você tentar utilizar a função em um componente hidratado (por exemplo, como um event handler), um erro irá ocorrer.
+
+Isso acontece pois funções não podem ser _serializadas_ (transferidas do servidor para o cliente) pelo Astro.
 :::
 
 ## Passando Filhos para Componentes de Frameworks

--- a/src/pages/pt-br/core-concepts/framework-components.mdx
+++ b/src/pages/pt-br/core-concepts/framework-components.mdx
@@ -10,31 +10,7 @@ Astro suporta uma variedade de frameworks populares incluindo [React](https://re
 
 ## Instalando Integrações
 
-Astro vem com integrações opcionais para React, Preact, Svelte, Vue, SolidJS, AlpineJS e Lit. Uma ou mais destas integrações podem ser instaladas e configuradas no seu projeto.
-
-Para configurar Astro para utilizar estes frameworks, primeiro, instale sua integração e quaisquer dependências associadas:
-
-```bash
-npm install --save-dev @astrojs/react react react-dom
-```
-
-Então importe e adicione a função a sua lista de integrações em `astro.config.mjs`:
-
-```js title="astro.config.mjs" ins={3} ins=/(?<!p)react\\(\\)/
-import { defineConfig } from 'astro/config';
-
-import react from '@astrojs/react';
-import preact from '@astrojs/preact';
-import svelte from '@astrojs/svelte';
-import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
-import lit from '@astrojs/lit';
-import alpine from '@astrojs/alpine';
-
-export default defineConfig({
-	integrations: [react(), preact(),svelte(), vue(), solid(), lit(), alpine()],
-});
-```
+Astro vem com [integrações opcionais](/pt-br/guides/integrations-guide/) para React, Preact, Svelte, Vue, SolidJS, AlpineJS e Lit. Uma ou várias destas integrações Astro podem ser instaladas e configuradas em seu projeto.
 
 ⚙️ Veja o [Guia de Integrações](/pt-br/guides/integrations-guide/) para mais detalhes em como instalar e configurar integrações Astro.
 

--- a/src/pages/pt-br/guides/configuring-astro.mdx
+++ b/src/pages/pt-br/guides/configuring-astro.mdx
@@ -118,6 +118,10 @@ export default defineConfig({
 })
 ```
 
+:::note
+Propriedades específicas do Vite de `import.meta`, como `import.meta.env` ou `import.meta.glob`, _não_ são acessíveis em seu arquivo de configuração. Nós recomendamos alternativas como [dotenv](https://github.com/motdotla/dotenv) ou [fast-glob](https://github.com/mrmlnc/fast-glob) para esses respectivos casos de uso.
+:::
+
 ## Customizando Nomes de Arquivos Finais
 
 Para código que o Astro processa, como arquivos JavaScript e CSS importados, você pode customizar os nomes de arquivos finais utilizando [`entryFileNames`](https://rollupjs.org/guide/en/#outputentryfilenames), [`chunkFileNames`](https://rollupjs.org/guide/en/#outputchunkfilenames), e [`assetFileNames`](https://rollupjs.org/guide/en/#outputassetfilenames) na entrada `vite.build.rollupOptions` no seu arquivo `astro.config.*`.
@@ -142,6 +146,11 @@ export default defineConfig({
 ```
 
 Isto pode ser útil caso você tenha scripts com nomes que podem ser afetados por bloqueadores de anúncios (ex. `ads.js` ou `google-tag-manager.js`).
+
+## Variáveis de Ambiente
+
+Astro verifica arquivos de configuração antes de carregar seus outros arquivos. Portanto, você não pode utilizar `import.meta.env` ou acessar variáveis de ambiente que foram definidas em arquivos `.env`. 
+Você pode utilizar `process.env` em um arquivo de configuração para acessar outras variáveis de ambiente, como aquelas [definidas pela CLI](/pt-br/guides/environment-variables/#usando-a-cli).
 
 ## Referência de Configuração
 

--- a/src/pages/pt-br/guides/deploy.mdx
+++ b/src/pages/pt-br/guides/deploy.mdx
@@ -78,7 +78,7 @@ Por padrão, o resultado da build será colocado em `dist/`. Este local pode ser
 :::note
 Antes de fazer deploy do seu site Astro com [SSR (renderização no lado do servidor)](/pt-br/guides/server-side-rendering/) ativado, certifique-se de que você:
 
-    - Instalou o [adaptador correto](/pt-br/guides/server-side-rendering/#habilitando-o-ssr-em-seu-projeto) nas dependências do seu projeto (seja manualmente ou utilizando o comando `astro add` do adaptador, e.x. `npx astro add netlify`).
-    - [Adicionou o adaptador](/pt-br/reference/configuration-reference/#integrações) na importação e exportação padrão do seu arquivo `astro.config.mjs` ao instalar manualmente. (O comando `astro add` irá tomar conta dessa etapa por você!)
+    - Instalou o [adaptador correto](/pt-br/guides/server-side-rendering/#adicionando-um-adaptador) nas dependências do seu projeto (seja manualmente ou utilizando o comando `astro add` do adaptador, e.x. `npx astro add netlify`).
+    - [Adicionou o adaptador](/pt-br/reference/configuration-reference/#adapter) na importação e exportação padrão do seu arquivo `astro.config.mjs` ao instalar manualmente. (O comando `astro add` irá tomar conta dessa etapa por você!)
 :::
 

--- a/src/pages/pt-br/guides/deploy/gitlab.mdx
+++ b/src/pages/pt-br/guides/deploy/gitlab.mdx
@@ -16,9 +16,9 @@ Veja o [exemplo oficial de um projeto Astro no GitLab Pages](https://gitlab.com/
 1. Defina a opção `site` corretamente em `astro.config.mjs`.
 2. Defina `outDir:public` em `astro.config.mjs`. Essa opção instrui o Astro a colocar o resultado estático da build do site em um diretório chamado `public`, que é o local exigido pelo GitLab Pages para arquivos expostos.
 
-Se você estava usando o [diretório `public/`](/pt-br/core-concepts/project-structure/#public) como fonte de arquivos estáticos em seu projeto Astro, renomeie o diretório e defina `publicDir` com o novo nome em `astro.config.mjs`.
+  Se você estava usando o [diretório `public/`](/pt-br/core-concepts/project-structure/#public) como fonte de arquivos estáticos em seu projeto Astro, renomeie o diretório e defina `publicDir` com o novo nome em `astro.config.mjs`.
 
-Por exemplo, aqui estão as configurações corretas de `astro.config.mjs` quando o diretório `public/` é renomeado para `static/`:
+  Por exemplo, aqui estão as configurações corretas de `astro.config.mjs` quando o diretório `public/` é renomeado para `static/`:
 
    ```js
    import { defineConfig } from 'astro/config';

--- a/src/pages/pt-br/guides/deploy/netlify.mdx
+++ b/src/pages/pt-br/guides/deploy/netlify.mdx
@@ -89,18 +89,8 @@ Para definir as configurações padrão, crie um arquivo `netlify.toml` com o se
 
 ```toml
 [build]
-  command = "npm run build"
+  command = "npx pnpm install --store=node_modules/.pnpm-store && npm run build"
   publish = "dist"
-```
-
-Usando [`pnpm` na Netlify?](https://answers.netlify.com/t/using-pnpm-and-pnpm-workspaces/2759) Use as seguintes configurações no lugar:
-
-```toml
-[build.environment]
-  NPM_FLAGS = "--version" # previne a Netlify de executar npm install
-[build]
-  command = 'npx pnpm i --store=node_modules/.pnpm-store && npm run build'
-  publish = 'dist'
 ```
 
 📚 Mais informações em [“Deploying an existing Astro Git repository”](https://www.netlify.com/blog/how-to-deploy-astro/#deploy-an-existing-git-repository-to-netlify) no blog da Netlify

--- a/src/pages/pt-br/guides/deploy/vercel.mdx
+++ b/src/pages/pt-br/guides/deploy/vercel.mdx
@@ -17,16 +17,6 @@ Você pode fazer o deploy do seu projeto Astro na Vercel como um site estático 
 
 Seu projeto Astro é um site estático por padrão. Você não precisa de nenhuma configuração adicional para fazer o deploy de um site Astro estático na Vercel. 
 
-:::note
-Atualmente há um problema da Vercel exibindo uma página 404 em sites Astro. Até que isso seja corrigido, você pode adicionar o seguinte arquivo de configuração na raiz do seu projeto:
-
-```json title="vercel.json"
-{
-  "cleanUrls": true
-}
-```
-:::
-
 ### Adaptador para SSR
 
 Para habilitar o SSR em seu projeto Astro e fazer o deploy na Vercel:
@@ -86,3 +76,8 @@ Depois que seu projeto foi importado e o deploy foi feito, todos os pushs subseq
 3. Quando perguntado `Want to override the settings? [y/N]`, escolha `N`.
 4. O deploy de sua aplicação está feito! (ex. [astro.vercel.app](https://astro.vercel.app/))
 
+### Configuração de projeto com vercel.json
+
+Você pode utilizar `vercel.json` para sobreescrever o comportamento padrão da Vercel e configurar opções adicionais. Por exemplo, você pode desejar anexar headers a respostas HTTP a partir de seus Deployments. 
+
+📚 Aprenda mais sobre [configuração de projetos da Vercel](https://vercel.com/docs/project-configuration).

--- a/src/pages/pt-br/guides/environment-variables.mdx
+++ b/src/pages/pt-br/guides/environment-variables.mdx
@@ -4,12 +4,11 @@ title: Usando variáveis de ambiente
 description: Aprenda como utilizar variáveis de ambiente em um projeto Astro.
 i18nReady: true
 ---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-Astro utiliza Vite para suas variáveis de ambiente e o permite [utilizar qualquer um de seus métodos](https://vitejs.dev/guide/env-and-mode.html) para obter e definir variáveis de ambiente.
+Astro utiliza o suporte integrado do Vite para variáveis de ambiente e o deixa [utilizar quaisquer de seus métodos](https://vitejs.dev/guide/env-and-mode.html) para trabalhar com elas.
 
 Note que enquanto _todas_ as variáveis de ambiente estão disponíveis em código no lado do servidor, apenas variáveis de ambiente com o prefixo `PUBLIC_` estão disponíveis em código no lado do cliente por segurança.
-
-Veja o exemplo oficial de [variáveis de ambiente](https://github.com/withastro/astro/tree/main/examples/env-vars) para entender as melhores práticas.
 
 ```ini title=".env"
 SENHA_SECRETA=senha123
@@ -18,17 +17,23 @@ PUBLIC_TODOS=aqui
 
 Nesse exemplo, `PUBLIC_TODOS` (acessível via `import.meta.env.PUBLIC_TODOS`) estará disponível no código do cliente e do servidor, enquanto `SENHA_SECRETA` (acessível via `import.meta.env.SENHA_SECRETA`) estará apenas no lado do servidor.
 
+:::caution
+Arquivos `import.meta.env` e `.env` não estão disponíveis dentro de [arquivos de configuração](/pt-br/guides/configuring-astro/#variáveis-de-ambiente). 
+:::
+
 ## Variáveis de ambiente padrões
 
 Astro inclui algumas variáveis de ambiente por padrão:
 
-- `import.meta.env.MODE` (`development` (desenvolvimento) | `production` (produção)): o modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.
-- `import.meta.env.BASE_URL` (`string`): a URL base na qual o seu site está sendo acessado. Isso é determinado pela [opção `base` da configuração](/pt-br/reference/configuration-reference/#base).
-- `import.meta.env.PROD` (`boolean`): Se o seu site está sendo executado em produção.
-- `import.meta.env.DEV` (`boolean`): Se o seu site está sendo executado em desenvolvimento (sempre o contrário de `import.meta.env.PROD`).
-- `import.meta.env.SITE` (`string`): [A opção `site`](/pt-br/reference/configuration-reference/#site) especificada no `astro.config` do seu projeto.
+- `import.meta.env.MODE`: O modo no qual o seu site está sendo executado. Seu valor é `development` quando estiver executando `astro dev` e será `production` quando estiver executando `astro build`.
+- `import.meta.env.PROD`: `true` se o seu site está sendo executado em produção; `false` caso contrário.
+- `import.meta.env.DEV`: `true` se o seu site está sendo executado em desenvolvimento; `false` caso contrário. Sempre o oposto de `import.meta.env.PROD`.
+- `import.meta.env.BASE_URL`: A URL base na qual o seu site está sendo servido de. Isso é determinado pela [opção `base` da configuração](/pt-br/reference/configuration-reference/#base).
+- `import.meta.env.SITE`: É definida para [a opção `site`](/pt-br/reference/configuration-reference/#site) especificada no `astro.config` do seu projeto.
 
 ## Definindo variáveis de ambiente
+
+### Arquivos `.env`
 
 Variáveis de ambiente podem ser carregadas de arquivos `.env` no diretório do seu projeto.
 
@@ -43,21 +48,37 @@ SENHA_BD="foobar"
 PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 ```
 
-```yaml
-# Nomes de arquivo suportados:
-.env                # carregado em todos os casos
-.env.local          # carregado em todos os casos, ignorado pelo git
-.env.[modo]         # carregado apenas no modo especificado
-.env.[modo].local   # carregado apenas no modo especificado, ignorado pelo git
-```
+Para mais sobre arquivos `.env`, [veja a documentação do Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).
+
+### Usando a CLI
+
+Você também pode adicionar variáveis de ambiente enquanto você executa seu projeto:
+
+<PackageManagerTabs>
+ <Fragment slot="yarn">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 yarn run dev
+    ```
+ </Fragment>
+ <Fragment slot="npm">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 npm run dev
+    ```
+ </Fragment>
+ <Fragment slot="pnpm">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 pnpm run dev
+    ```
+ </Fragment>
+</PackageManagerTabs>
+
+:::caution
+Variáveis definidas dessa forma estarão disponíveis em todo lugar no seu projeto, inclusive no cliente.
+:::
 
 ## Obtendo variáveis de ambiente
 
 Ao invés de utilizar `process.env` com o Vite, você pode utilizar `import.meta.env`, que usa a funcionalidade `import.meta` adicionado no ES2020.
-
-:::tip[Não se preocupe com a compatibilidade dos navegadores!]
-Vite substitui todas as menções de `import.meta.env` por valores estáticos.
-:::
 
 Por exemplo, utilize `import.meta.env.PUBLIC_POKEAPI` para obter a variável de ambiente `PUBLIC_POKEAPI`.
 

--- a/src/pages/pt-br/guides/server-side-rendering.mdx
+++ b/src/pages/pt-br/guides/server-side-rendering.mdx
@@ -3,6 +3,8 @@ layout: ~/layouts/MainLayout.astro
 title: Renderização no lado do Servidor
 i18nReady: true
 ---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import Since from '~/components/Since.astro';
 
 **Renderização no lado do Servidor**, também conhecido como SSR, pode ser habilitado no Astro. Quando você habilita o SSR você pode:
 - Implementar sessões para um estado de login no seu app.
@@ -21,6 +23,8 @@ export default defineConfig({
 });
 ```
 
+### Adicionando um Adaptador
+
 Quando for a hora de fazer deploy de um projeto SSR, você também vai precisar adicionar um adaptador. Isso porque SSR precisa de um _runtime_ do servidor: o ambiente que executa o seu código no lado do servidor. Cada adaptador permite que o Astro retorne um script que executa seu projeto em um runtime específico.
 
 Instalar um adaptador dá ao Astro acesso à API correspondente, e permite que Astro retorne um script que executa o seu projeto em qualquer tipo de servidor.
@@ -33,21 +37,53 @@ Estes são os adaptadores disponíveis hoje, com mais por vir no futuro:
 - [Node.js](/pt-br/guides/integrations-guide/node/)
 - [Vercel](/pt-br/guides/integrations-guide/vercel/)
 
+#### Instalação com `astro add`
+
 Você pode adicionar qualquer um dos adaptadores oficiais com o comando `astro add`. Ele irá instalar o adaptador e fazer as mudanças apropriadas em seu arquivo `astro.config.mjs` em uma só etapa. Por exemplo, para instalar o adaptador para Netlify, execute:
 
-```bash
-npx astro add netlify
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add netlify
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpx astro add netlify
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add netlify
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+#### Instalação Manual
 
 Você também pode adicionar um adaptador manualmente instalando o pacote e atualizando `astro.config.mjs` sozinho. (Veja os links acima para instruções específicadas de cada adaptador para completar as etapas necessárias para habilitar SSR.) Utilizando `meu-adaptador` como um exemplo, as instruções vão se parecer com isso:
 
-1. Instale o adaptador nas depedências do seu projetado utilizando seu gerenciador de pacotes preferido. Se você está utilizando npm ou não tem certeza, execute isto no terminal:
+1. Instale o adaptador nas depedências do seu projetado utilizando seu gerenciador de pacotes preferido:
 
-   ```bash
-      npm install @astrojs/meu-adaptador
+  <PackageManagerTabs>
+    <Fragment slot="npm">
+    ```shell
+    npx astro add netlify
     ```
+    </Fragment>
+    <Fragment slot="pnpm">
+    ```shell
+    pnpx astro add netlify
+    ```
+    </Fragment>
+    <Fragment slot="yarn">
+    ```shell
+    yarn astro add netlify
+    ```
+    </Fragment>
+  </PackageManagerTabs>
 
-1. [Adicione o adaptador](/pt-br/reference/configuration-reference/) no import e default export do seu arquivo `astro.config.mjs`
+1. [Adicione o adaptador](/pt-br/reference/configuration-reference/#adapter) no import e default export do seu arquivo `astro.config.mjs`
 
     ```js ins={3,6-7}
     // astro.config.mjs
@@ -63,6 +99,22 @@ Você também pode adicionar um adaptador manualmente instalando o pacote e atua
 ## Funcionalidades
 
 O Astro continuará sendo um gerador de sites estáticos por padrão. Porém, quando você habilita um adaptador de renderização no lado do servidor, **todas as rotas no seu diretório pages se torna uma rota renderizada no servidor** e algumas novas funcionalidades são disponibilizadas a você.
+
+### Pré-renderização
+
+<Since v="2.0.0-beta.0" />
+
+Qualquer arquivo `.astro` dentro do diretório `pages/` pode optar pela pré-renderização ou comportamento padrão em tempo de build, ao incluir a seguinte linha.
+
+```astro title="src/pages/index.astro" {2}
+---
+export const prerender = true;
+// ...
+---
+<html>
+  <!-- Página aqui... -->
+</html>
+```
 
 ### `Astro.request.headers`
 
@@ -83,6 +135,28 @@ As funcionalidades abaixo estão disponíveis apenas em páginas. (Você não po
 
 Isso é por que essas funcionalidades modificam os [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header), que não podem ser modificados após serem enviados ao navegador. No modo SSR, Astro utiliza streaming de HTML para enviar cada componente ao navegador enquanto são renderizados. Isso permite que o usuário veja o HTML o mais rápido o possível, mas também significa que no momento em que o Astro executar o código de seu componente, ele já terá enviado os Response headers.
 :::
+
+### `Astro.cookies`
+
+Este é um utilitário para ler e modificar um único cookie. Ele te permite verificar, definir, pegar e deletar um cookie.
+
+Para mais detalhes sobre [`Astro.cookies` e o tipo `AstroCookie`](/pt-br/reference/api-reference/#astrocookies) na referência da API.
+
+O exemplo abaixo atualiza o valor de um cookie da contagem de visualizações da página.
+
+```astro title="src/pages/index.astro" {4,5,9}
+---
+let contagem = 0
+if(Astro.cookies.has("contagem")){
+  const cookie = Astro.cookies.get("contagem")
+	contagem = cookie.number() + 1
+}
+Astro.cookies.set("contagem", contagem)
+---
+<html>
+  <h1>Contagem = {contagem}</h1>
+</html>
+```
 
 ### `Astro.redirect`
 
@@ -127,122 +201,6 @@ if (!produto) {
 </html>
 ```
 
-## Rotas de API
+### Endpoints do Servidor
 
-Uma [rota de API](https://medium.com/@rajat_m/what-are-restful-routes-and-how-to-use-them-929129ae7bf6) é um arquivo `.js` ou `.ts` no diretório `/src/pages` que recebe um [Request](https://developer.mozilla.org/pt-BR/docs/Web/API/Request) e retorna uma [Response](https://developer.mozilla.org/pt-BR/docs/Web/API/Response). Uma poderosa funcionalidade do SSR, rotas de API são capazes de executar código de forma segura no lado do servidor.
-
-### SSR e Rotas
-
-No Astro, essas rotas se tornam em rotas renderizadas no servidor, te permitindo utilizar funcionalidades que eram previamente indisponíveis no lado do cliente ou necessitavam de chamadas explícitas a um servidor backend e código extra no cliente para renderizar os resultados.
-
-No exemplo abaixo, uma rota de API é utilizada para pegar um produto de um banco de dados, sem precisar gerar uma página para cada uma das opções.
-
-```js title="src/pages/[id].js"
-import { getProduto } from '../db';
-
-export async function get({ params }) {
-  const { id } = params;
-  const produto = await getProduto(id);
-
-  if (!produto) {
-    return new Response(null, {
-      status: 404,
-      statusText: 'Não encontrado'
-    });
-  }
-
-  return new Response(JSON.stringify(produto), {
-    status: 200
-  });
-}
-```
-
-Neste exemplo, código HTML válido pode ser retornado para renderizar toda a página ou parte de seu conteúdo.
-
-Além de buscar conteúdo e renderização no servidor, rotas de API podem ser utilizadas como endpoints de uma API Rest para executar funções como autenticações, acesso a bancos de dados, e verificações sem expor dados sensíveis para o cliente.
-
-Nesse exemplo abaixo, uma rota de API é usada para verificar o reCaptcha v3 do Google sem expor a chave secreta aos clientes.
-
-```astro title="src/pages/index.astro"
-<html>
-  <head>
-    <script src="https://www.google.com/recaptcha/api.js"></script>
-  </head>
-  
-  <body>
-    <button class="g-recaptcha" 
-      data-sitekey="PUBLIC_SITE_KEY" 
-      data-callback="onSubmit" 
-      data-action="submit"> Clique aqui para verificar o desafio captcha! </button>
-
-    <script is:inline>
-      function onSubmit(token) {
-        fetch("/recaptcha", {
-          method: "POST",
-          body: JSON.stringify({ recaptcha: token })
-        })
-        .then((resposta) => resposta.json())
-        .then((gResposta) => {
-          if (gResposta.success) {
-            // Verificação do captcha foi um sucesso
-          } else {
-            // Verificação do captcha falhou
-          }
-        })
-      }
-    </script>
-  </body>
-</html>
-```
-
-Na rota de API você pode seguramente definir valores secretos, ou ler suas variáveis de ambiente secretas.
-
-```js title="src/pages/recaptcha.js"
-import fetch from 'node-fetch';
-
-export async function post({ request }) {
-  const dados = await request.json();
-
-  const recaptchaURL = 'https://www.google.com/recaptcha/api/siteverify';
-  const corpoRequisicao = {
-    secret: "CHAVE_SECRETA_DO_SEU_SITE",   // Isto pode ser uma variável de ambiente
-    response: dados.recaptcha          // O token passado para o cliente
-  };
-
-  const resposta = await fetch(recaptchaURL, {
-    method: "POST",
-    body: JSON.stringify(corpoRequisicao)
-  });
-
-  const dadosResposta = await resposta.json();
-
-  return new Response(JSON.stringify(dadosResposta), { status: 200 });
-}
-```
-
-### Redirecionamentos
-
-Já que `Astro.redirect` não está disponível em Rotas de API, você pode utilizar [`Response.redirect`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect).
-
-```js title="src/pages/links/[id].js" {14}
-import { getUrlLink } from '../db';
-export async function get({ params }) {
-  const { id } = params;
-  const link = await getUrlLink(id);
-  if (!link) {
-    return new Response(null, {
-      status: 404,
-      statusText: 'Não encontrado'
-    });
-  }
-  return Response.redirect(link, 307);
-}
-```
-
-`Response.redirect` requer que você passe uma URL inteira. Para redirecionamentos locais, você pode utilizar `request.url` como base com o [construtor `URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) para construir uma URL absoluta:
-
-```js title="src/pages/redirecionamentos.js"
-export async function get({ request }) {
-  const url = new URL('/home', request.url);
-  return Response.redirect(url, 307);
-}
+Um endpoint do servidor, também conhecido como **rota de API**, é um arquivo `.js` ou `.ts` dentro da pasta `src/pages` que recebe um [Request](https://developer.mozilla.org/pt-BR/docs/Web/API/Request) e retorna uma [Response](https://developer.mozilla.org/pt-BR/docs/Web/API/Response). Sendo uma poderosa funcionalidade de SSR, rotas de API são capazes de executar código no lado do servidor de forma segura. Para aprender mais, veja nosso [Guia de Endpoints](/pt-br/core-concepts/endpoints/#endpoints-do-servidor-rotas-de-api).

--- a/src/pages/pt-br/integrations/integrations.mdx
+++ b/src/pages/pt-br/integrations/integrations.mdx
@@ -3,6 +3,7 @@ layout: ~/layouts/MainLayout.astro
 title: Feito com Astro
 i18nReady: true
 ---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 Membros da comunidade Astro tem integrado com sucesso as ferramentas e serviços de terceiros em seus websites Astro!
 
@@ -60,6 +61,21 @@ Apesar das descrições abaixo estarem traduzidas, o conteúdo dos links é em I
 [The Net Ninja](https://www.youtube.com/playlist?list=PL4cUxeGkcC9hZm9NYpd4G-jhoeEk0ls--) - **Vídeo**: Construção de site estático com Figma e Astro 
 
 ## Repositórios / Templates Iniciais
+
+Você pode iniciar um novo projeto Astro com base em um repositório existente no GitHub ao passar o argumento `--template` para o comando `create astro`.
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro@latest -- --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro@latest --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
 
 [delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms/) - Template inicial com Astro e Netlify CMS
 

--- a/src/pages/pt-br/integrations/integrations.mdx
+++ b/src/pages/pt-br/integrations/integrations.mdx
@@ -25,11 +25,7 @@ Apesar das descrições abaixo estarem traduzidas, o conteúdo dos links é em I
 
 [Spread Bagelry](https://spreadbagelry.com) - Astro / Vue / Tailwind / Strapi CMS / Cloudinary
 
-[Public Transport Forum New Zealand](https://publictransportforum.nz/articles) - Astro / Netlify CMS
-
 [My Workshops Live](https://myworkshops.live) - Astro / Svelte / Firebase / Vonage / Web Speech API / reveal.js
-
-[Rafid Muhymin Wafi](https://softhardsystem.com/) -  Astro / Tailwind / WordPress: Headless CMS, comentários, pesquisa
 
 [meizuflux](https://meizuflux.com) - Astro / Hygraph
 
@@ -48,13 +44,7 @@ Apesar das descrições abaixo estarem traduzidas, o conteúdo dos links é em I
 
 [Learn With Jason](https://youtube.com/watch?v=FJOJmKFngLI) - **Vídeo**: Construindo um carrinho de compras customizado com Astro e a API Storefront da Shopify
 
-[Chris Bongers](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms) - **Postagem**: Construindo um site Astro com WordPress como Headless CMS
-
 [Front End Horse](https://www.youtube.com/watch?v=qFUfuDSLdxM) - **Vídeo**: Desenvolvendo com Astro & Prismic
-
-[Jaydan Urwin](https://www.youtube.com/watch?v=-jAWLTfsSQw) - **Vídeo**: Crie o seu próprio blog com Astro e Sanity.io
-
-[Aftab Alam](https://aalam.vercel.app/blog/astro-and-git-cms-netlify) - **Postagem**: Escreva o conteúdo do seu site Astro com CMs baseados em Git
 
 [Chris Bongers](https://aviyel.com/post/1006/adding-typesense-search-to-an-astro-static-generated-website) - **Postagem**: Adicionando Typesense Search a um site Astro
 
@@ -76,6 +66,11 @@ Você pode iniciar um novo projeto Astro com base em um repositório existente n
   ```
   </Fragment>
   <Fragment slot="yarn">
+  ```shell
+  yarn create astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 [delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms/) - Template inicial com Astro e Netlify CMS
 

--- a/src/pages/pt-br/reference/adapter-reference.mdx
+++ b/src/pages/pt-br/reference/adapter-reference.mdx
@@ -4,7 +4,7 @@ title: API de Adaptadores do Astro
 i18nReady: true
 ---
 
-Astro foi projetado para ser fácil realizar deploy em qualquer provedor da nuvem para SSR (renderização no lado do servidor). Essa habilidade é providenciada por __adaptadores__, que são [integrações](/pt-br/reference/integrations-reference/).
+Astro foi projetado para ser fácil realizar deploy em qualquer provedor da nuvem para SSR (renderização no lado do servidor). Essa habilidade é providenciada por __adaptadores__, que são [integrações](/pt-br/reference/integrations-reference/). Veja o [guia de SSR](/pt-br/guides/server-side-rendering/#adicionando-um-adaptador) para aprender como utilizar um adaptador existente.
 
 ## O que é um adaptador
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

Updated PT-BR translations for:
- `framework-components.mdx`
- `configuring-astro.mdx`
- `deploy.mdx`
- `gitlab.mdx`
- `netlify.mdx`
- `vercel.mdx`
- `environment-variables.mdx`
- `server-side-rendering.mdx`
- `integrations.mdx`
- `adapter-reference.mdx`