### PR TITLE
SST deploy: no need for create-sst@rc anymore

### DIFF
--- a/src/content/docs/en/guides/deploy/sst.mdx
+++ b/src/content/docs/en/guides/deploy/sst.mdx
@@ -12,7 +12,7 @@ You can also use any additional SST constructs like Cron Jobs, Buckets, Queues, 
 ## Quickstart
 
 1. Create an astro project
-1. Run `npx create-sst@rc`
+1. Run `npx create-sst`
 1. It should detect that you are using Astro and ask you to confirm.
 1. Once you're ready for deployment you can run `npx sst deploy --stage=production`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description
create-sst@2.0 and sst@2.0  were released last week, so there's no need to use create-sst@rc anymore.

![image](https://user-images.githubusercontent.com/504279/219182406-1ee4c9b2-dc59-40b3-bbc6-cb8818f47c91.png)


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
