### PR TITLE
Fix `importsNotUsedAsValues` error in src/i18n

### DIFF
--- a/src/i18n/translation-checkers.ts
+++ b/src/i18n/translation-checkers.ts
@@ -1,7 +1,7 @@
 import type { ModalTranslations } from '@docsearch/react';
 import enNav from './en/nav';
 import type enUI from './en/ui';
-import languages from './languages';
+import type languages from './languages';
 
 export type UIDictionaryKeys = keyof typeof enUI;
 export type UIDict = Partial<typeof enUI>;

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -3,7 +3,7 @@ import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { getLanguageFromURL } from '../util';
-import {
+import type {
 	DocSearchTranslation,
 	NavDict,
 	UIDict,


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fix importsNotUsedAsValues error in i18n/translation-checkers.ts and i18n/util.ts.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
