### PR TITLE
Fix of the Nginx configuration file

### DIFF
--- a/src/content/docs/en/recipes/docker.mdx
+++ b/src/content/docs/en/recipes/docker.mdx
@@ -107,7 +107,7 @@ http {
     gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
     location / {
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/index.html $uri.html;
     }
   }
 }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This pull request is a fix for a configuration issue in the Nginx file. 

The current Nginx configuration does not automatically serve index.html files in subdirectories such as /dist/about/index.html, resulting in a "301 Moved Permanently" error when attempting to access the /about URL (for example). This error creates an issue when using a reverse proxy upstream, because Nginx redirects us to an URL with the container's port.


