### PR TITLE
Replace `drop-shadow` with `box-shadow` in `<CodeSnippet>`

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.astro
+++ b/src/components/CodeSnippet/CodeSnippet.astro
@@ -143,7 +143,6 @@ function parseMarkingDefinition(serializedArr: string, parts: RegExp, parseError
 <style lang="scss" is:global>
 	.code-snippet {
 		--glow-border: 1px solid var(--theme-glow-highlight);
-		filter: drop-shadow(0 0 0.3rem var(--theme-glow-diffuse));
 
 		.header,
 		pre {
@@ -167,12 +166,17 @@ function parseMarkingDefinition(serializedArr: string, parts: RegExp, parseError
 			letter-spacing: 0.025ch;
 			border-bottom-left-radius: 0;
 			border-bottom-right-radius: 0;
+			box-shadow: calc(var(--theme-glow-blur) * -0.5) calc(var(--theme-glow-blur) * -0.5)
+					var(--theme-glow-blur) calc(var(--theme-glow-blur) * -0.5) var(--theme-glow-diffuse),
+				calc(var(--theme-glow-blur) * 0.5) calc(var(--theme-glow-blur) * -0.5)
+					var(--theme-glow-blur) calc(var(--theme-glow-blur) * -0.5) var(--theme-glow-diffuse);
 		}
 
 		pre {
 			margin: 0;
 			padding: var(--padding-block) 0;
 			background-color: var(--theme-code-bg) !important;
+			box-shadow: 0 0 var(--theme-glow-blur) var(--theme-glow-diffuse);
 
 			&:focus-visible {
 				outline: 3px solid var(--theme-accent);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
- Changes to the docs site code

#### Description

- Closes #1790 (and maybe #2726?)

- Changes how the glow around our code samples is rendered. Previously this used the `drop-shadow` CSS filter which has poor performance in some browsers. I’ve replaced this with several `box-shadow`s tweaked to try and replicate roughly the same effect. This isn’t quite possible but hopefully folks agree the difference is small enough to be OK for the performance gain.

| Before | After |
|---|---|
| <img width="575" alt="image" src="https://user-images.githubusercontent.com/357379/222277408-e5e00eab-dfd2-4191-b286-3a4133638cb6.png"> | <img width="575" alt="image" src="https://user-images.githubusercontent.com/357379/222277503-f86340e2-f775-4155-a9be-27b98730db70.png"> |
| <img width="575" alt="image" src="https://user-images.githubusercontent.com/357379/222277618-ccb2dabc-c822-4894-83c1-42329f9ec0c5.png"> | <img width="575" alt="image" src="https://user-images.githubusercontent.com/357379/222277692-205cac3f-9bd5-49d9-9bc5-d56dd1be980e.png"> |


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
