### PR TITLE
Improve subpages handling and add missing pages

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -17,9 +17,10 @@ export function removeTrailingSlash(path: string) {
 export function removeSubpageSegment(path: string) {
 	// Include new pages with subpages as part of this regex.
 	const regex = /(?:install|deploy|integrations-guide|tutorial|migrate-to-astro|cms)\//;
+	const matches = regex.exec(path);
 
-	if (regex.test(path)) {
-		const matchIndex = regex.exec(path)!.index;
+	if (matches) {
+		const matchIndex = matches.index;
 		// Get the first slash index after the main page path segment.
 		const slashIndex = path.slice(matchIndex).indexOf('/') + matchIndex;
 		return path.slice(0, slashIndex);

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,9 +15,14 @@ export function removeTrailingSlash(path: string) {
 
 /** Remove the subpage segment of a URL string */
 export function removeSubpageSegment(path: string) {
-	// Include new pages with subpages as part of this if statement.
-	if (/(?:install|deploy|integrations-guide|tutorial)\//.test(path)) {
-		return path.slice(0, path.lastIndexOf('/'));
+	// Include new pages with subpages as part of this regex.
+	const regex = /(?:install|deploy|integrations-guide|tutorial|migrate-to-astro|cms)\//;
+
+	if (regex.test(path)) {
+		const matchIndex = regex.exec(path)!.index;
+		// Get the first slash index after the main page path segment.
+		const slashIndex = path.slice(matchIndex).indexOf('/') + matchIndex;
+		return path.slice(0, slashIndex);
 	}
 	return path;
 }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR improves our sidebar subpages handling, now making it work for pages with technically infinite segments, so `en/example/[subpage-1]/[subpage-2]/[subpage-3]/[subpage-4]` will still be considered a subpage of `en/example/`, not only `en/example/[subpage]`.

This improves the navigation experience by highlighting the current main page in the sidebar and also collapsing the page section on mobile. I also added the missing "CMS" and "Migrate to Astro" to the subpages regex.

| Before | After |
| ------------- | ------------- |
| ![5zcVqgU](https://user-images.githubusercontent.com/61414485/212682662-b348f34a-193e-4539-8dd4-28c51ffbbeef.gif) | ![UEpLS0S](https://user-images.githubusercontent.com/61414485/212682498-d8e57132-e8b0-48b0-9a28-9b653aada6c4.gif) |

FIRST SIDEBAR PR OF THE YEAR BTW! 🥳 

