### PR TITLE
Add frontmatter to make code highlight work

### DIFF
--- a/src/pages/en/guides/configuring-astro.mdx
+++ b/src/pages/en/guides/configuring-astro.mdx
@@ -152,8 +152,10 @@ You can use `process.env` in a configuration file to access other environment va
 You can also use [Vite's `loadEnv` helper](https://main.vitejs.dev/config/#using-environment-variables-in-config) to manually load `.env` files.
 
 ```astro title="astro.config.mjs"
+---
 import { loadEnv } from "vite";
 const { SECRET_PASSWORD } = loadEnv(import.meta.env.MODE, process.cwd(), "");
+---
 ```
 
 ## Configuration Reference


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Added the frontmatter to codesample.
This makes the Astro codesample highlights work again

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
