### PR TITLE
🔢 Numbered sitemap file notes

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -138,6 +138,8 @@ Sitemap: https://<YOUR SITE>/sitemap-index.xml
 </urlset>
 ```
 
+It should be noted that `sitemap-index.xml` will point to all other `sitemap-#.xml` files. If your site were to grow really big, you would have `sitemap-0.xml` `sitemap-1.xml`, `sitemap-2.xml`, etc. By using the `sitemap-index.xml` file, it will include and point to all of these numbered sitemap files.
+
 ## Configuration
 
 To configure this integration, pass an object to the `sitemap()` function call in `astro.config.mjs`.


### PR DESCRIPTION
# 🔢 Numbered sitemap file notes

#### What kind of changes does this PR include?

- New or updated content

#### Description

After chatting with `erica` in Discord (one of the core maintainers) I learned that the `sitemap-index.xml` file will automatically point to all other numbered sitemap files (ex: `sitemap-#.xml`).

This was unclear to me when reading the docs, and the only files I really found _sitemap style content_ in was the "numbered" sitemap files. I was totally unaware that if I simply pointed to the `sitemap-index.xml` file that all other sitemap files would be included.

This pull request updates the sitemap documentation to improve clarity around numbered sitemap files that get generated.

<img width="998" alt="Screenshot 2023-04-01 at 10 21 43 PM" src="https://user-images.githubusercontent.com/23362539/229314396-2834a02a-bce7-4e93-b545-0d1d833abf36.png">
