### PR TITLE
[assets] folder recommendation updated

### DIFF
--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -49,9 +49,9 @@ When you next run Astro, it will update your `src/env.d.ts` file to configure ty
 
 Create `src/assets/`, which Astro will recognize as your new assets folder.
 
-We recommend storing all images to be optimized in the `src/assets/` directory, although this location is optional.
+We recommend storing all images to be optimized in the `src/assets/` directory to make use of our official `~/assets` alias, although this location is optional. If you don't know where to put your images, or if you're building a product around Astro (e.g. a CMS), you can put your images there and we promise we won't break them! But, images can be stored anywhere, including alongside your content, if you prefer.
 
-Your images stored in `src/assets/` can be used by components (`.astro`, `.mdx`, and other UI frameworks) and in Markdown files.
+Your images can be used by components (`.astro`, `.mdx`, and other UI frameworks) and in Markdown files.
 
 ### Update existing `<img>` tags
 


### PR DESCRIPTION
Minor content update to the experimental assets page.

Updates the suggestion to use store images in `src/assets/` to be strong-ish, with a reason, but clearly optional.

Also removes suggestion that images MUST be in this folder to work in component files and Markdown.