### PR TITLE
Bump `astro-og-canvas` to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "astro": "^2.0.17",
     "astro-auto-import": "^0.2.1",
     "astro-eslint-parser": "^0.9.2",
-    "astro-og-canvas": "^0.1.6",
+    "astro-og-canvas": "^0.1.7",
     "bcp-47-normalize": "^2.1.0",
     "canvaskit-wasm": "^0.37.0",
     "chroma-js": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ specifiers:
   astro: ^2.0.17
   astro-auto-import: ^0.2.1
   astro-eslint-parser: ^0.9.2
-  astro-og-canvas: ^0.1.6
+  astro-og-canvas: ^0.1.7
   bcp-47-normalize: ^2.1.0
   canvas-confetti: ^1.6.0
   canvaskit-wasm: ^0.37.0
@@ -105,7 +105,7 @@ devDependencies:
   astro: 2.0.17_lo4g36gygrjg64j6jydpsd7m54
   astro-auto-import: 0.2.1_astro@2.0.17
   astro-eslint-parser: 0.9.2
-  astro-og-canvas: 0.1.6_astro@2.0.17
+  astro-og-canvas: 0.1.7_astro@2.0.17
   bcp-47-normalize: 2.1.0
   canvaskit-wasm: 0.37.0
   chroma-js: 2.4.2
@@ -1712,8 +1712,8 @@ packages:
       - supports-color
     dev: true
 
-  /astro-og-canvas/0.1.6_astro@2.0.17:
-    resolution: {integrity: sha512-yDmS2dtCeN+gr6X/Y7N8ieupUTXwfs4L72w6Mx1xLtzkhuzTDf4W29vPZKMtKFU6N+T6Cjx6aDXwIG2k5A2GVA==}
+  /astro-og-canvas/0.1.7_astro@2.0.17:
+    resolution: {integrity: sha512-agUArDfxLPnoz+3fqQaKy8NkDGK3JpNdES0Z82OLyOnRTppv2E6pNR+sR9lpiX4RH+3jMpmuD6b/i4dR6MMcMg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       astro: ^1.0.0 || ^2.0.0-beta


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Upgrades to the latest version of `astro-og-canvas` which manually frees memory after generating each image. #2856 builds were erroring and my working hypothesis is that we were hitting an internal memory limit in canvaskit-wasm.

I’m testing this update against the changes in #2856 in #2869.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
