### PR TITLE
[migrate-to] update docs suggestions to starlight

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -42,24 +42,24 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 ## Switch from Docusaurus to Astro
 
-To convert a Docusaurus documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs). 
+To convert a Docusaurus documentation site to Astro, start with our official [Starlight docs theme starter template](https://starlight.astro.build), or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs). 
 
 You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro@latest -- --template docs
+    npm create astro@latest -- --template starlight
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro@latest --template docs
+    pnpm create astro@latest --template starlight
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template docs
+    yarn create astro --template starlight
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
@@ -33,24 +33,24 @@ When you migrate your GitBook docs to Astro, you will notice some important diff
 
 ## Switch from GitBook to Astro
 
-To convert a GitBook documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs).
+To convert a GitBook documentation site to Astro, start with our official [Starlight docs theme starter template](https://starlight.astro.build), or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs).
 
 You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro@latest -- --template docs
+    npm create astro@latest -- --template starlight
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro@latest --template docs
+    pnpm create astro@latest --template starlight
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template docs
+    yarn create astro --template starlight
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/content/docs/en/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-pelican.mdx
@@ -31,24 +31,24 @@ When you rebuild your Pelican site in Astro, you will notice some important diff
 
 ## Switch from Pelican to Astro
 
-To convert a Pelican documentation site to Astro, start with our official blog theme starter template, or explore more community blog themes in our [theme showcase](https://astro.build/themes/). 
+To convert a Pelican documentation site to Astro, start with our official [Starlight docs theme starter template](https://starlight.astro.build), or explore more community themes in our [theme showcase](https://astro.build/themes/). 
 
 You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro@latest -- --template docs
+    npm create astro@latest -- --template starlight
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro@latest --template docs
+    pnpm create astro@latest --template starlight
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template docs
+    yarn create astro --template starlight
     ```
     </Fragment>
   </PackageManagerTabs>

--- a/src/content/docs/en/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-vuepress.mdx
@@ -33,24 +33,24 @@ When you rebuild your VuePress site in Astro, you will notice some important dif
 
 ## Switch from VuePress to Astro
 
-To convert a VuePress documentation site to Astro, start with our official docs theme starter template, or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs). 
+To convert a VuePress documentation site to Astro, start with our official [Starlight docs theme starter template](https://starlight.astro.build), or explore more community docs themes in our [theme showcase](https://astro.build/themes?search=&categories%5B%5D=docs). 
 
 You can pass a `--template` argument to the `create astro` command to start a new Astro project with one of our official starters. Or, you can [start a new project from any existing Astro repository on GitHub](/en/install/auto/#starter-templates).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
     ```shell
-    npm create astro@latest -- --template docs
+    npm create astro@latest -- --template Starlight
     ```
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm create astro@latest --template docs
+    pnpm create astro@latest --template Starlight
     ```
     </Fragment>
     <Fragment slot="yarn">
     ```shell
-    yarn create astro --template docs
+    yarn create astro --template Starlight
     ```
     </Fragment>
   </PackageManagerTabs>


### PR DESCRIPTION
Updates four of our "migrate to" guides that previously recommended starting with our docs template.
- refers (and links to) Starlight instead of "docs template"
- updates `-- template` install instructions for Starlight