### PR TITLE
Small tweaks to the new i18n status page

### DIFF
--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -7,6 +7,12 @@
 		<meta name="theme-color" content="hsl(273, 37%, 93%)" media="(prefers-color-scheme: light)" />
 
 		<title>Astro Docs Translation Status</title>
+		<meta name="description" content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!">
+		<link rel="canonical" href="https://i18n.docs.astro.build/">
+		<meta property="og:title" content="Astro Docs Translation Status" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://i18n.docs.astro.build/" />
+		<meta property="og:description" content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!" />
 
 		<style>
 			:root {

--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -126,6 +126,9 @@
 			a:hover {
 				text-decoration: underline;
 			}
+			ul {
+				font-size: 0.875rem;
+			}
 			details summary {
 				cursor: pointer;
 				user-select: none;

--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -157,6 +157,8 @@
 				position: sticky;
 				top: -1px;
 				background: var(--theme-table-header);
+				white-space: nowrap;
+				padding-inline: .3rem;
 			}
 			.status-by-page th,
 			.status-by-page td {

--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -7,12 +7,18 @@
 		<meta name="theme-color" content="hsl(273, 37%, 93%)" media="(prefers-color-scheme: light)" />
 
 		<title>Astro Docs Translation Status</title>
-		<meta name="description" content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!">
-		<link rel="canonical" href="https://i18n.docs.astro.build/">
+		<meta
+			name="description"
+			content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!"
+		/>
+		<link rel="canonical" href="https://i18n.docs.astro.build/" />
 		<meta property="og:title" content="Astro Docs Translation Status" />
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://i18n.docs.astro.build/" />
-		<meta property="og:description" content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!" />
+		<meta
+			property="og:description"
+			content="Translation progress tracker for the Astro Docs site. See how much has been translated in your language and get involved!"
+		/>
 
 		<style>
 			:root {
@@ -129,6 +135,9 @@
 			ul {
 				font-size: 0.875rem;
 			}
+			details {
+				margin-bottom: 1.25rem;
+			}
 			details summary {
 				cursor: pointer;
 				user-select: none;
@@ -146,7 +155,7 @@
 				padding: 0.1em 0.5em;
 				background-color: hsl(213deg 89% 64% / 20%);
 				display: inline-block;
-				border-radius: .5em;
+				border-radius: 0.5em;
 				font-weight: bold;
 				font-size: 0.75rem;
 			}
@@ -162,7 +171,7 @@
 				top: -1px;
 				background: var(--theme-table-header);
 				white-space: nowrap;
-				padding-inline: .3rem;
+				padding-inline: 0.3rem;
 			}
 			.status-by-page th,
 			.status-by-page td {
@@ -191,6 +200,12 @@
 			}
 			.status-by-page td:not(:first-of-type) a {
 				text-decoration: none;
+			}
+			.progress-summary {
+				font-size: 0.8125rem;
+			}
+			.progress-bar {
+				font-size: 0.6875rem;
 			}
 		</style>
 	</head>

--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -139,16 +139,16 @@
 			details h5 {
 				margin-top: 1rem !important;
 			}
-			details *:last-child {
+			details > :last-child {
 				margin-bottom: 1rem;
 			}
-			code {
-				font-family: var(--font-mono);
-				font-size: 0.95rem;
+			.create-button {
+				padding: 0.1em 0.5em;
 				background-color: hsl(213deg 89% 64% / 20%);
-				padding-inline: 0.4rem;
-				padding-block: 0.1rem;
-				border-radius: 0.2rem;
+				display: inline-block;
+				border-radius: .5em;
+				font-weight: bold;
+				font-size: 0.75rem;
 			}
 			.status-by-page {
 				margin-bottom: 1rem;

--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -152,6 +152,7 @@
 				border-collapse: collapse;
 				margin-inline: -1rem;
 				border: var(--theme-table-border);
+				font-size: 0.8125rem;
 			}
 			.status-by-page th {
 				position: sticky;

--- a/scripts/translation-status.ts
+++ b/scripts/translation-status.ts
@@ -279,13 +279,13 @@ class TranslationStatusBuilder {
 				`<summary><strong>` +
 					`${this.languageLabels[lang]} (${lang})` +
 					`</strong><br>` +
-					`<sup>` +
+					`<span class="progress-summary">` +
 					`${statusByPage.length - outdated.length - missing.length} done, ` +
 					`${outdated.length} need${outdated.length === 1 ? 's' : ''} updating, ` +
 					`${missing.length} missing` +
-					'<br><sup>' +
+					`</span>` +
+					'<br>' +
 					this.renderProgressBar(statusByPage.length, outdated.length, missing.length) +
-					`</sup></sup>` +
 					`</summary>`
 			);
 			lines.push(``);
@@ -398,14 +398,18 @@ class TranslationStatusBuilder {
 		const outdatedLength = Math.round((outdated / total) * size);
 		const missingLength = Math.round((missing / total) * size);
 		const doneLength = size - outdatedLength - missingLength;
-		return [
-			[doneLength, '🟪'],
-			[outdatedLength, '🟧'],
-			[missingLength, '⬜'],
-		]
-			.map(([length, icon]) => Array(length).fill(icon))
-			.flat()
-			.join('');
+		return (
+			'<span class="progress-bar" aria-hidden="true">' +
+			[
+				[doneLength, '🟪'],
+				[outdatedLength, '🟧'],
+				[missingLength, '⬜'],
+			]
+				.map(([length, icon]) => Array(length).fill(icon))
+				.flat()
+				.join('') +
+			'</span>'
+		);
 	}
 
 	renderLink(href: string, text: string, className = ''): string {

--- a/scripts/translation-status.ts
+++ b/scripts/translation-status.ts
@@ -352,10 +352,11 @@ class TranslationStatusBuilder {
 			cols.push(
 				...this.targetLanguages.map((lang) => {
 					const translation = content.translations[lang];
-					if (translation.isMissing) return `<span title="${lang}: Missing">❌</span>`;
+					if (translation.isMissing)
+						return `<span title="${lang}: Missing"><span aria-hidden="true">❌</span></span>`;
 					if (translation.isOutdated)
-						return `<a href="${translation.githubUrl}" title="${lang}: Needs updating">🔄</a>`;
-					return `<a href="${translation.githubUrl}" title="${lang}: Completed">✔</a>`;
+						return `<a href="${translation.githubUrl}" title="${lang}: Needs updating"><span aria-hidden="true">🔄</span></a>`;
+					return `<a href="${translation.githubUrl}" title="${lang}: Completed"><span aria-hidden="true">✔</span></a>`;
 				})
 			);
 			lines.push(`<tr>\n${cols.map((col) => `<td>${col}</td>`).join('\n')}\n</tr>`);

--- a/scripts/translation-status.ts
+++ b/scripts/translation-status.ts
@@ -383,10 +383,7 @@ class TranslationStatusBuilder {
 		);
 		createUrl.searchParams.set('filename', lang + '/' + filename);
 		createUrl.searchParams.set('value', '---\ntitle:\ndescription:\n---\n');
-		return `<strong><code>${this.renderLink(
-			createUrl.href,
-			`Create\xa0page\xa0+`
-		)}</code></strong>`;
+		return this.renderLink(createUrl.href, `Create\xa0page\xa0+`, 'create-button');
 	}
 
 	/**
@@ -411,8 +408,8 @@ class TranslationStatusBuilder {
 			.join('');
 	}
 
-	renderLink(href: string, text: string): string {
-		return `<a href="${escape(href)}">${escape(text)}</a>`;
+	renderLink(href: string, text: string, className = ''): string {
+		return `<a href="${escape(href)}" class="${escape(className)}">${escape(text)}</a>`;
 	}
 }
 


### PR DESCRIPTION
#### Description

- Add meta tags
- Tweak some styles
- Use more accessible mark-up than was possible on GitHub

Mostly very subtle visually. Here is before on the left and after on the right:
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/357379/221327334-8f452780-af08-48fe-beb1-85de07ec3f5d.png">


Similarly for the table that is just slightly tweaked:
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/357379/221327396-e58c3d22-1b24-47b0-9597-1f5a13cf55a8.png">


Some of the key stuff is invisible changes to mark-up to use `aria-hidden="true"` on emoji and avoid abusing the `<code>` element like we used to to get a kind of “button” styling.