### PR TITLE
content collections `type` only v2.5.0+

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -141,7 +141,7 @@ Schemas also power Astro's automatic TypeScript typings for your content. When y
 To define your first collection, create a `src/content/config.ts` file if one does not already exist (`.js` and `.mjs` extensions are also supported.) This file should:
 
 1. **Import the proper utilities** from `astro:content`. 
-2. **Define each collection that you'd like to validate.** This includes a `type` specifying whether the collection contains content authoring formats like Markdown (`type: 'content'`) or data formats like JSON or YAML (`type: 'data'`). It also includes a `schema` that defines the shape of your frontmatter or entry data.
+2. **Define each collection that you'd like to validate.** This includes a `type` (introduced in Astro v2.5.0) specifying whether the collection contains content authoring formats like Markdown (`type: 'content'`) or data formats like JSON or YAML (`type: 'data'`). It also includes a `schema` that defines the shape of your frontmatter or entry data.
 3. **Export a single `collections` object** to register your collections.
 
 ```ts
@@ -151,7 +151,7 @@ import { z, defineCollection } from 'astro:content';
 
 // 2. Define a `type` and `schema` for each collection
 const blogCollection = defineCollection({
-  type: 'content',
+  type: 'content', // v2.5.0 and later
   schema: z.object({
     title: z.string(),
     tags: z.array(z.string()),


### PR DESCRIPTION
Someone was getting an error setting up their content collections with `type: content` because they hadn't yet upgraded to 2.5.0.

This quick change explicitly says that the `type` property was added in 2.5.0. We shouldn't need this for very long, and we can figure out a better way to handle changes like this. But there will still be some people on other pre 2.5 versions of Astro who may run into this issue if they just try setting up content collections from scratch with our existing docs, not realizing this isn't just how it always was.