### PR TITLE
Minor content fixes in the `Migrating from File-Based Routing` section

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -569,7 +569,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
 
 5. [Generate routes from your collections](/en/guides/content-collections/#generating-routes-from-content). Inside a collection, Markdown and MDX files no longer automatically become pages using Astro's [file-based routing](/en/guides/markdown-content/#file-based-routing), so you must generate the pages yourself.
 
-    For the tutorial, create a `src/pages/posts/[...slug].astro`. This page will use [dynamic routing](/en/core-concepts/routing/#dynamic-routes) and to generate a page for each collection entry. 
+    For the tutorial, create a `src/pages/posts/[...slug].astro`. This page will use [dynamic routing](/en/core-concepts/routing/#dynamic-routes) to generate a page for each collection entry. 
 
     This page will also need to [query your collection](#querying-collections) to fetch page slugs and make the page content available to each route.
 
@@ -610,7 +610,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
 
     The blog index page in the tutorial lists a card for each post. This becomes:
 
-    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")"
+    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")" "\"/posts/\" + post.slug"
     ---
     import { getCollection } from "astro:content";
     import BaseLayout from "../layouts/BaseLayout.astro";
@@ -634,7 +634,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
 
     The tutorial blog project also dynamically generates a page for each tag. This page now becomes:
 
-    ```astro title="src/pages/tags/[tag].astro" "post.data" "getCollection(\"posts\")" "post.data.title"
+    ```astro title="src/pages/tags/[tag].astro" "post.data" "getCollection(\"posts\")" "post.data.title" "'/posts/' + post.slug"
     ---
     export async function getStaticPaths() {
       const allPosts = await getCollection("posts");

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -610,7 +610,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
 
     The blog index page in the tutorial lists a card for each post. This becomes:
 
-    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")" "\"/posts/\" + post.slug"
+    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")" "'/posts/' + post.slug"
     ---
     import { getCollection } from "astro:content";
     import BaseLayout from "../layouts/BaseLayout.astro";
@@ -625,7 +625,7 @@ This guide shows you how to convert an existing Astro project with Markdown file
       <ul>
         {
           allPosts.map((post) => (
-            <BlogPost url={"/posts/" + post.slug} title={post.data.title} />
+            <BlogPost url={'/posts/' + post.slug} title={post.data.title} />
           ))
         }
       </ul>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- a little typo (from `and to` to `to`):

![typo](https://github.com/withastro/docs/assets/48165230/d3842978-bb20-4444-8b74-df5414f106b5)

- missing a `highlight` for changes in the `Migrating from File-Based Routing` section:

  - before `Content Collections` (the tutorial version):

  ![before](https://github.com/withastro/docs/assets/48165230/bc9f70ff-293d-40c4-8544-2ded25e423ef)

  - after introducing `Content Collections`:

  ![after](https://github.com/withastro/docs/assets/48165230/a1562164-3369-4f35-989e-9fdaee09cf6c)

  - my fix (highlighting the new url format):

  ![fix](https://github.com/withastro/docs/assets/48165230/cb2aad09-8be9-4754-89e7-4d85ac2bb789)

