### PR TITLE
i18n(es): add multiple error pages

### DIFF
--- a/src/pages/es/reference/errors/get-static-paths-removed-rsshelper.mdx
+++ b/src/pages/es/reference/errors/get-static-paths-removed-rsshelper.mdx
@@ -1,0 +1,21 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: getStaticPaths RSS helper is not available anymore.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GetStaticPathsRemovedRSSHelper**: El ayudante de RSS se ha eliminado de `getStaticPaths`. Prueba el nuevo paquete @astrojs/rss en su lugar. (E03012)
+
+## ¿Qué salió mal?
+
+`getStaticPaths` ya no expone un asistente para generar un RSS feed. Recomendamos migrar a la integración [@astrojs/rss](/es/guides/rss/#configurando-astrojsrss) en su lugar.
+
+**Ver también:**
+-  [Guía RSS](/es/guides/rss/)
+

--- a/src/pages/es/reference/errors/get-static-paths-required.mdx
+++ b/src/pages/es/reference/errors/get-static-paths-required.mdx
@@ -1,0 +1,23 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: getStaticPaths() function required for dynamic routes.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GetStaticPathsRequired**: Se requiere la función `getStaticPaths()` para las rutas dinámicas. Asegúrate de `exportar` la función `getStaticPaths` desde la ruta dinámica. (E03015)
+
+## ¿Qué salió mal?
+
+En [modo estático](/es/core-concepts/routing/#modo-estático-ssg), todas las rutas deben determinarse en el momento de la compilación. Como tal, las rutas dinámicas deben `exportar` una función `getStaticPaths` que devuelva las diferentes rutas para generar.
+
+**Ver también:**
+-  [Rutas Dinámicas](/es/core-concepts/routing/#rutas-dinámicas)
+-  [`getStaticPaths()`](/es/reference/api-reference/#getstaticpaths)
+-  [Renderizado en el servidor](/es/guides/server-side-rendering/)
+

--- a/src/pages/es/reference/errors/invalid-frontmatter-injection-error.mdx
+++ b/src/pages/es/reference/errors/invalid-frontmatter-injection-error.mdx
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Invalid frontmatter injection.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidFrontmatterInjectionError**: Un plugin de remark o rehype intentó inyectar frontmatter inválido. Asegúrate que "astro.frontmatter" esté configurado en un objeto JSON válido que no sea `null` o `undefined`. (E06003)
+
+## ¿Qué salió mal?
+
+Un plugin de remark o rehype intentó inyectar frontmatter inválido. Esto ocurre cuando "astro.frontmatter" es `null`, `undefined` o un objeto JSON inválido.
+
+**Ver también:**
+
+-  [Modifición programática del frontmatter](/en/guides/markdown-content/#modificación-programática-del-frontmatter)
+

--- a/src/pages/es/reference/errors/invalid-frontmatter-injection-error.mdx
+++ b/src/pages/es/reference/errors/invalid-frontmatter-injection-error.mdx
@@ -18,5 +18,5 @@ Un plugin de remark o rehype intentó inyectar frontmatter inválido. Esto ocurr
 
 **Ver también:**
 
--  [Modifición programática del frontmatter](/en/guides/markdown-content/#modificación-programática-del-frontmatter)
+-  [Modificación programática del frontmatter](/es/guides/markdown-content/#modificación-programática-del-frontmatter)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Translated content

#### Description

- adds `reference/errors/get-static-paths-removed-rsshelper.mdx`
- adds `reference/errors/get-static-paths-required.mdx`
- adds `reference/errors/invalid-frontmatter-injection-error.mdx`

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
