### PR TITLE
fix: Fix InferGetStaticPropsType example

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -35,7 +35,7 @@ Additionally, our templates include an `env.d.ts` file inside the `src` folder t
 /// <reference types="astro/client" />
 ```
 
-If you are not using VSCode, you can install the [Astro TypeScript plugin](https://www.npmjs.com/package/@astrojs/ts-plugin) to support importing `.astro` files from `.ts` files (which can be useful for re-exporting). 
+If you are not using VSCode, you can install the [Astro TypeScript plugin](https://www.npmjs.com/package/@astrojs/ts-plugin) to support importing `.astro` files from `.ts` files (which can be useful for re-exporting).
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -259,10 +259,10 @@ export async function getStaticPaths() {
 type Params = InferGetStaticParamsType<typeof getStaticPaths>;
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-const { slug } = Astro.params;
-//               ^? { slug: string; }
+const { slug } = Astro.params as Params;
+//               			 ^? { slug: string; }
 const { title } = Astro.props;
-//                ^? { draft: boolean; title: string; }
+//                			^? { draft: boolean; title: string; }
 ---
 ```
 


### PR DESCRIPTION

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Our tooling does not automatically uses `type Params` to type `Astro.params`. It never has, actually. Additionally, the two slash commands were in the wrong spot