### PR TITLE
i18n(es): Translated `prerender-dynamic-endpoint-path-collide.mdx`

### DIFF
--- a/src/content/docs/es/reference/errors/prerender-dynamic-endpoint-path-collide.mdx
+++ b/src/content/docs/es/reference/errors/prerender-dynamic-endpoint-path-collide.mdx
@@ -1,0 +1,19 @@
+---
+title: El endpoint dinámico prerenderizado tiene una colisión de rutas.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **PrerenderDynamicEndpointPathCollide**: No pudo renderizar `PATHNAME` con un parámetro `undefined`, ya que la ruta generada colisionará durante la prerrenderización. ` +
+            `Evita pasar `undefined` como `params` para la función del endpoint `getStaticPaths()` , ` +
+            `o agrega una extensión adicional al nombre del archivo endpoint. (E03026)
+
+## ¿Qué salió mal?
+El endpoint se prerrenderiza con un parámetro `undefined`, por lo que la ruta generada entrará en conflicto con otra ruta.
+
+Si no puedes evitar pasar `undefined`, entonces se puede agregar una extensión adicional al nombre del archivo endpoint para generar el archivo con un nombre diferente. Por ejemplo, renombrar `pages/api/[slug].ts` a `pages/api/[slug].json.ts`.
+
+**Ver también:**
+-  [`getStaticPaths()`](/en/reference/api-reference/#getstaticpaths)
+-  [`params`](/en/reference/api-reference/#params)
+


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Translated `prerender-dynamic-endpoint-path-collide.mdx` to spanish