### PR TITLE
i18n(es): Added error pages

### DIFF
--- a/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
@@ -1,0 +1,21 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Content Schema should not contain slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ContentSchemaContainsSlugError**: 
+            return `Un esquema de colecciónde contenido no contiene el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.`;
+         (E09003)
+
+## ¿Qué salió mal?
+Un esquema de colección de contenido no debe contener el campo `slug`. Esto está reservado por Astro para generar slugs de entrada. Elimine el campo `slug` de su esquema o elija un nombre diferente.
+
+**Ver también:**
+-  [El campo reservado de entrada `slug`](/es/guides/content-collections/)

--- a/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
@@ -11,11 +11,11 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 ---
 
 > **ContentSchemaContainsSlugError**: 
-            return `Un esquema de colecciónde contenido no contiene el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.`;
+            return `Un esquema de colección de contenido no debe contener el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.`;
          (E09003)
 
 ## ¿Qué salió mal?
-Un esquema de colección de contenido no debe contener el campo `slug`. Esto está reservado por Astro para generar slugs de entrada. Elimine el campo `slug` de su esquema o elija un nombre diferente.
+Un esquema de colección de contenido no debe contener la propiedad `slug`. Esto está reservado por Astro para generar slugs. Elimine el campo `slug` de su esquema o elija un nombre diferente.
 
 **Ver también:**
--  [El campo reservado de entrada `slug`](/es/guides/content-collections/)
+-  [La propiedad reservada `slug`](/es/guides/content-collections/)

--- a/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Content entry frontmatter does not match schema.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Example error message:**<br/>
+**blog** → el frontmatter de **post.md** no coincide con el esquema de colección.<br/>
+"title" es requerido.<br/>
+"date" debe ser una fecha válida. (E09001)
+
+## ¿Qué salió mal?
+Un archivo Markdown o MDX en `src/content/` no coincide con su esquema de colección.
+Asegúrate que todos los campos requeridos estén presentes y que todos los campos sean del tipo correcto.
+Puedes verificar el esquema de colección en su archivo `src/content/config.*`.
+Ve la [documentación de colecciones de contenido](/es/guides/content-collections/) para más información.

--- a/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **Example error message:**<br/>
+> **Mensaje de error de ejemplo:**<br/>
 **blog** → el frontmatter de **post.md** no coincide con el esquema de colección.<br/>
 "title" es requerido.<br/>
 "date" debe ser una fecha válida. (E09001)

--- a/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-frontmatter-error.mdx
@@ -16,7 +16,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 "date" debe ser una fecha válida. (E09001)
 
 ## ¿Qué salió mal?
-Un archivo Markdown o MDX en `src/content/` no coincide con su esquema de colección.
-Asegúrate que todos los campos requeridos estén presentes y que todos los campos sean del tipo correcto.
-Puedes verificar el esquema de colección en su archivo `src/content/config.*`.
-Ve la [documentación de colecciones de contenido](/es/guides/content-collections/) para más información.
+Un archivo Markdown o MDX en `src/content/` no coincide con tu esquema de colección.
+Asegúrate que todos los campos requeridos estén presentes y que todos las propiedades sean del tipo correcto.
+Puedes verificar el esquema de colección en tu archivo `src/content/config.*`.
+Vea la [documentación de colecciones de contenido](/es/guides/content-collections/) para más información.

--- a/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
@@ -15,7 +15,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
          (E09002)
 
 ## ¿Qué salió mal?
-Una entrada en `src/content/` tiene un `slug` no válido. Este campo está reservado para generar slugs de entrada y debe ser una cadena cuando está presente.
+Un archivo en `src/content/` tiene un `slug` no válido. Este campo está reservado para generar slugs y debe ser un string cuando está presente.
 
 **Ver también:**
--  [El campo reservado de entrada `slug`](/es/guides/content-collections/)
+-  [La propipedad reservada `slug`](/es/guides/content-collections/)

--- a/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
@@ -1,0 +1,21 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+layout: ~/layouts/MainLayout.astro
+title: Invalid content entry slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidContentEntrySlugError**: 
+            return `STRING(COLLECTION) → STRING(ENTRY_ID) tiene un slug no válido. El campo `slug` debe ser un string.`;
+         (E09002)
+
+## ¿Qué salió mal?
+Una entrada en `src/content/` tiene un `slug` no válido. Este campo está reservado para generar slugs de entrada y debe ser una cadena cuando está presente.
+
+**Ver también:**
+-  [El campo reservado de entrada `slug`](/es/guides/content-collections/)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

- What does this PR change? Give us a brief description.
Added error pages: 

1. `content-schema-contains-slug-error.mdx`
2. `invalid-content-entry-frontmatter-error.mdx`
3. `invalid-content-entry-slug-error.mdx`