### PR TITLE
fix: code example for built-in html attributes

### DIFF
--- a/src/pages/en/guides/typescript.mdx
+++ b/src/pages/en/guides/typescript.mdx
@@ -127,7 +127,7 @@ interface Props extends HTMLAttributes<'a'> {
 }
 const { href, ...attrs } = Astro.props;
 ---
-<a {href} {...attrs}>
+<a href={href} {...attrs}>
   <slot />
 </a>
 ```

--- a/src/pages/es/guides/typescript.mdx
+++ b/src/pages/es/guides/typescript.mdx
@@ -126,7 +126,7 @@ interface Props extends HTMLAttributes<'a'> {
 }
 const { href, ...attrs } = Astro.props;
 ---
-<a {href} {...attrs}>
+<a href={href} {...attrs}>
   <slot />
 </a>
 ```

--- a/src/pages/ja/guides/typescript.mdx
+++ b/src/pages/ja/guides/typescript.mdx
@@ -128,7 +128,7 @@ interface Props extends HTMLAttributes<'a'> {
 }
 const { href, ...attrs } = Astro.props;
 ---
-<a {href} {...attrs}>
+<a href={href} {...attrs}>
   <slot />
 </a>
 ```

--- a/src/pages/pt-br/guides/typescript.mdx
+++ b/src/pages/pt-br/guides/typescript.mdx
@@ -112,7 +112,7 @@ Astro providencia definições de tipo JSX para verificar se sua marcação est�
 export type Props = astroHTML.JSX.AnchorHTMLAttributes;
 const { href, ...attrs } = Astro.props;
 ---
-<a {href} {...attrs}>
+<a href={href} {...attrs}>
   <slot />
 </a>
 ```

--- a/src/pages/zh-cn/guides/typescript.mdx
+++ b/src/pages/zh-cn/guides/typescript.mdx
@@ -128,7 +128,7 @@ interface Props extends HTMLAttributes<'a'> {
 }
 const { href, ...attrs } = Astro.props;
 ---
-<a {href} {...attrs}>
+<a href={href} {...attrs}>
   <slot />
 </a>
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?


- Fix code example in docs

#### Description


- Code example for [Built-in HTML attributes](https://docs.astro.build/en/guides/typescript/#built-in-html-attributes) throws error via linting and `astro check`
- Error: `Spread types may only be created from object types.`

**Current example:**


```astro
---
import type { HTMLAttributes } from 'astro/types'
// use a `type`
type Props = HTMLAttributes<'a'>;
// or extend with an `interface`
interface Props extends HTMLAttributes<'a'> {
  myProp?: boolean;
}
const { href, ...attrs } = Astro.props;
---
<a {href} {...attrs}>
  <slot />
</a>
```

**Change added to docs via this PR in files where section is present:**


```astro
---
import type { HTMLAttributes } from 'astro/types'
// use a `type`
type Props = HTMLAttributes<'a'>;
// or extend with an `interface`
interface Props extends HTMLAttributes<'a'> {
  myProp?: boolean;
}
const { href, ...attrs } = Astro.props;
---
<a href={href} {...attrs}>
  <slot />
</a>
```
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
