### PR TITLE
i18n(es): Update of `configuration-reference.mdx`, `server-side-rendering.mdx` & `integrations-guide.mdx`

### DIFF
--- a/src/content/docs/en/recipes.mdx
+++ b/src/content/docs/en/recipes.mdx
@@ -22,4 +22,6 @@ Add your own here! See our [recipes contributing guide](https://github.com/witha
 - [Add animated page transitions with Swup](https://navillus.dev/blog/astro-plus-swup)
 - [Use UnoCSS in Astro](https://www.elian.codes/blog/23-02-11-implementing-unocss-in-astro/)
 - [Build a table of contents from Astro's Markdown headings](https://kld.dev/building-table-of-contents/)
+- [Create a Remark plugin to remove runts from your Markdown files](https://eatmon.co/blog/remove-runts-markdown/)
 - [Add searching to your site with Pagefind](https://blog.otterlord.dev/post/astro-search/)
+- [Get VSCode, ESLint & Prettier working with Astro](https://patheticgeek.dev/blog/astro-prettier-eslint-vscode)

--- a/src/content/docs/es/guides/integrations-guide.mdx
+++ b/src/content/docs/es/guides/integrations-guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: Usando integraciones
+title: Agrega integraciones
 i18nReady: true
 ---
 import IntegrationsNav from '~/components/IntegrationsNav.astro';
@@ -7,7 +7,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
 
-Las **integraciones de Astro** agregan nuevas funcionalidades a su proyecto con solo unas pocas líneas de código. Tú mismo puedes escribir una integración personalizada, utilizar una integración oficial o utilizar integraciones desarrolladas por la comunidad. 
+Las **Integraciones de Astro** agregan nuevas funcionalidades a su proyecto con solo unas pocas líneas de código. Tú mismo puedes escribir una integración personalizada, utilizar una integración oficial o utilizar integraciones desarrolladas por la comunidad. 
 
 Usando integraciones puedes...
 
@@ -44,7 +44,7 @@ Puedes correr el comando `astro add` utilizando el gestor de paquetes de tu pref
   </Fragment>
 </PackageManagerTabs>
 
-¡Incluso es posible configurar múltiples integraciones al mismo tiempo!
+¡Incluso es posible agregar múltiples integraciones al mismo tiempo!
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -225,4 +225,4 @@ if (!product) {
 ### Server Endpoints
 
 Un server endpoint, también conocido como una **ruta API**, es una función exportada desde un archivo `.js` o `.ts` dentro de la carpeta `src/pages/`. 
-La función recibe un [contexto del endpoint](/es/reference/api-reference/#contexto-del-endpoint) y devuelve una [Response](https://developer.mozilla.org/es/docs/Web/API/Response). Una característica poderosa de SSR, las rutas API son capaces de ejecutar código de forma segura en el servidor. Para aprender más, consulta nuestra [guía de Endpoints](/es/core-concepts/endpoints/#endpoints-del-servidor-rutas-de-api).
+La función recibe un [contexto del endpoint](/es/reference/api-reference/#contexto-del-endpoint) y devuelve una [Response](https://developer.mozilla.org/es/docs/Web/API/Response). Una característica poderosa de SSR, las rutas API son capaces de ejecutar código de forma segura en el servidor. Para aprender más, consulta nuestra [guía de endpoints](/es/core-concepts/endpoints/#endpoints-del-servidor-rutas-de-api).

--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -224,4 +224,5 @@ if (!product) {
 
 ### Server Endpoints
 
-Un server endpoint, también conocido como una **ruta API**, es un archivo `.js` o `.ts` dentro de la carpeta `src/pages/` que recibe una [Request](https://developer.mozilla.org/es/docs/Web/API/Request) y devuelve una [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). Una característica poderosa de SSR: Las rutas API permiten ejecutar código del lado del servidor de forma segura. Para aprender más consulta nuestra [guía de Endpoints](/es/core-concepts/endpoints/#endpoints-del-servidor-rutas-de-api).
+Un server endpoint, también conocido como una **ruta API**, es una función exportada desde un archivo `.js` o `.ts` dentro de la carpeta `src/pages/`. 
+La función recibe un [contexto del endpoint](/es/reference/api-reference/#contexto-del-endpoint) y devuelve una [Response](https://developer.mozilla.org/es/docs/Web/API/Response). Una característica poderosa de SSR, las rutas API son capaces de ejecutar código de forma segura en el servidor. Para aprender más, consulta nuestra [guía de Endpoints](/es/core-concepts/endpoints/#endpoints-del-servidor-rutas-de-api).

--- a/src/content/docs/es/reference/configuration-reference.mdx
+++ b/src/content/docs/es/reference/configuration-reference.mdx
@@ -400,7 +400,6 @@ Si el puerto dado ya está en uso, Astro probará automáticamente el siguiente 
 <Since v="1.7.0" />
 </p>
 
-Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 Establece encabezados de respuesta HTTP personalizados para enviar en `astro dev` y `astro preview`.
 
 

--- a/src/content/docs/es/reference/configuration-reference.mdx
+++ b/src/content/docs/es/reference/configuration-reference.mdx
@@ -391,6 +391,46 @@ Si el puerto dado ya está en uso, Astro probará automáticamente el siguiente 
 ```
 
 
+### server.headers
+
+<p>
+
+**Tipo:** `OutgoingHttpHeaders`<br />
+**Por defecto:** `{}`<br />
+<Since v="1.7.0" />
+</p>
+
+Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
+Establece encabezados de respuesta HTTP personalizados para enviar en `astro dev` y `astro preview`.
+
+
+## Opciones de Imagen
+
+### image.service (Experimental)
+
+<p>
+
+**Tipo:** `'astro/assets/services/sharp' | 'astro/assets/services/squoosh' | string`<br />
+**Por defecto:** `'astro/assets/services/squoosh'`<br />
+<Since v="2.1.0" />
+</p>
+
+Establece qué servicio de imágenes se utiliza para el soporte experimental de activos de Astro.
+
+El valor debe ser un especificador de módulo para el servicio de imágenes que se utilizará:
+uno de los dos servicios incorporados de Astro o una implementación de terceros.
+
+
+```js
+{
+  image: {
+    // Ejemplo: Habilita el servicio de imágenes basado en Sharp
+    service: 'astro/assets/services/sharp',
+  },
+}
+```
+
+
 ## Opciones de Markdown
 
 ### markdown.drafts
@@ -593,3 +633,28 @@ Para ayudar a algunos usuarios a migrar entre versiones de Astro, ocasionalmente
 Estas flags te permiten optar por algunos comportamientos desactualizados u obsoletos de Astro
 en la última versión, para que pueda continuar actualizándose y aprovechar los nuevos lanzamientos de Astro.
 
+## Flags Experimentales
+
+Astro ofrece flags experimentales para dar a los usuarios acceso temprano a nuevas características.
+
+Estas flags no son garantía de ser estables.
+
+### experimental.assets
+
+<p>
+
+**Tipo:** `boolean`<br />
+**Por defecto:** `false`<br />
+<Since v="2.1.0" />
+</p>
+
+Habilita soporte experimental para optimizar y cambiar el tamaño de las imágenes. Con esto habilitado, se expondrá un nuevo módulo `astro:assets`.
+
+Para habilitar esta característica, establezca `experimental.assets` en `true` en la configuración de Astro:
+
+```js
+{
+	experimental: {
+		assets: true,
+	},
+}

--- a/src/i18n/es/nav.ts
+++ b/src/i18n/es/nav.ts
@@ -30,7 +30,7 @@ export default NavDictionary({
 	examples: 'Recetas',
 	'guides/migrate-to-astro': 'Migrar a Astro',
 	'guides/cms': 'Conectando un CMS',
-	'guides/integrations-guide': 'Integraciones',
+	'guides/integrations-guide': 'Agrega integraciones',
 	'guides/deploy': 'Desplegar',
 	'guides/recipes': 'Más recetas',
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.

Updated files as the following list:
  - `configuration-reference.mdx` -> 2c7e9f3d2a0d3548427495d7be30bb340ac13e98
  - `server-side-rendering.mdx` -> 60f35d65a6ef99bb13fafbbc312c332213ab5a70
  -  `integrations-guide.mdx` -> 60f35d65a6ef99bb13fafbbc312c332213ab5a70
