### PR TITLE
Covered Auto Minify settings

### DIFF
--- a/src/pages/en/guides/deploy/cloudflare.mdx
+++ b/src/pages/en/guides/deploy/cloudflare.mdx
@@ -136,4 +136,4 @@ If you're encountering errors, double-check the version of `node` you're using l
 
 Cloudflare requires [Node v16.13](https://miniflare.dev/get-started/cli#installation), which is a more recent version than Astro’s out-of-the-box minimum, so double check you’re using at least v16.13.
 
-When your client-side code is not working as expected after deploying your site and you see `Hydration completed but contains mismatches` in the console, make sure to check your Auto Minify under Cloudflare settings. Client-side hydration may fail as a result of this optimization setting.
+Client-side hydration may fail as a result of Cloudflare's Auto Minify setting. If you see `Hydration completed but contains mismatches` in the console, make sure to disable Auto Minify under Cloudflare settings.

--- a/src/pages/en/guides/deploy/cloudflare.mdx
+++ b/src/pages/en/guides/deploy/cloudflare.mdx
@@ -135,3 +135,5 @@ To get started, create a `/functions` directory at the root of your project. Wri
 If you're encountering errors, double-check the version of `node` you're using locally (`node -v`) matches the version you're specifying in the environment variable.
 
 Cloudflare requires [Node v16.13](https://miniflare.dev/get-started/cli#installation), which is a more recent version than Astro’s out-of-the-box minimum, so double check you’re using at least v16.13.
+
+When your client-side code is not working as expected after deploying your site and you see `Hydration completed but contains mismatches` in the console, make sure to check your Auto Minify under Cloudflare settings. Client-side hydration may fail as a result of this optimization setting.


### PR DESCRIPTION
#### What kind of changes does this PR include?
- New or **updated** content

#### Description
When Cloudflare's Auto Minify setting is enabled for HTML, client-side hydration may not function properly as the HTML does not match the one it expected to find. After using Astro + Cloudflare + Vue myself, I ran into this issue, and when digging into I found this thread: https://github.com/vuejs/vitepress/issues/1143#issuecomment-1210294112

Vitepress actually has this in the docs, so I figured it may save others some trouble if we add it to the Astro docs as well.