### PR TITLE
Remove parameters from astro:build:start

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -273,7 +273,7 @@ The address, family and port number supplied by the [NodeJS Net module](https://
 **Why:** To set up any global objects or clients needed during a production build. This can also extend the build configuration options in the [adapter API](/en/reference/adapter-reference/).
 
 ```js
-'astro:build:start'?: (options: { buildConfig: BuildConfig }) => void | Promise<void>;
+'astro:build:start'?: () => void | Promise<void>;
 ```
 
 ### `astro:build:setup`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Closes #2721
- Removes the parameters from `astro:build:start` in the integrations reference, to match the current APIO

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
