### PR TITLE
Update from-sveltekit.mdx

### DIFF
--- a/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -30,11 +30,9 @@ When you rebuild your SvelteKit site in Astro, you will notice some important di
 
 - [Components](/en/core-concepts/astro-components/): SvelteKit uses [Svelte](https://svelte.dev). Astro pages are built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 
-- [Content-focus](/en/concepts/why-astro/): Astro was designed to excel at making content-focused websites. An existing SvelteKit app might be built for high client-side interactivity and may include items that are difficult to replicate in Astro, such as dashboards.
+- [Content-focus](/en/concepts/why-astro/): Astro was designed to excel at making content-focused websites. An existing SvelteKit app might be built for high client-side interactivity and may include pages such as dashboards or use features like SvelteKit’s [form actions](https://kit.svelte.dev/docs/form-actions) that are more difficult to replicate in Astro.
 
 - [Markdown-ready](/en/guides/markdown-content/): Astro includes built-in Markdown support, and includes a [special frontmatter YAML `layout` property](/en/core-concepts/layouts/#markdownmdx-layouts) used per-file for page templating. If you are converting a SvelteKit Markdown-based blog, you will not have to install a separate Markdown integration and you will not set a layout via a configuration file. You can bring your existing Markdown files, but you may need to reorganize as Astro's file-based routing does not require a folder for each page route.
-
-- SvelteKit has features like [form actions](https://kit.svelte.dev/docs/form-actions) that do not have a direct equivalent in Astro. 
 
 
 ## Switch from SvelteKit to Astro

--- a/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -26,7 +26,7 @@ SvelteKit and Astro share some similarities that will help you migrate your proj
 
 When you rebuild your SvelteKit site in Astro, you will notice some important differences:
 
-- [MPA vs alternatives](/en/concepts/mpa-vs-spa/): Astro sites are multi-page apps, whereas SvelteKit defaults to SPAs (single-page applications) with server-side rendering, but can also create MPAs or traditional SPAs. SvelteKit supports different modes for different pages.
+- [MPA vs alternatives](/en/concepts/mpa-vs-spa/): Astro sites are multi-page apps, whereas SvelteKit defaults to SPAs (single-page applications) with server-side rendering, but can also create MPAs, traditional SPAs, or you can mix and match these techniques within an app.
 
 - [Components](/en/core-concepts/astro-components/): SvelteKit uses [Svelte](https://svelte.dev). Astro pages are built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 

--- a/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/pages/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating from SvelteKit
-description: Tips for migrating an existing Sveltekit project to Astro
+description: Tips for migrating an existing SvelteKit project to Astro
 layout: ~/layouts/MigrationLayout.astro
 stub: true
 framework: SvelteKit
@@ -14,7 +14,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 SvelteKit and Astro share some similarities that will help you migrate your project:
 
-- Both SvelteKit and Astro are modern Javascript static-site generators. 
+- Both SvelteKit and Astro are modern JavaScript static-site generators and server-side rendering frameworks. 
 
 - Both SvelteKit and Astro use a [`src/` folder for your project files](/en/core-concepts/project-structure/#src) and a [special folder for file-based routing](/en/core-concepts/astro-pages/). Creating and managing pages for your site should feel familiar.
 
@@ -26,11 +26,15 @@ SvelteKit and Astro share some similarities that will help you migrate your proj
 
 When you rebuild your SvelteKit site in Astro, you will notice some important differences:
 
-- [MPA vs SPA](/en/concepts/mpa-vs-spa/): SvelteKit is a Svelte-based SPA (single-page application). Astro sites are multi-page apps built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
+- [MPA vs alternatives](/en/concepts/mpa-vs-spa/): Astro sites are multi-page apps, whereas SvelteKit defaults to SPAs (single-page applications) with server-side rendering, but can also create MPAs or traditional SPAs. SvelteKit supports different modes for different pages.
+
+- [Components](/en/core-concepts/astro-components/): SvelteKit uses [Svelte](https://svelte.dev). Astro pages are built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 
 - [Content-focus](/en/concepts/why-astro/): Astro was designed to excel at making content-focused websites. An existing SvelteKit app might be built for high client-side interactivity and may include items that are difficult to replicate in Astro, such as dashboards.
 
-- [Markdown-ready](/en/guides/markdown-content/): Astro includes built-in Markdown support, and includes a [special frontmatter YAML `layout` property](/en/core-concepts/layouts/#markdownmdx-layouts) used per-file for page templating. If you are converting a Sveltekit Markdown-based blog, you will not have to install a separate Markdown integration and you will not set a layout via a configuration file. You can bring your existing Markdown files, but you may need to reorganize as Astro's file-based routing does not require a folder for each page route.
+- [Markdown-ready](/en/guides/markdown-content/): Astro includes built-in Markdown support, and includes a [special frontmatter YAML `layout` property](/en/core-concepts/layouts/#markdownmdx-layouts) used per-file for page templating. If you are converting a SvelteKit Markdown-based blog, you will not have to install a separate Markdown integration and you will not set a layout via a configuration file. You can bring your existing Markdown files, but you may need to reorganize as Astro's file-based routing does not require a folder for each page route.
+
+- SvelteKit has features like [form actions](https://kit.svelte.dev/docs/form-actions) that do not have a direct equivalent in Astro. 
 
 
 ## Switch from SvelteKit to Astro


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

Hey! I noticed a couple of small inaccuracies on https://docs.astro.build/en/guides/migrate-to-astro/from-sveltekit:

- It describes Astro and SvelteKit as SSGs, which sells both of them short
- It categorises SvelteKit as an SPA (and is missing "framework"), but the reality is more nuanced — SvelteKit is capable of producing MPAs, and server-rendered HTML is optional
- There's no mention of SvelteKit features that don't have a direct equivalent in Astro (such as form actions), which is helpful information for someone considering a migration

The PR also fixes a couple of typos — Javascript -> JavaScript and Sveltekit -> SvelteKit.

Thanks!