### PR TITLE
Get rid of ‘txt not found’

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -104,7 +104,7 @@ After verifying that the sitemaps are built, you can add them to your site's `<h
 </head>
 ```
 
-```txt ins={4} title="public/robots.txt"
+```yaml ins={4} title="public/robots.txt"
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
Switch syntax highlighting to yaml

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Changes the syntax highlighting for sitemap docs to `yaml` instead of none.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
