### PR TITLE
remove scary warning

### DIFF
--- a/src/pages/en/guides/integrations-guide.mdx
+++ b/src/pages/en/guides/integrations-guide.mdx
@@ -25,10 +25,6 @@ Integrations can…
 
 Astro includes an `astro add` command to automate the setup of integrations.
 
-:::caution
-We will always ask for confirmation before updating any of your files, but it never hurts to have a version-controlled backup just in case.
-:::
-
 Run the `astro add` command using the package manager of your choice and our automatic integration wizard will update your configuration file and install any necessary dependencies.
 
 <PackageManagerTabs>


### PR DESCRIPTION
Warning is scary, not helpful!

- `astro add` is more reliable/familiar to users than at the time of this warning
- Houston walks a user through the changes to their file
- the integration READMEs show manual installation and what a properly installed and configured integration should look like, in case a user needs to compare.

Removing the scary warning as a quick fix not to scare off new users. Will revisit this page with more intention in the future.