### PR TITLE
Removed link to missing 404 page

### DIFF
--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -49,7 +49,7 @@ This example will demonstrate adding a custom font using the font file `DistantG
 
 The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts and other open-source fonts. It provides npm modules you can install for the fonts you want to use.
 
-1. Find the font you want to use in [Fontsource's catalog](https://fontsource.org/fonts). This example will use [Twinkle Star](https://fontsource.org/fonts/twinkle-star).
+1. Find the font you want to use in [Fontsource's catalog](https://fontsource.org/). This example will use [Twinkle Star](https://fontsource.org/fonts/twinkle-star).
 1. Install the package for your chosen font.
 
     <PackageManagerTabs>


### PR DESCRIPTION
The link titled ‘Fonts catalogue’ points to a 404 page: https://fontsource.org/fonts 

I have edited it to point to the main page which still has the catalogue search filter.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->
Fixed broken link
- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
