### PR TITLE
Fix typo in `zh-cn` -> `astro-components.mdx`

### DIFF
--- a/src/content/docs/zh-cn/core-concepts/astro-components.mdx
+++ b/src/content/docs/zh-cn/core-concepts/astro-components.mdx
@@ -273,7 +273,7 @@ Astro 组件的语法是 HTML 的超集。它的设计使得任何有 HTML 或 J
 
 ## 组件参数
 
-Astro 组件可以定义和接受参数。 然后，这些参数可用于组件模板以呈现 HTML。 可以在 frontmatter scsipt 中的 `Astro.props` 中使用。
+Astro 组件可以定义和接受参数。 然后，这些参数可用于组件模板以呈现 HTML。 可以在 frontmatter script 中的 `Astro.props` 中使用。
 
 这是一个接收 `greeting` 参数和 `name` 参数的组件示例。请注意，要接收的参数是从全局 `Astro.props` 对象中解构的。
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)
- Translated content

#### Description

Typo: `frontmatter scispt` -> `frontmatter script`