### PR TITLE
Add `withastro` keyword to npm publishing guide

### DIFF
--- a/src/pages/en/reference/publish-to-npm.mdx
+++ b/src/pages/en/reference/publish-to-npm.mdx
@@ -262,7 +262,7 @@ Share your hard work by adding your integration to our [integrations library](ht
 
 ### `package.json` data
 
-The library is automatically updated nightly, pulling in every package published to NPM with the `astro-component` keyword.
+The library is automatically updated nightly, pulling in every package published to NPM with the `astro-component` or `withastro` keyword.
 
 The integrations library reads the `name`, `description`, `repository`, and `homepage` data from your `package.json`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Add the `withastro` keyword in one additional place in the npm publishing guide. We mention this elsewhere in the guide but missed this one spot.