### PR TITLE
i18n(fr): create error code references part 1

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -1,10 +1,5 @@
 ---
-# NOTE: This file is auto-generated from 'scripts/error-docgen.mjs'
-# Do not make edits to it directly, they will be overwritten.
-# Instead, change this file: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
-# Translators, please remove this note and the <DontEditWarning/> component.
-
-title:  Référence des erreurs
+title: Référence des erreurs
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
@@ -35,6 +30,21 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**InvalidPrerenderExport**](/fr/reference/errors/invalid-prerender-export/) (E03019)<br/>Invalid prerender export.
 - [**InvalidComponentArgs**](/fr/reference/errors/invalid-component-args/) (E03020)<br/>Invalid component arguments.
 - [**PageNumberParamNotFound**](/fr/reference/errors/page-number-param-not-found/) (E03021)<br/>Page number param not found.
+- [**ImageMissingAlt**](/fr/reference/errors/image-missing-alt/) (E03022)<br/>Missing alt property.
+- [**InvalidImageService**](/fr/reference/errors/invalid-image-service/) (E03023)<br/>Error while loading image service.
+- [**MissingImageDimension**](/fr/reference/errors/missing-image-dimension/) (E03024)<br/>Missing image dimensions
+- [**UnsupportedImageFormat**](/fr/reference/errors/unsupported-image-format/) (E03025)<br/>Unsupported image format
+- [**PrerenderDynamicEndpointPathCollide**](/fr/reference/errors/prerender-dynamic-endpoint-path-collide/) (E03026)<br/>Prerendered dynamic endpoint has path collision.
+- [**ExpectedImage**](/fr/reference/errors/expected-image/) (E03027)<br/>Expected src to be an image.
+- [**ExpectedImageOptions**](/fr/reference/errors/expected-image-options/) (E03028)<br/>Expected image options.
+- [**MarkdownImageNotFound**](/fr/reference/errors/markdown-image-not-found/) (E03029)<br/>Image not found.
+- [**ResponseSentError**](/fr/reference/errors/response-sent-error/) (E03030)<br/>Unable to set response.
+- [**MiddlewareNoDataOrNextCalled**](/fr/reference/errors/middleware-no-data-or-next-called/) (E03031)<br/>The middleware didn't return a response or call `next`.
+- [**MiddlewareNotAResponse**](/fr/reference/errors/middleware-not-aresponse/) (E03032)<br/>The middleware returned something that is not a `Response` object.
+- [**LocalsNotAnObject**](/fr/reference/errors/locals-not-an-object/) (E03033)<br/>Value assigned to `locals` is not accepted.
+- [**LocalImageUsedWrongly**](/fr/reference/errors/local-image-used-wrongly/) (E03034)<br/>ESM imported images must be passed as-is.
+- [**AstroGlobUsedOutside**](/fr/reference/errors/astro-glob-used-outside/) (E03035)<br/>Astro.glob() used outside of an Astro file.
+- [**AstroGlobNoMatch**](/fr/reference/errors/astro-glob-no-match/) (E03036)<br/>Astro.glob() did not match any files.
 - [**UnknownViteError**](/fr/reference/errors/unknown-vite-error/) (E04000)<br/>Unknown Vite Error.
 - [**FailedToLoadModuleSSR**](/fr/reference/errors/failed-to-load-module-ssr/) (E04001)<br/>Could not import file.
 - [**InvalidGlob**](/fr/reference/errors/invalid-glob/) (E04002)<br/>Invalid glob pattern.
@@ -61,3 +71,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**InvalidContentEntryFrontmatterError**](/fr/reference/errors/invalid-content-entry-frontmatter-error/) (E09001)<br/>Content entry frontmatter does not match schema.
 - [**InvalidContentEntrySlugError**](/fr/reference/errors/invalid-content-entry-slug-error/) (E09002)<br/>Invalid content entry slug.
 - [**ContentSchemaContainsSlugError**](/fr/reference/errors/content-schema-contains-slug-error/) (E09003)<br/>Content Schema should not contain `slug`.
+- [**CollectionDoesNotExistError**](/fr/reference/errors/collection-does-not-exist-error/) (E09004)<br/>Collection does not exist
+- [**MixedContentDataCollectionError**](/fr/reference/errors/mixed-content-data-collection-error/) (E09005)<br/>Content and data cannot be in same collection.
+- [**ContentCollectionTypeMismatchError**](/fr/reference/errors/content-collection-type-mismatch-error/) (E09006)<br/>Collection contains entries of a different type.
+- [**DataCollectionEntryParseError**](/fr/reference/errors/data-collection-entry-parse-error/) (E09007)<br/>Data collection entry failed to parse.

--- a/src/content/docs/fr/reference/errors/collection-does-not-exist-error.mdx
+++ b/src/content/docs/fr/reference/errors/collection-does-not-exist-error.mdx
@@ -1,0 +1,10 @@
+---
+title: Collection does not exist
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Aucune collection n'a été trouvée lors de l'appel à `getCollection()`. (E09004)
+
+## Qu'est-ce qui a mal tourné ?
+Lorsque vous effectuez une requête à une collection, assurez-vous qu'un répertoire de collection portant le nom demandé existe dans `src/content/`.

--- a/src/content/docs/fr/reference/errors/content-collection-type-mismatch-error.mdx
+++ b/src/content/docs/fr/reference/errors/content-collection-type-mismatch-error.mdx
@@ -1,0 +1,13 @@
+---
+title: Collection contains entries of a different type.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` contient des entrées de type `ACTUAL_TYPE`, mais est configurée comme une collection de type `EXPECTED_TYPE`. (E09006)
+
+## Qu'est-ce qui a mal tourné ?
+Les collections de contenu doivent contenir des entrées du type configuré. Par défaut, les collections ont `type: 'content'`. Essayez d'ajouter `type: 'data'` à la configuration de votre collection pour les collections de données.
+
+**Voir aussi:**
+- [Définition des collections de contenu](/fr/guides/content-collections/#defining-collections)

--- a/src/content/docs/fr/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/content/docs/fr/reference/errors/content-schema-contains-slug-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Content Schema should not contain slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ContentSchemaContainsSlugError**: Un schéma de collection de contenu ne doit pas contenir `slug` puisqu'il est réservé à la génération de slug. Supprimez ceci de votre schéma de collection COLLECTION_NAME. (E09003)
+
+## Qu'est-ce qui a mal tourné ?
+Un schéma de collection ne doit pas contenir le champ `slug`. Ce champ est réservé par Astro pour la génération d'entrées. Supprimez le champ `slug` de votre schéma, ou choisissez un nom différent.
+
+**Voir aussi :**
+-  [Le champ slug d'entrée réservé](/fr/guides/content-collections/)
+
+

--- a/src/content/docs/fr/reference/errors/csssyntax-error.mdx
+++ b/src/content/docs/fr/reference/errors/csssyntax-error.mdx
@@ -1,0 +1,13 @@
+---
+title: CSS Syntax Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Exemples de messages d'erreur :**<br/>
+CSSSyntaxError: Point-virgule manquant<br/>
+CSSSyntaxError: String non fermée<br/> (E05001)
+
+## Qu'est-ce qui a mal tourné ?
+
+Astro a rencontré une erreur lors de l'analyse du CSS en raison d'une erreur de syntaxe. Cela est souvent causé par l'absence d'un point-virgule.

--- a/src/content/docs/fr/reference/errors/data-collection-entry-parse-error.mdx
+++ b/src/content/docs/fr/reference/errors/data-collection-entry-parse-error.mdx
@@ -1,0 +1,10 @@
+---
+title: Data collection entry failed to parse.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Impossible d'analyser `COLLECTION_ENTRY_NAME`. (E09007)
+
+## Qu'est-ce qui a mal tourné ?
+Les entrées de collection avec `type: 'data'` doivent renvoyer un objet au format JSON valide (pour les entrées `.json`) ou YAML (pour les entrées `.yaml`).

--- a/src/content/docs/fr/reference/errors/generate-content-types-error.mdx
+++ b/src/content/docs/fr/reference/errors/generate-content-types-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Failed to generate content types.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GenerateContentTypesError**: La commande `astro sync` n'a pas pu générer les types de collection de contenu: ERROR_MESSAGE (E08001)
+
+## Qu'est-ce qui a mal tourné ?
+
+La commande `astro sync` n'a pas pu générer les types de collection de contenu.
+
+**Voir aussi :**
+
+-  [La documentation sur les collections de contenu](/fr/guides/content-collections/)

--- a/src/content/docs/fr/reference/errors/invalid-content-entry-frontmatter-error.mdx
+++ b/src/content/docs/fr/reference/errors/invalid-content-entry-frontmatter-error.mdx
@@ -1,0 +1,16 @@
+---
+title: Content entry frontmatter does not match schema.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Exemple de message d'erreur :**<br/>
+**blog** → le frontmatter de **post.md** ne correspond pas au schéma de la collection.<br/>
+"titre" est requis.<br/>
+"date" doit être une date valide. (E09001)
+
+## Qu'est-ce qui a mal tourné ?
+Une entrée Markdown ou MDX dans `src/content/` ne correspond pas au schéma de sa collection.
+Vérifiez que tous les champs requis sont présents et que tous les champs sont du bon type.
+Vous pouvez vérifier par rapport au schéma de collection dans votre fichier `src/content/config.*`.
+Voir la [documentation des collections de contenu](/fr/guides/content-collections/#defining-a-collection-schema) pour plus d'informations.

--- a/src/content/docs/fr/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/content/docs/fr/reference/errors/invalid-content-entry-slug-error.mdx
@@ -1,0 +1,16 @@
+---
+title: Invalid content entry slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+
+> `COLLECTION_NAME` → `ENTRY_ID` a un slug invalide. `slug` doit être un string. (E09002)
+
+## Qu'est-ce qui a mal tourné ?
+Une entrée dans src/content/ a un slug invalide. Ce champ est réservé pour générer des slugs d'entrée, et doit être un string lorsqu'il est présent.
+
+**Voir aussi :**
+-  [Le champ slug d'entrée réservé](/en/guides/content-collections/)
+
+

--- a/src/content/docs/fr/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/content/docs/fr/reference/errors/invalid-content-entry-slug-error.mdx
@@ -11,6 +11,6 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 Une entrée dans src/content/ a un slug invalide. Ce champ est réservé pour générer des slugs d'entrée, et doit être un string lorsqu'il est présent.
 
 **Voir aussi :**
--  [Le champ slug d'entrée réservé](/en/guides/content-collections/)
+- [Le champ slug d'entrée réservé](/fr/guides/content-collections/)
 
 

--- a/src/content/docs/fr/reference/errors/mixed-content-data-collection-error.mdx
+++ b/src/content/docs/fr/reference/errors/mixed-content-data-collection-error.mdx
@@ -1,0 +1,13 @@
+---
+title: Content and data cannot be in same collection.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` contient une combinaison d'entrées de contenu et de données. Toutes les entrées doivent être du même type. (E09005)
+
+## Qu'est-ce qui a mal tourné ?
+Une collection de contenu ne peut pas contenir une combinaison d'entrées de contenu et de données. Vous devez stocker les entrées dans des collections séparées en fonction de leur type.
+
+**Voir aussi:**
+- [Définition des collections de contenu](/fr/guides/content-collections/#defining-collections)

--- a/src/content/docs/fr/reference/errors/unknown-clierror.mdx
+++ b/src/content/docs/fr/reference/errors/unknown-clierror.mdx
@@ -1,0 +1,10 @@
+---
+title: Unknown CLI Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## Qu'est-ce qui a mal tourné ?
+Astro a rencontré une erreur inconnue lors du démarrage d'une de vos commandes CLI. Le message d'erreur devrait contenir plus d'informations.
+
+Si vous parvenez à reproduire cette erreur de manière fiable, nous vous serions reconnaissants si vous pouviez [créer une Issue GitHub](https://astro.build/issues/).

--- a/src/content/docs/fr/reference/errors/unknown-content-collection-error.mdx
+++ b/src/content/docs/fr/reference/errors/unknown-content-collection-error.mdx
@@ -1,0 +1,11 @@
+---
+title: Unknown Content Collection Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## Qu'est-ce qui a mal tourné ?
+Astro a rencontré une erreur inconnue lors du chargement de vos collections de contenu.
+Cela peut être causé par certaines erreurs dans votre fichier `src/content/config.ts` ou par certaines erreurs internes.
+
+Si vous parvenez à reproduire cette erreur de manière fiable, nous vous serions reconnaissants si vous pouviez [créer une Issue GitHub](https://astro.build/issues/).

--- a/src/content/docs/fr/reference/errors/unknown-csserror.mdx
+++ b/src/content/docs/fr/reference/errors/unknown-csserror.mdx
@@ -1,0 +1,12 @@
+---
+title: Unknown CSS Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## Qu'est-ce qui a mal tourné ?
+
+Astro a rencontré une erreur inconnue lors de l'analyse du CSS. Cela est souvent dû à une erreur de syntaxe et le message d'erreur devrait contenir plus d'informations.
+
+**Voir aussi :**
+-  [Styles et CSS](/fr/guides/styling/)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description


- Updated main `error-reference.mdx` page to have new error links
- Translated:
  - content collection errors
  - cli errors
  - css errors

To do:
- Astro errors
- Markdown errors: #3387 
