### PR TITLE
Use more reliable image source for tutorial

### DIFF
--- a/src/pages/en/tutorial/5-astro-api/1.mdx
+++ b/src/pages/en/tutorial/5-astro-api/1.mdx
@@ -73,8 +73,8 @@ Now that you have a few blog posts to link to, let's configure the Blog page to 
   author: Astro Learner
   description: "This post will show up on its own!"
   image: 
-    url: "https://astro.build/assets/cover_Z1RSGKy.avif"
-    alt: "Diagram of HTML being fetched from a server."
+    url: "https://docs.astro.build/default-og-image.png"
+    alt: "The word “astro” against an illustration of planets and stars."
   pubDate: 2022-08-08
   tags: ["astro", "successes"]
   ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Follow up to #2382 
- The tutorial is using an image from astro.build but because these are optimized with `@astrojs/image` they are liable to change filename, breaking the tutorial. This PR switches to using [a static image](https://docs.astro.build/default-og-image.png) within the docs site instead.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
