### PR TITLE
Remove fake tabs from install guides

### DIFF
--- a/src/pages/en/install/auto.mdx
+++ b/src/pages/en/install/auto.mdx
@@ -4,19 +4,19 @@ description: 'How to install Astro with NPM, PNPM, or Yarn via the create-astro 
 layout: ~/layouts/MainLayout.astro
 i18nReady: true
 ---
-import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-Ready to install Astro? Follow our automatic or manual setup guide to get started.
+Ready to install Astro? Follow this guide to using the `create astro` CLI to get started.
 
+:::note[Prefer to install Astro manually?]
+Read our [step-by-step manual installation guide](/en/install/manual/) instead.
+:::
 #### Prerequisites
 
 - **Node.js** - `v16.12.0` or higher.
 - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro is accessed through its command-line interface (CLI).
-
-<InstallGuideTabGroup />
 
 #### Installation
 

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -11,7 +11,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 This guide will walk you through the steps to manually install and configure a new Astro project if you prefer not to use [the automatic CLI tool](/en/install/auto/).
 
-#### Want a quick way to get started?
+#### Prefer a quicker way to get started?
 
 <Button href="/en/install/auto/">Try the create astro CLI wizard →</Button>
 

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -4,20 +4,22 @@ description: 'How to install Astro manually with NPM, PNPM, or Yarn.'
 layout: ~/layouts/MainLayout.astro
 i18nReady: true
 ---
+import Button from '~/components/Button.astro'
 import FileTree from '~/components/FileTree.astro';
-import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-Ready to install Astro? Follow our automatic or manual set-up guide to get started.
+Ready to install Astro? Follow this manual set-up guide to get started.
+
+#### Want a quick way to get started?
+
+<Button href="/en/install/auto/">Try the create astro CLI wizard →</Button>
 
 #### Prerequisites
 
 - **Node.js** - `v16.12.0` or higher.
 - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro is accessed through its command-line interface (CLI).
-
-<InstallGuideTabGroup />
 
 #### Installation
 

--- a/src/pages/en/install/manual.mdx
+++ b/src/pages/en/install/manual.mdx
@@ -9,7 +9,7 @@ import FileTree from '~/components/FileTree.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-Ready to install Astro? Follow this manual set-up guide to get started.
+This guide will walk you through the steps to manually install and configure a new Astro project if you prefer not to use [the automatic CLI tool](/en/install/auto/).
 
 #### Want a quick way to get started?
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Supersedes #2326 

The “fake” tab pattern in the install guides has been tripping us up a bit. These are two separate pages, so let’s treat them that way properly! This also gives us some leeway to stress preferences a bit and encourage use of the `create astro` guide which is generally the better DX.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
