### PR TITLE
Fix typo in `src/content/docs/en/tutorial/5-astro-api/2.mdx`

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -239,7 +239,7 @@ To check your work, or if you just want complete, correct code to copy into `[ta
 ```astro title="src/pages/tags/[tag].astro"
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import BlogPost from '../../components/BlogPost.astro'
+import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
   const allPosts = await Astro.glob('../posts/*.md');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

There was a missing semi column when importing `BlogPost` in the final code sample.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
