### PR TITLE
i18n(ja): Fix typo in client-side-scripts.mdx

### DIFF
--- a/src/content/docs/ja/guides/client-side-scripts.mdx
+++ b/src/content/docs/ja/guides/client-side-scripts.mdx
@@ -68,7 +68,7 @@ Astroは[スクリプトのバンドルのルール](#スクリプトのバン�
 <!-- `src/scripts/local.js`への相対パス -->
 <script src="../scripts/local.js"></script>
 
-<!-- このローカルのTypoeScriptファイルも動作します。 -->
+<!-- このローカルのTypeScriptファイルも動作します。 -->
 <script src="./script-with-types.ts"></script>
 ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- fix typo: `TypoeScript` -> `TypeScript`
