### PR TITLE
fix: removes wrong inline style info

### DIFF
--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -252,7 +252,7 @@ const message = "Astro is awesome!";
 ```
 
 :::caution
-Using `define:vars` on a `<script>` or `<style>` tag implies the [`is:inline` directive](#isinline), which means your scripts or styles won't be bundled and will be inlined directly into the HTML. 
+Using `define:vars` on a `<script>` tag implies the [`is:inline` directive](#isinline), which means your scripts won't be bundled and will be inlined directly into the HTML. 
 
 This is because when Astro bundles a script, it includes and runs the script once even if you include the component containing the script multiple times on one page. `define:vars` requires a script to rerun with each set of values, so Astro creates an inline script instead.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

- Closes #3165
- What does this PR change? Give us a brief description.

> Using define:vars in a <style> within a component markup still bundles the component styles, i.e., contrary to what's documented. Please refer to the #3165 for more details.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
