### PR TITLE
Add feature directories to project structure guide

### DIFF
--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -118,10 +118,10 @@ This file is generated in every starter template and includes TypeScript configu
 
 See the [TypeScript Guide](/en/guides/typescript/) for details on setting configurations.
 
-### `src/content`
+### `src/content/`
 
-The `src/content` directory powers [Content Collections](/en/guides/content-collections/), so only content collections are allowed inside it.
+The `src/content/` directory is used to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder
 
-### `src/assets`
+### `src/assets/`
 
-The [`src/assets`](/en/guides/assets/) directory is used to store assets that are processed by Astro. While not required, this directory is the [recommended convention](/en/guides/assets/#move-your-images-to-srcassets) and it's recommended to use this directory for your assets.
+The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -128,4 +128,4 @@ The `src/content` directory powers [Content Collections](/en/guides/content-coll
 
 ### `src/assets`
 
-The [`src/assets`](https://docs.astro.build/en/guides/assets/) directory is used to store assets that are processed by Astro and rendered to HTML. While not required, this directory is the [recommended convention](https://docs.astro.build/en/guides/assets/#move-your-images-to-srcassets).
+The [`src/assets`](/en/guides/assets/) directory is used to store assets that are processed by Astro and rendered to HTML. While not required, this directory is the [recommended convention](/en/guides/assets/#move-your-images-to-srcassets).

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -120,7 +120,7 @@ See the [TypeScript Guide](/en/guides/typescript/) for details on setting config
 
 ### `src/content`
 
-The `src/content` directory powers [Content Collections](/en/guides/content-collections/). Only content collections are allowed inside the src/content directory.
+The `src/content` directory powers [Content Collections](/en/guides/content-collections/), so only content collections are allowed inside it.
 
 ### `src/assets`
 

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -118,14 +118,10 @@ This file is generated in every starter template and includes TypeScript configu
 
 See the [TypeScript Guide](/en/guides/typescript/) for details on setting configurations.
 
-## Feature Directories
-
-Astro supports a number of features that are not required for every project. These features utilize reserved directory names. These directories should not be used for anything else.
-
 ### `src/content`
 
 The `src/content` directory powers [Content Collections](/en/guides/content-collections/). Only content collections are allowed inside the src/content directory.
 
 ### `src/assets`
 
-The [`src/assets`](/en/guides/assets/) directory is used to store assets that are processed by Astro and rendered to HTML. While not required, this directory is the [recommended convention](/en/guides/assets/#move-your-images-to-srcassets).
+The [`src/assets`](/en/guides/assets/) directory is used to store assets that are processed by Astro. While not required, this directory is the [recommended convention](/en/guides/assets/#move-your-images-to-srcassets) and it's recommended to use this directory for your assets.

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -62,7 +62,7 @@ Astro processes, optimizes, and bundles your `src/` files to create the final we
 
 Some files (like Astro components) are not even sent to the browser as written but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
 
-### `src/assets/`
+### `src/assets`
 
 The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.
 
@@ -72,7 +72,7 @@ The [`src/assets`](/en/guides/assets/) directory is the recommended folder to us
 
 This is a common convention in Astro projects, but it is not required. Feel free to organize your components however you like!
 
-### `src/content/`
+### `src/content`
 
 The `src/content/` directory is reserved to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder.
 

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -58,6 +58,10 @@ The `src/` folder is where most of your project source code lives. This includes
 - [Styles (CSS, Sass)](/en/guides/styling/)
 - [Markdown](/en/guides/markdown-content/)
 
+### `src/assets/`
+
+The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.
+
 Astro processes, optimizes, and bundles your `src/` files to create the final website that is shipped to the browser.  Unlike the static `public/` directory, your `src/` files are built and handled for you by Astro.
 
 Some files (like Astro components) are not even sent to the browser as written but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
@@ -67,6 +71,10 @@ Some files (like Astro components) are not even sent to the browser as written b
 **Components** are reusable units of code for your HTML pages. These could be [Astro components](/en/core-concepts/astro-components/), or [UI framework components](/en/core-concepts/framework-components/) like React or Vue.  It is common to group and organize all of your project components together in this folder.
 
 This is a common convention in Astro projects, but it is not required. Feel free to organize your components however you like!
+
+### `src/content/`
+
+The `src/content/` directory is used to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder
 
 ### `src/layouts`
 
@@ -117,11 +125,3 @@ See the [Configuring Astro Guide](/en/guides/configuring-astro/) for details on 
 This file is generated in every starter template and includes TypeScript configuration options for your Astro project. Some features (like npm package imports) aren’t fully supported in the editor without a `tsconfig.json` file. 
 
 See the [TypeScript Guide](/en/guides/typescript/) for details on setting configurations.
-
-### `src/content/`
-
-The `src/content/` directory is used to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder
-
-### `src/assets/`
-
-The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -58,13 +58,13 @@ The `src/` folder is where most of your project source code lives. This includes
 - [Styles (CSS, Sass)](/en/guides/styling/)
 - [Markdown](/en/guides/markdown-content/)
 
-### `src/assets/`
-
-The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.
-
 Astro processes, optimizes, and bundles your `src/` files to create the final website that is shipped to the browser.  Unlike the static `public/` directory, your `src/` files are built and handled for you by Astro.
 
 Some files (like Astro components) are not even sent to the browser as written but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
+
+### `src/assets/`
+
+The [`src/assets`](/en/guides/assets/) directory is the recommended folder to use for storing assets (e.g. images) that are processed by Astro. This is not required, and this is not a special reserved folder.
 
 ### `src/components`
 
@@ -74,7 +74,7 @@ This is a common convention in Astro projects, but it is not required. Feel free
 
 ### `src/content/`
 
-The `src/content/` directory is used to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder
+The `src/content/` directory is reserved to store [content collections](/en/guides/content-collections/) and an optional collections configuration file. No other files are allowed inside this folder.
 
 ### `src/layouts`
 

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -117,3 +117,15 @@ See the [Configuring Astro Guide](/en/guides/configuring-astro/) for details on 
 This file is generated in every starter template and includes TypeScript configuration options for your Astro project. Some features (like npm package imports) aren’t fully supported in the editor without a `tsconfig.json` file. 
 
 See the [TypeScript Guide](/en/guides/typescript/) for details on setting configurations.
+
+## Feature Directories
+
+Astro supports a number of features that are not required for every project. These features utilize reserved directory names. These directories should not be used for anything else.
+
+### `src/content`
+
+The `src/content` directory powers [Content Collections](/en/guides/content-collections/). Only content collections are allowed inside the src/content directory.
+
+### `src/assets`
+
+The [`src/assets`](https://docs.astro.build/en/guides/assets/) directory is used to store assets that are processed by Astro and rendered to HTML. While not required, this directory is the [recommended convention](https://docs.astro.build/en/guides/assets/#move-your-images-to-srcassets).


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Closes #2797
- What does this PR change? Adds a section "Feature Directories" to the project structure guide to describe `src/content` & `src/assets`
