### PR TITLE
i18n(zh-cn): Add 5 error translations

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
@@ -1,0 +1,23 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Invalid component arguments.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+<DontEditWarning />
+
+
+> **Example error messages:**<br/>
+InvalidComponentArgs: Invalid arguments passed to `<MyAstroComponent>` component. (E03020)
+
+## What went wrong?
+Astro components cannot be rendered manually via a function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
+
+
+

--- a/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
@@ -1,9 +1,4 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
 title: Invalid component arguments.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
@@ -13,11 +8,8 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **Example error messages:**<br/>
-InvalidComponentArgs: Invalid arguments passed to `<MyAstroComponent>` component. (E03020)
+> **错误信息示例：**<br/>
+InvalidComponentArgs: 向 `<MyAstroComponent>` 组件传递了无效的参数。（E03020）
 
-## What went wrong?
-Astro components cannot be rendered manually via a function call, such as `Component()` or `{items.map(Component)}`. Prefer the component syntax `<Component />` or `{items.map(item => <Component {...item} />)}`.
-
-
-
+## 哪里出了问题？
+Astro 组件不能通过函数调用的方式手动渲染，如 `Component()` 或 `{items.map(Component)}`。请使用组件语法 `<Component />` 或 `{items.map(item => <Component {...item} />)}`。

--- a/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-component-args.mdx
@@ -3,10 +3,6 @@ title: Invalid component arguments.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-import DontEditWarning from '~/components/DontEditWarning.astro'
-
-<DontEditWarning />
-
 
 > **错误信息示例：**<br/>
 InvalidComponentArgs: 向 `<MyAstroComponent>` 组件传递了无效的参数。（E03020）

--- a/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
@@ -1,0 +1,23 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Invalid prerender export.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+<DontEditWarning />
+
+
+> **Example error messages:**<br/>
+InvalidPrerenderExport: A `prerender` export has been detected, but its value cannot be statically analyzed. (E03019)
+
+## What went wrong?
+The `prerender` feature only supports a subset of valid JavaScript — be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
+
+
+

--- a/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
@@ -3,10 +3,6 @@ title: Invalid prerender export.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-import DontEditWarning from '~/components/DontEditWarning.astro'
-
-<DontEditWarning />
-
 
 > **错误信息示例：**<br/>
 InvalidPrerenderExport: 检测到了一个 `prerender` 预渲染导出，但无法对其值进行静态分析。（E03019）

--- a/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-prerender-export.mdx
@@ -1,9 +1,4 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
 title: Invalid prerender export.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
@@ -13,11 +8,8 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **Example error messages:**<br/>
-InvalidPrerenderExport: A `prerender` export has been detected, but its value cannot be statically analyzed. (E03019)
+> **错误信息示例：**<br/>
+InvalidPrerenderExport: 检测到了一个 `prerender` 预渲染导出，但无法对其值进行静态分析。（E03019）
 
-## What went wrong?
-The `prerender` feature only supports a subset of valid JavaScript — be sure to use exactly `export const prerender = true` so that our compiler can detect this directive at build time. Variables, `let`, and `var` declarations are not supported.
-
-
-
+## 哪里出了问题？
+`prerender` 预渲染功能只支持 JavaScript 的部分语法 - 请确保一字不差地使用 `export const prerender = true`，这样我们的编译器在构建时才能识别这个指令。不支持使用变量、`let` 和 `var` 声明。

--- a/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
@@ -1,0 +1,25 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Cannot use Server-side Rendering without an adapter.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+<DontEditWarning />
+
+
+> **NoAdapterInstalled**: Cannot use `output: 'server'` without an adapter. Please install and configure the appropriate server adapter for your final deployment. (E03017)
+
+## What went wrong?
+To use server-side rendering, an adapter needs to be installed so Astro knows how to generate the proper output for your targeted deployment platform.
+
+**See Also:**
+-  [Server-side Rendering](/en/guides/server-side-rendering/)
+-  [Adding an Adapter](/en/guides/server-side-rendering/#adding-an-adapter)
+
+

--- a/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
@@ -8,7 +8,7 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **NoAdapterInstalled**: 在没有适配器的情况下，无法使用 `output: 'server'`。请为你的部署目标安装并配置适当的服务器适配器。 (E03017)
+> **NoAdapterInstalled**: 在没有适配器的情况下，无法使用 `output: 'server'`。请为你的部署目标安装并配置适当的服务器适配器。（E03017）
 
 ## 哪里出了问题？
 要使用服务器端渲染，需要安装适配器，这样 Astro 才能知道如何为你的目标部署平台生成正确的输出。

--- a/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
@@ -1,9 +1,4 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
 title: Cannot use Server-side Rendering without an adapter.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
@@ -13,13 +8,13 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **NoAdapterInstalled**: Cannot use `output: 'server'` without an adapter. Please install and configure the appropriate server adapter for your final deployment. (E03017)
+> **NoAdapterInstalled**: 在没有适配器的情况下，无法使用 `output: 'server'`。请为你的部署目标安装并配置适当的服务器适配器。 (E03017)
 
-## What went wrong?
-To use server-side rendering, an adapter needs to be installed so Astro knows how to generate the proper output for your targeted deployment platform.
+## 哪里出了问题？
+要使用服务器端渲染，需要安装适配器，这样 Astro 才能知道如何为你的目标部署平台生成正确的输出。
 
-**See Also:**
--  [Server-side Rendering](/en/guides/server-side-rendering/)
--  [Adding an Adapter](/en/guides/server-side-rendering/#adding-an-adapter)
+**请参阅：**
+-  [服务端渲染](/zh-cn/guides/server-side-rendering/)
+-  [添加适配器](/zh-cn/guides/server-side-rendering/#添加一个适配器)
 
 

--- a/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-adapter-installed.mdx
@@ -3,10 +3,6 @@ title: Cannot use Server-side Rendering without an adapter.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-import DontEditWarning from '~/components/DontEditWarning.astro'
-
-<DontEditWarning />
-
 
 > **NoAdapterInstalled**: 在没有适配器的情况下，无法使用 `output: 'server'`。请为你的部署目标安装并配置适当的服务器适配器。（E03017）
 

--- a/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
@@ -1,0 +1,22 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: No import found for component.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+<DontEditWarning />
+
+
+> **NoMatchingImport**: Could not render `COMPONENT_NAME`. No matching import has been found for `COMPONENT_NAME`. (E03018)
+
+## What went wrong?
+No import statement was found for one of the components. If there is an import statement, make sure you are using the same identifier in both the imports and the component usage.
+
+
+

--- a/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
@@ -1,9 +1,4 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
 title: No import found for component.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
@@ -13,10 +8,10 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **NoMatchingImport**: Could not render `COMPONENT_NAME`. No matching import has been found for `COMPONENT_NAME`. (E03018)
+> **NoMatchingImport**: 无法渲染 `COMPONENT_NAME` 组件。找不到与 `COMPONENT_NAME` 组件匹配的导入。（E03018）
 
-## What went wrong?
-No import statement was found for one of the components. If there is an import statement, make sure you are using the same identifier in both the imports and the component usage.
+## 哪里出了问题？
+找不到某个组件的导入语句。如果你已经导入了这个组件，请确保你在导入语句和使用组件的地方使用的标识符是一致的。
 
 
 

--- a/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
+++ b/src/content/docs/zh-cn/reference/errors/no-matching-import.mdx
@@ -3,10 +3,6 @@ title: No import found for component.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-import DontEditWarning from '~/components/DontEditWarning.astro'
-
-<DontEditWarning />
-
 
 > **NoMatchingImport**: 无法渲染 `COMPONENT_NAME` 组件。找不到与 `COMPONENT_NAME` 组件匹配的导入。（E03018）
 

--- a/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
+++ b/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
@@ -1,0 +1,24 @@
+---
+# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
+# Do not make edits to it directly, they will be overwritten.
+# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+# Translators, please remove this note and the <DontEditWarning/> component.
+
+title: Invalid slot name.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+<DontEditWarning />
+
+
+> **ReservedSlotName**: Unable to create a slot named `SLOT_NAME`. `SLOT_NAME` is a reserved slot name. Please update the name of this slot. (E03016)
+
+## What went wrong?
+Certain words cannot be used for slot names due to being already used internally.
+
+**See Also:**
+-  [Named slots](/en/core-concepts/astro-components/#named-slots)
+
+

--- a/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
+++ b/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
@@ -3,10 +3,6 @@ title: Invalid slot name.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-import DontEditWarning from '~/components/DontEditWarning.astro'
-
-<DontEditWarning />
-
 
 > **ReservedSlotName**: 无法创建名为 `SLOT_NAME` 的插槽。 `SLOT_NAME` 是保留的插槽名称。请更改此插槽的名称。（E03016）
 

--- a/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
+++ b/src/content/docs/zh-cn/reference/errors/reserved-slot-name.mdx
@@ -1,9 +1,4 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
 title: Invalid slot name.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
@@ -13,12 +8,12 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **ReservedSlotName**: Unable to create a slot named `SLOT_NAME`. `SLOT_NAME` is a reserved slot name. Please update the name of this slot. (E03016)
+> **ReservedSlotName**: 无法创建名为 `SLOT_NAME` 的插槽。 `SLOT_NAME` 是保留的插槽名称。请更改此插槽的名称。（E03016）
 
-## What went wrong?
-Certain words cannot be used for slot names due to being already used internally.
+## 哪里出了问题？
+某些词语由于已经被内部占用，因此不能作为插槽名称使用。
 
-**See Also:**
--  [Named slots](/en/core-concepts/astro-components/#named-slots)
+**请参阅：**
+-  [命名插槽](/zh-cn/core-concepts/astro-components/#命名插槽)
 
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content


#### Description

Added 5 Astro error translations:
`reserved-slot-name.mdx` (E03016)
`no-adapter-installed.mdx`(E03017)
`no-matching-import.mdx`(E03018)
`invalid-prerender-export.mdx`(E03019)
`invalid-component-args.mdx`(E03020)


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
