### PR TITLE
Moving off of custom domains for Fathom analytics

### DIFF
--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -57,4 +57,4 @@ import '@fontsource/ibm-plex-mono/400-italic.css';
 	});
 </script>
 <!-- Fathom - beautiful, simple website analytics -->
-<script src="https://certain-quality.astro.build/script.js" data-site="EZBHTSIG" defer></script>
+<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Updates how the Fathom Analytics script is loaded.

**Why?** Fathom recently ran into an issue with some events being lost when the script is loaded via a custom subdomain.  The bug is specifically related to SSL certificates sometimes not auto-renewing on time, ours hasn't been impacted yet so we shouldn't have lost any analytics data to date. 

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
