### PR TITLE
fix: update sharpImageService example to come from the right place

### DIFF
--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -355,8 +355,7 @@ If you're deploying to a Node environment, you may want to use [sharp](https://g
 Then, enable Astro's sharp image service in your config:
 
 ```js title="astro.config.mjs"
-import { defineConfig } from "astro/config";
-import { sharpImageService } from "astro/assets";
+import { defineConfig, sharpImageService } from "astro/config";
 
 export default defineConfig({
 	experimental: {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

https://github.com/withastro/astro/pull/6995 updates the utilities methods to come from `astro/config` instead of `astro/assets`, since the later didn't work