### PR TITLE
Properly decode html entities in copy button

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@fontsource/ibm-plex-mono": "^4.5.10",
     "@nanostores/preact": "^0.1.3",
     "canvas-confetti": "^1.6.0",
+    "html-entities": "^2.3.3",
     "jsdoc-api": "^7.1.1",
     "nanostores": "^0.5.13",
     "rehype-autolink-headings": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ dependencies:
   canvas-confetti:
     specifier: ^1.6.0
     version: 1.6.0
+  html-entities:
+    specifier: ^2.3.3
+    version: 2.3.3
   jsdoc-api:
     specifier: ^7.1.1
     version: 7.1.1
@@ -3762,6 +3765,10 @@ packages:
       property-information: 6.1.1
       space-separated-tokens: 2.0.1
     dev: true
+
+  /html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+    dev: false
 
   /html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}

--- a/src/components/CodeSnippet/copy-button.ts
+++ b/src/components/CodeSnippet/copy-button.ts
@@ -1,4 +1,4 @@
-import { unescape } from 'html-escaper';
+import { decode } from 'html-entities';
 
 export type CopyButtonArgs = {
 	copyButtonTitle?: string;
@@ -36,19 +36,14 @@ export class CopyButton {
 
 			for (const tokenMatch of tokenMatches) {
 				const [, innerHtml] = tokenMatch;
-				const text = unescape(innerHtml);
+				const text = innerHtml;
 				textLine += text;
 			}
 
 			this.code += textLine + '\n';
 		}
 
-		this.code = this.code
-			.replace(/&amp;/g, '&')
-			.replace(/&lt;/g, '<')
-			.replace(/&gt;/g, '>')
-			.replace(/&quot;/g, '"')
-			.replace(/&#39;/g, "'");
+		this.code = decode(this.code)
 	}
 
 	renderToHtml() {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

- Closes #3186
Use the well tested [html-entities](https://www.npmjs.com/package/html-entities) npm package to handle HTML entities decoding for the copy button.