### PR TITLE
i18n(es): add multiple error pages

### DIFF
--- a/src/pages/es/reference/errors/failed-to-load-module-ssr.mdx
+++ b/src/pages/es/reference/errors/failed-to-load-module-ssr.mdx
@@ -1,0 +1,24 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Could not import file.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **FailedToLoadModuleSSR**: No se pudo importar `IMPORT_NAME`. (E04001)
+
+## ¿Qué salió mal?
+
+Astro no pudo importar el archivo solicitado. A menudo, esto se debe a que la ruta de importación es incorrecta (ya sea porque el archivo no existe o hay un error ortográficos en la ruta)
+
+Este mensaje también puede aparecer cuando se importa un tipo sin especificar que se trata de una [importación de tipo](/es/guides/typescript/#importación-de-tipos).
+
+**Ver también:**
+
+-  [Importación de tipos](/es/guides/typescript/#importación-de-tipos)
+

--- a/src/pages/es/reference/errors/generate-content-types-error.mdx
+++ b/src/pages/es/reference/errors/generate-content-types-error.mdx
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Failed to generate content types.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GenerateContentTypesError**: El comando `astro sync` no pudo generar tipos de colección de contenido. (E08001)
+
+## ¿Qué salió mal?
+
+El comando `astro sync` no pudo generar tipos de colección de contenido.
+
+**Ver también:**
+
+-  [Documentación de colecciones de contenido](/es/guides/content-collections/)
+

--- a/src/pages/es/reference/errors/get-static-paths-expected-params.mdx
+++ b/src/pages/es/reference/errors/get-static-paths-expected-params.mdx
@@ -1,0 +1,36 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Missing params property on getStaticPaths route.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GetStaticPathsExpectedParams**: Falta o está vacía la propiedad `params` requerida en la ruta `getStaticPaths`. (E03013)
+
+## ¿Qué salió mal?
+
+Cada ruta especificada por `getStaticPaths` requiere una propiedad `params` que especifique los parámetros de ruta necesarios para que coincidan con la ruta.
+
+Por ejemplo, el siguiente código:
+
+```astro title="pages/blog/[id].astro"
+---
+export async function getStaticPaths() {
+	return [
+		{ params: { id: '1' } }
+	];
+}
+---
+```
+Creará la siguiente ruta: `site.com/blog/1`.
+
+**Ver también:**
+
+-  [`getStaticPaths()`](/es/reference/api-reference/#getstaticpaths)
+-  [`params`](/es/reference/api-reference/#params)
+

--- a/src/pages/es/reference/errors/get-static-paths-invalid-route-param.mdx
+++ b/src/pages/es/reference/errors/get-static-paths-invalid-route-param.mdx
@@ -1,0 +1,49 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Invalid value for getStaticPaths route parameter.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GetStaticPathsInvalidRouteParam**: Parámetro de ruta inválido en `getStaticPaths` para la `KEY`. Se esperaba undefined, una string o un número, pero se recibió `VALUE_TYPE` (`VALUE`) (E03014)
+
+## ¿Qué salió mal?
+
+Dado que los `parámetros` están codificados en la URL, solo se admiten ciertos tipos como valores.
+
+```astro title="/route/[id].astro"
+---
+export async function getStaticPaths() {
+	return [
+		{ params: { id: '1' } } // Works
+		{ params: { id: 2 } } // Works
+		{ params: { id: false } } // Does not work
+	];
+}
+---
+```
+
+En las rutas que usan [parámetros rest](/es/core-concepts/routing/#parámetros-rest), `undefined` se puede usar para representar una ruta sin parámetros pasados en la URL:
+
+```astro title="/route/[...id].astro"
+---
+export async function getStaticPaths() {
+	return [
+		{ params: { id: 1 } } // /route/1
+		{ params: { id: 2 } } // /route/2
+		{ params: { id: undefined } } // /route/
+	];
+}
+---
+```
+
+**Ver también:**
+
+-  [`getStaticPaths()`](/es/reference/api-reference/#getstaticpaths)
+-  [`params`](/es/reference/api-reference/#params)
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Translated content

#### Description
Adds translation in Spanish for:

- `reference/errors/failed-to-load-module-ssr.mdx`
- `reference/errors/generate-content-types-error.mdx`
- `reference/errors/get-static-paths-expected-params.mdx`
- `reference/errors/get-static-paths-invalid-route-param.mdx`
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
