### PR TITLE
Fix astro logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Astro Docs <picture><source media="(prefers-color-scheme: dark)" srcset="https://astro.build/assets/press/astro-icon-light.png"><source media="(prefers-color-scheme: light)" srcset="https://astro.build/assets/press/astro-icon-dark.png"><img align="right" valign="center" height="157" width="126" src="https://astro.build/assets/press/astro-icon-dark.png" alt="Astro logo" /></picture>
+# Astro Docs <picture><source media="(prefers-color-scheme: dark)" srcset="https://astro.build/assets/press/astro-icon-light.png"><source media="(prefers-color-scheme: light)" srcset="https://astro.build/assets/press/astro-icon-dark.png"><img align="right" valign="center" height="79" width="63" src="https://astro.build/assets/press/astro-icon-dark.png" alt="Astro logo" /></picture>
 
 
 To all who come to this happy place: welcome.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

The logo in the readme has been broken (probably) since the new branding update, since the old logo URL (`https://raw.githubusercontent.com/withastro/astro/main/assets/brand/logo.svg`) no longer exists.

#### Description

This PR fixes the logo, and, because the new one is monochrome, also makes it theme-reactive.

[theme reactivity source](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)

Because of :sparkles:markdown:sparkles: I had to make it a single line so it correctly appends to the `<h1>`, sorry in advance!

#### Screenshots:

Before:
![image](https://user-images.githubusercontent.com/55956895/225396650-68f2915c-dcba-4b16-8aaf-375dbe050409.png)

After
![image](https://user-images.githubusercontent.com/55956895/225396810-a85b069f-5bac-4efa-9681-e0b1cc9f4589.png)

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
