### PR TITLE
Add Vue's reactivity API to sharing state      alternatives list

### DIFF
--- a/src/pages/en/core-concepts/sharing-state.mdx
+++ b/src/pages/en/core-concepts/sharing-state.mdx
@@ -23,6 +23,7 @@ The [Nano Stores](https://github.com/nanostores/nanostores) library allows you t
 Still, there are a number of alternatives you can explore. These include:
 - [Svelte's built-in stores](https://svelte.dev/tutorial/writable-stores)
 - [Solid signals](https://www.solidjs.com/docs/latest) outside of a component context
+- [Vue's reactivity API](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api)
 - [Sending custom browser events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events) between components
 
 :::note[FAQ]


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- Changes to the docs site code

#### Description

- Closes #2453 
- What does this PR change?
It adds a [link](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api) to the alternatives listed on the Nano Stores docs pointing to the `reactive()` Vue docs.

- Did you change something visual? A before/after screenshot can be helpful.
No, I did not.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
