### PR TITLE
Renamed prerendering section to hybrid rendering

### DIFF
--- a/src/pages/en/guides/server-side-rendering.mdx
+++ b/src/pages/en/guides/server-side-rendering.mdx
@@ -101,11 +101,11 @@ You can also add an adapter manually by installing the package and updating `ast
 
 Astro will remain a static-site generator by default. But once you enable a server-side rendering adapter, **every route in your pages directory defaults to a server-rendered route** and a few new features become available to you.
 
-### Prerendering
+### Hybrid Rendering
 
 <Since v="2.0.0" />
 
-To enable **Hybrid Rendering**, any [page](/en/core-concepts/astro-pages/) or [server endpoint](/en/core-concepts/endpoints/#server-endpoints-api-routes) can opt-in to prerendering. These files will be statically rendered at build-time, similar to the default static [`output`](/en/reference/configuration-reference/#output) mode.
+To enable **hybrid rendering**, any [page](/en/core-concepts/astro-pages/) or [server endpoint](/en/core-concepts/endpoints/#server-endpoints-api-routes) can opt-in to prerendering. These files will be statically rendered at build-time, similar to the default static [`output`](/en/reference/configuration-reference/#output) mode.
 
 ```astro title="src/pages/index.astro" {2}
 ---

--- a/src/pages/en/guides/upgrade-to/v2.mdx
+++ b/src/pages/en/guides/upgrade-to/v2.mdx
@@ -416,7 +416,7 @@ export default defineConfig({
 These features are now available by default:
 
 - [Content collections](/en/guides/content-collections/) as a way to manage your Markdown and MDX files with type-safety.
-- [Prerendering individual pages to static HTML](/en/guides/server-side-rendering/#prerendering) when using SSR to improve speed and cacheability.
+- [Prerendering individual pages to static HTML](/en/guides/server-side-rendering/#hybrid-rendering) when using SSR to improve speed and cacheability.
 - A redesigned error message overlay.
 
 ## Known Issues


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Updates the Server-Side Rendering: Prerendering section title to use "Hybrid Rendering" for consistency

Updates captialization from "Hybrid Rendering" to "hybrid rendering"

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
