### PR TITLE
Fix bug in how recipe links handles fallback slugs

### DIFF
--- a/src/components/RecipeLinks.astro
+++ b/src/components/RecipeLinks.astro
@@ -21,7 +21,7 @@ const recipes = Astro.props.slugs.map((slug) => {
 	if (!entry) {
 		throw new Error(`Could not find entry for slug "${slug}"`);
 	}
-	return { entry, isFallback };
+	return { slug, isFallback, title: entry.data.title };
 });
 
 const isList = recipes.length > 1;
@@ -38,8 +38,8 @@ if (!firstRecipe) {
 		<strong><UIString key={labelKey} /></strong>
 		{
 			!isList && (
-				<a href={`/${firstRecipe.entry.slug}/`}>
-					{firstRecipe.entry.data.title} {firstRecipe.isFallback && '(EN)'}
+				<a href={`/${firstRecipe.slug}/`}>
+					{firstRecipe.title} {firstRecipe.isFallback && '(EN)'}
 				</a>
 			)
 		}
@@ -49,8 +49,8 @@ if (!firstRecipe) {
 			<ul>
 				{recipes.map((recipe) => (
 					<li>
-						<a href={`/${recipe.entry.slug}/`}>
-							{recipe.entry.data.title} {recipe.isFallback && '(EN)'}
+						<a href={`/${recipe.slug}/`}>
+							{recipe.title} {recipe.isFallback && '(EN)'}
 						</a>
 					</li>
 				))}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Uses the page’s language in links generated by the `<RecipeLinks>` component, even if the link is to fallback content. (Currently it uses the `/en/` on non-English pages, breaking our link checks.)
- Unblocks #3214 <!-- Add an issue number if this PR will close it. -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
