### PR TITLE
Fix font rendering problem with og images for Korean pages

### DIFF
--- a/src/pages/open-graph/[...path].ts
+++ b/src/pages/open-graph/[...path].ts
@@ -38,6 +38,7 @@ export const { getStaticPaths, get } = OGImageRoute({
 						'Noto Sans SC Black',
 						'Noto Sans TC Black',
 						'Noto Sans JP Black',
+						'Noto Sans KR Black',
 					],
 					weight: 'ExtraBold',
 				},
@@ -51,6 +52,7 @@ export const { getStaticPaths, get } = OGImageRoute({
 						'Noto Sans SC',
 						'Noto Sans TC',
 						'Noto Sans JP',
+						'Noto Sans KR',
 					],
 					weight: 'Normal',
 				},
@@ -73,6 +75,9 @@ export const { getStaticPaths, get } = OGImageRoute({
 
 				'https://api.fontsource.org/v1/fonts/noto-sans-arabic/arabic-400-normal.ttf',
 				'https://api.fontsource.org/v1/fonts/noto-sans-arabic/arabic-800-normal.ttf',
+
+				'https://api.fontsource.org/v1/fonts/noto-sans-kr/korean-400-normal.ttf',
+				'https://api.fontsource.org/v1/fonts/noto-sans-kr/korean-900-normal.ttf',
 			],
 		};
 	},


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This pull request resolves a font rendering issue with Open Graph images that are generated for Korean pages.
I discovered that the matching Korean fonts do not exist which caused this error:

<img width="442" alt="Screenshot_2023-02-21_at_10 23 58" src="https://user-images.githubusercontent.com/29053796/220231369-e4ac94cd-dcff-4704-9cfb-614bd8ee807a.png">

I added Noto Sans KR fonts and the result is:

![getting-started](https://user-images.githubusercontent.com/29053796/220232199-e69ad241-997d-4b18-8c02-bd122a2aefc2.png)
