### PR TITLE
Change code block extension to make syntax highlighting work in `configuring-astro.mdx`

### DIFF
--- a/src/pages/en/guides/configuring-astro.mdx
+++ b/src/pages/en/guides/configuring-astro.mdx
@@ -151,11 +151,9 @@ You can use `process.env` in a configuration file to access other environment va
 
 You can also use [Vite's `loadEnv` helper](https://main.vitejs.dev/config/#using-environment-variables-in-config) to manually load `.env` files.
 
-```astro title="astro.config.mjs"
----
+```js title="astro.config.mjs"
 import { loadEnv } from "vite";
 const { SECRET_PASSWORD } = loadEnv(import.meta.env.MODE, process.cwd(), "");
----
 ```
 
 ## Configuration Reference


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Revert #2637 to change the code block extension to `js` instead of adding a frontmatter