### PR TITLE
Remark-toc heading disclaimer

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -497,6 +497,7 @@ export default defineConfig({
 #### Customizing a plugin
 
 In order to customize a plugin, provide an options object after it in a nested array. 
+
 The example below adds the [heading option to the `remarkToc` plugin](https://github.com/remarkjs/remark-toc#optionsheading) to change where the table of contents is placed, and the [`behavior` option to the `rehype-autolink-headings` plugin](https://github.com/rehypejs/rehype-autolink-headings#optionsbehavior) in order to add the anchor tag after the headline text.
 
 ```js title="astro.config.mjs"

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -469,6 +469,8 @@ export default defineConfig({
 });
 ```
 
+Note that by default, `remarkToc` requires a "ToC" or "Table of Contents" heading on the page to show the table of contents.
+
 #### Heading IDs and plugins
 
 Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#exported-properties).

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -496,16 +496,18 @@ export default defineConfig({
 
 #### Customizing a plugin
 
-In order to customize a plugin, provide an options object after it in a nested array. The example below adds the [`behavior` option to the `rehype-autolink-headings` plugin](https://github.com/rehypejs/rehype-autolink-headings#optionsbehavior) in order to add the anchor tag after the headline text.
+In order to customize a plugin, provide an options object after it in a nested array. 
+The example below adds the [heading option to the `remarkToc` plugin](https://github.com/remarkjs/remark-toc#optionsheading) to change where the table of contents is placed, and the [`behavior` option to the `rehype-autolink-headings` plugin](https://github.com/rehypejs/rehype-autolink-headings#optionsbehavior) in order to add the anchor tag after the headline text.
 
 ```js title="astro.config.mjs"
+import remarkToc from 'remark-toc';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 
 export default {
   markdown: {
-    remarkPlugins: [],
+    remarkPlugins: [ [remarkToc, { heading: "contents"} ] ],
     rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'append' }]],
   },
 }

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -469,7 +469,7 @@ export default defineConfig({
 });
 ```
 
-Note that by default, `remarkToc` requires a "ToC" or "Table of Contents" heading on the page to show the table of contents.
+Note that by default, `remarkToc` requires a "ToC" or "Table of Contents" [heading](https://github.com/remarkjs/remark-toc#optionsheading) (case-insensitive) on the page to show the table of contents.
 
 #### Heading IDs and plugins
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- 
#### Description

- Addresses Feedback Fish:
> remark-toc  ... other than adding to the config, what else is there??? I do that and it does not show up on my page. This is not clear.

- Adds a note that remark-toc expects a "toc" or "table of contents" heading by default in order to show the table of contents.
- Adds a remark-toc customization to the Customizing a plugin example
