### PR TITLE
Fix: broken link - removed www. from https link

### DIFF
--- a/src/content/docs/en/guides/cms/tina-cms.mdx
+++ b/src/content/docs/en/guides/cms/tina-cms.mdx
@@ -7,7 +7,7 @@ service: Tina CMS
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-[Tina CMS](https://www.tina.io/) is a Git-backed headless content management system.
+[Tina CMS](https://tina.io/) is a Git-backed headless content management system.
 
 ## Integrating with Astro
 


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.) -> broken link.


#### Description

This caused privacy error in Chrome browsers when trying to open the link.

Your connection is not private
Attackers might be trying to steal your information from www.tina.io (for example, passwords, messages or credit cards). Learn more NET::ERR_CERT_AUTHORITY_INVALID

