### PR TITLE
Remove old `extendDefaultPlugins` from examples

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -543,8 +543,7 @@ You can add frontmatter properties to all of your Markdown and MDX files by usin
 
     export default defineConfig({
       markdown: {
-        remarkPlugins: [exampleRemarkPlugin],
-        extendDefaultPlugins: true,
+        remarkPlugins: [exampleRemarkPlugin]
       },
     });
     ```
@@ -601,8 +600,7 @@ import { remarkReadingTime } from './remark-reading-time.mjs';
 
 export default defineConfig({
   markdown: {
-    remarkPlugins: [remarkReadingTime],
-    extendDefaultPlugins: true,
+    remarkPlugins: [remarkReadingTime]
   },
 });
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Remove old `extendDefaultPlugins` option from config examples for remark plugins

#### Note

With the changes to markdown plugin configuration in 2.0 the second MDX  example in step 2 of [this section](https://docs.astro.build/en/guides/markdown-content/#modifying-frontmatter-programmatically) may be redundant since the first example will now work with MDX by default, should it be removed too?

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
