### PR TITLE
Updates Node Version requirements in GitLab deploy

### DIFF
--- a/src/pages/en/guides/deploy/gitlab.mdx
+++ b/src/pages/en/guides/deploy/gitlab.mdx
@@ -35,7 +35,7 @@ Check out [the official GitLab Pages Astro example project](https://gitlab.com/p
 
    ```yaml
    # The Docker image that will be used to build your app
-   image: node:14
+   image: node:lts
    
    pages:
      cache:


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fix (wrong version in gitlab yaml)

#### Description

As of Astro Version 2.0.0, a node version >= 16 is required, which means that `node:lts` is better suited than `node:14` in the deploy file `.gitlab-ci.yml` for GitLab. This ensures that people who copy the file from the docs won't end up with a broken CI/CD pipeline.
