### PR TITLE
i18n(es): Translated pages

### DIFF
--- a/src/content/docs/es/reference/errors/unknown-clierror.mdx
+++ b/src/content/docs/es/reference/errors/unknown-clierror.mdx
@@ -1,0 +1,15 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Unknown CLI Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## ¿Qué salió mal?
+Astro encontró un error desconocido mientras iniciaba uno de tus comandos CLI. El mensaje de error debe contener más información.
+
+Si puedes reproducir este error de forma consistente, nos gustaría que [abrieras un issue](https://astro.build/issues/)

--- a/src/content/docs/es/reference/errors/unknown-compiler-error.mdx
+++ b/src/content/docs/es/reference/errors/unknown-compiler-error.mdx
@@ -1,0 +1,21 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Unknown compiler error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Error de compilador desconocido. (E01000)
+
+## ¿Qué salió mal?
+Astro encontró un error desconocido mientras compilaba tus archivos. En la mayoría de los casos, esto no es culpa tuya, sino un problema en nuestro compilador.
+
+Si no hay uno ya creado, [crea un issue](https://astro.build/issues/compiler).
+
+**Ver también:**
+
+-  [plantilla de issues de compilador/withastro](https://astro.build/issues/compiler)

--- a/src/content/docs/es/reference/errors/unknown-config-error.mdx
+++ b/src/content/docs/es/reference/errors/unknown-config-error.mdx
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Unknown configuration error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## ¿Qué salió mal?
+Astro encontró un error desconocido al cargar tu archivo de configuración de Astro.
+Esto es a menudo causado por un error de sintaxis en tu configuración y el mensaje debe ofrecer más información.
+
+Si puedes reproducir este error de forma consistente, nosotros apreciaríamos si pudieras [abrir un issue](https://astro.build/issues/)
+
+
+**Ver también:**
+-  [Referencia de Configuración](/es/reference/configuration-reference/)
+
+

--- a/src/content/docs/es/reference/errors/unknown-content-collection-error.mdx
+++ b/src/content/docs/es/reference/errors/unknown-content-collection-error.mdx
@@ -1,0 +1,16 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Unknown Content Collection Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## ¿Qué salió mal?
+Astro encontró un error desconocido al cargar tus colecciones de contenido.
+Esto pudo haber sido causado por ciertos errores dentro de tu archivo `src/content/config.ts` o algunos errores internos.
+
+Si puedes reproducir este error de forma consistente, nosotros apreciaríamos si pudieras [abrir un issue](https://astro.build/issues/)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.

Translated the following pages:

  - `unknown-clierror.mdx`
  - `unknown-compiler-error.mdx`
  - `unknown-config-error.mdx`
  - `unknown-content-collection-error.mdx`