### PR TITLE
i18n(pt-BR): Add error reference pages translations PART THREE

### DIFF
--- a/src/pages/pt-br/reference/errors/mdx-integration-missing-error.mdx
+++ b/src/pages/pt-br/reference/errors/mdx-integration-missing-error.mdx
@@ -1,0 +1,17 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: MDX integration missing.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MdxIntegrationMissingError**: Incapaz de renderizar `NOME_ARQUIVO`. Certifique-se de que a integração `@astrojs/mdx` está instalada. (E06004)
+
+## O que deu errado?
+
+Foi incapaz de encontrar a integração `@astrojs/mdx`. Esse erro acontece ao utilizar arquivos MDX sem a integração para MDX instalada.
+
+**Veja Também:**
+-  [Instalação e uso do MDX](/pt-br/guides/integrations-guide/mdx/)
+
+

--- a/src/pages/pt-br/reference/errors/missing-media-query-directive.mdx
+++ b/src/pages/pt-br/reference/errors/missing-media-query-directive.mdx
@@ -1,0 +1,21 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Missing value for client:media directive.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MissingMediaQueryDirective**: Media query não foi providenciada para a diretiva `client:media`. Uma media query similar a `client:media="(max-width: 600px)"` deve ser providenciada (E03006)
+
+## O que deu errado?
+
+Um parâmetro de [media query](https://developer.mozilla.org/pt-BR/docs/Web/CSS/Media_Queries/Using_media_queries) é obrigatório quando se utiliza a diretiva `client:media`.
+
+```astro
+<Contador client:media="(max-width: 640px)" />
+```
+
+**Veja Também:**
+-  [`client:media`](/pt-br/reference/directives-reference/#clientmedia)
+
+

--- a/src/pages/pt-br/reference/errors/no-adapter-installed.mdx
+++ b/src/pages/pt-br/reference/errors/no-adapter-installed.mdx
@@ -1,0 +1,18 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Cannot use Server-side Rendering without an adapter.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoAdapterInstalled**: Não é possível utilizar `output: 'server'` sem um adaptador. Por favor instale e configure o adaptador de servidor apropriado para seu deploy. (E03017)
+
+## O que deu errado?
+
+Para utilizar renderização no lado do servidor, um adaptador precisa ser instalado para que o Astro saiba como gerar o resultado apropriado para sua plataforma de deploy desejada.
+
+**Veja Também:**
+-  [Renderização no lado do Servidor](/pt-br/guides/server-side-rendering/)
+-  [Adicionando um Adaptador](/pt-br/guides/server-side-rendering/#adicionando-um-adaptador)
+
+

--- a/src/pages/pt-br/reference/errors/no-client-entrypoint.mdx
+++ b/src/pages/pt-br/reference/errors/no-client-entrypoint.mdx
@@ -1,0 +1,18 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: No client entrypoint specified in renderer.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoClientEntrypoint**: Componente `NOME_COMPONENTE` tem uma diretiva `client:DIRETIVA_CLIENTE`, mas nenhum entrypoint do cliente foi fornecido por `NOME_RENDERIZADOR`. (E03008)
+
+## O que deu errado?
+
+Astro tentou hidratar um componente no cliente, mas o renderizador utilizado não fornece um entrypoint do cliente para utilizar para hidratação.
+
+**Veja Também:**
+-  [Opção addRenderer](/pt-br/reference/integrations-reference/#opção-addrenderer)
+-  [Hidratando componentes de frameworks](/pt-br/core-concepts/framework-components/#hidratando-componentes-interativos)
+
+

--- a/src/pages/pt-br/reference/errors/no-client-only-hint.mdx
+++ b/src/pages/pt-br/reference/errors/no-client-only-hint.mdx
@@ -1,0 +1,21 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Missing hint on client:only directive.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoClientOnlyHint**: Incapaz de renderizar `NOME_COMPONENTE`. Ao utilizar a estratégia de hidratação `client:only`, Astro precisa de uma dica para utilizar o renderizador correto. (E03009)
+
+## O que deu errado?
+
+Componentes `client:only` não são executados no servidor, portanto o Astro não sabe (e não pode adivinhar) qual renderizador utilizar e precisa de uma dica. Desse jeito:
+
+```astro
+	<UmComponenteReact client:only="react" />
+```
+
+**Veja Também:**
+-  [`client:only`](/pt-br/reference/directives-reference/#clientonly)
+
+

--- a/src/pages/pt-br/reference/errors/no-matching-import.mdx
+++ b/src/pages/pt-br/reference/errors/no-matching-import.mdx
@@ -1,0 +1,13 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: No import found for component.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoMatchingImport**: Não foi possível renderizar `NOME_COMPONENTE`. Nenhuma importação correspondente foi encontrada para `NOME_COMPONENTE`. (E03018)
+
+## O que deu errado?
+
+Nenhuma declaração de importação foi encontrado para um dos componentes. Se tiver uma declaração de importação, certifique-se de que você está utilizando o mesmo identificador na importação e no uso do componente.
+

--- a/src/pages/pt-br/reference/errors/no-matching-renderer.mdx
+++ b/src/pages/pt-br/reference/errors/no-matching-renderer.mdx
@@ -1,0 +1,20 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: No matching renderer found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Incapaz de renderizar `NOME_COMPONENTE`. Há `CONTAGEM_RENDERIZADORES` renderizador(es) configurados no seu arquivo `astro.config.mjs`, mas nenhum foi capaz de renderizar `NOME_COMPONENTE` no lado do servidor. (E03007)
+
+## O que deu errado?
+
+Nenhuma das integrações instaladas foi capaz de renderizar o componente que você importou. Certifique-se de instalar a integração apropriada para o tipo de componente que você está tentando incluir na sua página.
+
+Para arquivos JSX / TSX, [@astrojs/react](/pt-br/guides/integrations-guide/react/), [@astrojs/preact](/pt-br/guides/integrations-guide/preact/) ou [@astrojs/solid-js](/pt-br/guides/integrations-guide/solid-js/) podem ser utilizados. Para arquivos Vue e Svelte, as integrações [@astrojs/vue](/pt-br/guides/integrations-guide/vue/) e [@astrojs/svelte](/pt-br/guides/integrations-guide/svelte/) podem ser utilizadas respectivamente.
+
+**Veja Também:**
+-  [Componentes de Frameworks](/pt-br/core-concepts/framework-components/)
+-  [Frameworks de UI](/pt-br/guides/integrations-guide/#integrações-oficiais)
+
+

--- a/src/pages/pt-br/reference/errors/no-matching-static-path-found.mdx
+++ b/src/pages/pt-br/reference/errors/no-matching-static-path-found.mdx
@@ -1,0 +1,17 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: No static path found for requested path.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoMatchingStaticPathFound**: Um padrão de rota `getStaticPaths()` foi correspondido, mas nenhum caminho estático correspondente foi encontrado para o caminho requisitado `NOME_CAMINHO`. (E03004)
+
+## O que deu errado?
+
+Uma [rota dinâmica](/pt-br/core-concepts/routing/#rotas-dinâmicas) foi correspondida, mas nenhum caminho correspondente foi encontrado para o parâmetros requisitados. Isso é geralmente causado por um erro de digitação no caminho requisitado ou gerado.
+
+**Veja Também:**
+-  [getStaticPaths()](/pt-br/reference/api-reference/#getstaticpaths)
+
+

--- a/src/pages/pt-br/reference/errors/only-response-can-be-returned.mdx
+++ b/src/pages/pt-br/reference/errors/only-response-can-be-returned.mdx
@@ -1,0 +1,29 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Invalid type returned by Astro page.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Rota retornou um `VALOR_RETORNADO`. Apenas uma Response pode ser retornada de arquivos Astro. (E03005)
+
+## O que deu errado?
+
+Apenas instâncias de [Response](https://developer.mozilla.org/pt-BR/docs/Web/API/Response) podem ser retornadas dentro de arquivos Astro.
+
+```astro title="pages/login.astro"
+---
+return new Response(null, {
+ status: 404,
+ statusText: 'Não encontrado'
+});
+
+// Alternativamente, para redirecionamentos, Astro.redirect também retorna uma instância de Response
+return Astro.redirect('/login');
+---
+```
+
+**Veja Também:**
+-  [Response](/pt-br/guides/server-side-rendering/#response)
+
+

--- a/src/pages/pt-br/reference/errors/page-number-param-not-found.mdx
+++ b/src/pages/pt-br/reference/errors/page-number-param-not-found.mdx
@@ -1,0 +1,14 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Page number param not found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **PageNumberParamNotFound**: [paginate()] número de parâmetro da página `NOME_PARAM` não foi encontrado em seu caminho de arquivo. (E03021)
+
+## O que deu errado?
+O número de parâmetro da página não foi encontrado em seu caminho de arquivo.
+
+**Veja Também:**
+-  [Paginação](/pt-br/core-concepts/routing/#paginação)

--- a/src/pages/pt-br/reference/errors/reserved-slot-name.mdx
+++ b/src/pages/pt-br/reference/errors/reserved-slot-name.mdx
@@ -1,0 +1,17 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Invalid slot name.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ReservedSlotName**: Incapaz de criar um slot chamado `NOME_SLOT`. `NOME_SLOT` é um nome de slot reservado. Por favor atualize o nome desse slot. (E03016)
+
+## O que deu errado?
+
+Certas palavras não podem ser utilizadas como nomes de slot por já serem utilizados internamente.
+
+**Veja Também:**
+-  [Slots nomeados](/pt-br/core-concepts/astro-components/#slots-nomeados)
+
+

--- a/src/pages/pt-br/reference/errors/static-client-address-not-available.mdx
+++ b/src/pages/pt-br/reference/errors/static-client-address-not-available.mdx
@@ -1,0 +1,20 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Astro.clientAddress is not available in static mode.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **StaticClientAddressNotAvailable**: `Astro.clientAddress` está apenas disponível ao utilizar `output: 'server'`. Atualize sua configuração do Astro se você precisa de funcionalidades de SSR. (E03003)
+
+## O que deu errado?
+
+A propriedade `Astro.clientAddress` está apenas disponível quando [Renderização no lado do servidor](/pt-br/guides/server-side-rendering/) está habilitada.
+
+Para conseguir o endereço de IP do usuário no modo estático, diferentes APIs como [Ipify](https://www.ipify.org/) podem ser utilizadas em um [Script no lado do cliente](/pt-br/core-concepts/astro-components/#scripts-no-lado-do-cliente) ou pode ser possível conseguir o IP do usuário utilizando uma função serverless hospedada no seu provedor de hospedagem.
+
+**Veja Também:**
+-  [Habilitando SSR no seu projeto](/pt-br/guides/server-side-rendering/#habilitando-o-ssr-em-seu-projeto)
+-  [Astro.clientAddress](/pt-br/reference/api-reference/#astroclientaddress)
+
+

--- a/src/pages/pt-br/reference/errors/static-redirect-not-available.mdx
+++ b/src/pages/pt-br/reference/errors/static-redirect-not-available.mdx
@@ -1,0 +1,20 @@
+---
+layout: ~/layouts/MainLayout.astro
+title: Astro.redirect is not available in static mode.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **StaticRedirectNotAvailable**: Redirecionamentos só estão disponíveis ao utilizar `output: 'server'`. Atualize sua configuração do Astro se você precisa de funcionalidades de SSR. (E03001)
+
+## O que deu errado?
+
+A função `Astro.redirect` está apenas disponível quando [Renderização no lado do servidor](/pt-br/guides/server-side-rendering/) está habilitada.
+
+Para redirecionar em um site estático, o [atributo meta refresh](https://developer.mozilla.org/pt-BR/docs/Web/HTML/Element/meta) pode ser utilizado. Certas hospedagens também providenciam redirecionamentos baseados em configuração (ex: [Netlify redirects](https://docs.netlify.com/routing/redirects/)).
+
+**Veja Também:**
+-  [Habilitando SSR no seu projeto](/pt-br/guides/server-side-rendering/#habilitando-o-ssr-em-seu-projeto)
+-  [Astro.redirect](/pt-br/guides/server-side-rendering/#astroredirect)
+
+


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

Added translations for:
- `mdx-integration-missing-error.mdx`
- `missing-media-query-directive.mdx`
- `no-adapter-installed.mdx`
- `no-client-entrypoint.mdx`
- `no-client-only-hint.mdx`
- `no-matching-import.mdx`
- `no-matching-renderer.mdx`
- `no-matching-static-path-found.mdx`
- `only-response-can-be-returned.mdx`
- `reserved-slot-name.mdx`
- `static-client-address-not-available.mdx`
- `static-redirect-not-available.mdx`