### PR TITLE
fix: handle inline highlight due to rehype-optimize-static

### DIFF
--- a/src/components/CodeSnippet/shiki-line.ts
+++ b/src/components/CodeSnippet/shiki-line.ts
@@ -1,5 +1,5 @@
 import chroma from 'chroma-js';
-import { escape, unescape } from '~/util/html-entities';
+import { unescape } from '~/util/html-entities';
 import { ensureTextContrast } from './color-contrast';
 import {
 	InlineMarkingDefinition,
@@ -224,15 +224,14 @@ export class ShikiLine {
 
 			// The text position is inside the current token
 			if (textPosition > token.textStart && textPosition < token.textEnd) {
-				// To determine the correct position in tokensHtml based on textPosition,
-				// we need to take position shifts due to HTML entity escaping into account,
-				// so we insert a special character ('\n') at textPosition, escape the string,
-				// and finally determine the new special character position
-				const innerHtmlOffset = escape(
+				// NOTE: We used to escape the string before `indexOf` as rehype would escape HTML entities
+				// at render-time, causing the text position to shift. However, with rehype-optimize-static,
+				// the HTML is preserved as is, so we don't have to anticipate for the shift anymore.
+				const innerHtmlOffset = (
 					token.text.slice(0, textPosition - token.textStart) +
-						// Insert our special character at textPosition
-						'\n' +
-						token.text.slice(textPosition - token.textStart)
+					// Insert our special character at textPosition
+					'\n' +
+					token.text.slice(textPosition - token.textStart)
 				).indexOf('\n');
 
 				return {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Fix #3215
Closes #3217 

Fix shiki inline highlight through `CodeSnippet.astro`. The code before used to anticipate rehype to encode the HTML entities, now with `rehype-optimize-static` it doesn't as it uses `set:html` instead, which skips through rehype rendering, but through Astro instead.

Before
<img width="699" alt="image" src="https://github.com/withastro/docs/assets/34116392/6fc5cac4-80e4-4476-8d0f-c7b1920703d4">


After

<img width="701" alt="image" src="https://github.com/withastro/docs/assets/34116392/80d556c9-7290-4f51-a0bb-ecf19c938012">

NOTE: If one day we remove `rehype-optimize-static`, the highlighting offset problem will return. I can't seem to find a way to fix both at once. For now I added comments, to link the two cases together.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
