### PR TITLE
i18n(pt-BR): Update and translate error pages

### DIFF
--- a/src/content/docs/pt-br/reference/error-reference.mdx
+++ b/src/content/docs/pt-br/reference/error-reference.mdx
@@ -30,6 +30,15 @@ A referência a seguir é uma lista completa dos erros que você pode encontrar 
 - [**InvalidPrerenderExport**](/pt-br/reference/errors/invalid-prerender-export/) (E03019)<br/>Invalid prerender export.
 - [**InvalidComponentArgs**](/pt-br/reference/errors/invalid-component-args/) (E03020)<br/>Invalid component arguments.
 - [**PageNumberParamNotFound**](/pt-br/reference/errors/page-number-param-not-found/) (E03021)<br/>Page number param not found.
+- [**ImageMissingAlt**](/pt-br/reference/errors/image-missing-alt/) (E03022)<br/>Missing alt property.
+- [**InvalidImageService**](/pt-br/reference/errors/invalid-image-service/) (E03023)<br/>Error while loading image service.
+- [**MissingImageDimension**](/pt-br/reference/errors/missing-image-dimension/) (E03024)<br/>Missing image dimensions.
+- [**UnsupportedImageFormat**](/pt-br/reference/errors/unsupported-image-format/) (E03025)<br/>Unsupported image format.
+- [**PrerenderDynamicEndpointPathCollide**](/pt-br/reference/errors/prerender-dynamic-endpoint-path-collide/) (E03026)<br/>Prerendered dynamic endpoint has path collision.
+- [**ExpectedImage**](/pt-br/reference/errors/expected-image/) (E03027)<br/>Expected src to be an image.
+- [**ExpectedImageOptions**](/pt-br/reference/errors/expected-image-options/) (E03028)<br/>Expected image options.
+- [**MarkdownImageNotFound**](/pt-br/reference/errors/markdown-image-not-found/) (E03029)<br/>Image not found.
+- [**ResponseSentError**](/pt-br/reference/errors/response-sent-error/) (E03030)<br/>Unable to set response.
 - [**UnknownViteError**](/pt-br/reference/errors/unknown-vite-error/) (E04000)<br/>Unknown Vite Error.
 - [**FailedToLoadModuleSSR**](/pt-br/reference/errors/failed-to-load-module-ssr/) (E04001)<br/>Could not import file.
 - [**InvalidGlob**](/pt-br/reference/errors/invalid-glob/) (E04002)<br/>Invalid glob pattern.

--- a/src/content/docs/pt-br/reference/errors/expected-image-options.mdx
+++ b/src/content/docs/pt-br/reference/errors/expected-image-options.mdx
@@ -1,0 +1,23 @@
+---
+title: Expected image options.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ExpectedImageOptions**: Esperava parâmetro de getImage() ser um objeto. Recebeu `OPÇÕES`. (E03028)
+
+## O que deu errado?
+
+O primeiro parâmetro de `getImage()` deve ser um objeto com as diferentes propriedades a serem aplicadas em sua imagem.
+
+```ts
+import { getImage } from "astro:assets";
+import minhaImagem from "../assets/minha_imagem.png";
+
+const imagemOtimizada = await getImage({src: minhaImagem, width: 300, height: 300});
+```
+
+Na maioria dos casos, este erro acontece pois os parâmetros foram passados diretamente, ao invés de dentro de um objeto.
+
+**Veja Também:**
+-  [Assets (Experimental)](/pt-br/guides/assets/)

--- a/src/content/docs/pt-br/reference/errors/expected-image.mdx
+++ b/src/content/docs/pt-br/reference/errors/expected-image.mdx
@@ -1,0 +1,28 @@
+---
+title: Expected src to be an image.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ExpectedImage**: Esperava propriedade `src` ser uma imagem importada por ESM ou uma string com o caminho de uma imagem remota. Recebeu `OPÇÕES`. (E03027)
+
+## O que deu errado?
+
+A propriedade `src` de uma imagem não é válida. O componente Image requer que o atributo `src` seja uma imagem que foi importada por ESM ou uma string. Isso também vale para o primeiro parâmetro de `getImage()`.
+
+```astro
+---
+import { Image } from "astro:assets";
+import minhaImagem from "../assets/minha_imagem.png";
+---
+
+<Image src={minhaImagem} alt="..." />
+<Image src="https://exemplo.com/logo.png" width={300} height={300} alt="..." />
+```
+
+Na maioria dos casos, este erro acontece quando o valor passado a `src` é undefined.
+
+**Veja Também:**
+-  [Assets (Experimental)](/pt-br/guides/assets/)
+
+

--- a/src/content/docs/pt-br/reference/errors/generate-content-types-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/generate-content-types-error.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **GenerateContentTypesError**: O comando `astro sync` falhou em gerar os tipos das coleções de conteúdo. (E08001)
+> **GenerateContentTypesError**: O comando `astro sync` falhou em gerar os tipos das coleções de conteúdo: MENSAGEM_DE_ERRO (E08001)
 
 ## O que deu errado?
 

--- a/src/content/docs/pt-br/reference/errors/image-missing-alt.mdx
+++ b/src/content/docs/pt-br/reference/errors/image-missing-alt.mdx
@@ -1,0 +1,20 @@
+---
+title: Missing alt property.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ImageMissingAlt**: A propriedade alt é obrigatória. (E03022)
+
+## O que deu errado?
+
+A propriedade `alt` permite que você providencie texto alternativo descritivo para usuários de leitores de tela e outras tecnologias assistivas. Para garantir que suas imagens sejam acessíveis, o componente `Image` requer que `alt` seja especificado.
+
+Se a imagem é meramente decorativa (isto é, não contribui para a compreensão da página), defina `alt=""` para que leitores de tela consigam ignorar a imagem.
+
+**Veja Também:**
+-  [Assets (Experimental)](/pt-br/guides/assets/)
+-  [Componente Image](/pt-br/guides/assets/#image--astroassets)
+-  [Componente Image#alt](/pt-br/guides/assets/#alt-required)
+
+

--- a/src/content/docs/pt-br/reference/errors/invalid-image-service.mdx
+++ b/src/content/docs/pt-br/reference/errors/invalid-image-service.mdx
@@ -1,0 +1,18 @@
+---
+title: Error while loading image service.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidImageService**: Houve um erro ao carregar o serviço de imagem configurado. Por favor veja o stack trace para mais informações. (E03023)
+
+## O que deu errado?
+
+Houve um erro ao carregar o serviço de imagem configurado. Isso pode ser causado por vários fatores, como o seu serviço de imagem não exportar um objeto propriamente compatível na sua exportação padrão, ou um caminho incorreto.
+
+Se você acredita que seu serviço está propriamente configurado e que o erro está errado, por favor [abra uma issue](https://astro.build/issues/).
+
+**Veja Também:**
+-  [API de Serviço de Imagem](/pt-br/reference/image-service-reference/)
+
+

--- a/src/content/docs/pt-br/reference/errors/markdown-image-not-found.mdx
+++ b/src/content/docs/pt-br/reference/errors/markdown-image-not-found.mdx
@@ -1,0 +1,18 @@
+---
+title: Image not found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Não foi possível a imagem requisitada `CAMINHO_IMAGEM` em `CAMINHO_COMPLETO_IMAGEM`. (E03029)
+
+## O que deu errado?
+
+Astro não foi capaz de encontrar uma imagem que você incluiu no seu conteúdo Markdown. Geralmente, isto é simplesmente causado por um erro de digitação no caminho.
+
+Imagens no Markdown são relativas ao arquivo atual. Para se referir a uma imagem que não está localizada na mesma pastas que o arquivo `.md`, o caminho deve começar com `./`
+
+**Veja Também:**
+-  [Assets (Experimental)](/pt-br/guides/assets/)
+
+

--- a/src/content/docs/pt-br/reference/errors/missing-image-dimension.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-image-dimension.mdx
@@ -1,0 +1,19 @@
+---
+title: Missing image dimensions
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Atributos width e height faltando para `URL_IMAGEM`. Ao usar imagens remotas, ambas as dimensões são sempre necessárias para evitar cumulative layout shift (CLS). (E03024)
+
+## O que deu errado?
+
+Para imagens remotas, `width` e `height` não podem ser inferidos a partir do arquivo original. Portanto, para evitar CLS, esses dois parâmetros são sempre obrigatórios.
+
+Se sua imagem está dentro do seu diretório `src`, você provavelmente quis importá-lo no lugar. Veja [o guia de Importações para mais informações](/pt-br/guides/imports/#outros-assets).
+
+**Veja Também:**
+-  [Assets (Experimental)](/pt-br/guides/assets/)
+-  [Componente Image#width-e-height](/pt-br/guides/assets/#width-and-height)
+
+

--- a/src/content/docs/pt-br/reference/errors/prerender-dynamic-endpoint-path-collide.mdx
+++ b/src/content/docs/pt-br/reference/errors/prerender-dynamic-endpoint-path-collide.mdx
@@ -1,0 +1,21 @@
+---
+title: Prerendered dynamic endpoint has path collision.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **PrerenderDynamicEndpointPathCollide**: Não foi possível renderizar `NOMEDOCAMINHO` com um parâmetro `undefined` já que o caminho gerado iria colidir durante a pré-renderização. ` +
+            `Evite passar `undefined` como `params` para a função `getStaticPaths()`, ` +
+            `ou adicione uma extensão adicional ao nome de arquivo do endpoint. (E03026)
+
+## O que deu errado?
+
+O endpoint é pré-renderizado com um parâmetro `undefined`, então o caminho gerado irá colidir com outra rota.
+
+Se você não consegue evitar passar `undefined`, então uma extensão adicional pode ser adicionada ao nome de arquivo do endpoint para gerar o arquivo com um nome diferente. Por exemplo, renomeando `pages/api/[slug].ts` para `pages/api/[slug].json.ts`.
+
+**Veja Também:**
+-  [`getStaticPaths()`](/pt-br/reference/api-reference/#getstaticpaths)
+-  [`params`](/pt-br/reference/api-reference/#params)
+
+

--- a/src/content/docs/pt-br/reference/errors/response-sent-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/response-sent-error.mdx
@@ -1,0 +1,14 @@
+---
+title: Unable to set response
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ResponseSentError**: A resposta já foi enviada ao navegador e não pode ser alterada. (E03030)
+
+## O que deu errado?
+
+Fazer mudanças a uma resposta, como definir headers, cookies e o status code, não pode ser feito fora de componentes de página.
+
+
+

--- a/src/content/docs/pt-br/reference/errors/static-client-address-not-available.mdx
+++ b/src/content/docs/pt-br/reference/errors/static-client-address-not-available.mdx
@@ -10,7 +10,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 
 A propriedade `Astro.clientAddress` está apenas disponível quando [Renderização no lado do servidor](/pt-br/guides/server-side-rendering/) está habilitada.
 
-Para conseguir o endereço de IP do usuário no modo estático, diferentes APIs como [Ipify](https://www.ipify.org/) podem ser utilizadas em um [Script no lado do cliente](/pt-br/core-concepts/astro-components/#scripts-no-lado-do-cliente) ou pode ser possível conseguir o IP do usuário utilizando uma função serverless hospedada no seu provedor de hospedagem.
+Para conseguir o endereço de IP do usuário no modo estático, diferentes APIs como [Ipify](https://www.ipify.org/) podem ser utilizadas em um [Script no lado do cliente](/pt-br/guides/client-side-scripts/) ou pode ser possível conseguir o IP do usuário utilizando uma função serverless hospedada no seu provedor de hospedagem.
 
 **Veja Também:**
 -  [Habilitando SSR no seu projeto](/pt-br/guides/server-side-rendering/#habilitando-o-ssr-em-seu-projeto)

--- a/src/content/docs/pt-br/reference/errors/unsupported-image-format.mdx
+++ b/src/content/docs/pt-br/reference/errors/unsupported-image-format.mdx
@@ -1,0 +1,24 @@
+---
+title: Unsupported image format
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnsupportedImageFormat**: Recebeu formato não suportado `FORMATO` de `CAMINHO_IMAGEM`. Atualmente, apenas `FORMATOS_SUPORTADOS` são suportados para otimização. (E03025)
+
+## O que deu errado?
+
+Os serviços de imagem integrados atualmente não suportam otimizar todos os formatos de imagem.
+
+Para formatos não suportados como SVGs e GIFs, você pode ser capaz de usar uma tag `img` diretamente:
+
+```astro
+---
+import foguete from '../assets/images/foguete.svg'
+---
+
+<img src={foguete.src} width={foguete.width} height={foguete.height} alt="Um foguete no espaço." />
+```
+
+
+


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content


#### Description

Updated:
- `error-reference.mdx`
- `generate-content-types-error.mdx`
- `static-client-address-not-available.mdx`

Translated:
- `expected-image-options.mdx`
- `expected-image.mdx`
- `image-missing-alt.mdx`
- `invalid-image-service.mdx`
- `markdown-image-not-found.mdx`
- `missing-image-dimension.mdx`
- `prerender-dynamic-endpoint-path-collide.mdx`
- `response-sent-error.mdx`
- `unsupported-image-format.mdx`