### PR TITLE
add `astro check` to CLI tip

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -119,7 +119,7 @@ This command only checks types within `.astro` files.
 </p>
 
 :::tip
-Running `astro dev` or `astro build` will run the `sync` command as well.
+Running `astro dev`, `astro build` or `astro check` will run the `sync` command as well.
 :::
 
 Generates TypeScript types for all Astro modules. This sets up a [`src/env.d.ts` file](/en/guides/typescript/#setup) for type inferencing, and defines the `astro:content` module for the [Content Collections API](/en/guides/content-collections/).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

This PR adds some content to a tip of the CLI.

#### Description

The tip says that `astro build` and `astro dev` run the `sync` command. Although, `astro check` does the same. This PR adds this information to the website.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
