### PR TITLE
Document version of RSS package needed for new features

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -88,18 +88,15 @@ Sometimes it is helpful to add a small badge to some content to label or highlig
 
 Badges work best when they only contain a single word or — at a push — two words. Think of them as a tag or label for something, not a way to highlight longer passages of text.
 
-```md
----
-setup: |
-  import Badge from '~/components/Badge.astro';
----
+```mdx
+import Badge from '~/components/Badge.astro';
 
 <Badge>Nice</Badge>
 ```
 
 By default, the badge uses a muted colour scheme to blend in. It also has an accented variant that can be used if you need it to stand out more from the surrounding context:
 
-```md
+```mdx
 <Badge variant="accent">Wow!</Badge>
 ```
 
@@ -182,14 +179,11 @@ Note that these components share state, so if a reader changes the active tab of
 
 #### Examples
 
-To use an existing Tabs component (e.g. `<PackageManagerTabs>` , `<UIFrameworkTabs>`), import it into the `.md` page's frontmatter using the `setup:` property. 
+To use an existing Tabs component (e.g. `<PackageManagerTabs>` , `<UIFrameworkTabs>`), import it in the `.mdx` file:
 
-```markdown
----
-setup: | 
-  import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
-  import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
----
+```mdx
+import InstallGuideTabGroup from '~/components/TabGroup/InstallGuideTabGroup.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 ```
 
 Then, create a `<Fragment>` for each tab. The fragment's slot name will identify the tab label and the content between the opening and closing `<Fragment>...</Fragment>` tags will be the panel content.

--- a/WRITING.md
+++ b/WRITING.md
@@ -127,7 +127,7 @@ This will render the text “**Added in:** `astro@1.0.0`”.
 The advantages of using the component include:
 
 - “Added in” is automatically translated on pages in other languages.
-- The passed version is checked against the current Astro version and “NEW” or “BETA” badges will be added automatically based on data from npm.
+- The passed version is checked against the current package version and “NEW” or “BETA” badges will be added automatically based on data from npm.
 
 #### Examples
 

--- a/WRITING.md
+++ b/WRITING.md
@@ -110,45 +110,54 @@ By default, the badge uses a muted colour scheme to blend in. It also has an acc
 
 ### Since Component
 
-As features are added to Astro, it can be helpful to document _when_ they were added. This allows users to easily see if the version of Astro they are running supports a specific feature as described in the docs.
+As features are added to Astro, it can be helpful to document _when_ they were added. This allows users to easily see if the version of Astro (or other packages) they are running supports a specific feature as described in the docs.
 
-You can use the `<Since />` component to display this information in a standardized way. This component takes a single `v` prop, which indicates the version of Astro in which the feature was added.
+You can use the `<Since />` component to display this information in a standardized way.
 
-```md
----
-setup: |
-  import Since from '~/components/Since.astro';
----
+This component takes two props:
+
+- A `v` prop, which indicates the version of the package in which the feature was added.
+- A `pkg` prop, which indicates which package is being documented. This is optional and will default to `'astro'` so is only required when using `<Since />` for other packages.
+
+```mdx
+import Since from '~/components/Since.astro';
 
 <Since v="1.0.0" />
 ```
 
-This will render the text “**Added in:** v1.0.0”.
+This will render the text “**Added in:** `astro@1.0.0`”.
 
 The advantages of using the component include:
 
 - “Added in” is automatically translated on pages in other languages.
-- The passed version is checked against the current Astro version and a “NEW” badge will be added automatically as long as the version is relatively recent.
+- The passed version is checked against the current Astro version and “NEW” or “BETA” badges will be added automatically based on data from npm.
 
 #### Examples
 
 The standard usage of this component is on its own line, immediately following the feature's heading, for example:
 
-```md
+```mdx
 ## `Astro.clientAddress`
+
 <Since v="1.0.0-rc" />
 
 Specifies the IP address of the request. This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
 ```
 
- Or, it can be used in a short block of information, for example:
+Or, it can be used in a short block of information, for example:
 
-```md
+```mdx
 ### `server.host`
 
 Type: `string | boolean`
 Default: `false`
 <Since v="0.24.0" />
+```
+
+Setting a custom package name helps us document integrations and other packages. For example:
+
+```mdx
+<Since v="2.1.0" pkg="@astrojs/rss" />
 ```
 
 ### Version Component

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -4,10 +4,11 @@ import Badge from './Badge.astro';
 import { cachedFetch } from '../util-server';
 
 export interface Props {
+	pkg?: string;
 	v: string;
 }
 
-const { v } = Astro.props as Props;
+const { v, pkg = 'astro' } = Astro.props as Props;
 
 /**
  * Split a semantic version string like `0.23.3` into a tuple of `[major, minor, patch]`.
@@ -20,7 +21,7 @@ const parseSemVer = (semver: string) =>
  * For example, `@version 0.24.0` will be new as long as `astro@latest` is 0.24.x
  */
 const getFeatureStatus = async (sinceVersion: string): Promise<'beta' | 'new' | 'current'> => {
-	const astroInfo = await cachedFetch('https://registry.npmjs.org/astro/latest').then((res) =>
+	const astroInfo = await cachedFetch(`https://registry.npmjs.org/${pkg}/latest`).then((res) =>
 		res.json()
 	);
 	const latestAstroVersion = astroInfo.version;
@@ -39,7 +40,8 @@ const featureStatus = await getFeatureStatus(v);
 ---
 
 <span>
-	<strong><UIString key="since.addedIn" /></strong> v{v}
+	<strong><UIString key="since.addedIn" /></strong>
+	<code>{pkg}@{v}</code>
 	{
 		featureStatus === 'new' && (
 			<Badge variant="accent">

--- a/src/components/Since.astro
+++ b/src/components/Since.astro
@@ -30,8 +30,9 @@ const getFeatureStatus = async (sinceVersion: string): Promise<'beta' | 'new' | 
 	if (sinceMajor > latestMajor) {
 		return 'beta';
 	}
-	if (sinceMajor === latestMajor && sinceMinor >= latestMinor) {
-		return 'new';
+	if (sinceMajor === latestMajor) {
+		if (sinceMinor > latestMinor) return 'beta';
+		if (sinceMinor === latestMinor) return 'new';
 	}
 	return 'current';
 };

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -129,7 +129,7 @@ export async function get(context) {
 ```
 
 :::note[Using an older version?]
-In versions `@astrojs/rss` before v2.1.0, pass your glob result straight to `items` without the `pagesGlobToRssItems` wrapper:
+In versions of `@astrojs/rss` before v2.1.0, pass your glob result straight to `items` without the `pagesGlobToRssItems()` wrapper:
 ```js
 items: import.meta.glob('./blog/*.{md,mdx}'),
 ```

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -107,6 +107,8 @@ export const collections = { blog };
 
 ### Using glob imports
 
+<Since v="2.1.0" pkg="@astrojs/rss" />
+
 To create an RSS feed from documents in `src/pages/`, use the `pagesGlobToRssItems()` helper. This accepts an [`import.meta.glob`](https://vitejs.dev/guide/features.html#glob-import) result and outputs an array of valid RSS feed items (see [more about writing glob patterns](/en/guides/imports/#glob-patterns) for specifying which pages to include).
 
 This function assumes, but does not verify, that all necessary feed properties are present in each document's frontmatter. If you encounter errors, verify each page frontmatter manually.
@@ -125,6 +127,13 @@ export async function get(context) {
   });
 }
 ```
+
+:::note[Using an older version?]
+In versions `@astrojs/rss` before v2.1.0, pass your glob result straight to `items` without the `pagesGlobToRssItems` wrapper:
+```js
+items: import.meta.glob('./blog/*.{md,mdx}'),
+```
+:::
 
 ### Including full post content
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- Changes to the docs site code

#### Description

- Adds a `<Since />` component to the new RSS docs to indicate the feature is new (in beta!)
- Adds a minimal note to the same docs showing the old behaviour for people using older versions. Maybe not needed? Excessively polite?
- Updates `<Since />` so we can use it in cases like this where we’re documenting changes to packages other than `astro`: `<Since v="2.0.0" pkg="@astrojs/rss" />`
- Updates `WRITING.md` to document these changes

This does slightly change the output of `<Since />` as it could now be talking about different packages:

| Before | After |
|---|---|
| <img width="171" alt="image" src="https://user-images.githubusercontent.com/357379/213693084-f8170c8d-dd68-40f5-8b59-360a81fca2d4.png"> | <img width="209" alt="image" src="https://user-images.githubusercontent.com/357379/213693001-fb72be45-ede7-4f66-9cec-ad9d7090ccab.png"> |

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
