### PR TITLE
docs: markdown-content: use `defineConfig` consistently

### DIFF
--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -461,12 +461,12 @@ import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
 import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
 
-export default {
+export default defineConfig({
   markdown: {
     // Applied to .md and .mdx files
     remarkPlugins: [remarkToc, rehypeAccessibleEmojis],
   },
-}
+});
 ```
 
 #### Heading IDs and plugins
@@ -477,18 +477,18 @@ You can customize these heading IDs by adding a rehype plugin that injects `id` 
 
 By default, Astro injects `id` attributes after your rehype plugins have run. If one of your custom rehype plugins needs to access the IDs injected by Astro, you can import and use Astro’s `rehypeHeadingIds` plugin directly. Be sure to add `rehypeHeadingIds` before any plugins that rely on it:
 
-```js {2,7}
-// astro.config.mjs
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 
-export default {
+export default defineConfig({
   markdown: {
     rehypePlugins: [
       rehypeHeadingIds,
-      otherPluginThatReliesOnHeadingIDs,
+      // otherPluginThatReliesOnHeadingIDs,
     ],
   },
-}
+});
 ```
 
 ### Modifying frontmatter programmatically
@@ -515,28 +515,30 @@ You can add frontmatter properties to all of your Markdown and MDX files by usin
 2. Apply this plugin to your `markdown`  or `mdx` integration config:
 
     ```js title="astro.config.mjs" "import { exampleRemarkPlugin } from './example-remark-plugin.mjs';" "remarkPlugins: [exampleRemarkPlugin],"
+    import { defineConfig } from 'astro/config'
     import { exampleRemarkPlugin } from './example-remark-plugin.mjs';
 
-    export default {
+    export default defineConfig({
       markdown: {
         remarkPlugins: [exampleRemarkPlugin],
         extendDefaultPlugins: true,
       },
-    };
-
+    });
     ```
+
     or
 
     ```js title="astro.config.mjs" "import { exampleRemarkPlugin } from './example-remark-plugin.mjs';" "remarkPlugins: [exampleRemarkPlugin],"
+    import { defineConfig } from 'astro/config'
     import { exampleRemarkPlugin } from './example-remark-plugin.mjs';
 
-    export default {
+    export default defineConfig({
       integrations: [
         mdx({
           remarkPlugins: [exampleRemarkPlugin],
         }),
       ],
-    }
+    });
     ```
 
 Now, every Markdown or MDX file will have `customProperty` in its frontmatter, making it available when [importing your markdown](#importing-markdown) and from [the `Astro.props.frontmatter` property in your layouts](#frontmatter-layout).
@@ -571,15 +573,15 @@ export function remarkReadingTime() {
 Once you apply this plugin to your config:
 
 ```js title="astro.config.mjs" "import { remarkReadingTime } from './remark-reading-time.mjs';" "remarkPlugins: [remarkReadingTime],"
+import { defineConfig } from 'astro/config'
 import { remarkReadingTime } from './remark-reading-time.mjs';
 
-export default {
+export default defineConfig({
   markdown: {
     remarkPlugins: [remarkReadingTime],
     extendDefaultPlugins: true,
   },
-};
-
+});
 ```
 
 ...all Markdown documents will have a calculated `minutesRead`. You can use this to include an "X min read" banner in a [markdown layout](#markdown-and-mdx-pages), for instance:
@@ -663,10 +665,10 @@ Shiki is enabled by default, preconfigured with the `github-dark` theme. The com
 #### Shiki configuration
 
 Shiki is our default syntax highlighter. You can configure all options via the `shikiConfig` object like so:
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
 
-```js
-// astro.config.mjs
-export default {
+export default defineConfig({
   markdown: {
     shikiConfig: {
       // Choose from Shiki's built-in themes (or add your own)
@@ -680,7 +682,7 @@ export default {
       wrap: true,
     },
   },
-};
+});
 ```
 
 #### Adding your own theme
@@ -704,14 +706,15 @@ We also suggest reading [Shiki's own theme documentation](https://github.com/shi
 
 If you'd like to switch to `'prism'` by default, or disable syntax highlighting entirely, you can use the `markdown.syntaxHighlighting` config object:
 
-```js ins={5}
-// astro.config.mjs
-export default {
+```js title="astro.config.mjs" ins={6}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   markdown: {
     // Can be 'shiki' (default), 'prism' or false to disable highlighting
     syntaxHighlight: 'prism',
   },
-};
+});
 ```
 
 #### Prism configuration

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -481,6 +481,7 @@ By default, Astro injects `id` attributes after your rehype plugins have run. If
 ```js title="astro.config.mjs" ins={2, 7}
 import { defineConfig } from 'astro/config';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
+import { otherPluginThatReliesOnHeadingIDs } from 'some/plugin/source';
 
 export default defineConfig({
   markdown: {

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -487,7 +487,7 @@ export default defineConfig({
   markdown: {
     rehypePlugins: [
       rehypeHeadingIds,
-      // otherPluginThatReliesOnHeadingIDs,
+      otherPluginThatReliesOnHeadingIDs,
     ],
   },
 });

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -478,7 +478,7 @@ You can customize these heading IDs by adding a rehype plugin that injects `id` 
 
 By default, Astro injects `id` attributes after your rehype plugins have run. If one of your custom rehype plugins needs to access the IDs injected by Astro, you can import and use Astro’s `rehypeHeadingIds` plugin directly. Be sure to add `rehypeHeadingIds` before any plugins that rely on it:
 
-```js title="astro.config.mjs" ins={2, 7}
+```js title="astro.config.mjs" ins={2, 8}
 import { defineConfig } from 'astro/config';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import { otherPluginThatReliesOnHeadingIDs } from 'some/plugin/source';

--- a/src/pages/en/guides/markdown-content.mdx
+++ b/src/pages/en/guides/markdown-content.mdx
@@ -477,7 +477,7 @@ You can customize these heading IDs by adding a rehype plugin that injects `id` 
 
 By default, Astro injects `id` attributes after your rehype plugins have run. If one of your custom rehype plugins needs to access the IDs injected by Astro, you can import and use Astro’s `rehypeHeadingIds` plugin directly. Be sure to add `rehypeHeadingIds` before any plugins that rely on it:
 
-```js title="astro.config.mjs"
+```js title="astro.config.mjs" ins={2, 7}
 import { defineConfig } from 'astro/config';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 
@@ -665,6 +665,7 @@ Shiki is enabled by default, preconfigured with the `github-dark` theme. The com
 #### Shiki configuration
 
 Shiki is our default syntax highlighter. You can configure all options via the `shikiConfig` object like so:
+
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

Minor content fixes (broken links, typos, etc.):

- use `defineConfig` consistently
- use the code "title" when not used

---

I find it confusing, when the docs sometimes use one pattern and other times something else. This changes it to use defineConfig everywhere on this page.