### PR TITLE
Update example for Generating Pages

### DIFF
--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -367,16 +367,20 @@ export default defineConfig({
 
 ### Generating pages
 
-To create a route for a specific `page`, you can fetch its content directly from the Storyblok API and pass it to the `Page` component. Create an `index.astro` file in `src/pages/` to render the `home` page:
+To create a route for a specific `page`, you can fetch its content directly from the Storyblok API and pass it to the `StoryblokComponent` component.  Remember to make sure you have added the `Page` component to your astro.config.mjs.
 
-```astro title="src/pages/index.astro" {7,8,15} 
+Create an `index.astro` file in `src/pages/` to render the `home` page:
+
+```astro title="src/pages/index.astro" {3,7,8,9,17} 
 ---
 import { useStoryblokApi } from '@storyblok/astro'
+import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro'
 import BaseLayout from '../layouts/BaseLayout.astro'
-import Page from '../storyblok/Page.astro';
 
 const storyblokApi = useStoryblokApi();
-const { data } = await storyblokApi.get('cdn/stories/home');
+const { data } = await storyblokApi.get('cdn/stories/home', {
+  version: import.meta.env.DEV ? "draft" : "published",
+});
 const content = data.story.content;
 ---
 <html lang="en">
@@ -384,7 +388,7 @@ const content = data.story.content;
     <title>Storyblok & Astro</title>
   </head>
   <body>
-    <Page blok={content} />
+    <StoryblokComponent blok={content} />
   </body>
 </html>
 ```


### PR DESCRIPTION
Using this example I ran into an issue with the static site build (astro build) where the directly imported Page component was in the wrong position in the generated bundle causing a "Cannot access '$$Page' before initialization" error.  Switching to use the StoryblokComponent resolved the issue.  See example on the storyblok/stpryblok astro Readme: https://github.com/storyblok/storyblok-astro#2-getting-storyblok-stories-and-using-the-storyblok-bridge

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content


#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
  -  Updates single page code example.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
