### PR TITLE
Make collection conversion more clear against the existing tutorial

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -233,10 +233,10 @@ defineCollection({
     tags: z.array(z.string()),
     // An optional frontmatter property. Very common!
     footnote: z.string().optional(),
-    // Dates in frontmatter, written without "" around them are read in as actual date objects
-    // Alternatively, you could transform a string date to a real date with
-    // z.string().transform((str) => new Date(str))
+    // In frontmatter, dates written without quotes around them are interpreted as Date objects
     publishDate: z.date(),
+    // You can also transform a date string (e.g. "2022-07-08") to a Date object
+	authorDate: z.string().transform((str) => new Date(str)),
     // Advanced: Validate that the string is also an email
     authorContact: z.string().email(),
     // Advanced: Validate that the string is also a URL

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -236,7 +236,7 @@ defineCollection({
     // In frontmatter, dates written without quotes around them are interpreted as Date objects
     publishDate: z.date(),
     // You can also transform a date string (e.g. "2022-07-08") to a Date object
-    // publishDash: z.string().transform((str) => new Date(str)),
+    // publishDate: z.string().transform((str) => new Date(str)),
     // Advanced: Validate that the string is also an email
     authorContact: z.string().email(),
     // Advanced: Validate that the string is also a URL

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -551,7 +551,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
     Any individual Markdown or MDX file imports should be replaced by [`getEntryBySlug()`](/en/reference/api-reference/#getentrybyslug).
     :::
 
-    Lastly, the tutorial blog project includes an RSS feed. This file must be converted to an async function, use `getCollection`, and use the `data` object:
+    Lastly, the tutorial blog project includes an RSS feed. This function must also use `getCollection` and the `data` object, and be converted to an async function to do so:
 
     ```js title="src/pages/rss.xml.js" {4-5, 10-15} 
     import rss from "@astrojs/rss";

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -233,8 +233,10 @@ defineCollection({
     tags: z.array(z.string()),
     // An optional frontmatter property. Very common!
     footnote: z.string().optional(),
-    // Convert a standard date-string into a `Date` object
-    publishDate: z.string().transform(str => new Date(str)),
+    // Dates in frontmatter, written without "" around them are read in as actual date objects
+    // Alternatively, you could transform a string date to a real date with
+    // z.string().transform((str) => new Date(str))
+    publishDate: z.date(),
     // Advanced: Validate that the string is also an email
     authorContact: z.string().email(),
     // Advanced: Validate that the string is also a URL
@@ -549,9 +551,9 @@ This guide shows you how to convert an existing Astro project with Markdown file
     Any individual Markdown or MDX file imports should be replaced by [`getEntryBySlug()`](/en/reference/api-reference/#getentrybyslug).
     :::
 
-    Lastly, the tutorial blog project includes an RSS feed. This file must also use `getCollection` and use the `data` object:
+    Lastly, the tutorial blog project includes an RSS feed. This file must be converted to an async function, use `getCollection`, and use the `data` object:
 
-    ```js title="src/pages/rss.xml.js" {5, 10-15} 
+    ```js title="src/pages/rss.xml.js" {4-5, 10-15} 
     import rss from "@astrojs/rss";
     import { getCollection } from "astro:content";
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -236,7 +236,7 @@ defineCollection({
     // In frontmatter, dates written without quotes around them are interpreted as Date objects
     publishDate: z.date(),
     // You can also transform a date string (e.g. "2022-07-08") to a Date object
-	authorDate: z.string().transform((str) => new Date(str)),
+    // publishDash: z.string().transform((str) => new Date(str)),
     // Advanced: Validate that the string is also an email
     authorContact: z.string().email(),
     // Advanced: Validate that the string is also a URL


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Coming from the blog tutorial, there are some slight changes to the conversion doc to make it 100% clear what needs to be done. Specifically [the new branch references the publish date](https://github.com/withastro/blog-tutorial-demo/blob/content-collections/src/content/config.ts#L6) as an actual `z.date()` object. If users are coming over form the tutorial, they'll have written their dates as `publishDate: 2022-02-03` not `publishDate: "2022-02-03"`. Copying the code as is with the transformation will actually cause a build error.

I left the old transformation in there as a comment, because it's difficult to know what a user would actually use, and seeing the transformation is helpful to show that types can be transformed.

With the RSS feed, it's important to note that the function itself now needs to be async, so I've added a highlight to that line and added to the comment.

FANTASTIC documentation. One of the best I've seen on the web. Thank you for being awesome.
