### PR TITLE
Achieve consistency with indefinite article in MPA vs SPA concept en-only

### DIFF
--- a/src/content/docs/en/concepts/mpa-vs-spa.mdx
+++ b/src/content/docs/en/concepts/mpa-vs-spa.mdx
@@ -35,7 +35,7 @@ MPAs render all HTML on a remote server and often don't require much (if any) Ja
 
 #### Server routing (MPA) vs. client routing (SPA)
 
-Where does your website router live? In an MPA, every request to the server decides which HTML to respond with, so the routing logic lives in the server. In a SPA, your router locally runs in the browser and hijacks any navigation to render the new page without ever hitting a server.
+Where does your website router live? In an MPA, every request to the server decides which HTML to respond with, so the routing logic lives in the server. In an SPA, your router locally runs in the browser and hijacks any navigation to render the new page without ever hitting a server.
 
 This is a similar tradeoff to the one described above: MPAs offer a faster first load experience, while SPAs may offer a faster second or third page load once the JavaScript application is fully loaded in the browser. 
 
@@ -43,7 +43,7 @@ SPAs can also offer more powerful transitions across page navigation because the
 
 #### Server state management (MPA) vs. client state management (SPA)
 
-SPAs are the superior architecture for websites that deal with complex, multi-page state management (think: Gmail). This is because a SPA runs the entire website as a single JavaScript application, which lets the application maintain state and memory across multiple pages. Interactive, data-driven experiences like inboxes and admin dashboards do well as SPAs because the website itself is inherently "app-like".
+SPAs are the superior architecture for websites that deal with complex, multi-page state management (think: Gmail). This is because an SPA runs the entire website as a single JavaScript application, which lets the application maintain state and memory across multiple pages. Interactive, data-driven experiences like inboxes and admin dashboards do well as SPAs because the website itself is inherently "app-like".
 
 
 ## Are MPAs Better than SPAs?


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description
- What does this PR change? Give us a brief description.

This PR aims to achieve consistency in the wording of "a SPA" and "an SPA" in the en [SPA vs MPA](https://github.com/withastro/docs/blob/main/src/content/docs/en/concepts/mpa-vs-spa.mdx) concept page. In some instances the wording "an SPA" is used and in others "a SPA" is used. "an SPA" seems to appear more commonly.

This PR changes the two instances of "a SPA" to "an SPA" to achieve consistency.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
