### PR TITLE
Update API reference with new slug frontmatter property

### DIFF
--- a/src/pages/en/reference/api-reference.mdx
+++ b/src/pages/en/reference/api-reference.mdx
@@ -800,7 +800,7 @@ A unique ID using the file path relative to `src/content/[collection]`. Enumerat
 
 **Example Type:** `'entry-1' | 'entry-2' | ...`
 
-A URL-ready slug. Defaults to the `id` without the file extension, but can be configured using [the `slug()` config property](#slug). Set to the type `string` if a `slug()` override is configured, and enumerates all possible string values otherwise.
+A URL-ready slug. Defaults to the `id` without the file extension, but can be overriden by setting [the `slug` property](/en/guides/content-collections/#defining-custom-slugs) in a file's frontmatter.
 
 #### `data`
 

--- a/src/pages/en/reference/api-reference.mdx
+++ b/src/pages/en/reference/api-reference.mdx
@@ -800,7 +800,7 @@ A unique ID using the file path relative to `src/content/[collection]`. Enumerat
 
 **Example Type:** `'entry-1' | 'entry-2' | ...`
 
-A URL-ready slug. Defaults to the `id` without the file extension, but can be overriden by setting [the `slug` property](/en/guides/content-collections/#defining-custom-slugs) in a file's frontmatter.
+A URL-ready slug. Defaults to the `id` without the file extension, but can be overridden by setting [the `slug` property](/en/guides/content-collections/#defining-custom-slugs) in a file's frontmatter.
 
 #### `data`
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Replace mention of the removed `slug()` function used with content collection in beta with the `slug`-property in frontmatter released in 2.0.0.

Related withastro/astro#5941