### PR TITLE
i18n(es): Update of `markdown-content.mdx`, `content-schema-containts-slug-error.mdx`, `invalid-content-entry-slug-error.mdx` and `publish-to-npm.mdx`

### DIFF
--- a/src/pages/es/guides/markdown-content.mdx
+++ b/src/pages/es/guides/markdown-content.mdx
@@ -131,7 +131,7 @@ description: ¡Descubre por qué Astro es genial!
 Este es un artículo escrito en Markdown.
 ```
 
-Luego las propiedades de frontmatter están disponibles en la plantilla a través de `Astro.props`:
+[Luego las propiedades especificas están disponibles para el componente plantilla](/es/core-concepts/layouts/#props-de-plantillas-markdown) a través de `Astro.props`. Por ejemplo, puedes acceder a las propiedades del frontmatter a través de `Astro.props.frontmatter`:
 
 **`src/layouts/BlogPostLayout.astro`**
 
@@ -143,11 +143,12 @@ const { frontmatter } = Astro.props;
   <!-- ... -->
   <h1>{frontmatter.title}</h1>
   <h2>Autor del artículo: {frontmatter.author}</h2>
-  <p>{frontmatter.description}<p>
+  <p>{frontmatter.description}</p>
   <slot /> <!-- Aquí se inyecta el contenido Markdown -->
    <!-- ... -->
 </html>
 ```
+
 
 Puedes también [aplicar estilos al Markdown](/es/guides/styling/#estilando-markdown) en tu componente plantilla.
 

--- a/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-Un esquema de colección de contenido no debe contener el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.
+Un esquema de colección de contenido no debe contener el `slug` ya que está reservado para la generación de slugs. Elimina esto de tu esquema de colección de contenido.
 (E09003)
 
 ## ¿Qué salió mal?

--- a/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/pages/es/reference/errors/content-schema-contains-slug-error.mdx
@@ -10,9 +10,8 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **ContentSchemaContainsSlugError**: 
-            return `Un esquema de colección de contenido no debe contener el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.`;
-         (E09003)
+Un esquema de colección de contenido no debe contener el `slug` ya que esta reservado para la generación de slugs. Elimine esto de su esquema de colección de contenido.
+(E09003)
 
 ## ¿Qué salió mal?
 Un esquema de colección de contenido no debe contener la propiedad `slug`. Esto está reservado por Astro para generar slugs. Elimine el campo `slug` de su esquema o elija un nombre diferente.

--- a/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/pages/es/reference/errors/invalid-content-entry-slug-error.mdx
@@ -10,9 +10,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **InvalidContentEntrySlugError**: 
-            return `STRING(COLLECTION) → STRING(ENTRY_ID) tiene un slug no válido. El campo `slug` debe ser un string.`;
-         (E09002)
+STRING(COLLECTION) → STRING(ENTRY_ID) tiene un slug no válido. El campo `slug` debe ser un string. (E09002)
 
 ## ¿Qué salió mal?
 Un archivo en `src/content/` tiene un `slug` no válido. Este campo está reservado para generar slugs y debe ser un string cuando está presente.

--- a/src/pages/es/reference/publish-to-npm.mdx
+++ b/src/pages/es/reference/publish-to-npm.mdx
@@ -263,7 +263,7 @@ Si necesitas algún otro tipo de archivo que Astro no admita de forma nativa, pu
 
 ### Datos en `package.json`
 
-La biblioteca se actualiza automáticamente todas las noches, agregando todos los paquetes publicados en NPM con la palabra clave `astro-component`.
+La biblioteca se actualiza automáticamente todas las noches, agregando todos los paquetes publicados en NPM con la palabra clave `astro-component` o `withastro`.
 
 La biblioteca de integraciones lee los datos `name`, `description`, `repository` y `homepage` de tu `package.json`.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.

Multiple page updates based on these commits as follows:
- - markdown-content.mdx → 471f2388d6ef0d60211eea75afd683c6138d415d & f3b0625a51f54636e203f8650352cb7fc4c443b6
- - content-schema-containts-slug-error.mdx → 0de27116b410c0e68d3702ff6f944edc5235a12b
- - invalid-content-entry-slug-error.mdx → 0de27116b410c0e68d3702ff6f944edc5235a12b
- - publish-to-npm.mdx → e58d23c63167bcf2c96e9a8a7f171f63f3286b21, 9d4bd688365a562ccf013310d8840f3271c232d9 & c5f02333db29b2810d986025d9f418d22f7693a0

## Note
`cloudflare.mdx` doesn't need update to spanish cause they fixed small typos which were translated properly based on these commits  471f2388d6ef0d60211eea75afd683c6138d415d & f3b0625a51f54636e203f8650352cb7fc4c443b6