### PR TITLE
remove outdated (and duplicated!) installation instructions

### DIFF
--- a/src/pages/en/core-concepts/framework-components.mdx
+++ b/src/pages/en/core-concepts/framework-components.mdx
@@ -11,31 +11,7 @@ Astro supports a variety of popular frameworks including [React](https://reactjs
 
 ## Installing Integrations
 
-Astro ships with optional integrations for React, Preact, Svelte, Vue, SolidJS, AlpineJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
-
-To configure Astro to use these frameworks, first, install its integration and any associated peer dependencies:
-
-```bash
-npm install --save-dev @astrojs/react react react-dom
-```
-
-Then import and add the function to your list of integrations in `astro.config.mjs`:
-
-```js title="astro.config.mjs" ins={3} ins=/(?<!p)react\\(\\)/
-import { defineConfig } from 'astro/config';
-
-import react from '@astrojs/react';
-import preact from '@astrojs/preact';
-import svelte from '@astrojs/svelte';
-import vue from '@astrojs/vue';
-import solid from '@astrojs/solid-js';
-import lit from '@astrojs/lit';
-import alpine from '@astrojs/alpinejs';
-
-export default defineConfig({
-	integrations: [react(), preact(), svelte(), vue(), solid(), lit(), alpine()],
-});
-```
+Astro ships with [optional integrations](/en/guides/integrations-guide/) for React, Preact, Svelte, Vue, SolidJS, AlpineJS and Lit. One or several of these Astro integrations can be installed and configured in your project.
 
 ⚙️ View the [Integrations Guide](/en/guides/integrations-guide/) for more details on installing and configuring Astro integrations.
 


### PR DESCRIPTION
- Minor content fixes (broken links, typos, etc.)

Removes integration installation instructions from the UI Framework components page because:
- duplication! These instructions are detailed elsewhere. Why maintain in 2 places?
- outdated! These instructions pre-dated the `astro add` command, and so were showing users more complicated, manual instructions when most shouldn't need them.

