### PR TITLE
Minor fix to file extensions in cypress section

### DIFF
--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -76,9 +76,9 @@ export default defineConfig({
     </html>
     ```
 
-2. Create an `index.spec.js` file in the `cypress/e2e` folder. Use the following test in the file to verify that the page title and header are correct.
+2. Create an `index.cy.js` file in the `cypress/e2e` folder. Use the following test in the file to verify that the page title and header are correct.
 
-    ```js title="cypress/e2e/index.cy.ts"
+    ```js title="cypress/e2e/index.cy.js"
     it('titles are correct', () => {
       const page = cy.visit('http://localhost:3000');
 
@@ -88,7 +88,7 @@ export default defineConfig({
     ```
 
     :::tip[set a baseUrl]
-    You can set [`"baseUrl": "http://localhost:3000"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.ts` configuration file to use `cy.visit("/")` instead of `page.goto("http://localhost:3000/")` for a more convenient URL.
+    You can set [`"baseUrl": "http://localhost:3000"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.js` configuration file to use `cy.visit("/")` instead of `page.goto("http://localhost:3000/")` for a more convenient URL.
     :::
 
 ### Running your Cypress tests
@@ -114,7 +114,7 @@ Once the Cypress App is launched, choose **E2E Testing**, then select the browse
 Once the test run is finished, you should see green check marks in the output confirming that your test passed:
 
 ```shell title="Output from npx cypress run"
-Running:  index.cy.ts                                                                     (1 of 1)
+Running:  index.cy.js                                                                     (1 of 1)
 
 
 ✓ titles are correct (107ms)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- `npm run cypress` failed for me, because the spec file the guide had me create was named `index.spec.ts`, but cypress was looking for `index.cy.ts`. Therefore, I updated the guide to state that you should create an `index.cy.ts` file instead.
- The guide was using `.ts` extensions in some places, and `.js` extensions in others. Therefore, I changed the `.ts` extensions to `.js` to make it more consistent.