### PR TITLE
Update Render deploy guide to account for Astro 2.0 Node.js version requirement

### DIFF
--- a/src/pages/en/guides/deploy/render.mdx
+++ b/src/pages/en/guides/deploy/render.mdx
@@ -15,4 +15,5 @@ You can deploy your Astro project to [Render](https://render.com/), a service to
 4. Give your website a name, select the branch and specify the build command and publish directory
    - **build command:** `npm run build`
    - **publish directory:** `dist`
+   - **Environment variables (advanced)**: By default, Render uses Node.js 14.17.0, but Astro [requires a higher version](/en/install/auto/#prerequisites). Add an environment variable with a **Variable key** of `NODE_VERSION` and a **Value** of `16.12.0` or higher to tell Render to use a compatible Node.js version. Alternatively, add a [`.node-version`](https://render.com/docs/node-version) or [`.nvmrc`](https://render.com/docs/node-version) file to your project to specify a Node.js version.
 5. Click the **Create Static Site** button


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

This PR is a follow-up of https://github.com/withastro/astro/issues/6004 and this [Discord support thread](https://discord.com/channels/830184174198718474/1068446497353498666).

It is currently not possible to deploy a project using Astro 2.0 to Render by blindly following the guide due to the fact that Astro 2.0 requires at least Node.js 16.12.0 and Render [using by default Node.js version 14](https://render.com/docs/node-version).

The proposed change is *heavily* inspired by the existing [Cloudflare Pages deploy guide](https://docs.astro.build/en/guides/deploy/cloudflare/) which has the same issue that is solved using an environment variable specifying the Node.js version added after clicking on an `Advanced` button in the UI, which is the exact same process on Render. Other solutions are also suggested with links to the relevant Render documentation describing how to use them.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->