### PR TITLE
Clarify "Content Focused" in Why Astro

### DIFF
--- a/src/content/docs/en/concepts/why-astro.mdx
+++ b/src/content/docs/en/concepts/why-astro.mdx
@@ -18,7 +18,7 @@ Why choose Astro over another web framework? Here are five core design principle
 
 ## Content-focused
 
-**Astro was designed for building content-rich websites.** This includes most marketing sites, publishing sites, documentation sites, blogs, portfolios, and some ecommerce sites.
+**Astro was designed for building content-rich websites.** This includes most marketing sites, publishing sites, documentation sites, blogs, portfolios, and some ecommerce sites. Astro sites can have interactivity, but Astro was not designed to share client-side state across routes. For example, you can create a cool interactive menu on one page, but when the user switches pages, you can not keep the menu open when the new page loads.
 
 By contrast, most modern web frameworks are designed for building *web applications*. These frameworks work best for building more complex, application-like experiences in the browser: logged-in admin dashboards, inboxes, social networks, todo lists, and even native-like applications like [Figma](https://figma.com/) and [Ping](https://ping.gg/).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #2959  <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description. I (hopefully) helped clarify the meaning of "content-focused" in the Why Astro page.

Before:

Astro was designed for building content-rich websites. This includes most marketing sites, publishing sites, documentation sites, blogs, portfolios, and some ecommerce sites.

After:

Astro was designed for building content-rich websites. This includes most marketing sites, publishing sites, documentation sites, blogs, portfolios, and some ecommerce sites. Astro sites can have interactivity, but Astro was not designed to share client-side state across routes. For example, you can create a cool interactive menu on one page, but when the user switches pages, you can not keep the menu open when the new page loads.


<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
