### PR TITLE
feat(image_services): Add mention of new validateOptions hook

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -18,13 +18,13 @@ Astro provides two types of image services: Local and External.
 
 ## Building using the Image Services API
 
-Service definitions take the shape of an exported default object with various required methods ("hooks"). 
+Service definitions take the shape of an exported default object with various required methods ("hooks").
 
 External services provide a `getURL()` that points to the `src` of the output `<img>` tag.
 
-Local services provide a `transform()` method to perform transformations on your image, and  `getURL()` and `parseURL()` methods to use an endpoint for dev mode and SSR. 
+Local services provide a `transform()` method to perform transformations on your image, and  `getURL()` and `parseURL()` methods to use an endpoint for dev mode and SSR.
 
-Both types of services can provide `getHTMLAttributes()` to determine the other attributes of the output `<img>`.
+Both types of services can provide `getHTMLAttributes()` to determine the other attributes of the output `<img>` and `validateOptions()` to validate and augment the passed options.
 
 ### External Services
 
@@ -112,9 +112,9 @@ const service: LocalImageService = {
 export default service;
 ```
 
-At build time for static sites and pre-rendered routes, both `<Image/>` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder.
+At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder.
 
-In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, (`/_image`) to process the images at runtime. `<Image/>` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
+In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
 
 #### getConfiguredImageService
 
@@ -135,12 +135,13 @@ export const get: APIRoute = async ({ request }) => {
 			headers: {
 				'Content-Type': mime.getType(format) || ''
       }
+    }
   );
 }
 ```
 
 [See the built-in endpoint](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/image-endpoint.ts) for a full example.
-  
+
 
 ## Hooks
 
@@ -195,6 +196,14 @@ You must return a `format` to ensure that the proper MIME type is served to user
 `getHTMLAttributes(options: ImageTransform): Record<string, any>`
 
 This hook returns all additional attributes used to render the image as HTML, based on the parameters passed by the user (`options`).
+
+### `validateOptions()`
+
+**Optional for both local and external services**
+
+`validateOptions(options: ImageTransform): ImageTransform`
+
+This hook allows you to validate and augment the options passed by the user. This is useful for setting default options, or telling the user that a parameter is required.
 
 ## User configuration
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

https://github.com/withastro/astro/pull/6555 adds a new hook to the Image Service API that can be used to validate and augment the passed options. The built-in services uses this hook to set the default format as `webp` if the user hasn't passed a format, for example.

It takes the same `options` as the other hooks, so an `ImageTransform` and it returns an ImageTransform as well. Returning an `ImageTransform` is mandatory, so the implementation should probably always end with `return options;`

This PR additionally contain some misc fix to the rest of the file
