### PR TITLE
Add return before Astro.redirect

### DIFF
--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -170,7 +170,7 @@ In SSR mode, Astro pages can both display and handle forms. In this recipe, you'
         }
         if (!Object.keys(errors).length) {
           await registerUser({name, email, password});
-          return Astro.redirect("/login")
+          return Astro.redirect("/login");
         }
       } catch (error) {
         if (error instanceof Error) {

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -170,7 +170,7 @@ In SSR mode, Astro pages can both display and handle forms. In this recipe, you'
         }
         if (!Object.keys(errors).length) {
           await registerUser({name, email, password});
-          Astro.redirect("/login")
+          return Astro.redirect("/login")
         }
       } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.

Adding return before Astro.redirect activates the redirect property. Otherwise, it doesn't work.
I just added `return`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
