### PR TITLE
Update assets guide to mention that images in the frontmatter are relative to the current file

### DIFF
--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -116,7 +116,7 @@ To avoid errors in your project, complete the following steps:
     Change all `import` statements from `@astrojs/image/components` to `astro:assets` to use the new built-in `<Image />` component.
 
     Remove any component attributes that are not [currently supported image asset properties](#properties).
-    
+
     For example `aspectRatio` is no longer supported, as it is now automatically inferred from the `width` and `height` attributes.
 
       ```astro title="src/components/MyComponent.astro" del= {2,11} ins={3}
@@ -145,12 +145,12 @@ To avoid errors in your project, complete the following steps:
 
 ### Update content collections schemas
 
-You can now declare images in your frontmatter as their paths relative to the `src/assets/` folder. 
+You can now declare images in your frontmatter as their paths relative to the current folder.
 
 ```md title="src/content/blog/my-post.md"
 ---
 title: "My first blog post"
-cover: "firstpostcover.jpeg" # will resolve to "src/assets/firstblogcover.jpeg"
+cover: "./firstpostcover.jpeg" # will resolve to "src/content/blog/firstblogcover.jpeg"
 coverAlt: "A photograph of a sunset behind a mountain range"
 ---
 
@@ -267,7 +267,7 @@ If the image is merely decorative (i.e. doesn't contribute to the understanding 
 
 ##### Additional properties
 
-In addition to the properties above, the `<Image />` component accepts all properties accepted by the HTML `<img>` tag. 
+In addition to the properties above, the `<Image />` component accepts all properties accepted by the HTML `<img>` tag.
 
 For example, you can provide a `class` to the final `img` element.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

https://github.com/withastro/astro/pull/6627 changes how frontmatter images work so they're now relative to the current file instead of `src/assets`. People can still use `src/assets` through the provided alias `~/assets/` or through pathing to it relatively.
