### PR TITLE
add recipes as search category

### DIFF
--- a/src/util/getPageCategory.ts
+++ b/src/util/getPageCategory.ts
@@ -5,6 +5,7 @@ const defaultCategory = 'Learn';
 // these paths and will return early when one matches. This means more specific
 // paths need to be earlier in the array, e.g. `reference/errors/` before `reference/`.
 const categories = [
+	['guides/rss/', 'Recipes'],
 	['guides/backend/', 'Recipes'],
 	['guides/cms/', 'Recipes'],
 	['guides/deploy/', 'Recipes'],

--- a/src/util/getPageCategory.ts
+++ b/src/util/getPageCategory.ts
@@ -5,8 +5,13 @@ const defaultCategory = 'Learn';
 // these paths and will return early when one matches. This means more specific
 // paths need to be earlier in the array, e.g. `reference/errors/` before `reference/`.
 const categories = [
-	['guides/deploy/', 'Deploy Guides'],
-	['guides/integrations-guide/', 'Integration Guides'],
+	['guides/backend/', 'Recipes'],
+	['guides/cms/', 'Recipes'],
+	['guides/deploy/', 'Recipes'],
+	['guides/integrations-guide/', 'Recipes'],
+	['guides/migrate-to-astro/', 'Recipes'],
+	['guides/upgrade-to/', 'Upgrade Guides'],
+	['recipes/', 'Recipes'],
 	['reference/errors/', 'Error Reference'],
 	['reference/', 'Reference'],
 	['tutorial/', 'Tutorials'],


### PR DESCRIPTION
Updates our search category definitions:

- All "special" guides, including new ones that never got special categories, as well as individual recipes, are now "Recipes" (instead of Deploy Guide, Integration Guide, e.g.)
- Also categorizes our Upgrade Guides (to v1, v2)

Will need to re-run Algolia to pick up the changes. 

Currently:
("Deploy Guide" too specific, "Learn" too general. Both will now show up under "Recipes")
![firebase](https://github.com/withastro/docs/assets/5098874/ea3ceb1c-9f30-4585-9d52-5819a9732466)
