### PR TITLE
Correct usage of `getImage` function 

### DIFF
--- a/src/pages/en/guides/integrations-guide/image.mdx
+++ b/src/pages/en/guides/integrations-guide/image.mdx
@@ -451,7 +451,11 @@ This can be helpful if you need to add preload links to a page's `<head>`.
 ---
 import { getImage } from '@astrojs/image';
 
-const { src } = await getImage({src: '../assets/hero.png'});
+const { src } = await getImage({
+    src: import('../assets/hero.png'),
+    height: 1080,
+    width: 1920
+  });
 ---
 
 <html>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

When providing a string to the `getImage` function, it is taken as a remote image. To import local images we need to import them.

`height` and `width` are required too (or `aspectRatio` if one is missing)