### PR TITLE
Documents `loadEnv` workaround 

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,10 +16,7 @@ import { rehypei18nAutolinkHeadings } from './plugins/rehype-i18n-autolink-headi
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
 import { remarkFallbackLang } from './plugins/remark-fallback-lang';
 import { theme } from './syntax-highlighting-theme';
-import { loadEnv } from 'vite';
 
-const env = loadEnv(import.meta.env.MODE, process.cwd(), '');
-console.log(env);
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://docs.astro.build/',

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,7 +16,10 @@ import { rehypei18nAutolinkHeadings } from './plugins/rehype-i18n-autolink-headi
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
 import { remarkFallbackLang } from './plugins/remark-fallback-lang';
 import { theme } from './syntax-highlighting-theme';
+import { loadEnv } from 'vite';
 
+const env = loadEnv(import.meta.env.MODE, process.cwd(), '');
+console.log(env);
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://docs.astro.build/',

--- a/src/pages/en/guides/configuring-astro.mdx
+++ b/src/pages/en/guides/configuring-astro.mdx
@@ -145,9 +145,16 @@ export default defineConfig({
 This can be helpful if you have scripts with names that might be impacted by ad blockers (e.g. `ads.js` or `google-tag-manager.js`).
 
 ## Environment Variables
-Astro evaluates configuration files before it loads your other files. As such, you can't use `import.meta.env` or access environment variables that were set in `.env` files. 
+Astro evaluates configuration files before it loads your other files. As such, you can't use `import.meta.env` to access environment variables that were set in `.env` files. 
 
 You can use `process.env` in a configuration file to access other environment variables, like those [set by the CLI](/en/guides/environment-variables/#using-the-cli).
+
+You can also use [Vite's `loadEnv` helper](https://main.vitejs.dev/config/#using-environment-variables-in-config) to manually load `.env` files.
+
+```astro title="astro.config.mjs"
+import { loadEnv } from "vite";
+const { SECRET_PASSWORD } = loadEnv(import.meta.env.MODE, process.cwd(), "");
+```
 
 ## Configuration Reference
 

--- a/src/pages/en/guides/environment-variables.mdx
+++ b/src/pages/en/guides/environment-variables.mdx
@@ -18,7 +18,7 @@ PUBLIC_ANYBODY=there
 In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 
 :::caution
-`import.meta.env` and `.env` files are not available inside [configuration files](/en/guides/configuring-astro/#environment-variables). 
+`.env` files are not loaded inside [configuration files](/en/guides/configuring-astro/#environment-variables). 
 :::
 
 ## Default environment variables


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #2506, but **doesn't** add a caution box to the integration API reference. That's because this doesn't have anything to do with integrations specifically, but rather the Astro config file.
- Documents the `loadEnv` workaround for accessing environment variables in the Astro config file. This comes up often in support, but is missing from our docs.
- Updates wording to implicate that `import.meta.env` **is** available - it just doesn't have `.env` variables on it. This is why we can use `import.meta.env.MODE` to tell `loadEnv` to grab the right `.env` files.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
