### PR TITLE
Document `verbatimModuleSyntax` for TS 5.0 users

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -84,7 +84,7 @@ import type { SomeType } from './script';
 
 This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
-In your `.tsconfig` file, you can instruct TypeScript to help with this.
+You can configure TypeScript to enforce type imports in your `.tsconfig` file.
 
 <Tabs client:visible sharedStore="typescript-version">
 	<Fragment slot="tab.4.9">TypeScript ≤4.9</Fragment>

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -9,7 +9,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 Astro ships with built-in support for [TypeScript](https://www.typescriptlang.org/). You can import `.ts` and `.tsx` files in your Astro project, write TypeScript code directly inside your [Astro component](/en/core-concepts/astro-components/#the-component-script), and even use an [`astro.config.ts`](/en/guides/configuring-astro/#the-astro-config-file) file if you like.
 
-Using TypeScript, you can prevent errors at runtime by defining the shapes of objects and components in your code. For example, if you use TypeScript to [type your component's props](#component-props), you'll get an error in your editor if you set a prop that your component doesn't accept. 
+Using TypeScript, you can prevent errors at runtime by defining the shapes of objects and components in your code. For example, if you use TypeScript to [type your component's props](#component-props), you'll get an error in your editor if you set a prop that your component doesn't accept.
 
 You don't need to write TypeScript code in your Astro projects to benefit from it. Astro always treats your component code as TypeScript, and the [Astro VSCode Extension](/en/editor-setup/) will infer as much as it can to provide autocompletion, hints, and errors in your editor.
 
@@ -83,12 +83,12 @@ import type { SomeType } from './script';
 
 This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
-In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`importsNotUsedAsValues` setting](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) can be set to `error`. Then, TypeScript will check your imports and tell you when  `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
+In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`verbatimModuleSyntax` setting](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) can be set to `true`. Then, TypeScript will check your imports and tell you when  `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
 
 ```json title="tsconfig.json" ins={3}
 {
   "compilerOptions": {
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
   }
 }
 ```

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -5,6 +5,7 @@ i18nReady: true
 ---
 import Since from '~/components/Since.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import Tabs from '~/components/tabs/Tabs'
 
 
 Astro ships with built-in support for [TypeScript](https://www.typescriptlang.org/). You can import `.ts` and `.tsx` files in your Astro project, write TypeScript code directly inside your [Astro component](/en/core-concepts/astro-components/#the-component-script), and even use an [`astro.config.ts`](/en/guides/configuring-astro/#the-astro-config-file) file if you like.
@@ -83,15 +84,35 @@ import type { SomeType } from './script';
 
 This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
-In your `.tsconfig` file, you can instruct TypeScript to help with this. The [`verbatimModuleSyntax` setting](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) can be set to `true`. Then, TypeScript will check your imports and tell you when  `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
+In your `.tsconfig` file, you can instruct TypeScript to help with this.
 
-```json title="tsconfig.json" ins={3}
-{
-  "compilerOptions": {
-    "verbatimModuleSyntax": true,
-  }
-}
-```
+<Tabs client:visible sharedStore="typescript-version">
+	<Fragment slot="tab.4.9">TypeScript ≤4.9</Fragment>
+	<Fragment slot="tab.5.0">TypeScript ≥5.0</Fragment>
+
+	<Fragment slot="panel.4.9">
+		Set [`importsNotUsedAsValues`](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) to `"error"`. TypeScript will check your imports and tell you when `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
+
+    ```json title="tsconfig.json" ins={3}
+    {
+      "compilerOptions": {
+        "importsNotUsedAsValues": "error",
+      }
+    }
+    ```
+	</Fragment>
+	<Fragment slot="panel.5.0">
+		Set [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) to `true`. TypeScript will check your imports and tell you when `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
+
+    ```json title="tsconfig.json" ins={3}
+    {
+      "compilerOptions": {
+        "verbatimModuleSyntax": true,
+      }
+    }
+    ```
+	</Fragment>
+</Tabs>
 
 ## Import Aliases
 

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -102,7 +102,7 @@ In your `.tsconfig` file, you can instruct TypeScript to help with this.
     ```
 	</Fragment>
 	<Fragment slot="panel.5.0">
-		Set [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) to `true`. TypeScript will check your imports and tell you when `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
+		Set [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) to `true`. TypeScript will check your imports and tell you when `import type` should be used.
 
     ```json title="tsconfig.json" ins={3}
     {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

In TypeScript 5.0, the latest version, the team deprecated `importsNotUsedAsValue` in favour of a boolean `verbatimModuleSyntax`. It does the same thing, it's just easier to use.

This PR updates our guidance to show both the new and old options.