### PR TITLE
Update content-collections.mdx: true drafts

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -390,7 +390,7 @@ You can use this to filter by any content criteria you like. For example, you ca
 ```js
 // Example: Filter out content entries with `draft: true`
 import { getCollection } from 'astro:content';
-const blogEntries = await getCollection('blog', ({ data }) => {
+const publishedBlogEntries = await getCollection('blog', ({ data }) => {
   return data.draft !== true;
 });
 ```

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -391,7 +391,7 @@ You can use this to filter by any content criteria you like. For example, you ca
 // Example: Filter content entries with `draft: true`
 import { getCollection } from 'astro:content';
 const draftBlogEntries = await getCollection('blog', ({ data }) => {
-  return data.draft !== true;
+  return data.draft === true;
 });
 ```
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -388,10 +388,10 @@ The `slug` property is specific to content collections, and will not be availabl
 You can use this to filter by any content criteria you like. For example, you can filter by properties like `draft` to prevent any draft blog posts from publishing to your blog:
 
 ```js
-// Example: Filter content entries with `draft: true`
+// Example: Filter out content entries with `draft: true`
 import { getCollection } from 'astro:content';
-const draftBlogEntries = await getCollection('blog', ({ data }) => {
-  return data.draft === true;
+const blogEntries = await getCollection('blog', ({ data }) => {
+  return data.draft !== true;
 });
 ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- Replaces filter back to what it was previous to https://github.com/withastro/docs/pull/2371. Filtering to non-drafts makes sense too, but currently either the variable name (and the copy above) or the filter should change for consistency.
- @FredKSchott, were you thinking of maybe changing it to be non-draft entries?
