### PR TITLE
Add `html` to RSS guide

### DIFF
--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -141,6 +141,10 @@ items: import.meta.glob('./blog/*.{md,mdx}'),
 
 The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
+:::caution
+These examples focus on rendering Markdown contents. If you are using MDX, you will need to compile MDX contents to HTML manually. We recommend standard Markdown parsers like [Markdown-it](https://github.com/markdown-it/markdown-it) to get started, though this will not resolve JSX expressions or components.
+:::
+
 When using content collections, you can render post contents by calling the post's `render()` function and using the `html` property. Note the `html` property **is not present** for MDX entries. If you need to render MDX content, you can compile your MDX manually using the post's `body` property.
 
 :::tip

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -151,7 +151,7 @@ When using content collections, you can render post contents by calling the post
 Whenever you're using HTML content in XML, we suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 :::
 
-```js title="src/pages/rss.xml.js" ins={2, 11, 14} "async (post)"
+```js title="src/pages/rss.xml.js" ins={2, 12, 15} "await Promise.all(" "async (post)"
 import rss from '@astrojs/rss';
 import sanitizeHtml from 'sanitize-html';
 
@@ -161,14 +161,16 @@ export async function get(context) {
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
     site: context.site,
-    items: blog.map(async (post) => {
-      const { html } = await post.render();
-      return {
-        link: `/blog/${post.slug}/`,
-        content: sanitizeHtml(html),
-        ...post.data,
-      }
-    }),
+    items: await Promise.all(
+			blog.map(async (post) => {
+				const { html } = await post.render();
+				return {
+					link: `/blog/${post.slug}/`,
+					content: sanitizeHtml(html),
+					...post.data,
+				};
+			})
+		),
   });
 }
 ```

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -173,7 +173,7 @@ export async function get(context) {
 }
 ```
 
-When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. This feature is **not** supported for MDX files.
+When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization.
 
 ```js title="src/pages/rss.xml.js" ins={2, 13}
 import rss from '@astrojs/rss';

--- a/src/pages/en/guides/rss.mdx
+++ b/src/pages/en/guides/rss.mdx
@@ -141,17 +141,15 @@ items: import.meta.glob('./blog/*.{md,mdx}'),
 
 The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
+When using content collections, you can render post contents by calling the post's `render()` function and using the `html` property. Note the `html` property **is not present** for MDX entries. If you need to render MDX content, you can compile your MDX manually using the post's `body` property.
+
 :::tip
 Whenever you're using HTML content in XML, we suggest using a package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) in order to make sure that your content is properly sanitized, escaped, and encoded.
 :::
 
-When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:
-
-```js title="src/pages/rss.xml.js" ins={2, 3, 4, 14}
+```js title="src/pages/rss.xml.js" ins={2, 11, 14} "async (post)"
 import rss from '@astrojs/rss';
 import sanitizeHtml from 'sanitize-html';
-import MarkdownIt from 'markdown-it';
-const parser = new MarkdownIt();
 
 export async function get(context) {
   const blog = await getCollection('blog');
@@ -159,17 +157,19 @@ export async function get(context) {
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
     site: context.site,
-    items: blog.map((post) => ({
-      link: `/blog/${post.slug}/`,
-      // Note: this will not process components or JSX expressions in MDX files.
-      content: sanitizeHtml(parser.render(post.body)),
-      ...post.data,
-    })),
+    items: blog.map(async (post) => {
+      const { html } = await post.render();
+      return {
+        link: `/blog/${post.slug}/`,
+        content: sanitizeHtml(html),
+        ...post.data,
+      }
+    }),
   });
 }
 ```
 
-When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. Note: this feature is **not** supported for MDX files.
+When using glob imports with Markdown, we suggest using the `compiledContent()` helper to retrieve the rendered HTML for sanitization. This feature is **not** supported for MDX files.
 
 ```js title="src/pages/rss.xml.js" ins={2, 13}
 import rss from '@astrojs/rss';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Recommend `html` helper for rendering Markdown contents https://github.com/withastro/astro/pull/6097
- Add MDX caution banner to make instructions more explicit. Felt like we were hiding this caveat before