### PR TITLE
Tutorial Styling Improvements

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -95,10 +95,6 @@ nav ul {
 	margin-top: 0.5rem;
 }
 
-.content > section > :is(ul, ol) :has(kbd) {
-	line-height: 2.0;
-}
-
 .content > section > :first-child {
 	margin-top: 0;
 }
@@ -238,8 +234,8 @@ h5 {
 }
 
 p,
-.content ul {
-	line-height: 1.65;
+.content ul, .content ol {
+	line-height: 1.75;
 }
 
 p,
@@ -364,9 +360,9 @@ pre {
 	font-family: var(--font-body);
 	font-size: 0.9375rem;
 	border-radius: 0.25rem;
-	padding: 0.125rem 0.375rem;
+	padding: 0.0625rem 0.375rem;
 	border: 1px solid var(--theme-shade-subtle);
-	box-shadow: 0 3px var(--theme-shade-subtle);
+	box-shadow: 0 2px var(--theme-shade-subtle);
 	background-color: var(--theme-bg-offset);
 	white-space: nowrap;
 }

--- a/public/index.css
+++ b/public/index.css
@@ -95,6 +95,10 @@ nav ul {
 	margin-top: 0.5rem;
 }
 
+.content > section > :is(ul, ol) :has(kbd) {
+	line-height: 2.0;
+}
+
 .content > section > :first-child {
 	margin-top: 0;
 }

--- a/src/components/Checklist.astro
+++ b/src/components/Checklist.astro
@@ -39,7 +39,8 @@ const { key = 'default' } = Astro.props as Props;
 		position: relative;
 		margin: 0 -1rem;
 		border-radius: 0.5rem;
-		padding: 0.5rem 0.5rem 0.5rem 4rem;
+		padding-block: 0.5rem;
+		padding-inline: 4rem 0.5rem;
 		cursor: pointer;
 		/* Compensate for space between checkbox and text. */
 		text-indent: -0.4ch;
@@ -62,7 +63,7 @@ const { key = 'default' } = Astro.props as Props;
 	check-list :global(input[type='checkbox']::after) {
 		content: '✔︎';
 		position: absolute;
-		left: 1rem;
+		inset-inline-start: 1rem;
 		top: 50%;
 		transform: translateY(-50%) translate(3px, -3px);
 		transform-origin: center;

--- a/src/components/tutorial/Box.astro
+++ b/src/components/tutorial/Box.astro
@@ -18,8 +18,10 @@ const { icon } = Astro.props;
 	}
 
 	.highlight-box {
-		position: relative;
-		padding: 2rem 4rem 2rem 2rem;
+		position: relative; 
+		padding-block: 2rem;
+		padding-inline-start: 2rem;
+		padding-inline-end: 4rem;
 		border: 1px solid var(--theme-shade-subtle);
 		box-shadow: -0.5rem 0.5rem 0 -1px var(--theme-bg), -0.5rem 0.5rem var(--theme-shade-subtle),
 			-1rem 1rem 0 -1px var(--theme-bg), -1rem 1rem var(--theme-shade-subtle);
@@ -32,7 +34,7 @@ const { icon } = Astro.props;
 			content: '';
 			position: absolute;
 			top: 0.5rem;
-			right: 0.5rem;
+			inset-inline-end: 0.5rem;
 			width: 5rem;
 			height: 5rem;
 			background-color: var(--theme-divider);

--- a/src/components/tutorial/TutorialNav.astro
+++ b/src/components/tutorial/TutorialNav.astro
@@ -106,6 +106,10 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 		font-weight: bold;
 	}
 
+	:global(a:focus unit-progress-icon) {
+		outline: 2px solid var(--theme-accent-secondary);
+	}
+
 	.header-link {
 		border: 0;
 		padding: 0;

--- a/src/components/tutorial/TutorialNav.astro
+++ b/src/components/tutorial/TutorialNav.astro
@@ -108,6 +108,7 @@ const isCurrentUnit = (unit: typeof units[number]) =>
 
 	:global(a:focus unit-progress-icon) {
 		outline: 2px solid var(--theme-accent-secondary);
+		outline-offset: 0.25em;
 	}
 
 	.header-link {

--- a/src/components/tutorial/UnitProgressIcon.astro
+++ b/src/components/tutorial/UnitProgressIcon.astro
@@ -123,11 +123,11 @@ const t = useTranslations(Astro);
 	}
 
 	:global([aria-selected='true']) .segment:not(.done) {
-		stroke: hsl(var(--color-gray-20));
+		stroke: hsl(var(--color-gray-95));
 	}
 
 	:global(.theme-dark [aria-selected='true']) .segment:not(.done) {
-		stroke: hsl(var(--color-gray-70));
+		stroke: hsl(var(--color-gray-20));
 	}
 
 	.segment {

--- a/src/components/tutorial/UnitProgressIcon.astro
+++ b/src/components/tutorial/UnitProgressIcon.astro
@@ -122,6 +122,14 @@ const t = useTranslations(Astro);
 		background-color: var(--theme-bg-offset);
 	}
 
+	:global([aria-selected='true']) .segment:not(.done) {
+		stroke: hsl(var(--color-gray-20));
+	}
+
+	:global(.theme-dark [aria-selected='true']) .segment:not(.done) {
+		stroke: hsl(var(--color-gray-70));
+	}
+
 	.segment {
 		fill: none;
 		stroke: var(--theme-bg-offset);


### PR DESCRIPTION

#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description

A few changes to get our tutorial ready for translations and to improve accessibility.

- Added RTL styles to `<Box/>` and `<Checklist/>` components:

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/225082788-2b091f44-e716-45d6-a58e-c6a7297c6ae8.png) | ![image](https://user-images.githubusercontent.com/61414485/225081647-f16be2aa-ae11-400f-b0f2-a312e21e922d.png) |

- Increased `line-height` for lists with `<kbd/>` elements

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/225083484-c1033bce-8e99-425c-bf0b-6e431fb284e9.png) | ![image](https://user-images.githubusercontent.com/61414485/225083269-e1352861-ce22-4c6f-8ecd-688a81926e93.png) |

- Improved Tutorial Tracker accessibility with better steps color contrast (now passing WCAG AAA) and added the missing focus style for the tab:

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61414485/225084478-8d56e295-ff0a-49a2-8377-d21a506b0be8.png) | ![image](https://user-images.githubusercontent.com/61414485/225084185-ed24d2da-0f1a-490c-aab4-61961181630c.png) |