### PR TITLE
Revamped RSS instructions for content collections

### DIFF
--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -40,8 +40,7 @@ Now, let's generate our first RSS feed! Create an `rss.xml.js` file under your `
 
 Next, import the `rss` helper from the `@astrojs/rss` package and call with the following parameters:
 
-```js
-// src/pages/rss.xml.js
+```js title="src/pages/rss.xml.js"
 import rss from '@astrojs/rss';
 
 export function get(context) {
@@ -117,8 +116,7 @@ You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` 
 
 You can apply `pagesGlobToRssItems()` like so. This function assumes that you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter.
 
-```ts "pagesGlobToRssItems"
-// src/pages/rss.xml.js
+```js title="src/pages/rss.xml.js" "pagesGlobToRssItems"
 import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
 export function get(context) {
@@ -178,7 +176,7 @@ export function get(context) {
   return rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
-    site: import.meta.env.SITE,
+    site: context.site,
     items: posts.map((post) => ({
       link: post.url,
       content: sanitizeHtml(post.compiledContent()),

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -97,7 +97,7 @@ export async function get(context) {
 The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
 :::
 
-`@astrojs/rss` also exposes an `rssSchema` for use with collection schemas. This ensures your frontmatter contains all properties expected by an RSS feed item. You can apply this schema to your content config like so:
+You can configure your collection schema to enforce these expected RSS properties. Import and apply `rssSchema` to ensure that each collection entry produces a valid RSS feed item.
 
 ```js title="src/content/config.ts" "rssSchema"
 import { rssSchema } from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -133,7 +133,7 @@ export async function get(context) {
 The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
 :::tip
-Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
+Whenever you're using HTML content in XML, we suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 :::
 
 When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -111,29 +111,26 @@ const blog = defineCollection({
 export const collections = { blog };
 ```
 
-### 2. List of RSS feed objects
+### Using glob imports
 
-We recommend this option for `.md` files outside of the `pages` directory. This is common when generating routes [via `getStaticPaths`](/en/reference/api-reference/#getstaticpaths).
+You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` is not available from endpoint routes, we've included a `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid RSS feed items.
 
-For instance, say your `.md` posts are stored under a `src/posts/` directory. Each post has a `title`, `pubDate`, and `slug` in its frontmatter, where `slug` corresponds to the output URL on your site. We can generate an RSS feed using [Vite's `import.meta.glob` helper](https://vitejs.dev/guide/features.html#glob-import) like so:
+You can apply `pagesGlobToRssItems()` like so. This function assumes that you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter.
 
-```js
+```ts "pagesGlobToRssItems"
 // src/pages/rss.xml.js
-import rss from '@astrojs/rss';
+import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true });
-const posts = Object.values(postImportResult);
-
-export const get = () => rss({
-  title: 'Buzz’s Blog',
-  description: 'A humble Astronaut’s guide to the stars',
-  site: import.meta.env.SITE,
-  items: posts.map((post) => ({
-    link: post.url,
-    title: post.frontmatter.title,
-    pubDate: post.frontmatter.pubDate,
-  }))
-});
+export function get(context) {
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: context.site,
+    items: pagesGlobToRssItems(
+      import.meta.glob('./blog/*.{md,mdx}'),
+    ),
+  });
+}
 ```
 
 ### Including full post content

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -63,7 +63,7 @@ export function get(context) {
 
 ## Generating `items`
 
-The `items` field accepts a list of RSS feed objects, each with a `link`, `title`, `pubDate`, and optional `description` and `customData` fields. You can generate this array from a content collection or by using glob imports.
+The `items` field accepts a list of RSS feed objects, each with a `link`, `title`, `pubDate`, and optional `description`, `content`, and `customData` fields. You can generate this array from a content collection or by using glob imports.
 
 ### Using content collections
 

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -137,29 +137,55 @@ export function get(context) {
 
 <Since v="1.6.14" />
 
-By default, the Astro RSS integration does not support including the content of each of your posts in the feed itself. 
+Items also accept a `content` key containing the full content of the post as HTML.
 
-However, if you create the list of RSS feed objects yourself, you can pass the content of Markdown files (not MDX), to the `content` key using the [`compiledContent()` property](/en/guides/markdown-content/#exported-properties). We suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded for use in the XML feed.
+:::tip
+Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
+:::
 
-```js ins={2, 16} title={src/pages/rss.xml.js}
+When using content collections, you may render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitizing the result:
+
+```js title="src/pages/rss.xml.js" ins={2, 3, 4, 14}
+import rss from '@astrojs/rss';
+import sanitizeHtml from 'sanitize-html';
+import MarkdownIt from 'markdown-it';
+const parser = new MarkdownIt();
+
+export async function get(context) {
+  const blog = await getCollection('blog');
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: context.site,
+    items: blog.map((post) => ({
+      link: `/blog/${post.slug}/`,
+      content: sanitizeHtml(parser.render(post.body)),
+      ...post.data,
+    })),
+  });
+}
+```
+
+When using glob imports with Markdown specifically, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization:
+
+```js title="src/pages/rss.xml.js" ins={2, 13}
 import rss from '@astrojs/rss';
 import sanitizeHtml from 'sanitize-html';
 
-// Works with Markdown files only!
-const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true }); 
-const posts = Object.values(postImportResult);
-
-export const get = () => rss({
-  title: 'Buzz’s Blog',
-  description: 'A humble Astronaut’s guide to the stars',
-  site: import.meta.env.SITE,
-  items: posts.map((post) => ({
-    link: post.url,
-    title: post.frontmatter.title,
-    pubDate: post.frontmatter.pubDate,
-    content: sanitizeHtml(post.compiledContent()),
-  }))
-});
+export function get(context) {
+  const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true }); 
+  const posts = Object.values(postImportResult);
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: import.meta.env.SITE,
+    items: posts.map((post) => ({
+      link: post.url,
+      content: sanitizeHtml(post.compiledContent()),
+      ...post.frontmatter,
+    })),
+  });
+}
 ```
 
 ## Adding a stylesheet

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -95,7 +95,7 @@ export async function get(context) {
 ```
 
 :::tip
-The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
+The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
 :::
 
 `@astrojs/rss` also exposes an `rssSchema` for use with collection schemas. This ensures your frontmatter contains all properties expected by an RSS feed item. You can apply this schema to your content config like so:

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -113,7 +113,7 @@ export const collections = { blog };
 
 You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` is not available from endpoint routes, we've included a `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid RSS feed items.
 
-You can apply `pagesGlobToRssItems()` like so. This function assumes that you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter.
+This function assumes, but does not verify, that all necessary feed properties are present in each document's frontmatter. If you encounter errors, verify each page frontmatter manually.
 
 ```js title="src/pages/rss.xml.js" "pagesGlobToRssItems" "await pagesGlobToRssItems("
 import rss, { pagesGlobToRssItems } from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -34,11 +34,7 @@ First, install `@astrojs/rss` using your preferred package manager:
   </Fragment>
 </PackageManagerTabs>
 
-Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links in your RSS feed [via the `SITE` environment variable](/en/guides/environment-variables/#default-environment-variables).
-
-:::note[Requires v1]
-The `SITE` environment variable only exists in the latest Astro 1.0 beta. Either upgrade to the latest version of Astro (`astro@latest`), or write your `site` manually if this isn't possible (see examples below).
-:::
+Then, ensure you've [configured a `site`](/en/reference/configuration-reference/#site) in your project's `astro.config`. You will use this to generate links to your RSS articles.
 
 Now, let's generate our first RSS feed! Create an `rss.xml.js` file under your `src/pages/` directory. `rss.xml` will be the output URL, so feel free to rename this if you prefer.
 
@@ -48,21 +44,22 @@ Next, import the `rss` helper from the `@astrojs/rss` package and call with the 
 // src/pages/rss.xml.js
 import rss from '@astrojs/rss';
 
-export const get = () => rss({
-  // `<title>` field in output xml
-  title: 'Buzz’s Blog',
-  // `<description>` field in output xml
-  description: 'A humble Astronaut’s guide to the stars',
-  // base URL for RSS <item> links
-  // SITE will use "site" from your project's astro.config.
-  site: import.meta.env.SITE,
-  // list of `<item>`s in output xml
-  // simple example: generate items for every md file in /src/pages
-  // see "Generating items" section for required frontmatter and advanced use cases
-  items: import.meta.glob('./**/*.md'),
-  // (optional) inject custom xml
-  customData: `<language>en-us</language>`,
-});
+export function get(context) {
+  return rss({
+    // `<title>` field in output xml
+    title: 'Buzz’s Blog',
+    // `<description>` field in output xml
+    description: 'A humble Astronaut’s guide to the stars',
+    // Pull in your project "site" from the endpoint context
+    // https://docs.astro.build/en/reference/api-reference/#contextsite
+    site: context.site,
+    // Array of `<item>`s in output xml
+    // See "Generating items" section for examples using content collections and glob imports
+    items: [],
+    // (optional) inject custom xml
+    customData: `<language>en-us</language>`,
+  });
+}
 ```
 
 ## Generating `items`

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -67,7 +67,7 @@ The `items` field accepts a list of RSS feed objects, each with a `link`, `title
 
 ### Using content collections
 
-You may use [content collections](/en/guides/content-collections/) to manage your Markdown or MDX content. This exposes a `getCollection()` function to retrieve a list of items that you can map to an RSS feed.
+To create an RSS feed of pages managed in [content collections](/en/guides/content-collections/), you use the `getCollection()` function to retrieve the list your of items.
 
 
 ```js title="src/pages/rss.xml.js" "items:" "const blog = await getCollection('blog');"

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -136,7 +136,7 @@ The `content` key contains the full content of the post as HTML. This allows you
 Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 :::
 
-When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitizing the result:
+When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:
 
 ```js title="src/pages/rss.xml.js" ins={2, 3, 4, 14}
 import rss from '@astrojs/rss';
@@ -152,6 +152,7 @@ export async function get(context) {
     site: context.site,
     items: blog.map((post) => ({
       link: `/blog/${post.slug}/`,
+      // Note: this will not process components or JSX expressions in MDX files.
       content: sanitizeHtml(parser.render(post.body)),
       ...post.data,
     })),
@@ -159,7 +160,7 @@ export async function get(context) {
 }
 ```
 
-When using glob imports with Markdown specifically, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization:
+When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. Note this feature is **not** supported for MDX files.
 
 ```js title="src/pages/rss.xml.js" ins={2, 13}
 import rss from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -93,10 +93,6 @@ export async function get(context) {
 }
 ```
 
-:::tip
-The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
-:::
-
 You can configure your collection schema to enforce these expected RSS properties. Import and apply `rssSchema` to ensure that each collection entry produces a valid RSS feed item.
 
 ```js title="src/content/config.ts" "rssSchema"

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -116,15 +116,15 @@ You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` 
 
 You can apply `pagesGlobToRssItems()` like so. This function assumes that you are globbing for items inside `src/pages/`, and all necessary feed properties are present in each document's frontmatter.
 
-```js title="src/pages/rss.xml.js" "pagesGlobToRssItems"
+```js title="src/pages/rss.xml.js" "pagesGlobToRssItems" "await pagesGlobToRssItems("
 import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-export function get(context) {
+export async function get(context) {
   return rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
     site: context.site,
-    items: pagesGlobToRssItems(
+    items: await pagesGlobToRssItems(
       import.meta.glob('./blog/*.{md,mdx}'),
     ),
   });

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -134,7 +134,7 @@ export async function get(context) {
 
 <Since v="1.6.14" />
 
-Items also accept a `content` key containing the full content of the post as HTML.
+The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
 :::tip
 Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -107,7 +107,7 @@ export const collections = { blog };
 
 ### Using glob imports
 
-You may generate an RSS feed from documents in `src/pages/`. Since `Astro.glob` is not available from endpoint routes, we've included a `pagesGlobToRssItems()` helper. This accepts an `import.meta.glob` result ([see Vite documentation](https://vitejs.dev/guide/features.html#glob-import)) and outputs an array of valid RSS feed items.
+To create an RSS feed from documents in `src/pages/`, use the `pagesGlobToRssItems()` helper. This accepts an [`import.meta.glob`](https://vitejs.dev/guide/features.html#glob-import) result and outputs an array of valid RSS feed items (see [more about writing glob patterns](/en/guides/imports/#glob-patterns) for specifying which pages to include).
 
 This function assumes, but does not verify, that all necessary feed properties are present in each document's frontmatter. If you encounter errors, verify each page frontmatter manually.
 

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -99,6 +99,18 @@ export async function get(context) {
 The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
 :::
 
+`@astrojs/rss` also exposes an `rssSchema` for use with collection schemas. This ensures your frontmatter contains all properties expected by an RSS feed item. You can apply this schema to your content config like so:
+
+```js title="src/content/config.ts" "rssSchema"
+import { rssSchema } from '@astrojs/rss';
+
+const blog = defineCollection({
+  schema: rssSchema,
+});
+
+export const collections = { blog };
+```
+
 ### 2. List of RSS feed objects
 
 We recommend this option for `.md` files outside of the `pages` directory. This is common when generating routes [via `getStaticPaths`](/en/reference/api-reference/#getstaticpaths).

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -140,7 +140,7 @@ The `content` key contains the full content of the post as HTML. This allows you
 Whenever you're using HTML content in XML, suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 :::
 
-When using content collections, you may render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitizing the result:
+When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitizing the result:
 
 ```js title="src/pages/rss.xml.js" ins={2, 3, 4, 14}
 import rss from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -64,29 +64,40 @@ export function get(context) {
 
 ## Generating `items`
 
-The `items` field accepts either:
-1. [An `import.meta.glob(...)` result](#1-importmetaglob-result) **(only use this for `.md` files within the `src/pages/` directory!)**
-2. [A list of RSS feed objects](#2-list-of-rss-feed-objects), each with a `link`, `title`, `pubDate`, and optional `description` and `customData` fields.
+The `items` field accepts a list of RSS feed objects, each with a `link`, `title`, `pubDate`, and optional `description` and `customData` fields. You can generate this array from a content collection or by using glob imports.
 
-### 1. `import.meta.glob` result
+### Using content collections
 
-We recommend this option as a convenient shorthand for `.md` files under `src/pages/`. Each post should have a `title`, `pubDate`, and optional `description` and `customData` fields in its frontmatter. If this isn't possible, or you'd prefer to generate this frontmatter in code, [see option 2](#2-list-of-rss-feed-objects).
+You may use [content collections](/en/guides/content-collections/) to manage your Markdown or MDX content. This exposes a `getCollection()` function to retrieve a list of items that you can map to an RSS feed.
 
-Say your blog posts are stored under the `src/pages/blog/` directory. You can generate an RSS feed like so:
+For example, say you have a `blog` collection under `src/content/blog/`. You can retrieve this collection and generate an RSS feed like so:
 
-```js
-// src/pages/rss.xml.js
+```js title="src/pages/rss.xml.js" "items:" "const blog = await getCollection('blog');"
 import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
 
-export const get = () => rss({
-  title: 'Buzz’s Blog',
-  description: 'A humble Astronaut’s guide to the stars',
-  site: import.meta.env.SITE,
-  items: import.meta.glob('./blog/**/*.md'),
-});
+export async function get(context) {
+  const blog = await getCollection('blog');
+  return rss({
+    title: 'Buzz’s Blog',
+    description: 'A humble Astronaut’s guide to the stars',
+    site: context.site,
+    items: blog.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.pubDate,
+      description: post.data.description,
+      customData: post.data.customData,
+      // Compute RSS link from post `slug`
+      // This example assumes all posts are rendered as `/blog/[slug]` routes
+      link: `/blog/${post.slug}/`,
+    })),
+  });
+}
 ```
 
-See [Vite's glob import documentation](https://vitejs.dev/guide/features.html#glob-import) for more on this import syntax.
+:::tip
+The `link` property of each feed item can be computed from the content entry `slug`. See [our guide on generating pages from content collections](https://docs.astro.build/en/guides/content-collections/#generating-pages-from-content-collections) to see how slugs correspond to routes.
+:::
 
 ### 2. List of RSS feed objects
 

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -160,7 +160,7 @@ export async function get(context) {
 }
 ```
 
-When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. Note this feature is **not** supported for MDX files.
+When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. Note: this feature is **not** supported for MDX files.
 
 ```js title="src/pages/rss.xml.js" ins={2, 13}
 import rss from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -69,7 +69,6 @@ The `items` field accepts a list of RSS feed objects, each with a `link`, `title
 
 You may use [content collections](/en/guides/content-collections/) to manage your Markdown or MDX content. This exposes a `getCollection()` function to retrieve a list of items that you can map to an RSS feed.
 
-For example, say you have a `blog` collection under `src/content/blog/`. You can retrieve this collection and generate an RSS feed like so:
 
 ```js title="src/pages/rss.xml.js" "items:" "const blog = await getCollection('blog');"
 import rss from '@astrojs/rss';

--- a/src/pages/en/tutorial/5-astro-api/4.mdx
+++ b/src/pages/en/tutorial/5-astro-api/4.mdx
@@ -134,4 +134,4 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
 
 ### Resources
 
-- [RSS item generation in Astro](/en/guides/rss/#1-importmetaglob-result)
+- [RSS item generation in Astro](/en/guides/rss/#using-glob-imports)

--- a/src/pages/en/tutorial/5-astro-api/4.mdx
+++ b/src/pages/en/tutorial/5-astro-api/4.mdx
@@ -75,15 +75,17 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
 
     ```js title="src/pages/rss.xml.js"
 
-    import rss from '@astrojs/rss';
+    import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-    export const get = () => rss({
-      title: 'Astro Learner | Blog',
-      description: 'My journey learning Astro',
-      site: 'https://my-blog-site.netlify.app',
-      items: import.meta.glob('./**/*.md'),
-      customData: `<language>en-us</language>`,
-    });
+    export async function get() {
+      return rss({
+        title: 'Astro Learner | Blog',
+        description: 'My journey learning Astro',
+        site: 'https://my-blog-site.netlify.app',
+        items: await pagesGlobToRssItems(import.meta.glob('./**/*.md')),
+        customData: `<language>en-us</language>`,
+      });
+    }
     ```
 
 3. This `rss.xml` document is only created when your site is built, so you won't be able to see this page in your browser during development. Quit the dev server and run the following commands to first, build your site locally and then, view a preview of your build:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Updates for https://github.com/withastro/astro/pull/5851
- Change `import.meta.env.SITE` to new `context.site`
- Update leading example to use content collections
- Add new "using content collections" section to "Generating items"
- Update glob import instructions to recommend the `pagesGlobToRssItems()` function
- Update "including full post content" with content collections instructions. **The `markdown-it` recommendation may change** once we support an `html` output for content collections!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
