### PR TITLE
Warning for using `<img>` with the image integration installed

### DIFF
--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -34,7 +34,7 @@ The official [image integration](#astros-image-integration) will change image im
 If you have the image integration installed, add `?url` to your imports when using `<img>`.
 ```astro "?url"
 ---
-import rocket from '../images/rocket.svg';
+import rocket from '../images/rocket.svg?url';
 ---
 <img src={rocket} alt="A rocketship in space."/>
 ```

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -139,9 +139,6 @@ This component is useful for images where you want to keep a consistent size acr
 
 For responsive images, or art direction, use the `<Picture />` component instead.
 
-:::note
-Installing the image integration
-:::
 #### Local Images in `src/`
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src), and [`alt`](/en/guides/integrations-guide/image/#alt))

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -104,7 +104,7 @@ Import them from a **relative file path** or [import alias](/en/guides/aliases/)
 // src/pages/index.astro
 
 // Access images in `src/images/`
-import logo from '../images/logo.png?url';
+import logo from '../images/logo.png';
 ---
 <img src={logo} width="40" alt="Astro" />
 ```

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -17,7 +17,7 @@ The `src` attribute is required, and its format will depend on where your images
 
 ```astro title="src/pages/index.astro"
 ---
-import rocket from '../images/rocket.svg?url';
+import rocket from '../images/rocket.svg';
 ---
 <!-- Remote image on another server -->
 <img src="https://astro.build/assets/logo.png" width="25" alt="Astro">
@@ -34,7 +34,7 @@ The official [image integration](#astros-image-integration) will change image im
 If you have the image integration installed, add `?url` to your imports when using `<img>`.
 ```astro "?url"
 ---
-import rocket from '../images/rocket.svg?url';
+import rocket from '../images/rocket.svg';
 ---
 <img src={rocket} alt="A rocketship in space."/>
 ```
@@ -68,7 +68,7 @@ Additionally, you can import and use images located in your project's `src/` dir
 
 ```mdx title="src/pages/post-1.mdx"
 
-import rocket from '../images/rocket.svg?url';
+import rocket from '../images/rocket.svg';
 
 # My MDX Page
 

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -29,6 +29,17 @@ import rocket from '../images/rocket.svg';
 <img src={rocket} alt="A rocketship in space."/>
 ```
 
+:::caution
+The official [image integration](#astros-image-integration) will change image imports to return an object.
+If you're using the image integration, add `?url` to your imports to achieve the above behavior.
+```astro
+---
+import rocket from '../images/rocket.svg?url';
+---
+<img src={rocket} alt="A rocketship in space."/>
+```
+:::
+
 ### In Markdown files
 
 You can use standard Markdown `![]()` syntax or standard HTML `<img>` tags in your `.md` files for images located in your `public/` folder, or remote images on another server.
@@ -93,7 +104,7 @@ Import them from a **relative file path** or [import alias](/en/guides/aliases/)
 // src/pages/index.astro
 
 // Access images in `src/images/`
-import logo from '../images/logo.png';
+import logo from '../images/logo.png?url';
 ---
 <img src={logo} width="40" alt="Astro" />
 ```
@@ -128,6 +139,9 @@ This component is useful for images where you want to keep a consistent size acr
 
 For responsive images, or art direction, use the `<Picture />` component instead.
 
+:::note
+Installing the image integration
+:::
 #### Local Images in `src/`
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src), and [`alt`](/en/guides/integrations-guide/image/#alt))

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -31,8 +31,8 @@ import rocket from '../images/rocket.svg';
 
 :::caution
 The official [image integration](#astros-image-integration) will change image imports to return an object.
-If you're using the image integration, add `?url` to your imports to achieve the above behavior.
-```astro
+If you have the image integration installed, add `?url` to your imports when using `<img>`.
+```astro "?url"
 ---
 import rocket from '../images/rocket.svg?url';
 ---

--- a/src/pages/en/guides/images.mdx
+++ b/src/pages/en/guides/images.mdx
@@ -29,17 +29,6 @@ import rocket from '../images/rocket.svg';
 <img src={rocket} alt="A rocketship in space."/>
 ```
 
-:::caution
-The official [image integration](#astros-image-integration) will change image imports to return an object.
-If you have the image integration installed, add `?url` to your imports when using `<img>`.
-```astro "?url"
----
-import rocket from '../images/rocket.svg?url';
----
-<img src={rocket} alt="A rocketship in space."/>
-```
-:::
-
 ### In Markdown files
 
 You can use standard Markdown `![]()` syntax or standard HTML `<img>` tags in your `.md` files for images located in your `public/` folder, or remote images on another server.
@@ -320,6 +309,37 @@ const {src, ...attrs} = Astro.props;
 </style>
 ```
 
+### Using `<img>` with the Image Integration
+
+The official image integration will change image imports to return an object rather than a source string.
+The object has the following properties, derived from the imported file:
+```ts
+{
+  src: string;
+  width: number;
+  height: number;
+  format: 'avif' | 'gif' | 'heic' | 'heif' | 'jpeg' | 'jpg' | 'png' | 'tiff' | 'webp';
+}
+```
+
+If you have the image integration installed, refer to the `src` property of the object when using `<img>`. 
+
+```astro ".src"
+---
+import rocket from '../images/rocket.svg';
+---
+<img src={rocket.src} alt="A rocketship in space."/>
+```
+
+Alternatively, add `?url` to your imports to tell them to return a source string.
+
+```astro "?url"
+---
+import rocket from '../images/rocket.svg?url';
+---
+<img src={rocket} alt="A rocketship in space."/>
+```
+
 ## Using Images from a CMS or CDN
 
 Image CDNs work with Astro. Use an image's full URL as the `src` attribute in an `<img>` tag or Markdown notation. 
@@ -335,6 +355,8 @@ Not all users can see images in the same way, so accessibility is an especially 
 This attribute is required for the image integration's `<Image />` and `<Picture />` components. These components will throw an error if no alt text is provided. 
 
 If the image is merely decorative (i.e. doesn’t contribute to the understanding of the page), set `alt=""` so that screen readers know to ignore the image.
+
+
 
 ## Community Integrations
 

--- a/src/pages/fr/guides/client-side-scripts.mdx
+++ b/src/pages/fr/guides/client-side-scripts.mdx
@@ -1,0 +1,213 @@
+---
+title: Scripts et gestion d'évènements.
+description: >-
+  Comment ajouter de l'interactivité côté client aux composants Astro en utilisant les 
+  API JavaScript natives du navigateur.
+layout: ~/layouts/MainLayout.astro
+i18nReady: true
+---
+
+Vous pouvez ajouter de l'interactivité à vos composants Astro sans [utiliser un framework UI](/fr/core-concepts/framework-components/) comme React, Svelte, Vue, etc. en utilisant la balise HTML `<script>`. Cela vous permet d'exécuter votre JavaScript dans le navigateur et ajouter des fonctionnalités à vos composants Astro.
+
+## Utilisation du `<script>` en Astro.
+
+Dans les fichiers `.astro`, vous pouvez ajouter du JavaScript côté client en ajoutant une (ou plusieurs) balises `<script>`.
+
+Dans cet example, l'ajout du composant `<Hello />` à un page enregistrera un message dans la console du navigateur.
+
+```astro title="src/compnonents/Hello.astro"
+<h1>Bienvenue, monde !</h1>
+
+<script>
+  console.log('Bienvenue, console du navigateur !');
+</script>
+```
+
+### Regroupement de script
+
+Par défaut, les balises `<script>` sont optimisées par Astro.
+
+- Toutes les importations seront regroupées, ce qui vous permettra d'importer des fichiers locaux ou des modules Node.
+- Le script optimisé sera injecté dans le `<head>` de votre page HTML avec [`type="module"`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Guide/Modules).
+- TypeScript est entièrement supporté, y compris l'importation de fichiers TypeScript.
+- Si votre composant est utilisé plusieurs fois sur un page, le script ne sera inclus qu'une seule fois.
+
+```astro title="src/components/Example.astro"
+<script>
+  // Optimisé ! Regroupé ! TypeScript supporté !
+  // L'importation de fichiers locaux et de modules Node est supportée.
+<script>
+```
+
+Pour éviter le regroupement de script, vous pouvez utiliser la directive `is:inline`.
+
+``` astro title:"src/components/InlineScript.astro" "is:inline"
+<script is:inline>
+  // Sera rendu dans le HTML exactement comme écrit.
+  // Les importations locales ne sont pas résolues et ne fonctionneront pas.
+  // S'il se trouve dans un composant, il se répète chaque fois que le composant est utilisé.
+</script>
+```
+
+:::note
+L'ajout de `type="module"` ou de tout autre attribut que `src` à une balise `<script>` désactivera le comportement de regroupement par défaut d'Astro, en traitant la balise comme si elle avait une directive `is:inline`.
+:::
+
+📚 Consultez notre page [référence des directives](/fr/reference/directives-reference/#script--style-directives) pour plus d'informations sur les directives disponibles des balises `<script>`.
+
+### Chargement de script
+
+Vous voudriez écrire vos scripts dans un fichier séparé `.js`/`.ts` ou avoir besoin de référencer un script externe sur un autre serveur. Vous pouvez le faire en les référençant dans l'attribut `src` d'une balise `<script>`.
+
+### Importer des scripts locaux
+
+**Quand l'utiliser :** Si vos script est dedans `src/`
+
+Astro va compiler, optimiser et ajouter ces scripts à la page pour vous, en suivant ses [règles de regroupement de script](#regroupement-de-script)
+
+```astro title="src/components/LocalScripts.astro"
+<!-- chemin relatif du script dans `src/scripts/local.js` -->
+<script src="../scripts/local.js"></script>
+
+<!-- fonctionne également pour les fichiers TypeScript locaux -->
+<script src="./script-with-types.ts"></script>
+```
+#### Charger des scripts externes
+
+**Quand l'utiliser :** Si votre fichier JavaScript se trouve à l'intérieur du dossier `public/` ou sur un CDN.
+
+Pour charger des scripts en dehors du dossier `src/` de votre projet, incluez la directive `is:inline`. Cette approche permet d'éviter le traitement JavaScript, le regroupement et l'optimisation du JavaScript qui sont fournis par Astro lorsque vous importez des scripts comme décrit ci-dessus.
+
+```astro title="src/components/ExternalScripts.astro" "is:inline"
+<!-- chemin absolu du script à `public/my-script.js` -->
+<script is:inline src="/my-script.js"></script>
+
+<!-- URL complète vers un script sur un serveur distant -->
+<script is:inline src="https://my-analytics.com/script.js"></script>
+```
+
+## Modèles communs de script
+
+### Gérer le `onclick` et d'autres évènements
+
+Certains frameworks d'interface utilisent une syntaxe personnalisée pour la gestion d'événements comme `onClick={...}` (React/Preact) ou `@click="..."` (Vue). Astro suit le HTML standard de plus près et n’utilise pas de syntaxe personnalisée pour les évènements.
+
+Au lieu de cela, vous pouvez utiliser [`addEventListener`](https://developer.mozilla.org/fr/docs/Web/API/EventTarget/addEventListener) dans une balise `<script>` pour gérer les interactions utilisateur.
+
+```astro title="src/components/AlertButton.astro"
+<button class="alert">Cliquez-moi !</button>
+
+<script>
+  // Trouver tous les boutons avec la classe `alert` sur la page.
+  const buttons = document.querySelectorAll('button.alert');
+
+  // Gérer les clics sur chaque bouton.
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      alert('Button was clicked !');
+    });
+  });
+</script>
+```
+
+:::note
+Si vous avez plusieurs composants `<AlertButton />` sur une page, Astro n'exécutera pas le script plusieurs fois. Les scripts sont groupés et inclus seulement une fois par page. L'utilisation de `querySelectorAll` garantit que ce script attache l'écouteur d'évènement à chaque bouton ayant la classe `alert` trouvé sur la page.
+:::
+
+### Composants Web avec des éléments personnalisés
+
+Vous pouvez créer vos propres éléments HTML ayant un comportement personnalisé en utilisant les composants web standards. Définir un [élément personnalisé](https://developer.mozilla.org/fr/docs/Web/Web_Components/Using_custom_elements) dans un composant `.astro` vous permet de créer des composants interactifs sans avoir besoin d'une bibliothèque de cadres d'interface utilisateur.
+
+Dans cet exemple, nous définissons un nouvel élément HTML `<astro-heart>` qui suit le nombre de fois que vous cliquez sur le bouton cœur et met à jour le `<span>` avec le dernier compte.
+
+```astro title="src/components/AstroHeart.astro"
+<!-- Enveloppez les éléments du composant dans notre élément personnalisé "astro-heart" -->
+<astro-heart>
+  <button aria-label="Heart">💜</button> × <span>0</span>
+</astro-heart>
+
+<script>
+  // Définir le comportement de notre nouveau type d'élément HTML.
+  class AstroHeart extends HTMLElement {
+    constructor() {
+			super();
+      let count = 0;
+
+      const heartButton = this.querySelector('button');
+      const countSpan = this.querySelector('span');
+
+      // À chaque fois que le bouton est cliqué, on met à jour le compte.
+			heartButton.addEventListener('click', () => {
+        count++;
+        countSpan.textContent = count;
+      });
+		}
+  }
+
+  // Dites au navigateur d'utiliser notre classe AstroHeart pour les éléments <astro-heart>.
+  customElements.define('astro-heart', AstroHeart);
+</script>
+```
+
+Il y a deux avantages à utiliser un élément personnalisé ici:
+
+1. Au lieu de chercher dans toute la page en utilisant `document.querySelector()`, vous pouvez utiliser `this.querySelector()`, qui ne recherche que dans l'instance courante de l'élément personnalisé. Cela permet de travailler plus facilement avec les enfants d'une seule instance de composant à la fois.
+
+2. Bien qu'un `<script>` ne s'exécute qu'une seule fois, le navigateur exécutera la méthode `constructor()` de notre élément personnalisé chaque fois qu'il trouvera `<astro-heart>` sur la page. Cela signifie que vous pouvez écrire du code en toute sécurité pour un composant à la fois, même si vous avez l'intention d'utiliser ce composant plusieurs fois sur une page.
+
+Vous pouvez en savoir plus sur les éléments personnalisés dans le [guide des composants Web réutilisables de web.dev](https://web.dev/custom-elements-v1/) et dans l'[introduction aux composants personnalisés de MDN](https://developer.mozilla.org/fr/docs/Web/Web_Components/Using_custom_elements).
+
+### Passer les variables frontmatter aux scripts
+
+Dans les composants Astro, le code dans [le frontmatter](/fr/core-concepts/astro-components/#le-script-du-composant) entre les clôtures “---” s'exécute sur le serveur et n'est pas disponible dans le navigateur. Pour envoyer des variables du serveur au client, nous avons besoin d'un moyen de stocker nos variables et de les lire lorsque le JavaScript s'exécute dans le navigateur.
+
+Une façon de le faire est d'utiliser les [attributs `data-*`](https://developer.mozilla.org/fr/docs/Learn/HTML/Howto/Use_data_attributes) pour stocker la valeur des variables dans votre sortie HTML. Les scripts, y compris les éléments personnalisés, peuvent alors lire ces attributs en utilisant la propriété `dataset` d'un élément une fois que votre HTML se charge dans le navigateur.
+
+Dans cet exemple de composant, une propriété `message` est stockée dans un attribut `data-message`, de sorte que l'élément personnalisé puisse lire `this.dataset.message` et obtenir la valeur de la propriété dans le navigateur.
+
+```astro title="src/components/AstroGreet.astro" {2} /data-message={.+}/ "this.dataset.message"
+---
+const { message = 'Welcome, world!' } = Astro.props;
+---
+
+<!-- Stocker la propriété de message comme attribut de données. -->
+<astro-greet data-message={message}>
+  <button>Saluer!</button>
+</astro-greet>
+
+<script>
+  class AstroGreet extends HTMLElement {
+    constructor() {
+			super();
+
+      // Lisez le message de l’attribut data.
+      const message = this.dataset.message;
+      const button = this.querySelector('button');
+      button.addEventListener('click', () => {
+        alert(message);
+      });
+		}
+  }
+
+  customElements.define('astro-greet', AstroGreet);
+</script>
+```
+
+Maintenant, nous pouvons utiliser notre composant plusieurs fois et être accueillis par un message différent pour chacun.
+
+```astro title="src/pages/example.astro"
+---
+import AstroGreet from '../components/AstroGreet.astro';
+---
+
+<!-- Utilisez le message par défaut: "Bienvenue, monde!" -->
+<AstroGreet />
+
+<!-- Utiliser des messages personnalisés passés comme prop. -->
+<AstroGreet message="Belle journée pour construire des composants !" />
+<AstroGreet message="Content que tu sois là ! 👋" />
+```
+
+:::tip[Le saviez-vous?]
+C'est en fait ce que fait Astro dans les coulisses lorsque vous passez des propriétés à un composant écrit en utilisant un framework d'interface utilisateur comme React ! Pour les composants avec une directive `client:*`, Astro crée un élément personnalisé `<astro-island>` avec un attribut `props` qui stocke vos props côté serveur dans la sortie HTML.
+:::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Replaces https://github.com/withastro/docs/pull/2415
- Closes #2586 
- Documents the `?url` workaround for using image imports with `<img>` when the image integration is installed
- We could also document the `rocket.src` workaround, but I chose to go with one recommended solution for this PR.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
