### PR TITLE
i18n(es): Updated `locals-not-serializable.mdx` & `configuration-reference.mdx`

### DIFF
--- a/src/content/docs/es/reference/configuration-reference.mdx
+++ b/src/content/docs/es/reference/configuration-reference.mdx
@@ -119,7 +119,7 @@ El valor puede ser una ruta absoluta del sistema de archivos o una ruta relativa
 
 <p>
 
-**Tipo:** `RedirectConfig`<br />
+**Tipo:** `Record.<string, RedirectConfig>`<br />
 **Por defecto:** `{}`<br />
 <Since v="2.6.0" />
 </p>

--- a/src/content/docs/es/reference/errors/locals-not-serializable.mdx
+++ b/src/content/docs/es/reference/errors/locals-not-serializable.mdx
@@ -4,9 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **LocalsNotSerializable**: 
-            devuelve `La información almacenada en `Astro.locals`  para la ruta "HREF" no es serializable.\nAsegúrate de almacenar solo datos serializables.`;
-         (E03034)
+> **LocalsNotSerializable**: La información almacenada en `Astro.locals` para la ruta "`HREF`" no es serializable. Asegúrate de almacenar solo datos serializables. (E03034)
 
 ## ¿Qué salió mal?
 Se produce un error en el modo de desarrollo cuando un usuario intenta almacenar algo que no es serializable en `locals`.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Updated `locals-not-serializable.mdx` & `configuration-reference.mdx`.

* `locals-not-serializable.mdx` -> [`d8a80f0`](https://github.com/withastro/docs/commit/d8a80f01dfc19ae6d2cf039e6e6e93f3e400bc01)
* `configuration-reference.mdx` -> [`5e76ca4`](https://github.com/withastro/docs/commit/5e76ca4701b0c3e52aa6bfb286974b528d99cc4d)