### PR TITLE
fix(typescript): Update getStaticPaths option to be fully typed

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -244,9 +244,9 @@ You can get the type of [`Astro.params`](/en/reference/api-reference/#astroparam
 
 ```astro title="src/pages/posts/[...slug].astro" {2,14-15}
 ---
-import { InferGetStaticParamsType, InferGetStaticPropsType } from 'astro';
+import { InferGetStaticParamsType, InferGetStaticPropsType, GetStaticPaths } from 'astro';
 
-export async function getStaticPaths() {
+export const getStaticPaths = (async () => {
   const posts = await getCollection('blog');
   return posts.map((post) => {
     return {
@@ -254,7 +254,7 @@ export async function getStaticPaths() {
       props: { draft: post.data.draft, title: post.data.title },
     };
   });
-}
+}) satisfies GetStaticPaths;
 
 type Params = InferGetStaticParamsType<typeof getStaticPaths>;
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;


### PR DESCRIPTION

#### What kind of changes does this PR include?

- New or updated content

#### Description

This updates the `getStaticPaths` example in the TypeScript guide to be fully typed. The syntax does look weird because of `satisfies`, but it's important to show that this is the best way to type `getStaticPaths`, because typing it normally (using `: GetStaticPaths`) breaks `InferGetStaticParamsType` (and its Props equivalent) since it works by inferring the return value (which typing it directly removes the ability to)

