### PR TITLE
Change Translation Tuesday bot post time to 10:00 UTC

### DIFF
--- a/.github/workflows/discord-i18n-ping.yml
+++ b/.github/workflows/discord-i18n-ping.yml
@@ -2,7 +2,7 @@ name: Translation Tuesday
 
 on:
   schedule:
-    - cron:  '0 0 * * TUE'
+    - cron:  '0 10 * * TUE'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

- Changes the GitHub Actions workflow to run at `0 10 * * TUE`, which is 10:00 UTC, instead of 0:00 UTC like before.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
