### PR TITLE
Fix escaped code in code copy button

### DIFF
--- a/src/components/CodeSnippet/copy-button.ts
+++ b/src/components/CodeSnippet/copy-button.ts
@@ -1,4 +1,4 @@
-import { unescape } from 'html-escaper';
+import type { ShikiLine } from './shiki-line';
 
 export type CopyButtonArgs = {
 	copyButtonTitle?: string;
@@ -6,49 +6,14 @@ export type CopyButtonArgs = {
 };
 
 export class CopyButton {
-	private codeLines: string[] = [];
 	private code: string;
 	private title: string;
 	private tooltip: string;
 
-	constructor(codeHtmlLines: string[], CopyButtonArgs: CopyButtonArgs) {
-		this.codeLines = codeHtmlLines;
-		this.code = '';
+	constructor(lines: ShikiLine[], CopyButtonArgs: CopyButtonArgs) {
 		this.title = CopyButtonArgs.copyButtonTitle || '';
 		this.tooltip = CopyButtonArgs.copyButtonTooltip || '';
-
-		const lineRegExp = /^<span class="line.*?".*?>(.*)<\/span>$/;
-		const tokenRegExp = /<span style="color: ?#[0-9A-Fa-f]+[^"]*">(.*?)<\/span>/g;
-
-		for (const line of this.codeLines) {
-			const lineMatches = line.match(lineRegExp);
-			if (!lineMatches)
-				throw new Error(
-					`Shiki-highlighted code line HTML did not match expected format. HTML code:\n${line}`
-				);
-
-			const tokensHtml = lineMatches[1];
-
-			// Split line into inline tokens
-			const tokenMatches = tokensHtml.matchAll(tokenRegExp);
-
-			let textLine = '';
-
-			for (const tokenMatch of tokenMatches) {
-				const [, innerHtml] = tokenMatch;
-				const text = unescape(innerHtml);
-				textLine += text;
-			}
-
-			this.code += textLine + '\n';
-		}
-
-		this.code = this.code
-			.replace(/&amp;/g, '&')
-			.replace(/&lt;/g, '<')
-			.replace(/&gt;/g, '>')
-			.replace(/&quot;/g, '"')
-			.replace(/&#39;/g, "'");
+		this.code = lines.map((line) => line.textLine).join('\n');
 	}
 
 	renderToHtml() {

--- a/src/components/CodeSnippet/shiki-block.ts
+++ b/src/components/CodeSnippet/shiki-block.ts
@@ -26,7 +26,7 @@ export class ShikiBlock {
 		const innerHtmlLines = innerHtml.split(/\r?\n/);
 		this.shikiLines = innerHtmlLines.map((htmlLine) => new ShikiLine(htmlLine));
 
-		this.copyButton = new CopyButton(innerHtmlLines, copyButtonArgs);
+		this.copyButton = new CopyButton(this.shikiLines, copyButtonArgs);
 	}
 
 	applyMarkings(lineMarkings: LineMarkingDefinition[], inlineMarkings: InlineMarkingDefinition[]) {

--- a/src/components/CodeSnippet/shiki-line.ts
+++ b/src/components/CodeSnippet/shiki-line.ts
@@ -1,5 +1,5 @@
 import chroma from 'chroma-js';
-import { escape, unescape } from 'html-escaper';
+import { escape, unescape } from '~/util/html-entities';
 import { ensureTextContrast } from './color-contrast';
 import {
 	InlineMarkingDefinition,

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -1,7 +1,7 @@
-import { unescape } from 'html-escaper';
 import type { ComponentChildren, JSX } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import type { TocItem } from '../../util/generateToc';
+import { unescape } from '../../util/html-entities';
 import './TableOfContents.css';
 
 interface Props {

--- a/src/util/html-entities.ts
+++ b/src/util/html-entities.ts
@@ -1,0 +1,7 @@
+import { unescape as unEsc } from 'html-escaper';
+export { escape } from 'html-escaper';
+
+/** Unescape HTML while catering for `&#x3C;` (`<`) and `'&#x26;'` (`&`), which the Astro compiler outputs. */
+export function unescape(str: string) {
+	return unEsc(str).replaceAll('&#x3C;', '<').replaceAll('&#x26;', '&');
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code
- Yet another fix for #3186 😁 

#### Description

- Closes #3186
- Also closes #3190
- @MoustaphaDev’s PR #3189 could still be useful: this PR applies a patch for the two problematic characters we currently have (`<` and `&`) but it may make sense to use that more robust solution — we could rebase that PR onto this one

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
