### PR TITLE
Scoped styles: make compiler transformation clear

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -25,15 +25,32 @@ Styling an Astro component is as easy as adding a `<style>` tag to your componen
 
 Astro `<style>` CSS rules are automatically **scoped by default**. Scoped styles are compiled behind-the-scenes to only apply to HTML written inside of that same component. The CSS that you write inside of an Astro component is automatically encapsulated inside of that component.
 
-```astro del={2,5} ins={3,6} ins=":where(.astro-HHNQFKH6)"
+This CSS:
+```astro title="index.astro"
 <style>
-  h1 { color: red; }
-  h1:where(.astro-HHNQFKH6) { color: red; }
+  h1 { 
+    color: red; 
+  }
 
-  .text { color: blue; }
-  .text:where(.astro-HHNQFKH6) { color: blue; }
+  .text { 
+    color: blue; 
+  }
 </style>
 ```
+
+Compiles to this:
+```astro
+<style>
+  h1:where(.astro-HHNQFKH6) {
+     color: red;
+  }
+
+  .text:where(.astro-HHNQFKH6) {
+    color: blue;
+  }
+</style>
+```
+
 
 Scoped styles don't leak and won't impact the rest of your site. In Astro, it is okay to use low-specificity selectors like `h1 {}` or `p {}` because they will be compiled with scopes in the final output.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

The code sample made it seem like _you_ are the one adding the `:where`, instead of the compiler. This [confused people](https://discord.com/channels/830184174198718474/853350631389265940/1091085688138629160).

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
