### PR TITLE
i18n(es): Translated `invalid-dyndamic-route.mdx`

### DIFF
--- a/src/content/docs/es/reference/error-reference.mdx
+++ b/src/content/docs/es/reference/error-reference.mdx
@@ -49,6 +49,7 @@ La siguiente referencia es una lista completa de los errores que puedes encontra
 - [**AstroGlobUsedOutside**](/es/reference/errors/astro-glob-used-outside/) (E03035)<br/>Astro.glob() used outside of an Astro file.
 - [**AstroGlobNoMatch**](/es/reference/errors/astro-glob-no-match/) (E03036)<br/>Astro.glob() did not match any files.
 - [**RedirectWithNoLocation**](/es/reference/errors/redirect-with-no-location/) (E03037)<br/>A redirect must be given a location with the `Location` header.
+- [**InvalidDynamicRoute**](/es/reference/errors/invalid-dynamic-route/) (E03038)<br/>Invalid dynamic route.
 - [**UnknownViteError**](/es/reference/errors/unknown-vite-error/) (E04000)<br/>Unknown Vite Error.
 - [**FailedToLoadModuleSSR**](/es/reference/errors/failed-to-load-module-ssr/) (E04001)<br/>Could not import file.
 - [**InvalidGlob**](/es/reference/errors/invalid-glob/) (E04002)<br/>Invalid glob pattern.

--- a/src/content/docs/es/reference/errors/invalid-dynamic-route.mdx
+++ b/src/content/docs/es/reference/errors/invalid-dynamic-route.mdx
@@ -1,0 +1,17 @@
+---
+title: Invalid dynamic route.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+
+
+> **InvalidDynamicRoute**: El parámetro INVALID_PARAM para la ruta ROUTE es inválido. Recibido **RECEIVED**. (E03038)
+
+## ¿Qué salió mal?
+Un parámetro de ruta dinámica es inválido. Esto es a menudo causado por un parámetro `undefined` o un [parámetro rest](/es/core-concepts/routing/#parámetros-rest) faltante.
+
+**Ver también:**
+-  [Rutas dinámicas](/es/core-concepts/routing/#rutas-dinámicas)
+
+


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Translated `invalid-dyndamic-route.mdx` to spanish and added the reference to `error-reference.mdx`