### PR TITLE
Redirect `/` to `/en/getting-started/` in Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -86,6 +86,10 @@
   [[redirects]]
     from = "/:lang/migrate"
     to = "/:lang/guides/upgrade-to/v1"
+    
+  [[redirects]]
+    from = "/"
+    to = "/en/getting-started"
 
   [[redirects]]
     from = "/:lang/*"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

I noticed we don’t currently have a server-side redirect for folks visiting https://docs.astro.build

Instead, the page has to load, then the `<meta>` redirect is used to take us to the English landing page. This can be a little slow, so I’ve updated the Netlify config to do this redirect on the server instead of in the browser.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
