### PR TITLE
Corrected the way to use imported images in a regular img tag

### DIFF
--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -26,7 +26,7 @@ import rocket from '../images/rocket.svg';
 <img src="/assets/stars.png" alt="A starry night sky.">
 
 <!-- Local image stored at src/images/rocket.svg -->
-<img src={rocket} alt="A rocketship in space."/>
+<img src={rocket.src} alt="A rocketship in space."/>
 ```
 
 ### In Markdown files
@@ -62,7 +62,7 @@ import rocket from '../images/rocket.svg';
 # My MDX Page
 
 // Local image stored at src/images/rocket.svg
-<img src={rocket} alt="A rocketship in space."/>
+<img src={rocket.src} alt="A rocketship in space."/>
 
 // Local image stored at public/assets/stars.png
 ![A starry night sky.](/assets/stars.png)
@@ -95,7 +95,7 @@ Import them from a **relative file path** or [import alias](/en/guides/aliases/)
 // Access images in `src/images/`
 import logo from '../images/logo.png';
 ---
-<img src={logo} width="40" alt="Astro" />
+<img src={logo.src} width="40" alt="Astro" />
 ```
 
 ### `public/`


### PR DESCRIPTION
As pointed out in [this support thread](https://discord.com/channels/830184174198718474/1065656313784307722/1065656313784307722) the way that the docs say you need to import images into a normal <img> tag is inaccurate. This corrects that

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes `none` <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
Changes `src={IMAGE}` to `src={IMAGE.dev}` in the image integration guide
- Did you change something visual? A before/after screenshot can be helpful.
Not really

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
