### PR TITLE
Fix multiple `h1`s in glob example

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -158,7 +158,7 @@ const posts = await Astro.glob('../pages/post/*.md');
 <div>
 {posts.slice(0, 4).map((post) => (
   <article>
-    <h1>{post.frontmatter.title}</h1>
+    <h2>{post.frontmatter.title}</h2>
     <p>{post.frontmatter.description}</p>
     <a href={post.url}>Read more</a>
   </article>

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -24,7 +24,7 @@ const posts = await Astro.glob('../pages/post/*.md'); // returns an array of pos
 <div>
 {posts.slice(0, 3).map((post) => (
   <article>
-    <h1>{post.frontmatter.title}</h1>
+    <h2>{post.frontmatter.title}</h2>
     <p>{post.frontmatter.description}</p>
     <a href={post.url}>Read more</a>
   </article>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

It was pointed out on Discord that this example renders multiple h1 tags, which is bad for accessibility. This PR changes them to h2s.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
