### PR TITLE
Add hint for rest parameter subdirectory necessity

### DIFF
--- a/src/pages/en/guides/content-collections.mdx
+++ b/src/pages/en/guides/content-collections.mdx
@@ -345,7 +345,7 @@ const { Content, headings } = await entry.render();
 
 ## Generating Routes from Content
 
-Content collections are stored outside of the `src/pages/` directory. You will need to create a new [dynamic route](/en/core-concepts/routing/#dynamic-routes) to generate HTML pages from your collection entries. Your dynamic route will map the incoming request param (ex: `Astro.params.slug` in `src/pages/blog/[slug].astro`) to fetch the correct entry inside a collection.
+Content collections are stored outside of the `src/pages/` directory. You will need to create a new [dynamic route](/en/core-concepts/routing/#dynamic-routes) to generate HTML pages from your collection entries. Your dynamic route will map the incoming request param (ex: `Astro.params.slug` in `src/pages/blog/[...slug].astro`) to fetch the correct entry inside a collection.
 
 The exact method for generating routes will depend on your build [`output`](/en/reference/configuration-reference/#output) mode: 'static' (the default) or 'server' (for SSR).
 
@@ -357,7 +357,7 @@ Call [`getCollection()`](/en/reference/api-reference/#getcollection) inside of `
 
 ```astro "{ slug: entry.slug }"
 ---
-// src/pages/posts/[slug].astro
+// src/pages/posts/[...slug].astro
 import { getCollection } from 'astro:content';
 // 1. Generate a new path for every collection entry
 export async function getStaticPaths() {
@@ -383,7 +383,7 @@ If you are building a dynamic website (using Astro's SSR support), you are not e
 
 ```astro
 ---
-// src/pages/posts/[slug].astro
+// src/pages/posts/[...slug].astro
 import { getEntryBySlug } from 'astro:content';
 // 1. Get the slug from the incoming server request
 const { slug } = Astro.params;


### PR DESCRIPTION
Highlight the necessity to use a rest parameter when using subdirectories to organize collections.

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

I updated the docs to include a hint to highlight the necessity of a rest parameter when using subdirectories to organize collections. 

This wasn't really obvious to me since the error that was thrown (`Expected "slug" to match "[^\/#\?]+?", but got "foo/bar"`) when starting `dev` and trying to `build` only gave some kind of hint to what went wrong.

The blog starter template helped me clarify. In hindsight it was clear that this was necessary but I thought it would be a good addition to the docs since others might run into the same issue.

Thanks btw. for the amazingly wonderful great work you guys are doing 🥳