### PR TITLE
Update Assets image service import

### DIFF
--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -356,14 +356,14 @@ Then, enable Astro's sharp image service in your config:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
-import { getSharpImageService } from "astro/assets";
+import { sharpImageService } from "astro/assets";
 
 export default defineConfig({
 	experimental: {
 		assets: true,
 	},
 	image: {
-		service: getSharpImageService(),
+		service: sharpImageService(),
 	},
 });
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Closes #3143  <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Updates the Astro Assets `sharp` image service import into `astro.config.mjs` since `getSharpImageService` isn't a function that exists. It should instead be replaced with `sharpImageService`.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
