### PR TITLE
improve performance, fix flash of content on load

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
+[[headers]]
+  for = "/_astro/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800, immutable"
+
 [build]
   command = "NODE_OPTIONS=--max_old_space_size=4096 pnpm netlify:build"
   ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- /"

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -20,20 +20,28 @@ import '@fontsource/ibm-plex-mono/400-italic.css';
 <script type="module" src="/make-scrollable-code-focusable.js"></script>
 
 <!-- This is intentionally inlined to avoid FOUC -->
-<script>
+<script is:inline>
 	const root = document.documentElement;
-	const theme = localStorage.getItem('theme');
-	if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-		root.classList.add('theme-dark');
-	} else {
+	const theme = (() => {
+		if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+			return localStorage.getItem('theme');
+		}
+		if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+			return 'dark';
+		}
+		return 'light';
+	})();
+	if (theme === 'light') {
 		root.classList.remove('theme-dark');
+	} else {
+		root.classList.add('theme-dark');
 	}
 </script>
 
 <!-- Double-click to highlight code blocks (inline only). -->
-<script>
+<script is:inline>
 	document.addEventListener('dblclick', (el) => {
-		const node = el.target as Node;
+		const node = el.target;
 		if (!node) return;
 		if (node.nodeName !== 'CODE') return;
 		if (node.parentElement?.nodeName === 'PRE') return;

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -84,11 +84,18 @@ if (isReference) {
 	</ul>
 </nav>
 
-<script>
-	window.addEventListener('DOMContentLoaded', () => {
-		var target = document.querySelector('[data-current-parent="true"]');
-		target?.scrollIntoView({ block: 'center' });
-	});
+<!-- Preserve sidebar scroll across page loads -->
+<script is:inline>
+	{
+		const leftSidebar = document.querySelector('.nav-groups');
+		const leftSidebarScroll = localStorage.getItem('sidebar-scroll');
+		if (leftSidebarScroll !== null) {
+			leftSidebar.scrollTop = parseInt(leftSidebarScroll, 10);
+		}
+		window.addEventListener('beforeunload', () => {
+			localStorage.setItem('sidebar-scroll', leftSidebar.scrollTop);
+		});
+	}
 </script>
 
 <style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -112,24 +112,6 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
 				}
 			}
 		</style>
-		<script is:inline>
-			// This code was migrated/copied from ThemToggleBotton to make the
-			// dark mode toggle instant, vs. hidden inside of a Preact useEffect() call.
-			const theme = (() => {
-				if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-					return localStorage.getItem('theme');
-				}
-				if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-					return 'dark';
-				}
-				return 'light';
-			})();
-			if (theme === 'light') {
-				document.documentElement.classList.remove('theme-dark');
-			} else {
-				document.documentElement.classList.add('theme-dark');
-			}
-		</script>
 	</head>
 
 	<body>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Improve UX while browsing the docs site!

#### Description

- Add local cache headers for all statically generated (fingerprinted!) assets
- Inline a few very small scripts that were important to be inlined for reducing thrash on load
- ~~Move `index.css` and `theme.css` out of `public/` and into `src/` so that they get automatic fingerprinting for free.~~ CSS Ordering issues, had to revert this.
- Replace `scrollIntoView` sidebar scroll position method with a LocalStorage approach which has zero flash of unscrolled content (Note: I can still see some flash of unscrolled content on "Fast 3G" while the sidebar loads in, since this script runs inline but only after its fully populated. Maybe there's some hack where we could give it a min-height that can be scrolled _before_ the content loads in? I'll leave this out of scope for now).

#### Before

<img width="1342" alt="Screen Shot 2023-03-20 at 12 51 15 PM" src="https://user-images.githubusercontent.com/622227/226450546-cf536c7b-4f8b-4be0-a20f-c5f02962da18.png">


#### After

<img width="1340" alt="Screen Shot 2023-03-20 at 12 50 56 PM" src="https://user-images.githubusercontent.com/622227/226450566-61d76dd9-336b-4dd3-9d29-887030cc2126.png">
