### PR TITLE
Refactor `<RecipeLink>` to handle i18n

### DIFF
--- a/src/components/RecipeLinks.astro
+++ b/src/components/RecipeLinks.astro
@@ -1,39 +1,56 @@
 ---
-import { getEntryBySlug } from 'astro:content';
-import { removeLeadingSlash, removeTrailingSlash } from '~/util';
+import { recipePages } from '~/content';
+import { getLanguageFromURL, stripLangFromSlug } from '~/util';
 
 export interface Props {
 	slugs: string[];
 }
 
-const slugs = Astro.props.slugs.map((slug) => removeLeadingSlash(removeTrailingSlash(slug)));
+const lang = getLanguageFromURL(Astro.url.pathname);
+const fallbackSlug = (slug: string) =>
+	'en/' + stripLangFromSlug(slug as Parameters<typeof stripLangFromSlug>[0]);
 
-const entries = await Promise.all(
-	slugs.map(async (slug, i) => {
-		const entry = await getEntryBySlug('docs', slug);
-		if (!entry) {
-			throw new Error(`Could not find entry for slug "${Astro.props.slugs[i]}"`);
-		}
-		return entry;
-	})
-);
+const recipes = Astro.props.slugs.map((slug) => {
+	let isFallback = lang !== 'en' && slug.startsWith('en/');
+	let entry = recipePages.find((recipe) => recipe.slug === slug);
+	if (!entry) {
+		isFallback = true;
+		entry = recipePages.find((recipe) => recipe.slug === fallbackSlug(slug));
+	}
+	if (!entry) {
+		throw new Error(`Could not find entry for slug "${slug}"`);
+	}
+	return { entry, isFallback };
+});
 
-const isList = entries.length > 1;
+const isList = recipes.length > 1;
 const noun = isList ? 'recipes' : 'recipe';
+const firstRecipe = recipes[0];
+if (!firstRecipe) {
+	throw new Error('No slugs passed to `<RecipeLinks>` component. Make sure you pass at least one.');
+}
 ---
 
 <div class="root">
 	<div class="flex">
 		<img src="/houston_chef.webp" width="26" alt="" />
 		<strong>Related {noun}:</strong>
-		{!isList && <a href={`/${entries[0]!.slug}/`}> {entries[0]!.data.title}</a>}
+		{
+			!isList && (
+				<a href={`/${firstRecipe.entry.slug}/`}>
+					{firstRecipe.entry.data.title} {firstRecipe.isFallback && '(EN)'}
+				</a>
+			)
+		}
 	</div>
 	{
 		isList && (
 			<ul>
-				{entries.map((entry) => (
+				{recipes.map((recipe) => (
 					<li>
-						<a href={`/${entry!.slug}/`}>{entry!.data.title}</a>
+						<a href={`/${recipe.entry.slug}/`}>
+							{recipe.entry.data.title} {recipe.isFallback && '(EN)'}
+						</a>
 					</li>
 				))}
 			</ul>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Updates `<RecipeLink>` to work better with our i18n system
  - Slugs can be set using their translation path, e.g. `pt-br/recipes/foo`, even if the translation doesn’t exist yet — we’ll grab the English title in this case.
  - When a recipe hasn’t been translated yet, the link will be shown with an `(EN)` suffix on non-English pages like we do for other links on the site.

Here’s an example of the component on the Polish endpoints guide, which hasn’t been translated yet: 
![image](https://user-images.githubusercontent.com/357379/236143426-60d02ce4-92fb-4429-8443-9d554b581086.png)

This PR should unblock proper `<RecipeLink>` usage in #3044.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
