### PR TITLE
[assets] add Image API to reference navigation

### DIFF
--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -108,6 +108,7 @@ export default [
 		key: 'reference/integrations-reference',
 	},
 	{ text: 'Adapter API', slug: 'reference/adapter-reference', key: 'reference/adapter-reference' },
+	{ text: 'Image Service API', slug: 'reference/image-service-reference', key: 'reference/image-service-reference' },
 	{
 		text: 'Template Directives',
 		slug: 'reference/directives-reference',


### PR DESCRIPTION
Puts the Image Service API reference page in the sidebar