### PR TITLE
Add anchors to headings on i18n site

### DIFF
--- a/scripts/lib/translation-status/template.html
+++ b/scripts/lib/translation-status/template.html
@@ -125,6 +125,9 @@
 				color: var(--theme-accent);
 				text-decoration: none;
 			}
+      h2 a {
+        color: inherit;
+      }
 			p a {
 				color: var(--theme-accent-secondary);
 				text-decoration: underline;
@@ -227,13 +230,19 @@
 					to learn about our translation process and how you can get involved.
 				</p>
 
-				<h2>Translation progress by language</h2>
+				<h2 id="by-language">
+          <a href="#by-language">Translation progress by language</a>
+        </h2>
 				<!-- TranslationStatusByLanguage -->
 
-				<h2>Translations that need reviews</h2>
+				<h2 id="needs-review">
+          <a href="#needs-review">Translations that need reviews</a>
+        </h2>
 				<!-- TranslationNeedsReview -->
 
-				<h2>Translation status by content</h2>
+				<h2 id="by-content">
+          <a href="#by-content">Translation status by content</a>
+        </h2>
 			</div>
 			<!-- This table is not limited to the viewport to allow horizontal scrolling -->
 			<!-- TranslationStatusByPage -->


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

- What does this PR change? Adds anchor headings to the i18n site
- Did you change something visual? On hover of an h2 element an underline becomes visible to indicate it being a link, but the colour remains the same.
<details>
<summary>Preview</summary>
<img src="https://user-images.githubusercontent.com/64310361/227320906-73a1e11a-113b-4603-8e6c-9be05fc81afb.png" alt=""/>
</details>

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
