### PR TITLE
docs: direct users to payloads install instead of home page

### DIFF
--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -16,7 +16,7 @@ i18nReady: false
 
 1. **An Astro project** - If you don't have an Astro project yet, our [Installation guide](/en/install/auto/) will get you up and running in no time.
 2. **A MongoDB database** - PayloadCMS will ask you for a MongoDB connection string when creating a new project. You can set one up locally or use [MongoDBAtlas](https://www.mongodb.com/) to host a database on the web for free.
-3. **A PayloadCMS REST API** - Create a [PayloadCMS](https://payloadcms.com/) project and connect it to your MongoDB database during the setup.
+3. **A PayloadCMS REST API** - Create a [PayloadCMS](https://payloadcms.com/docs/getting-started/installation) project and connect it to your MongoDB database during the setup.
 
 :::note[Choosing a template]
 During the PayloadCMS installation, you will be asked if you want to use a template.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Directs users to payloads installation guide when mentioned in step 3 on [this page](https://docs.astro.build/en/guides/cms/payload/#prerequisites).
