### PR TITLE
Update ghost.mdx

### DIFF
--- a/src/pages/en/guides/cms/ghost.mdx
+++ b/src/pages/en/guides/cms/ghost.mdx
@@ -112,7 +112,7 @@ import GhostContentAPI from '@tryghost/content-api';
 
 // Create API instance with site credentials
 export const ghostClient = new GhostContentAPI({
-    url: 'http://localhost:2368', // This is the default URL if your site is running on a local environment
+    url: 'http://127.0.0.1:2368', // This is the default URL if your site is running on a local environment
     key: import.meta.env.CONTENT_API_KEY,
     version: 'v5.0',
 });


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
When running ghost locally and running Astro locally, "localhost" is resolved as ":::", which in turn crashes it. Changing it to "127.0.0.1" (provided that both are running locally) fixes the problem. Just ran into this now while integrating Ghost.
