### PR TITLE
fix: delete `(` that should not exist in mjs config intellisense

### DIFF
--- a/src/pages/en/guides/configuring-astro.mdx
+++ b/src/pages/en/guides/configuring-astro.mdx
@@ -67,7 +67,7 @@ You can also provide type definitions manually to VSCode, using this JSDoc notat
 
 ```js
 // astro.config.mjs
-export default /** @type {import('astro').AstroUserConfig} */ ({
+export default /** @type {import('astro').AstroUserConfig} */ {
   // your configuration options here...
   // https://docs.astro.build/en/reference/configuration-reference/
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

delete `(` that should not exist in mjs config intelliSense

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
