### PR TITLE
i18n(es): Updated `server-side-rendering.mdx` & `csssyntax-error.mdx`

### DIFF
--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -333,8 +333,7 @@ const factData = await factResponse.json();
 <p>{factData.fact}</p>
 ```
 
-
-La página de Astro a continuación, utilizando estos componentes, puede renderizar partes de la página más rápidamente. Las etiquetas `<head>`, `<body>` y `<h1>` ya no están bloqueadas por las recuperaciones de datos. Luego, el navegador esperará a que `RandomName` termine de cargar sus Promises y enviará el HTML resultante a través de la red. Renderizará el siguiente encabezado y luego esperará a que `RandomFact` envíe su HTML resultante al navegador.
+La página Astro a continuación, utilizando estos componentes, puede renderizar partes de la página más rápido. Las etiquetas `<head>`, `<body>` y `<h1>` ya no se bloquean por las solicitudes de datos. El servidor luego obtendrá los datos de `RandomName` y `RandomFact` en paralelo y transmitirá el HTML resultante al navegador.
 
 ```astro title="src/pages/index.astro"
 ---

--- a/src/content/docs/es/reference/errors/csssyntax-error.mdx
+++ b/src/content/docs/es/reference/errors/csssyntax-error.mdx
@@ -16,5 +16,3 @@ CSSSyntaxError: Unclosed string<br/> (E05001)
 ## ¿Qué salió mal?
 
 Astro encontró un error al analizar el CSS debido a un error de sintaxis. Esto a menudo es causado por la falta de un punto y coma.
-
-


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Updated `server-side-rendering.mdx` with the commit [`278f33e`](https://github.com/withastro/docs/commit/278f33ec366aa379e1919be63418d67fa28e48f2) & `csssyntax-error.mdx`

> The update of `csssyntax-error.mdx` is to show this page as updated because the translation update against the original would have no change.
