### PR TITLE
Link Firebase pages to each other

### DIFF
--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -9,7 +9,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'
 
 
-[Firebase](https://firebase.google.com/) is an app development platform that provides a NoSQL database, authentication, realtime subscriptions, functions, and storage.
+[Firebase](https://firebase.google.com/) is an app development platform that provides a NoSQL database, authentication, realtime subscriptions, functions, and storage. See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/google-firebase/).
 
 ## Adding authentication with Firebase
 

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -9,7 +9,9 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'
 
 
-[Firebase](https://firebase.google.com/) is an app development platform that provides a NoSQL database, authentication, realtime subscriptions, functions, and storage. See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/google-firebase/).
+[Firebase](https://firebase.google.com/) is an app development platform that provides a NoSQL database, authentication, realtime subscriptions, functions, and storage. 
+
+See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/google-firebase/).
 
 ## Adding authentication with Firebase
 

--- a/src/content/docs/en/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/en/guides/deploy/google-firebase.mdx
@@ -7,7 +7,7 @@ i18nReady: true
 
 [Firebase Hosting](https://firebase.google.com/products/hosting) is a service provided by Google’s [Firebase](https://firebase.google.com/) app development platform, which can be used to deploy an Astro site. 
 
-See our separate guide for [adding a Firebase backend services](/en/guides/deploy/google-firebase/) such as databases, authentication, and storage.
+See our separate guide for [adding Firebase backend services](/en/guides/deploy/google-firebase/) such as databases, authentication, and storage.
 
 ## How to deploy
 

--- a/src/content/docs/en/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/en/guides/deploy/google-firebase.mdx
@@ -5,7 +5,9 @@ type: deploy
 i18nReady: true
 ---
 
-[Firebase Hosting](https://firebase.google.com/products/hosting) is a service provided by Google’s [Firebase](https://firebase.google.com/) app development platform, which can be used to deploy an Astro site. See our separate guide for [adding a Firebase backend services](/en/guides/deploy/google-firebase/) such as databases, authentication, and storage.
+[Firebase Hosting](https://firebase.google.com/products/hosting) is a service provided by Google’s [Firebase](https://firebase.google.com/) app development platform, which can be used to deploy an Astro site. 
+
+See our separate guide for [adding a Firebase backend services](/en/guides/deploy/google-firebase/) such as databases, authentication, and storage.
 
 ## How to deploy
 

--- a/src/content/docs/en/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/en/guides/deploy/google-firebase.mdx
@@ -5,7 +5,7 @@ type: deploy
 i18nReady: true
 ---
 
-[Firebase Hosting](https://firebase.google.com/products/hosting) is a service provided by Google’s [Firebase](https://firebase.google.com/) app development platform, which can be used to deploy an Astro site.
+[Firebase Hosting](https://firebase.google.com/products/hosting) is a service provided by Google’s [Firebase](https://firebase.google.com/) app development platform, which can be used to deploy an Astro site. See our separate guide for [adding a Firebase backend services](/en/guides/deploy/google-firebase/) such as databases, authentication, and storage.
 
 ## How to deploy
 


### PR DESCRIPTION
We currently have two separate Firebase pages: a Firebase Hosting deployment guide and a Firebase backend services recipe for authentication.

This PR adds a prominent link to the other one on each of the pages.

Out of scope, for future follow up: 
- we can discuss whether one single Firebase page makes more sense, or whether continuing to separate our content by user goal (e.g. Deploy your site, add a backend service) makes more sense.

