### PR TITLE
Remove dev dependency flag from CSS preprocessor installation

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -415,7 +415,7 @@ Astro supports CSS preprocessors such as [Sass][sass], [Stylus][stylus], and [Le
 ### Sass and SCSS
 
  ```shell
- npm install -D sass
+ npm install sass
  ```
 
 Use  `<style lang="scss">` or `<style lang="sass">` in `.astro` files
@@ -423,7 +423,7 @@ Use  `<style lang="scss">` or `<style lang="sass">` in `.astro` files
 ### Stylus
 
 ```shell
-npm install -D stylus
+npm install stylus
 ```
 
 Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files
@@ -431,7 +431,7 @@ Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files
 ### Less
 
 ```shell
-npm install -D less
+npm install less
 ```
 
 Use `<style lang="less">` in `.astro` files.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Addresses feedback fish:

> Earlier in the docs, we're told to import dependencies as plain dependencies, not dev dependencies. Here we're shown the -D flag being passed... quick explanation as to why this case warrants adding preprocessors as dev dependencies would be helpful!

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
