### PR TITLE
docs(svelte): Fix vitePreprocess import

### DIFF
--- a/src/pages/en/guides/integrations-guide/svelte.mdx
+++ b/src/pages/en/guides/integrations-guide/svelte.mdx
@@ -140,7 +140,7 @@ If you're using a preprocessor like TypeScript or SCSS in your Svelte files, you
 
 ```js
 // svelte.config.js
-import { vitePreprocess } from '@astrojs/svelte';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default {
 	preprocess: vitePreprocess(),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
- Changes to the docs site code


#### Description

I was integrating Astro with Svelte by following https://docs.astro.build/pt-br/guides/integrations-guide/svelte/.

But when I used the code snippet from the `Intellisense for TypeScript`, it broke my application.

The problem that the docs say to import `vitePreprocess` from `@astrojs/svelte`, but the right import is:

```js
import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
```

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
