### PR TITLE
Tutorial 2.2 - Explain Frontmatter

### DIFF
--- a/src/pages/en/tutorial/2-pages/2.mdx
+++ b/src/pages/en/tutorial/2-pages/2.mdx
@@ -74,7 +74,7 @@ Now that you have built pages using `.astro` files, let's make some blog posts u
 3. Use your browser's Dev Tools to inspect this page. Notice that although you have not typed any HTML elements, your Markdown has been converted to HTML. You can see elements such as headings, paragraphs, and list items.
 
 :::note
-The information at the top of the file, inside the code fences, is called frontmatter. This data—including tags and a post image—won't appear until we access it later in the tutorial. 
+The information at the top of the file, inside the code fences, is called frontmatter. This data—including tags and a post image—is information *about* your post that Astro can use. It does not appear on the page automatically, but we will access it later in the tutorial to enhance your site. 
 :::
 
 ## Link to your posts

--- a/src/pages/en/tutorial/2-pages/2.mdx
+++ b/src/pages/en/tutorial/2-pages/2.mdx
@@ -73,6 +73,10 @@ Now that you have built pages using `.astro` files, let's make some blog posts u
 
 3. Use your browser's Dev Tools to inspect this page. Notice that although you have not typed any HTML elements, your Markdown has been converted to HTML. You can see elements such as headings, paragraphs, and list items.
 
+:::note
+The information at the top of the file, inside the code fences, is called frontmatter. This data—including tags and a post image—won't appear until we access it later in the tutorial. 
+:::
+
 ## Link to your posts
 
 1. Link to your first post with an anchor tag in `src/pages/blog.astro`:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content


#### Description

Addresses this Feedback Fish:
> In those example, the images are not being rendered...

If a reader doesn't know what frontmatter is, they might expect the image to be rendered alongside the rest of the document. (This is especially true since the title _does_ show up, as we have it in both the frontmatter and the body.)

This change briefly introduces frontmatter and tells the reader not to expect the image to show up.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
