### PR TITLE
Image guide tweak for images in path clarity

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -147,7 +147,7 @@ You must also either provide [`width`](/en/guides/integrations-guide/image/#widt
 
 [All other properties](/en/guides/integrations-guide/image/#image-) are optional.
 
-#### Local Images in `public/`
+#### Images in `public/`
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src), [`alt`](/en/guides/integrations-guide/image/#alt), [`format`](/en/guides/integrations-guide/image/#format), and dimensions)
 
@@ -231,7 +231,7 @@ You must provide the component with guidance for image widths and screen sizes, 
 
 Although [`formats`](/en/guides/integrations-guide/image/#formats) is not required, the original image format of remote images is unknown and will not be included by default. If not provided, only `webp` and `avif` will be included.
 
-#### Local Images in `public/`
+#### Images in `public/`
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src-1), [`widths`](/en/guides/integrations-guide/image/#widths), [`sizes`](/en/guides/integrations-guide/image/#sizes), [`alt`](/en/guides/integrations-guide/image/#alt-1), and [`aspectRatio`](/en/guides/integrations-guide/image/#aspectratio-1))
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -127,14 +127,6 @@ This component is useful for images where you want to keep a consistent size acr
 
 For responsive images, or art direction, use the `<Picture />` component instead.
 
-#### Local Images in `src/`
-
-(required attributes: [`src`](/en/guides/integrations-guide/image/#src), and [`alt`](/en/guides/integrations-guide/image/#alt))
-
-Import your image in frontmatter and pass it directly to the `<Image />` component's `src` attribute.
-
-`alt` is required, but [all other properties](/en/guides/integrations-guide/image/#image-) are optional and will default to the image file's original properties if not provided.
-
 #### Remote Images
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src), [`alt`](/en/guides/integrations-guide/image/#alt), [`format`](/en/guides/integrations-guide/image/#format), and dimensions)
@@ -146,6 +138,14 @@ The `<Image />` component cannot determine the original file format of a remote 
 You must also either provide [`width`](/en/guides/integrations-guide/image/#width) and [`height`](/en/guides/integrations-guide/image/#height), or one of the dimensions plus an [`aspectRatio`](/en/guides/integrations-guide/image/#aspectratio) to avoid content layout shifts because the `<Image />` component does not know the dimensions of a remote image.
 
 [All other properties](/en/guides/integrations-guide/image/#image-) are optional.
+
+#### Local Images in `src/`
+
+(required attributes: [`src`](/en/guides/integrations-guide/image/#src), and [`alt`](/en/guides/integrations-guide/image/#alt))
+
+Import your image in frontmatter and pass it directly to the `<Image />` component's `src` attribute.
+
+`alt` is required, but [all other properties](/en/guides/integrations-guide/image/#image-) are optional and will default to the image file's original properties if not provided.
 
 #### Images in `public/`
 
@@ -209,16 +209,6 @@ This component is useful to optimize what your user sees at various screen sizes
 Check out MDN's guide for more information about [responsive images and art direction](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction).
 :::
 
-#### Local Images
-
-(required attributes: [`src`](/en/guides/integrations-guide/image/#src-1), [`widths`](/en/guides/integrations-guide/image/#widths), [`sizes`](/en/guides/integrations-guide/image/#sizes), [`alt`](/en/guides/integrations-guide/image/#alt-1))
-
-Import your image in frontmatter and pass it directly to the `<Picture />` component's `src` attribute.
-
-You must provide the component with guidance for image widths and screen sizes, but [all other properties](/en/guides/integrations-guide/image/#picture-) are optional.
-
-By default, the `<Picture />` component's [`formats`](/en/guides/integrations-guide/image/#formats) will include `avif` and `webp` in addition to the image's original format if not specified.
-
 #### Remote Images 
 
 (required attributes: [`src`](/en/guides/integrations-guide/image/#src-1), [`widths`](/en/guides/integrations-guide/image/#widths), [`sizes`](/en/guides/integrations-guide/image/#sizes), [`alt`](/en/guides/integrations-guide/image/#alt-1), and [`aspectRatio`](/en/guides/integrations-guide/image/#aspectratio-1))
@@ -230,6 +220,16 @@ A value for `aspectRatio` is also required to ensure the correct height can be c
 You must provide the component with guidance for image widths and screen sizes, but [all other properties](/en/guides/integrations-guide/image/#picture-) are optional.
 
 Although [`formats`](/en/guides/integrations-guide/image/#formats) is not required, the original image format of remote images is unknown and will not be included by default. If not provided, only `webp` and `avif` will be included.
+
+#### Local Images
+
+(required attributes: [`src`](/en/guides/integrations-guide/image/#src-1), [`widths`](/en/guides/integrations-guide/image/#widths), [`sizes`](/en/guides/integrations-guide/image/#sizes), [`alt`](/en/guides/integrations-guide/image/#alt-1))
+
+Import your image in frontmatter and pass it directly to the `<Picture />` component's `src` attribute.
+
+You must provide the component with guidance for image widths and screen sizes, but [all other properties](/en/guides/integrations-guide/image/#picture-) are optional.
+
+By default, the `<Picture />` component's [`formats`](/en/guides/integrations-guide/image/#formats) will include `avif` and `webp` in addition to the image's original format if not specified.
 
 #### Images in `public/`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- 
#### Description

- Addresses #2620 along with https://github.com/withastro/astro/pull/6290
- Removes "local" to describe images in path, to reduce confusion as they're treated like remote images
- Reorders to remote -> src -> path to match https://github.com/withastro/astro/pull/6290

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
