### PR TITLE
content collections in styling, markdown pages

### DIFF
--- a/src/pages/en/core-concepts/astro-pages.mdx
+++ b/src/pages/en/core-concepts/astro-pages.mdx
@@ -20,7 +20,7 @@ Astro supports the following file types in the `src/pages/` directory:
 
 Astro leverages a routing strategy called **file-based routing**. Each file in your `src/pages/` directory becomes an endpoint on your site based on its file path.
 
-An Astro page can also generate multiple pages dynamically, allowing your content to live outside of the special `/pages/` directory, such as in a [content collection](/en/guides/content-collections/#rendering-entry-content) or a [CMS](/en/guides/cms/).
+A single file can also generate multiple pages using [dynamic routing](/en/core-concepts/routing/#dynamic-routes). This allows you to create pages even if your content lives outside of the special `/pages/` directory, such as in a [content collection](/en/guides/content-collections/#rendering-entry-content) or a [CMS](/en/guides/cms/).
 
 📚 Read more about [Routing in Astro](/en/core-concepts/routing/).
 
@@ -64,7 +64,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 Astro also treats any Markdown (`.md`) files inside of `src/pages/` as pages in your final website. If you have the [MDX Integration installed](/en/guides/integrations-guide/mdx/#installation), it also treats MDX (`.mdx`) files the same way. These are commonly used for text-heavy pages like blog posts and documentation.
 
-[Collections of similar Markdown or MDX page content files](/en/guides/content-collections/) can be located in `src/content/`. Then, these pages can be [generated dynamically](/en/core-concepts/routing/#dynamic-routes).
+[Collections of Markdown or MDX page content](/en/guides/content-collections/) in `src/content/` can be used to [generate pages dynamically](/en/core-concepts/routing/#dynamic-routes).
 
 Page layouts are especially useful for [Markdown files](#markdownmdx-pages). Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layouts/) that will wrap their Markdown content in a full `<html>...</html>` page document.
 

--- a/src/pages/en/core-concepts/astro-pages.mdx
+++ b/src/pages/en/core-concepts/astro-pages.mdx
@@ -20,6 +20,8 @@ Astro supports the following file types in the `src/pages/` directory:
 
 Astro leverages a routing strategy called **file-based routing**. Each file in your `src/pages/` directory becomes an endpoint on your site based on its file path.
 
+An Astro page can also generate multiple pages dynamically, allowing your content to live outside of the special `/pages/` directory, such as in a [content collection](/en/guides/content-collections/#rendering-entry-content) or a [CMS](/en/guides/cms/).
+
 📚 Read more about [Routing in Astro](/en/core-concepts/routing/).
 
 ### Link between pages
@@ -61,6 +63,8 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 ## Markdown/MDX Pages
 
 Astro also treats any Markdown (`.md`) files inside of `src/pages/` as pages in your final website. If you have the [MDX Integration installed](/en/guides/integrations-guide/mdx/#installation), it also treats MDX (`.mdx`) files the same way. These are commonly used for text-heavy pages like blog posts and documentation.
+
+[Collections of similar Markdown or MDX page content files](/en/guides/content-collections/) can be located in `src/content/`. Then, these pages can be [generated dynamically](/en/core-concepts/routing/#dynamic-routes).
 
 Page layouts are especially useful for [Markdown files](#markdownmdx-pages). Markdown files can use the special `layout` front matter property to specify a [layout component](/en/core-concepts/layouts/) that will wrap their Markdown content in a full `<html>...</html>` page document.
 

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -6,6 +6,7 @@ i18nReady: true
 ---
 
 import Since from '~/components/Since.astro'
+import FileTree from '~/components/FileTree.astro'
 
 [Markdown](https://daringfireball.net/projects/markdown/) is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for standard Markdown files. 
 
@@ -14,6 +15,28 @@ With the [@astrojs/mdx integration](/en/guides/integrations-guide/mdx/) installe
 Use either or both types of files to write your Markdown content!
 
 ## Markdown and MDX Pages
+
+### Content collections 
+
+Astro allows you to manage your Markdown and MDX files in Astro in a special `src/content/` folder. [Content collections](/en/guides/content-collections/) will organize your content, validate your frontmatter, and provide automatic TypeScript type-safety of fetched content. 
+
+<FileTree>
+- src/content/
+  - **newsletter/** 
+    - week-1.md
+    - week-2.md
+    - week-3.md
+  - **authors/**
+    - grace-hopper.md
+    - alan-turing.md
+    - batman.md
+</FileTree>
+
+
+Available in both SSG and SSR mode, collections can optionally include schemas to enforce consistent frontmatter within each collection and provide helpful autocompletion.
+
+See more about using [content collections in Astro](/en/guides/content-collections/).
+
 
 ### File-based Routing
 
@@ -131,6 +154,9 @@ const {frontmatter} = Astro.props;
 </html>
 ```
 
+You can apply global styles to your Markdown with [`<style>` tags](/en/guides/styling/#global-styles) and [imported stylesheets](/en/guides/styling/#external-styles) in your layout component.
+
+
 📚 Learn more about [Markdown Layouts](/en/core-concepts/layouts/#markdownmdx-layouts).
 
 
@@ -150,7 +176,6 @@ I can link internally to [my conclusion](#conclusion) on the same page when writ
 
 I can use the URL `https://my-domain.com/page-1/#introduction` to navigate directly to my Introduction on the page. 
 ```
-
 
 ### Escaping special characters
 
@@ -428,7 +453,7 @@ You can customize how remark parses your Markdown in `astro.config.mjs`. See the
 
 ### Markdown Plugins
 
-Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and more. 
+Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and [styling your Markdown](/en/guides/styling/#markdown-styling). 
 
 We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins! See each plugin's own README for specific installation instructions.
 

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -18,22 +18,19 @@ Use either or both types of files to write your Markdown content!
 
 ### Content collections 
 
-Astro allows you to manage your Markdown and MDX files in Astro in a special `src/content/` folder. [Content collections](/en/guides/content-collections/) will organize your content, validate your frontmatter, and provide automatic TypeScript type-safety of fetched content. 
+You can manage your Markdown and MDX files in Astro in a special `src/content/` folder. [Content collections](/en/guides/content-collections/) help you organize your content, validate your frontmatter, and provide automatic TypeScript type-safety while working with your content. 
 
 <FileTree>
 - src/content/
   - **newsletter/** 
     - week-1.md
     - week-2.md
-    - week-3.md
   - **authors/**
     - grace-hopper.md
     - alan-turing.md
-    - batman.md
 </FileTree>
 
 
-Available in both SSG and SSR mode, collections can optionally include schemas to enforce consistent frontmatter within each collection and provide helpful autocompletion.
 
 See more about using [content collections in Astro](/en/guides/content-collections/).
 

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -154,7 +154,7 @@ const {frontmatter} = Astro.props;
 </html>
 ```
 
-You can apply global styles to your Markdown with [`<style>` tags](/en/guides/styling/#global-styles) and [imported stylesheets](/en/guides/styling/#external-styles) in your layout component.
+You can also [style your Markdown](/en/guides/styling/#markdown-styling) in your layout component.
 
 
 📚 Learn more about [Markdown Layouts](/en/core-concepts/layouts/#markdownmdx-layouts).

--- a/src/pages/en/guides/styling.mdx
+++ b/src/pages/en/guides/styling.mdx
@@ -12,7 +12,7 @@ import Since from '../../../components/Since.astro';
 
 Astro was designed to make styling and writing CSS a breeze. Write your own CSS directly inside of an Astro component or import your favorite CSS library like [Tailwind][tailwind]. Advanced styling languages like [Sass][sass] and [Less][less] are also supported.
 
-## Styling in Astro
+## Styling in Astro Components
 
 Styling an Astro component is as easy as adding a `<style>` tag to your component or page template. When you place a `<style>` tag inside of an Astro component, Astro will detect the CSS and handle your styles for you, automatically.
 
@@ -481,6 +481,13 @@ Vue in Astro supports the same methods as `vue-loader` does:
 
 Svelte in Astro also works exactly as expected: [Svelte Styling Docs][svelte-style].
 
+## Markdown Styling
+
+Any Astro styling methods are available to a [Markdown layout component](/en/core-concepts/layouts/#markdownmdx-layouts).
+
+You can apply global styles to your Markdown content by adding [`<style>` tags](#global-styles) and [imported stylesheets](#external-styles) to the layout that wraps your page content. You can also add [CSS integrations](#css-integrations) including [Tailwind](/en/guides/integrations-guide/tailwind).
+
+Additionally, you can install and use [Markdown plugins](/en/guides/markdown-content/#markdown-plugins) such as the [Tailwind/typography plugin](https://tailwindcss.com/docs/typography-plugin) for styling Markdown.
 
 ## Advanced
 

--- a/src/pages/en/guides/styling.mdx
+++ b/src/pages/en/guides/styling.mdx
@@ -487,7 +487,7 @@ Any Astro styling methods are available to a [Markdown layout component](/en/cor
 
 You can apply global styles to your Markdown content by adding [`<style>` tags](#global-styles) and [imported stylesheets](#external-styles) to the layout that wraps your page content. You can also add [CSS integrations](#css-integrations) including [Tailwind](/en/guides/integrations-guide/tailwind/).
 
-Additionally, you can install and use [Markdown plugins](/en/guides/markdown-content/#markdown-plugins) such as the [Tailwind/typography plugin](https://tailwindcss.com/docs/typography-plugin) for styling Markdown.
+If you are using Tailwind, the [typography plugin](https://tailwindcss.com/docs/typography-plugin) can be useful for styling Markdown.
 
 ## Advanced
 

--- a/src/pages/en/guides/styling.mdx
+++ b/src/pages/en/guides/styling.mdx
@@ -12,7 +12,7 @@ import Since from '../../../components/Since.astro';
 
 Astro was designed to make styling and writing CSS a breeze. Write your own CSS directly inside of an Astro component or import your favorite CSS library like [Tailwind][tailwind]. Advanced styling languages like [Sass][sass] and [Less][less] are also supported.
 
-## Styling in Astro Components
+## Styling in Astro
 
 Styling an Astro component is as easy as adding a `<style>` tag to your component or page template. When you place a `<style>` tag inside of an Astro component, Astro will detect the CSS and handle your styles for you, automatically.
 
@@ -485,7 +485,7 @@ Svelte in Astro also works exactly as expected: [Svelte Styling Docs][svelte-sty
 
 Any Astro styling methods are available to a [Markdown layout component](/en/core-concepts/layouts/#markdownmdx-layouts).
 
-You can apply global styles to your Markdown content by adding [`<style>` tags](#global-styles) and [imported stylesheets](#external-styles) to the layout that wraps your page content. You can also add [CSS integrations](#css-integrations) including [Tailwind](/en/guides/integrations-guide/tailwind).
+You can apply global styles to your Markdown content by adding [`<style>` tags](#global-styles) and [imported stylesheets](#external-styles) to the layout that wraps your page content. You can also add [CSS integrations](#css-integrations) including [Tailwind](/en/guides/integrations-guide/tailwind/).
 
 Additionally, you can install and use [Markdown plugins](/en/guides/markdown-content/#markdown-plugins) such as the [Tailwind/typography plugin](https://tailwindcss.com/docs/typography-plugin) for styling Markdown.
 


### PR DESCRIPTION
This PR starts to sprinkle in content collections in appropriate places throughout the docs.

1. Markdown/MDX: Content collections is now the recommended suggestion for creating pages, so it is now listed under the `## Markdown and MDX Pages` heading.

1. Pages: Content collections is now mentioned in Pages

1. Styling of content collections came up in discussion, which is really no different than styling your Markdown content anywhere it occurs. So, in order to support new collections users this PR adds a section on Markdown styling to the Styling page. And, the Markdown/MDX page links TO it, rather than duplicating content.

TODO: Link to this new styling markdown section FROM the content collections page itself. This page already has a complicated PR in the works, so this will be added later to this PR or in a future one.