### PR TITLE
Use double quotes to enclose html attributes for consistency

### DIFF
--- a/src/pages/en/guides/testing.mdx
+++ b/src/pages/en/guides/testing.mdx
@@ -55,7 +55,7 @@ Alternatively, you can install Playwright within your Astro project using the pa
 <html lang="en">
   <head>
     <title>Astro is awesome!</title>
-    <meta name='description' content="Pull content from anywhere and serve it fast with Astro's next-gen island architecture." />
+    <meta name="description" content="Pull content from anywhere and serve it fast with Astro's next-gen island architecture." />
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Although this is very trivial, while translating testing.mdx, I found that one of html attributes in the code sample was enclosed in single quotes. Since there seems to be no particular reason to use single quotes here, I have changed them to double quotes for consistency.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
