### PR TITLE
docs: fix typo, wrong hint function name

### DIFF
--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -88,7 +88,7 @@ export default defineConfig({
     ```
 
     :::tip[set a baseUrl]
-    You can set [`"baseUrl": "http://localhost:3000"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.js` configuration file to use `cy.visit("/")` instead of `page.goto("http://localhost:3000/")` for a more convenient URL.
+    You can set [`"baseUrl": "http://localhost:3000"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.js` configuration file to use `cy.visit("/")` instead of `cy.visit("http://localhost:3000/")` for a more convenient URL.
     :::
 
 ### Running your Cypress tests


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- wrong function name in doc's testing section

#### Description

- Closes #3070 
- What does this PR change? Give us a brief description: Change function name from playwright one to cypress one.
- Did you change something visual? A before/after screenshot can be helpful: I think it's not need a screenshot because basically changed a word.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
