### PR TITLE
Add Xata guide to BE Recipe section

### DIFF
--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -11,60 +11,6 @@ import FileTree from '~/components/FileTree.astro'
 
 [Xata](https://xata.io) is a **Serverless Data Platform** because it combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
 
-## Quick Intro
-
-Because Xata is a database, it’s ill-advised to connect directly to it from the frontend. There are 3 options to handle data-fetching from Xata in your Astro app. And understanding **when** fetch happens will help you identify the best strategy for your app:
-
-1. Fetching once at build-time and have static data.
-2. Using [Server-Side Rendering](/guides/server-side-rendering/) and fetching every time your page is rendered.
-3. Connecting to a backend API, e.g.: a Backend For Frontend (BFF), a Serverless Function, or an Edge Function.
-
-## Zero to Production
-
-Xata offers a starter template which is the fastest way to get a new project setup.
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```shell
-npx degit xataio/examples/apps/starter-astro my-awesome-app
-  ```
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```shell
-pnpx degit xataio/examples/apps/starter-astro my-awesome-app
-
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```shell
-  # Yarn does not have a `npx` equivalent
-  npx degit xataio/examples/apps/starter-astro my-awesome-app
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
-Once the code is copied, dependencies installed, run the following command:
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```shell
-npm run xata:init
-  ```
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```shell
-pnpm xata:init
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```shell
-yarn xata:init
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
-This will walk you through the database connection. Create a workspace and apply the schema migration.
-
 ## Adding a database with Xata
 
 ### Prerequisites
@@ -182,9 +128,20 @@ const { records } = await xata.db.Posts.getPaginated({
 
 Since the SDK is generated dynamically, and will be updated any time you tweak your schema, it's better to leave it untouched. In case you wish to hoist a few common queries to keep your code base DRY, it's a best practice to create an additional file where your queries can be re-used.
 
+## Different query strategies
+
+As the Xata SDK connects directly to your database, it is important to never query from the client-side. As a matter of fact, the SDK access `process.env` and thus it will not even work.
+
+:::caution
+Never import the Xata SDK into your client-side bundle.
+:::
+
+So there are 3 ways to fetch your data from Xata in an Astro app:
+
+1. On-build time, in a prerendered page.
+2. On-demand, in a [server-side rendered (SSR)](/en/guides/server-side-rendering/#enabling-ssr-in-your-project) page.
+3. From the client-side with a Backend-For-Frontend (BFF) in the middle, such as a Serverless Function.
+
 ## Official Resources
 - [Xata Astro Starter](https://github.com/xataio/examples/tree/main/apps/starter-astro)
 - [Xata Docs: Quick Start Guide](https://xata.io/docs/getting-started/quickstart-astro)
-
-## Community Resources
-

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -57,7 +57,7 @@ XATA_API_KEY=hash_key
 
 # Xata branch that will be used
 # if there's not a xata branch with
-#the same name as your git branch
+# the same name as your git branch
 XATA_FALLBACK_BRANCH=main
 ```
 

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -9,7 +9,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'
 
 
-[Xata](https://xata.io) is a **Serverless Data Platform** because it combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
+[Xata](https://xata.io) is a **Serverless Data Platform** that combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
 
 ## Adding a database with Xata
 

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -105,7 +105,7 @@ Finally, your project should have the following structure:
 
 ## Create your queries
 
-To illustrate how to make a query, let's query the first 50 posts from Xata's Sample Blog Database.
+To query your posts, import and use `getXataClient()` in a `.astro` file. The example below queries the first 50 posts from Xata's Sample Blog Database.
 
 ```astro title="src/pages/blog/index.astro"
 ---

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -89,7 +89,7 @@ And a `.xatarc` file with a `databaseURL`. Though it can be extended to have mor
 }
 ```
 
-Additionally, the prompt may have assisted you on creating an instance of the SDK (Software Development Kit) and, if you chose TypeScript, you also have the types generated from your schema. Notice `@xata.io/client` was added to your `package.json` as well.
+Additionally, the prompt may have assisted you in creating an instance of the SDK (Software Development Kit) and, if you chose TypeScript, you also have the types generated from your schema. Notice `@xata.io/client` was added to your `package.json` as well.
 
 Finally, your project should have the following structure:
 

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -34,11 +34,10 @@ XATA_FALLBACK_BRANCH=main
 
 And the `databaseURL` defined:
 
-```ini title=".xatarc
+```ini title=".xatarc"
 {
   "databaseUrl": "https://your-database-url"
 }
-```
 
 ### Environment configuration
 

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -15,7 +15,7 @@ import FileTree from '~/components/FileTree.astro'
 
 ### Prerequisites
 
-- A [Xata](https://app.xata.io/signin) account with a created database (you can use the sample database from the Web UI).
+- A [Xata](https://app.xata.io/signin) account with a created database. (You can use the sample database from the Web UI.)
 - An Access Token (`XATA_TOKEN_API`).
 
 ### Environment configuration

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -7,8 +7,65 @@ stub: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-[Xata](https://xata.io) is a **Serverless Data Platform** that combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
+[Xata](https://xata.io) is a **Serverless Data Platform** because it combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
+
+## Quick Intro
+
+Because Xata is a database, it’s ill-advised to connect directly to it from the frontend. There are 3 options to handle data-fetching from Xata in your Astro app. And understanding **when** fetch happens will help you identify the best strategy for your app:
+
+1. Fetching once at build-time and have static data.
+2. Using [Server-Side Rendering](/guides/server-side-rendering/) and fetching every time your page is rendered.
+3. Connecting to a backend API, e.g.: a Backend For Frontend (BFF), a Serverless Function, or an Edge Function.
+
+## Zero to Production
+
+Xata offers a starter template which is the fastest way to get a new project setup.
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+npx degit xataio/examples/apps/starter-astro my-awesome-app
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+pnpx degit xataio/examples/apps/starter-astro my-awesome-app
+
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  # Yarn does not have a `npx` equivalent
+  npx degit xataio/examples/apps/starter-astro my-awesome-app
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Once the code is copied, dependencies installed, run the following command:
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+npm run xata:init
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+pnpm xata:init
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+yarn xata:init
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+This will walk you through the database connection. Create a workspace and apply the schema migration.
 
 ## Official Resources
-- [Xata with Astro: Quick Start Guide](https://xata.io/docs/getting-started/quickstart-astro)
 - [Xata Astro Starter](https://github.com/xataio/examples/tree/main/apps/starter-astro)
+- [Xata Docs: Quick Start Guide](https://xata.io/docs/getting-started/quickstart-astro)
+
+## Community Resources
+

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -6,6 +6,8 @@ service: Xata
 stub: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import FileTree from '~/components/FileTree.astro'
+
 
 [Xata](https://xata.io) is a **Serverless Data Platform** because it combines the features of a relational database, a search engine, and an analytics engine by exposing a single consistent REST API.
 
@@ -62,6 +64,123 @@ yarn xata:init
 </PackageManagerTabs>
 
 This will walk you through the database connection. Create a workspace and apply the schema migration.
+
+## Adding a database with Xata
+
+### Prerequisites
+
+- A [Xata](https://app.xata.io/signin) account with a created database (you can use the sample database from the Web UI).
+- An Access Token (`XATA_TOKEN_API`).
+
+### Environment configuration
+
+The quickest way to integrate is via the Xata CLI
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm install -g @xata.io/cli@latest
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm add -g @xata.io/cli@latest
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn global install @xata.io/cli@latest
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+The package will expose the `xata` command to your `$PATH` and now it's possible to initialize the integration:
+
+```shell
+xata init
+```
+
+:::note
+You can just execute the binary with `npx`, `pnpm dlx`, or `yarn dlx` if preferred.
+:::
+
+Once you follow the prompt, you should have a `.env` file in the root of your project with the following variables defined:
+
+```ini title=".env"
+XATA_API_KEY=hash_key
+
+# Xata branch that will be used
+# if there's not a xata branch with
+#the same name as your git branch
+XATA_FALLBACK_BRANCH=main
+```
+
+To have IntelliSense for your environment variables, edit or create the file `env.d.ts` in your `/src` directory to make your environment variables type-safe:
+
+```ts title="src/env.d.ts"
+interface ImportMetaEnv {
+  readonly XATA_API_KEY: string;
+  readonly XATA_FALLBACK_BRANCH?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+```
+
+:::tip
+Read more about [environment variables](/en/guides/environment-variables/) and `.env` files in Astro.
+:::
+
+And a `.xatarc` file with a `databaseURL`. Though it can be extended to have more definitions, such as the output path for your codegen, e.g.:
+
+```json title=".xatarc"
+{
+  "databaseURL": "https://{{ Xata DB URL }}",
+  "codegen": {
+    "output": "src/xata.codegen.ts"
+  }
+}
+```
+
+Additionally, the prompt may have assisted you on creating an instance of the SDK (Software Development Kit) and, if you chose TypeScript, you also have the types generated from your schema. Notice `@xata.io/client` was added to your `package.json` as well.
+
+Finally, your project should have the following structure:
+
+<FileTree title="Project Structure">
+- src/
+  - **xata.codegen.ts**
+  - **env.d.ts**
+- **.env**
+- astro.config.mjs
+- package.json
+- **.xatarc**
+</FileTree>
+
+## Create your queries
+
+To illustrate how to make a query, let's query the first 50 posts from Xata's Sample Blog Database.
+
+```astro title="src/pages/blog/index.astro"
+---
+import { getXataClient } from "../xata.codegen";
+
+const xata = getXataClient();
+const { records } = await xata.db.Posts.getPaginated({
+  pagination: {
+    size: 50
+  }
+})
+---
+
+<ul>
+  {records.map(post) => (
+    <li>{post.title}</li>
+  )}
+</ul>
+```
+
+Since the SDK is generated dynamically, and will be updated any time you tweak your schema, it's better to leave it untouched. In case you wish to hoist a few common queries to keep your code base DRY, it's a best practice to create an additional file where your queries can be re-used.
 
 ## Official Resources
 - [Xata Astro Starter](https://github.com/xataio/examples/tree/main/apps/starter-astro)

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -3,7 +3,7 @@ title: Xata & Astro
 description: Add a serverless database with full-text search to your project with Xata
 type: backend
 service: Xata
-stub: true
+stub: false
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -19,7 +19,7 @@ import FileTree from '~/components/FileTree.astro'
 - An Access Token (`XATA_TOKEN_API`).
 - Your Database URL.
 
-The quickest way to get an API token in your `.env` file and the database url ready to sync your project, is to update and initialize the [Xata CLI](https://xata.io/docs/getting-started/installation). 
+After you update and initialize the [Xata CLI](https://xata.io/docs/getting-started/installation), you will have your API token in your `.env` file and database URL defined. 
 
 By the end of the setup, you should have:
 
@@ -38,10 +38,11 @@ And the `databaseURL` defined:
 {
   "databaseUrl": "https://your-database-url"
 }
+```
 
 ### Environment configuration
 
-To have IntelliSense for your environment variables, edit or create the file `env.d.ts` in your `/src` directory to make your environment variables type-safe:
+To have IntelliSense and type safety for your environment variables, edit or create the file `env.d.ts` in your `src/` directory:
 
 ```ts title="src/env.d.ts"
 interface ImportMetaEnv {
@@ -58,9 +59,11 @@ interface ImportMeta {
 Read more about [environment variables](/en/guides/environment-variables/) and `.env` files in Astro.
 :::
 
-If you used the codegeneration from the Xata CLI, you now have an instance of the SDK (Software Development Kit) generated for you, with types tailored to your database schema - if you chose TypeScript. Notice `@xata.io/client` was added to your `package.json` as well.
+Using the codegeneration from the Xata CLI and choosing the TypeScript option, generated an instance of the SDK for you, with types tailored to your database schema. Additionally, `@xata.io/client` was added to your `package.json`.
 
-Your Xata environment variables and database url are automatically pulled by the SDK instance, so there's no more setup work needed.Finally, your project should have the following structure:
+Your Xata environment variables and database url were automatically pulled by the SDK instance, so there's no more setup work needed.
+
+Now, your project should have the following structure:
 
 <FileTree title="Project Structure">
 - src/
@@ -94,7 +97,7 @@ const { records } = await xata.db.Posts.getPaginated({
   )}
 </ul>
 ```
-It's important to note the SDK needs to be regenerated everytime your schema changes. So, avoid making changes to the files the Xata CLI creates.
+It's important to note the SDK needs to be regenerated everytime your schema changes. So, avoid making changes to the generated files the Xata CLI creates because once schema updates, your changes will be overwritten.
 
 
 ## Official Resources

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -128,19 +128,6 @@ const { records } = await xata.db.Posts.getPaginated({
 
 Since the SDK is generated dynamically, and will be updated any time you tweak your schema, it's better to leave it untouched. In case you wish to hoist a few common queries to keep your code base DRY, it's a best practice to create an additional file where your queries can be re-used.
 
-## Different query strategies
-
-As the Xata SDK connects directly to your database, it is important to never query from the client-side. As a matter of fact, the SDK access `process.env` and thus it will not even work.
-
-:::caution
-Never import the Xata SDK into your client-side bundle.
-:::
-
-So there are 3 ways to fetch your data from Xata in an Astro app:
-
-1. On-build time, in a prerendered page.
-2. On-demand, in a [server-side rendered (SSR)](/en/guides/server-side-rendering/#enabling-ssr-in-your-project) page.
-3. From the client-side with a Backend-For-Frontend (BFF) in the middle, such as a Serverless Function.
 
 ## Official Resources
 - [Xata Astro Starter](https://github.com/xataio/examples/tree/main/apps/starter-astro)

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -17,40 +17,11 @@ import FileTree from '~/components/FileTree.astro'
 
 - A [Xata](https://app.xata.io/signin) account with a created database. (You can use the sample database from the Web UI.)
 - An Access Token (`XATA_TOKEN_API`).
+- Your Database URL.
 
-### Environment configuration
+The quickest way to get an API token in your `.env` file and the database url ready to sync your project, is to update and initialize the [Xata CLI](https://xata.io/docs/getting-started/installation). 
 
-The quickest way to integrate is via the Xata CLI
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```shell
-  npm install -g @xata.io/cli@latest
-  ```
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```shell
-  pnpm add -g @xata.io/cli@latest
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```shell
-  yarn global install @xata.io/cli@latest
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
-The package will expose the `xata` command to your `$PATH` and now it's possible to initialize the integration:
-
-```shell
-xata init
-```
-
-:::note
-You can just execute the binary with `npx`, `pnpm dlx`, or `yarn dlx` if preferred.
-:::
-
-Once you follow the prompt, you should have a `.env` file in the root of your project with the following variables defined:
+By the end of the setup, you should have:
 
 ```ini title=".env"
 XATA_API_KEY=hash_key
@@ -60,6 +31,16 @@ XATA_API_KEY=hash_key
 # the same name as your git branch
 XATA_FALLBACK_BRANCH=main
 ```
+
+And the `databaseURL` defined:
+
+```ini title=".xatarc
+{
+  "databaseUrl": "https://your-database-url"
+}
+```
+
+### Environment configuration
 
 To have IntelliSense for your environment variables, edit or create the file `env.d.ts` in your `/src` directory to make your environment variables type-safe:
 
@@ -78,20 +59,9 @@ interface ImportMeta {
 Read more about [environment variables](/en/guides/environment-variables/) and `.env` files in Astro.
 :::
 
-And a `.xatarc` file with a `databaseURL`. Though it can be extended to have more definitions, such as the output path for your codegen, e.g.:
+If you used the codegeneration from the Xata CLI, you now have an instance of the SDK (Software Development Kit) generated for you, with types tailored to your database schema - if you chose TypeScript. Notice `@xata.io/client` was added to your `package.json` as well.
 
-```json title=".xatarc"
-{
-  "databaseURL": "https://{{ Xata DB URL }}",
-  "codegen": {
-    "output": "src/xata.codegen.ts"
-  }
-}
-```
-
-Additionally, the prompt may have assisted you in creating an instance of the SDK (Software Development Kit) and, if you chose TypeScript, you also have the types generated from your schema. Notice `@xata.io/client` was added to your `package.json` as well.
-
-Finally, your project should have the following structure:
+Your Xata environment variables and database url are automatically pulled by the SDK instance, so there's no more setup work needed.Finally, your project should have the following structure:
 
 <FileTree title="Project Structure">
 - src/
@@ -125,8 +95,7 @@ const { records } = await xata.db.Posts.getPaginated({
   )}
 </ul>
 ```
-
-Since the SDK is generated dynamically, and will be updated any time you tweak your schema, it's better to leave it untouched. In case you wish to hoist a few common queries to keep your code base DRY, it's a best practice to create an additional file where your queries can be re-used.
+It's important to note the SDK needs to be regenerated everytime your schema changes. So, avoid making changes to the files the Xata CLI creates.
 
 
 ## Official Resources


### PR DESCRIPTION
Hey folks, here I am again 🥳
Trying to fill up that stub for Xata as I promised.

## What kind of changes does this PR include?
-  Updated content

## Description

Adds a quick start guide with Xata.

## Changed route

- [Backend Service Guide: Xata](https://deploy-preview-3207--astro-docs-2.netlify.app/en/guides/backend/xata/)