### PR TITLE
i18n(pt-BR): Add final missing deploy pages translations

### DIFF
--- a/src/pages/pt-br/guides/deploy/cloudflare.mdx
+++ b/src/pages/pt-br/guides/deploy/cloudflare.mdx
@@ -1,0 +1,138 @@
+---
+title: Faça deploy do seu site Astro com Cloudflare Pages
+description: Como fazer o deploy do seu site Astro para web utilizando Cloudflare Pages.
+layout: ~/layouts/DeployGuideLayout.astro
+i18nReady: true
+---
+
+Você pode fazer o deploy do seu projeto Astro na [Cloudflare Pages](https://pages.cloudflare.com/), uma plataforma para desenvolvedores frontend colaborarem e fazerem deploy de websites estáticos (JAMstack) e SSR.
+
+Este guia inclui:
+
+- [Como fazer o deploy através do painel de controle da Cloudflare Pages](#como-fazer-deploy-de-um-site-utilizando-git)
+- [Como fazer o deploy utilizando Wrangler, a CLI da Cloudflare](#como-fazer-deploy-de-um-site-utilizando-wrangler)
+- [Como fazer o deploy de um site SSR utilizando `@astrojs/cloudflare`](#como-fazer-deploy-de-um-site-ssr)
+
+## Pré-requisitos
+
+Para começar, você vai precisar de:
+
+- Uma conta da Cloudflare. Se você já não tem uma, você pode criar uma conta gratuita da Cloudflare durante o processo.
+- O código da sua aplicação em um repositório do [GitHub](https://github.com/) ou [GitLab](https://about.gitlab.com/).
+
+## Como fazer deploy de um site utilizando Git
+
+1. Configure um novo projeto na Cloudflare Pages.
+2. Faça push do seu código para seu repositório git (GitHub, GitLab).
+3. Inicie a sessão no painel de controle da Cloudflare e selecione sua conta em **Account Home** > **Pages**.
+4. Selecione **Create a new Project** e a opção **Connect Git**.
+5. Selecione o projeto git que você quer fazer deploy e clique **Begin setup**.
+6. Use as seguintes configurações de build:
+
+    - **Framework preset**: `Astro`
+    - **Build command:** `npm run build`
+    - **Build output directory:** `dist`
+    - **Environment variables (advanced)**: Por padrão, a Cloudflare Pages utiliza Node.js 12.18.0, porém o Astro [requer uma versão mais alta](/pt-br/install/auto/#pré-requisitos). Adicione uma variável de ambiente, sendo **Variable name** igual a `NODE_VERSION` e **Value** igual a `v16.13.0` ou superior para dizer a Cloudflare para utilizar uma versão compatível do Node. Alternativamente, adicione um arquivo `.nvmrc` no seu projeto para especificar uma versão do Node.
+
+7. Clique no botão **Save and Deploy**.
+
+## Como fazer deploy de um site utilizando Wrangler
+
+1. Instale a [CLI Wrangler](https://developers.cloudflare.com/workers/wrangler/get-started/).
+2. Autentique Wrangler com sua conta da Cloudflare utilizando `wrangler login`.
+3. Execute seu comando de build.
+4. Faça o deploy utilizando `npx wrangler pages publish dist`.
+
+```bash
+# Instale a CLI Wrangler
+npm install -g wrangler
+# Faça login com a conta da Cloudflare pela CLI
+wrangler login
+# Execute seu comando de build
+npm run build
+# Crie um novo deploy
+npx wrangler pages publish dist
+```
+
+Depois dos seus assets serem enviados, Wrangler irá te dar uma URL de pré-visualização para inspecionar seu site. Quando você entrar no painel de controle da Cloudflare Pages, você verá o seu novo projeto.
+
+### Habilitando Pré-visualização local com Wrangler
+
+Para a pré-visualização funcionar, você precisa instalar `wrangler`
+
+```bash
+pnpm install wrangler --save-dev
+```
+
+Após, é possível atualizar o script "preview" para executar `wrangler` ao invés do comando "preview" integrado do Astro:
+
+
+```json title="package.json"
+"preview": "wrangler pages dev ./dist"
+```
+
+## Como fazer deploy de um site SSR
+
+Você pode fazer build de um site Astro SSR para deploy na Cloudflare Pages utilizando o [adaptador `@astrojs/cloudflare`](/pt-br/guides/integrations-guide/cloudflare/).
+
+Siga os passos abaixo para configurar o adaptador. Você pode então fazer o deploy utilizando qualquer uma das abordagens documentadas acima.
+
+### Instalação Rápida
+
+Adicione o adaptador para Cloudflare para habilitar SSR no seu projeto Astro com o seguinte comando `astro add`. Ele irá instalar o adaptador e fazer as mudanças apropriadas ao seu arquivo `astro.config.mjs` em uma etapa.
+
+```bash
+npx astro add cloudflare
+```
+
+### Instalação Manual
+
+Se você prefere instalar o adaptador manualmente, complete as duas seguintes etapas:
+
+1. Adicione o adaptador `@astrojs/cloudflare` nas dependências do seu projeto utilizando seu gerenciador de pacotes de preferência. Se você estiver utilizando npm ou não tem certeza, execute isso no terminal:
+
+    ```bash
+    npm install @astrojs/cloudflare
+    ```
+
+2. Adicione o seguinte no seu arquivo `astro.config.mjs`:
+
+    ```js title="astro.config.mjs" ins={2, 5-6}
+    import { defineConfig } from 'astro/config';
+    import cloudflare from '@astrojs/cloudflare';
+
+    export default defineConfig({
+      output: 'server',
+      adapter: cloudflare()
+    });
+    ```
+
+### Modos
+
+Há atualmente dois modos suportados ao utilizar Pages Functions com o adaptador [`@astrojs/cloudflare`](https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare#readme). 
+
+1. Modo **Advanced**: Este modo é utilizado quando você quer executar sua função no modo `advanced` que pega o `_worker.js` em `dist`, ou um modo diretório onde as páginas irão compilar o worker para fora de um diretório functions na raiz do projeto.  
+
+    Se nenhum modo for definido, o padrão é `"advanced"`.
+
+2. Modo **directory**: Este modo é utilizado quando você quer executar sua função no modo `directory`, que significa que o adaptador irá compilar a parte do cliente da sua aplicação da mesma forma, porém ele irá mover o script do worker para um diretório `functions` na raiz do projeto. O adaptador irá colocar apenas uma `[[path]].js` naquele diretório, te permitindo adicionar plugins e middleware de páginas que podem ser verificados em controle de versão.
+
+    ```ts title="astro.config.mjs" "directory"
+    export default defineConfig({
+      adapter: cloudflare({ mode: "directory" }),
+    });
+    ```
+
+### Utilizando Pages Functions
+
+[Pages Functions](https://developers.cloudflare.com/pages/platform/functions/) te permitem executar código server-side para habilitar funcionalidade dinâmica sem executar um servidor dedicado.
+
+Para começar, crie um diretório `/functions` na raiz do seu projeto. Escrevendo seus arquivos Functions nesse diretório automaticamente gera um Worker com funcionalidade customizada nas rotas pré-designadas. Para aprender mais sobre como escrever Functions, veja a [documentação de Pages Functions](https://developers.cloudflare.com/pages/platform/functions/).
+
+📚 Leia mais sobre [SSR no Astro](/pt-br/guides/server-side-rendering/).
+
+## Solução de Problemas
+
+Se você estiver encontrando erros, verifique novamente se a versão do `node` que você está utilizando localmente (`node -v`) é igual a versão que você está especificando na variável de ambiente.
+
+Cloudflare requer [Node v16.13](https://miniflare.dev/get-started/cli#installation), que é uma versão mais recente que o mínimo por padrão do Astro, então verifique novamente que você está utilizando pelo menos a v16.13.

--- a/src/pages/pt-br/guides/deploy/deno.mdx
+++ b/src/pages/pt-br/guides/deploy/deno.mdx
@@ -1,0 +1,173 @@
+---
+title: Faça deploy do seu site Astro com Deno
+description: Como fazer o deploy do seu site Astro para web utilizando Deno.
+layout: ~/layouts/DeployGuideLayout.astro
+i18nReady: true
+---
+
+Você pode fazer deploy de um site Astro renderizado no servidor para o [Deno Deploy](https://deno.com/deploy), um sistema distribuído que executa JavaScript, TypeScript e WebAssembly na edge globalmente.
+
+Este guia inclui instruções para fazer deploy para o Deno Deploy através de Github Actions ou da CLI do Deno Deploy.
+
+## Requisitos
+
+Este guia assume que você já tem [Deno](https://deno.land/) instalado.
+
+## Configuração do Projeto
+
+Seu projeto Astro pode ter deploy feito no [Deno Deploy](https://deno.com/deploy) como um site renderizado no lado do servidor (SSR). Deno Deploy não suporta sites estáticos.
+
+### Adaptador para SSR
+
+Para habilitar SSR no seu projeto Astro para fazer deploy no Deno Deploy:
+
+Adicione [o adaptador para Deno](/pt-br/guides/integrations-guide/deno/) para habilitar SSR no seu projeto Astro com o seguinte comando `astro add`. Ele irá instalar o adaptador e fazer as mudanças apropriadas para seu arquivo `astro.config.mjs` de uma vez.
+
+```bash
+npx astro add deno
+```
+
+Se você prefere instalar o adaptador manualmente, complete as duas etapas a seguir:
+
+ 1. Instale [o adaptador `@astrojs/deno`](https://github.com/withastro/astro/tree/main/packages/integrations/deno) nas dependências do seu projeto utilizando seu gerenciador de pacotes de preferência. Se você estiver utilizando npm ou não tiver certeza, execute isso no terminal:
+
+    ```bash
+      npm install @astrojs/deno
+    ```
+
+1. Atualize o arquivo de configuração do seu projeto `astro.config.mjs` com as mudanças abaixo.
+
+    ```js ins={3,6-7}
+    // astro.config.mjs
+    import { defineConfig } from 'astro/config';
+    import deno from '@astrojs/deno';
+
+    export default defineConfig({
+      output: 'server',
+      adapter: deno(),
+    });
+    ```
+
+    Em seguida, atualize seu script `preview` em `package.json` com as mudanças abaixo.
+
+    ```json del={8} ins={9}
+    // package.json
+    {
+      // ...
+      "scripts": {
+        "dev": "astro dev",
+        "start": "astro dev",
+        "build": "astro build",
+        "preview": "astro preview"
+        "preview": "deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs"
+      }
+    }
+    ```
+    
+    Você agora pode utilizar esse comando para pré-visualizar seu site Astro em produção localmente com Deno.
+    
+    ```bash
+    npm run preview
+    ```
+
+## Como fazer o deploy
+
+Você pode fazer o deploy para o Deno Deploy através de Github Actions ou utilizando a CLI (interface de linha de comando) do Deno Deploy.
+
+### Deploy por Github Actions
+
+Se o seu projeto está armazenado no GitHub, o [website do Deno Deploy](https://dash.deno.com/) irá te guiar em como configurar o Github Actions para fazer deploy do seu site Astro.
+
+1. Faça push do seu código para um repositório público ou privado do Github.
+
+1. Inicie sua sessão no [Deno Deploy](https://dash.deno.com/) com sua conta do Github e clique em [New Project](https://dash.deno.com).
+
+1. Selecione seu repositório, a branch do qual você quer que o deploy e selecione o modo **Github Action**. (Seu site Astro requer uma etapa de build e portanto não pode utilizar o modo automático.)
+   
+1. No seu projeto Astro, crie um novo arquivo em `.github/workflows/deploy.yml` e copie o YAML abaixo. Isso é similar ao YAML dado pelo Deno Deploy, com as etapas adicionais necessárias para seu site Astro.
+
+    ```yaml
+    name: Deploy
+    on: [push]
+
+    jobs:
+      deploy:
+        name: Deploy
+        runs-on: ubuntu-latest
+        permissions:
+          id-token: write # Necessário para se autenticar com o Deno Deploy
+          contents: read # Necessário para clonar o repositório
+
+        steps:
+          - name: Clone repository
+            uses: actions/checkout@v3
+
+          # Não está utilizando npm? Mude `npm ci` para `yarn install` ou `pnpm i`
+          - name: Install dependencies
+            run: npm ci
+    
+          # Não está utilizando npm? Mude `npm run build` para `yarn build` ou `pnpm run build`
+          - name: Build Astro
+            run: npm run build
+
+          - name: Upload to Deno Deploy
+            uses: denoland/deployctl@v1
+            with:
+              project: my-deno-project # TODO: replace with Deno Deploy project name
+              entrypoint: server/entry.mjs
+              root: dist
+    ```
+
+1. Após fazer o commit deste arquivo YAML e fazer o push para o Github na sua branch configurada para deploy, o deploy deve começar automaticamente!
+
+   Você pode verificar o progresso utilizando a aba "Actions" na página do seu repositório do Github ou no [Deno Deploy](https://dash.deno.com).
+
+
+### Deploy pela CLI
+
+1. Instale a [CLI do Deno Deploy](https://deno.com/deploy/docs/deployctl).
+
+    ```bash
+    deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
+    ```
+
+1. Execute a etapa de build do Astro.
+
+    ```bash
+    npm run build
+    ```
+
+1. Execute `deployctl` para fazer o deploy!
+
+   No comando abaixo, substitua `<TOKEN-DE-ACESSO>` com seu [Personal Access Token](https://dash.deno.com/user/access-tokens) e `<MEU-PROJETO-DENO>` com o nome do seu projeto do Deno Deploy.
+
+    ```bash
+    DENO_DEPLOY_TOKEN=<TOKEN-DE-ACESSO> deployctl deploy --project=<MEU-PROJETO-DENO> --no-static --include=./dist ./dist/server/entry.mjs
+    ```
+    
+    Você pode ver todos os seus deploys em [Deno Deploy](https://dash.deno.com).
+
+1. (Opcional) Para simplificar a build e o deploy em um só comando, adicione um script `deploy-deno` em `package.json`.
+
+    ```json ins={9}
+    // package.json
+    {
+      // ...
+      "scripts": {
+        "dev": "astro dev",
+        "start": "astro dev",
+        "build": "astro build",
+        "preview": "deno run --allow-net --allow-read --allow-env ./dist/server/entry.mjs",
+        "deno-deploy": "npm run build && deployctl deploy --project=<MY-DENO-PROJECT> --no-static --include=./dist ./dist/server/entry.mjs"
+      }
+    }
+    ```
+    
+    Então você poderá utilizar este comando para fazer a build e deploy do seu projeto Astro em uma etapa.
+    
+    ```bash
+    DENO_DEPLOY_TOKEN=<TOKEN-DE-ACESSO> npm run deno-deploy
+    ```
+
+
+📚 Leia mais sobre [SSR no Astro](/pt-br/guides/server-side-rendering/).

--- a/src/pages/pt-br/guides/deploy/kinsta.mdx
+++ b/src/pages/pt-br/guides/deploy/kinsta.mdx
@@ -1,0 +1,50 @@
+---
+title: Faça deploy do seu site Astro com Kinsta Application Hosting
+description: Como fazer o deploy do seu site Astro para web utilizando Kinsta Application Hosting.
+layout: ~/layouts/DeployGuideLayout.astro
+i18nReady: true
+---
+
+Você pode utilizar a [Kinsta Application Hosting](https://kinsta.com/application-hosting/) para hospedar um site Astro em sua hospedagem na nuvem.
+
+:::tip[Procurando por um exemplo?]
+Veja o [projeto inicial oficial da Kinsta Application Hosting para Astro](https://github.com/kinsta/hello-world-astro)!
+:::
+
+## Configurando seu projeto Astro
+
+Para hospedar seu projeto na **Kinsta Application Hosting**, você precisa de:
+- Incluir um campo `name` em seu `package.json`. (Pode ser qualquer um e não irá afetar seu deploy.)
+- Incluir um script `build` em seu `package.json`. (Seu projeto Astro já deve incluir isso.)
+- Instalar o pacote [`serve`](https://www.npmjs.com/package/serve) e definir o script `start` como `serve dist/`.
+
+Aqui estão as linhas necessárias no seu arquivo `package.json`:
+```json title="astro.config.mjs" {2,6} ins={12} "serv dist/"
+{
+  "name": "qualquerUm", // Isso é obrigatório, mas o valor não importa.
+  "scripts": {
+    "dev": "astro dev",
+    "start": "serve dist/",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^1.6.10",
+    "serve": "^14.0.1"
+  },
+}
+```
+
+## Como fazer o deploy
+
+Assim que o repositório no GitHub do seu projeto estiver conectado, você pode iniciar deploys manuais para a Kinsta Application Hosting no **MyKinsta Admin Panel**. Você também pode configurar deploys automáticos no seu painel de administrador.
+
+### Configurando uma nova aplicação Kinsta
+
+1. Vá para o painel de administrador [My Kinsta](https://my.kinsta.com/).
+2. Vá para a aba **Applications**.
+3. Conecte seu repositório do GitHub.
+4. Pressione o botão **Add service** > **Application**.
+5. Siga as etapas do assistente.
+6. O deploy da sua aplicação foi feito.

--- a/src/pages/pt-br/guides/deploy/microsoft-azure.mdx
+++ b/src/pages/pt-br/guides/deploy/microsoft-azure.mdx
@@ -1,0 +1,26 @@
+---
+title: Faça deploy do seu site Astro com Microsoft Azure
+description: Como fazer o deploy do seu site Astro para web utilizando Microsoft Azure.
+layout: ~/layouts/DeployGuideLayout.astro
+i18nReady: true
+---
+
+[Azure](https://azure.microsoft.com/) é uma plataforma na nuvem da Microsoft. Você pode fazer deploy do seu site Astro com o serviço [Static Web Apps](https://aka.ms/staticwebapps) da Microsoft Azure.
+
+## Pré-requisitos
+
+Para seguir este guia você vai precisar de:
+
+- Uma conta da Azure e uma chave de inscrição. Você pode criar uma [conta gratuita da Azure aqui](https://azure.microsoft.com/free).
+- Seu código no [GitHub](https://github.com/).
+- A [Extensão SWA](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) no [Visual Studio Code](https://code.visualstudio.com/).
+
+## Como fazer o deploy
+
+1. Abra seu projeto no VS Code.
+
+2. Abra a extensão Static Web Apps, inicie sua sessão na Azure e clique no botão **+** para criar um novo Static Web App. Será solicitado para você designar qual chave de inscrição utilizar.
+
+3. Siga o assistente iniciado pela extensão para dar um nome, escolher uma pré-definição de framework e designar a raiz da aplicação (geralmente `/`) e a localização de arquivos construídos `/dist`. O assistente será executado e irá criar uma [GitHub Action](https://github.com/features/actions) no seu repositório em um diretório `.github`.
+
+A GitHub Action irá fazer deploy da sua aplicação (você pode ver seu progresso na aba Actions do seu repositório no GitHub). Ao ser completado com sucesso, você pode ver sua aplicação no endereço mostrado pela aba de progresso da Extensão SWA clicando no botão **Browse Website** (isso irá aparecer após a GitHub Action ser executada).


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content


#### Description

Add PT-BR translations for the final missing deploy pages: `cloudflare.mdx`, `kinsta.mdx`, `microsoft-azure.mdx` and `deno.mdx`