### PR TITLE
i18n(fr): create error code references part 2

### DIFF
--- a/src/content/docs/fr/reference/errors/config-legacy-key.mdx
+++ b/src/content/docs/fr/reference/errors/config-legacy-key.mdx
@@ -1,0 +1,15 @@
+---
+title: Legacy configuration detected
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ConfigLegacyKey** : Configuration héritée détectée : `LEGACY_CONFIG_KEY`. (E07002)
+
+## Qu'est-ce qui a mal tourné ?
+
+Astro a détecté une option héritée de configuration dans votre fichier de configuration.
+
+**Voir aussi :**
+
+-  [Référence de configuration](/fr/reference/configuration-reference#options-h%C3%A9rit%C3%A9es)

--- a/src/content/docs/fr/reference/errors/config-legacy-key.mdx
+++ b/src/content/docs/fr/reference/errors/config-legacy-key.mdx
@@ -12,4 +12,4 @@ Astro a détecté une option héritée de configuration dans votre fichier de co
 
 **Voir aussi :**
 
--  [Référence de configuration](/fr/reference/configuration-reference#options-h%C3%A9rit%C3%A9es)
+- [Référence de configuration](/fr/reference/configuration-reference/#options-héritées)

--- a/src/content/docs/fr/reference/errors/config-not-found.mdx
+++ b/src/content/docs/fr/reference/errors/config-not-found.mdx
@@ -1,0 +1,16 @@
+---
+title: Specified configuration file not found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ConfigNotFound** : Impossible de résoudre `--config "CONFIG_FILE"`. Ce fichier existe-t-il ? (E07001)
+
+## Qu'est-ce qui a mal tourné ?
+
+Le fichier de configuration spécifié avec `--config` n'a pas pu être trouvé. Assurez-vous qu'il existe ou que le chemin est correct.
+
+**Voir aussi :**
+
+-  [--config](/fr/reference/cli-reference/#--config-chemin)
+

--- a/src/content/docs/fr/reference/errors/invalid-frontmatter-injection-error.mdx
+++ b/src/content/docs/fr/reference/errors/invalid-frontmatter-injection-error.mdx
@@ -12,4 +12,4 @@ Un plugin remark ou rehype a tenté d'injecter du frontmatter invalide. Cela se 
 
 **Voir aussi :**
 
--  [Modifier le frontmatter par un programme](/fr/guides/markdown-content#modifier-le-frontmatter-par-un-programme)
+- [Modifier le frontmatter par un programme](/fr/guides/markdown-content/#modifier-le-frontmatter-par-un-programme)

--- a/src/content/docs/fr/reference/errors/invalid-frontmatter-injection-error.mdx
+++ b/src/content/docs/fr/reference/errors/invalid-frontmatter-injection-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Invalid frontmatter injection.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidFrontmatterInjectionError** : Un plugin remark ou rehype a tenté d'injecter du frontmatter invalide. Assurez-vous que "astro.frontmatter" est configuré comme un objet JSON valide qui n'est pas `null` ou `undefined`. (E06003)
+
+## Qu'est-ce qui a mal tourné ?
+
+Un plugin remark ou rehype a tenté d'injecter du frontmatter invalide. Cela se produit lorsque "astro.frontmatter" est `null`, `undefined` ou un objet JSON invalide.
+
+**Voir aussi :**
+
+-  [Modifier le frontmatter par un programme](/fr/guides/markdown-content#modifier-le-frontmatter-par-un-programme)

--- a/src/content/docs/fr/reference/errors/markdown-frontmatter-parse-error.mdx
+++ b/src/content/docs/fr/reference/errors/markdown-frontmatter-parse-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Failed to parse Markdown frontmatter.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Exemple de message d'erreur :**<br/>
+Impossible de lire une correspondance implicite ; les deux-points sont manquants<br/>
+Fin inattendue de la séquence à l'intérieur d'un scalaire entre guillemets doubles<br/>
+Impossible de lire un bloc ; une clé multiligne ne peut pas être une clé implicite (E06001)
+
+## Qu'est-ce qui a mal tourné ?
+
+Astro a rencontré une erreur lors de l'analyse du frontmatter de votre fichier Markdown.
+Cela est souvent dû à une erreur de syntaxe, telle que l'absence de deux-points ou d'une guillemet final manquant.

--- a/src/content/docs/fr/reference/errors/mdx-integration-missing-error.mdx
+++ b/src/content/docs/fr/reference/errors/mdx-integration-missing-error.mdx
@@ -1,0 +1,16 @@
+---
+title: MDX integration missing.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MdxIntegrationMissingError** : Impossible de traiter `FICHIER`. Assurez-vous que l'intégration `@astrojs/mdx` est installée. (E06004)
+
+## Qu'est-ce qui a mal tourné ?
+
+L'intégration officielle `@astrojs/mdx` n'a pas pu être trouvée. Cette erreur se produit lorsque des fichiers MDX sont utilisés sans une intégration pour MDX installée.
+
+**Voir aussi :**
+
+-  [Installation et utilisation de MDX](/fr/guides/integrations-guide/mdx/)
+

--- a/src/content/docs/fr/reference/errors/unknown-config-error.mdx
+++ b/src/content/docs/fr/reference/errors/unknown-config-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Unknown configuration error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## Qu'est-ce qui a mal tourné ?
+Astro a rencontré une erreur inconnue lors du chargement de votre fichier de configuration Astro.
+Cela est souvent dû à une erreur de syntaxe dans votre configuration et le message devrait fournir plus d'informations.
+
+Si vous parvenez à reproduire cette erreur de manière fiable, nous vous serions reconnaissants si vous pouviez [créer une Issue GitHub](https://astro.build/issues/).
+
+**Voir aussi :**
+-  [Référence de configuration](/fr/reference/configuration-reference/)
+

--- a/src/content/docs/fr/reference/errors/unknown-markdown-error.mdx
+++ b/src/content/docs/fr/reference/errors/unknown-markdown-error.mdx
@@ -1,0 +1,8 @@
+---
+title: Unknown Markdown Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## Qu'est-ce qui a mal tourné ?
+Astro a rencontré une erreur inconnue lors de l'analyse du Markdown. Souvent, cela est dû à une erreur de syntaxe et le message d'erreur devrait fournir plus d'informations.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content

#### Description

- Translated:
  - markdown errors

To do:
- Astro errors

Done:
- misc. errors: #3386


Note: this PR doesn’t depend on part 1 in any way, I’m just splitting it for ease of review
