### PR TITLE
Fix `getEntryBySlug` function usage example

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -780,7 +780,7 @@ const draftBlogPosts = await getCollection('blog', ({ data }) => {
 
 ### `getEntryBySlug()`
 
-**Type:** `(collection: string, id: string) => CollectionEntry<collection>`
+**Type:** `(collection: string, slug: string) => CollectionEntry<collection>`
 
 `getEntryBySlug()` is a function that retrieves a single collection entry by collection name and entry `slug`.
 
@@ -789,7 +789,7 @@ const draftBlogPosts = await getCollection('blog', ({ data }) => {
 ---
 import { getEntryBySlug } from 'astro:content';
 
-const enterprise = await getEntryBySlug('blog', 'enterprise.md');
+const enterprise = await getEntryBySlug('blog', 'enterprise');
 ---
 ```
 
@@ -842,7 +842,7 @@ A function to compile a given Markdown or MDX document for rendering. This retur
 ```astro
 ---
 import { getEntryBySlug } from 'astro:content';
-const entry = await getEntryBySlug('blog', 'entry-1.md');
+const entry = await getEntryBySlug('blog', 'entry-1');
 
 const { Content, headings, remarkPluginFrontmatter } = await entry.render();
 ---


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

The example shows how to get entries by `id`, but the function is actually designed to retrieve entries by their `slug`. I have updated the example code and the function type signature to reflect the correct usage.
