### PR TITLE
Fix `</p>` typo in markdown-content.mdx code example

### DIFF
--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -145,7 +145,7 @@ const {frontmatter} = Astro.props;
   <!-- ... -->
   <h1>{frontmatter.title}</h1>
   <h2>Post author: {frontmatter.author}</h2>
-  <p>{frontmatter.description}<p>
+  <p>{frontmatter.description}</p>
   <slot /> <!-- Markdown content is injected here -->
    <!-- ... -->
 </html>


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, **typos**, etc.)

#### Description

- What does this PR change? Give us a brief description.

Fix the missed closing `</p>` tag

```html
<p>{frontmatter.description}<p>
```
to
```html
<p>{frontmatter.description}</p>
```

- Did you change something visual? A before/after screenshot can be helpful.
Yes, you can find my change [here](https://deploy-preview-2527--astro-docs-2.netlify.app/en/guides/markdown-content/#frontmatter-layout)
![image](https://user-images.githubusercontent.com/6337533/215955843-a7fcb1a1-8a8b-410a-a8ce-cd12ba2ce1f4.png)

