### PR TITLE
docs: front matter -> frontmatter

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -113,7 +113,7 @@ const { isRed } = Astro.props;
 
 <Since v="0.21.0" />
 
-The Astro `<style>` can reference any CSS variables available on the page. You can also pass CSS variables directly from your component front matter using the `define:vars` directive.
+The Astro `<style>` can reference any CSS variables available on the page. You can also pass CSS variables directly from your component frontmatter using the `define:vars` directive.
 
 ```astro title="src/components/DefineVars.astro" /define:vars={{.*}}/ /var\\(.*\\)/
 ---


### PR DESCRIPTION
Minor content fixes: all of the Astro's docs use "frontmatter" instead of "front matter"
