### PR TITLE
change where required response is mentioned

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -138,7 +138,7 @@ validation response
 
 ### `onRequest()`
 
-A required exported function from `src/middleware.js` that will be called before rendering every page or API route. It accepts two optional arguments: [context](#context) and [next()](#next)
+A required exported function from `src/middleware.js` that will be called before rendering every page or API route. It accepts two optional arguments: [context](#context) and [next()](#next). `onRequest()` must return a `Response`: either directly, or by calling `next()`.
 
 ### `context`
 
@@ -152,7 +152,7 @@ This is the same `context` object that is passed to API routes.
 
 A function that intercepts (reads and modifies) the `Response` of a `Request` or calls the "next" middleware in the chain and returns a `Response`. For example, this function could modify the HTML body of a response.
 
-This is an optional argument of `onRequest()`; however, your middleware **must** return a `Response`, either the one returned by `next()` or creating a new one.
+This is an optional argument of `onRequest()`, and may provide the required `Response` returned by the middleware.
 
 
 ### `locals`


### PR DESCRIPTION
@ematipico I think it's now easier to say right when we define `onRequest()` that a response is required, and perhaps it fits better up there because it is required. 

What do you think about a change in where the information goes like this?