### PR TITLE
Update: `astro-syntax.mdx`

### DIFF
--- a/src/content/docs/en/core-concepts/astro-syntax.mdx
+++ b/src/content/docs/en/core-concepts/astro-syntax.mdx
@@ -122,49 +122,11 @@ When using dynamic tags:
 
 - **Hydration directives are not supported.** When using [`client:*` hydration directives](/en/core-concepts/framework-components/#hydrating-interactive-components), Astro needs to know which components to bundle for production, and the dynamic tag pattern prevents this from working.
 
-### Fragments & Multiple Elements
+### Fragments
 
-An Astro component template can render multiple elements with no need to wrap everything in a single `<div>` or `<>`, unlike JavaScript or JSX.
+Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
 
-```astro title="src/components/RootElements.astro"
----
-// Template with multiple elements
----
-<p>No need to wrap elements in a single containing element.</p>
-<p>Astro supports multiple root elements in a template.</p>
-```
-
-However, you can use fragments if you wish to do it. Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
-
-Here you have some examples where fragments can be useful:
-
-Fragments can be handy when fetching HTML from a CMS(e.g. Ghost or WordPress).
-
-```astro title="/src/pages/index.astro"
----
-import Layout from "../layouts/Layout.astro"
-
-let res = await fetch("https://norian.studio/wp-json/wp/v2/dinos")
-let posts = await res.json();
----
-<Layout title="Dinos!">
-  <section>
-    <h1>List of Dinosaurs</h1>
-    {
-      posts.map((post) => (
-        <article>
-          <h2>
-            <a href={`/dinos/${post.slug}/`} set:html={post.title.rendered} />
-          </h2>
-          <Fragment set:html={post.content.rendered} />
-        </article>
-      ))
-    }
-  </section>
-</Layout>
-```
-
-Fragments can also be useful to avoid wrapper elements when adding [`set:*` directives](/en/reference/directives-reference/#sethtml), as in the following example:
+Fragments can be useful to avoid wrapper elements when adding [`set:*` directives](/en/reference/directives-reference/#sethtml), as in the following example:
 
 ```astro title="src/components/SetHtml.astro" "Fragment"
 ---
@@ -184,6 +146,18 @@ In Astro, you use the standard `kebab-case` format for all HTML attributes inste
 ```jsx del={1} ins={2} title="example.astro"
 <div className="box" dataValue="3" />
 <div class="box" data-value="3" />
+```
+
+#### Multiple Elements
+
+An Astro component template can render multiple elements with no need to wrap everything in a single `<div>` or `<>`, unlike JavaScript or JSX.
+
+```astro title="src/components/RootElements.astro"
+---
+// Template with multiple elements
+---
+<p>No need to wrap elements in a single containing element.</p>
+<p>Astro supports multiple root elements in a template.</p>
 ```
 
 #### Comments

--- a/src/content/docs/en/core-concepts/astro-syntax.mdx
+++ b/src/content/docs/en/core-concepts/astro-syntax.mdx
@@ -134,7 +134,35 @@ An Astro component template can render multiple elements with no need to wrap ev
 <p>Astro supports multiple root elements in a template.</p>
 ```
 
-Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
+However, you can use fragments if you wish to do it. Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
+
+Here you have some examples where fragments can be useful:
+
+Fragments can be handy when fetching HTML from a CMS(e.g. Ghost or WordPress).
+
+```astro title="/src/pages/index.astro"
+---
+import Layout from "../layouts/Layout.astro"
+
+let res = await fetch("https://norian.studio/wp-json/wp/v2/dinos")
+let posts = await res.json();
+---
+<Layout title="Dinos!">
+  <section>
+    <h1>List of Dinosaurs</h1>
+    {
+      posts.map((post) => (
+        <article>
+          <h2>
+            <a href={`/dinos/${post.slug}/`} set:html={post.title.rendered} />
+          </h2>
+          <Fragment set:html={post.content.rendered} />
+        </article>
+      ))
+    }
+  </section>
+</Layout>
+```
 
 Fragments can also be useful to avoid wrapper elements when adding [`set:*` directives](/en/reference/directives-reference/#sethtml), as in the following example:
 

--- a/src/content/docs/en/core-concepts/astro-syntax.mdx
+++ b/src/content/docs/en/core-concepts/astro-syntax.mdx
@@ -134,22 +134,7 @@ An Astro component template can render multiple elements with no need to wrap ev
 <p>Astro supports multiple root elements in a template.</p>
 ```
 
-However, when using an expression to dynamically create multiple elements, you should wrap these elements inside a **fragment** as you would in JavaScript or JSX. Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
-
-```astro title="src/components/FragmentWrapper.astro" "<>" "</>"
----
-const items = ["Dog", "Cat", "Platypus"];
----
-<ul>
-  {items.map((item) => (
-    <>
-      <li>Red {item}</li>
-      <li>Blue {item}</li>
-      <li>Green {item}</li>
-    </>
-  ))}
-</ul>
-```
+Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
 
 Fragments can also be useful to avoid wrapper elements when adding [`set:*` directives](/en/reference/directives-reference/#sethtml), as in the following example:
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

- Closes https://github.com/withastro/docs/issues/3269
- What does this PR change? Give us a brief description.
Removed the example where you should wrap elements inside in a fragment in order to avoid errors with the old compiler, there's no need to use fragments to use JSX expressions.
