### PR TITLE
Fix the example code errors in the Endpoints section

### DIFF
--- a/src/content/docs/en/core-concepts/endpoints.mdx
+++ b/src/content/docs/en/core-concepts/endpoints.mdx
@@ -54,7 +54,7 @@ export const get: APIRoute = async function get ({params, request}) {
 
 Endpoints support the same [dynamic routing](/en/core-concepts/routing/#dynamic-routes) features that pages do. Name your file with a bracketed parameter name and export a [`getStaticPaths()` function](/en/reference/api-reference/#getstaticpaths). Then, you can access the parameter using the `params` property passed to the endpoint function:
 
-```ts title="src/pages/[id].json.ts"
+```ts title="src/pages/api/[id].json.ts"
 import type { APIRoute } from 'astro';
 
 const usernames = ["Sarah", "Chris", "Dan"]
@@ -77,7 +77,7 @@ export function getStaticPaths () {
 }
 ```
 
-This will generate three JSON endpoints at build time: `/api/1.json`, `/api/2.json`, `/api/3.json`. Dynamic routing with endpoints works the same as it does with pages, but because the endpoint is a function and not a component, [props](/en/reference/api-reference/#data-passing-with-props) aren't supported.
+This will generate three JSON endpoints at build time: `/api/0.json`, `/api/1.json`, `/api/2.json`. Dynamic routing with endpoints works the same as it does with pages, but because the endpoint is a function and not a component, [props](/en/reference/api-reference/#data-passing-with-props) aren't supported.
 
 ### `request`
 All endpoints receive a `request` property, but in static mode, you only have access to `request.url`. This returns the full URL of the current endpoint and works the same as [Astro.request.url](/en/reference/api-reference/#astrorequest) does for pages.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- I found some issues in the example code in the [params and Dynamic routing](https://docs.astro.build/en/core-concepts/endpoints/#params-and-dynamic-routing) section while browsing through the documentation. The expected result mentioned in the documentation for the file path `src/pages/[id].json.ts` and the routes generated by the `getStaticPaths()` function is _**“This will generate three JSON endpoints at build time: `/api/1.json, /api/2.json, /api/3.json`.”**_  However, the actual result generated by the example code is **_`/0.json, /1.json, /2.json`._**

- So I modified the file path in the sample code in the document to `scr/pages/api/[id].json.ts`, and changed the expected generated JSON endpoints in the document to the actual ones that will be produced, namely /api/0.json, /api/1.json, /api/2.json.

- I found that this part has the same issue in other language versions as well.