### PR TITLE
[testing guide] add link to Vitest starter template

### DIFF
--- a/src/pages/en/guides/testing.mdx
+++ b/src/pages/en/guides/testing.mdx
@@ -11,6 +11,12 @@ Testing helps you write and maintain working Astro code. Astro supports many pop
 
 Testing frameworks allow you to state **assertions** or **expectations** about how your code should behave in specific situations, then compare these to the actual behavior of your current code. 
 
+## Vitest
+
+A Vite-native unit test framework with ESM, TypeScript and JSX support powered by esbuild.
+
+See the [Astro + Vitest starter template](https://github.com/withastro/astro/tree/latest/examples/with-vitest) on GitHub.
+
 ## Playwright
 
 Playwright is an end-to-end testing framework for modern web apps. Use the Playwright API in JavaScript or TypeScript to test your Astro code on all modern rendering engines including Chromium, WebKit, and Firefox.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- New or updated content

Since we have a `with-vitest` starter example template, added a very short (stubby!) section on Vitest to the testing page, with a link to the example. (From Feedback Fish suggestion.)