### PR TITLE
Add note on yaml types

### DIFF
--- a/src/content/docs/en/recipes/add-yaml-support.mdx
+++ b/src/content/docs/en/recipes/add-yaml-support.mdx
@@ -36,7 +36,7 @@ Astro builds on top of Vite, and supports both Vite and Rollup plugins. This rec
     ```
 
     :::note
-    While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create a `*.d.ts` file in the `src` directory of your project and add the following:
+    While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create or find an existing `*.d.ts` file in the `src` directory of your project and add the following:
     ```ts
     // Specify the file extension you want to import
     declare module "*.yml" {

--- a/src/content/docs/en/recipes/add-yaml-support.mdx
+++ b/src/content/docs/en/recipes/add-yaml-support.mdx
@@ -36,9 +36,9 @@ Astro builds on top of Vite, and supports both Vite and Rollup plugins. This rec
     ```
 
     :::note
-    While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create a `*.d.ts` file in your project and add the following:
+    While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create a `*.d.ts` file in the `src` directory of your project and add the following:
     ```ts
-    // specify the file extension you want to import
+    // Specify the file extension you want to import
     declare module "*.yml" {
       const value: any; // Add better type definitions here if desired
       export default value;

--- a/src/content/docs/en/recipes/add-yaml-support.mdx
+++ b/src/content/docs/en/recipes/add-yaml-support.mdx
@@ -37,10 +37,10 @@ Astro builds on top of Vite, and supports both Vite and Rollup plugins. This rec
 
     :::note
     While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create or find an existing `*.d.ts` file in the `src` directory of your project and add the following:
-    ```ts
+    ```ts title="src/files.d.ts"
     // Specify the file extension you want to import
     declare module "*.yml" {
-      const value: any; // Add better type definitions here if desired
+      const value: any; // Add type definitions here if desired
       export default value;
     }
     ```

--- a/src/content/docs/en/recipes/add-yaml-support.mdx
+++ b/src/content/docs/en/recipes/add-yaml-support.mdx
@@ -34,3 +34,15 @@ Astro builds on top of Vite, and supports both Vite and Rollup plugins. This rec
     ```js
     import yml from './data.yml';
     ```
+
+    :::note
+    While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create a `*.d.ts` file in your project and add the following:
+    ```ts
+    // specify the file extension you want to import
+    declare module "*.yml" {
+      const value: any; // Add better type definitions here if desired
+      export default value;
+    }
+    ```
+    This will allow your editor to provide type hints for your YAML data.
+    :::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- New or updated content

#### Description

- Closes #3019
- What does this PR change? Add a note for typing yaml files

> While you can now import YAML data in your Astro project, your editor will not provide types for the imported data. To add types, create a `*.d.ts` file in your project and add the following:
>    ```ts
>    // specify the file extension you want to import
>    declare module "*.yml" {
>      const value: any; // Add better type definitions here if desired
>      export default value;
>    }
>    ```
>    This will allow your editor to provide type hints for your YAML data.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
