### PR TITLE
docs: use `z.coerce.date()`

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -222,7 +222,7 @@ defineCollection({
     // An optional frontmatter property. Very common!
     footnote: z.string().optional(),
     // Convert a standard date-string into a `Date` object
-    publishDate: z.string().transform(str => new Date(str)),
+    publishDate: z.coerce.date(),
     // Advanced: Validate that the string is also an email
     authorContact: z.string().email(),
     // Advanced: Validate that the string is also a URL


### PR DESCRIPTION
Assuming a newish version of ZOD is used, this short hand is a lot easier to understand.