### PR TITLE
Add beta tag detection in `<Since>`

### DIFF
--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -19,26 +19,28 @@ const parseSemVer = (semver: string) =>
  * Decide a feature is “new” if it was added in the latest minor version.
  * For example, `@version 0.24.0` will be new as long as `astro@latest` is 0.24.x
  */
-const isFeatureNew = async (sinceVersion: string) => {
+const getFeatureStatus = async (sinceVersion: string): Promise<'beta' | 'new' | 'current'> => {
 	const astroInfo = await cachedFetch('https://registry.npmjs.org/astro/latest').then((res) =>
 		res.json()
 	);
 	const latestAstroVersion = astroInfo.version;
 	const [sinceMajor, sinceMinor] = parseSemVer(sinceVersion);
 	const [latestMajor, latestMinor] = parseSemVer(latestAstroVersion);
-	return sinceMajor >= latestMajor && sinceMinor >= latestMinor;
+	console.log(sinceMajor, latestMajor, sinceMinor, latestMinor);
+	if (sinceMajor > latestMajor) {
+		return 'beta';
+	}
+	if (sinceMajor === latestMajor && sinceMinor >= latestMinor) {
+		return 'new';
+	}
+	return 'current';
 };
 
-const isNew = await isFeatureNew(v);
+const featureStatus = await getFeatureStatus(v);
 ---
 
 <span>
 	<strong><UIString key="since.addedIn" /></strong> v{v}
-	{
-		isNew && (
-			<Badge variant="accent">
-				<UIString key="since.new" />
-			</Badge>
-		)
-	}
+	{featureStatus === 'new' && (<Badge variant="accent"><UIString key="since.new" /></Badge>)}
+	{featureStatus === 'beta' && (<Badge variant="accent"><UIString key="since.beta" /></Badge>)}
 </span>

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -26,7 +26,6 @@ const getFeatureStatus = async (sinceVersion: string): Promise<'beta' | 'new' | 
 	const latestAstroVersion = astroInfo.version;
 	const [sinceMajor, sinceMinor] = parseSemVer(sinceVersion);
 	const [latestMajor, latestMinor] = parseSemVer(latestAstroVersion);
-	console.log(sinceMajor, latestMajor, sinceMinor, latestMinor);
 	if (sinceMajor > latestMajor) {
 		return 'beta';
 	}

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -37,6 +37,7 @@ export default {
 	// Used in `<Since>`: Added in: v0.24.0 [NEW]
 	'since.addedIn': 'Added in:',
 	'since.new': 'New',
+	'since.beta': 'Beta',
 	// Installation Guide
 	'install.autoTab': 'Automatic CLI',
 	'install.manualTab': 'Manual Setup',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Changes to the docs site code

#### Description

Adds a "beta" tag to the `<Since />` component. Without this, it's unclear that a `v2.0.0` feature isn't actually available yet.

#### Previously:

<img width="600" alt="Screen Shot 2023-01-13 at 9 34 01 PM" src="https://user-images.githubusercontent.com/622227/212457602-859ee2ce-2ffe-4e62-a09f-dca4bb7b6416.png">

#### Now:

<img width="606" alt="Screen Shot 2023-01-13 at 9 34 06 PM" src="https://user-images.githubusercontent.com/622227/212457604-a9be51fd-d503-43a9-b4ca-0f0025298ec5.png">
