### PR TITLE
Update server-side-rendering.mdx => variable naming bug fix in Including Promise Directly code section

### DIFF
--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -346,10 +346,10 @@ You can also include promises directly in the template. Instead of blocking the 
 ```astro title="src/pages/index.astro"
 ---
 const personPromise = fetch('https://randomuser.me/api/')
-  .then(resp => response.json())
+  .then(response => response.json())
   .then(arr => arr[0].name.first);
 const factPromise = fetch('https://catfact.ninja/fact')
-  .then(resp => response.json())
+  .then(response => response.json())
   .then(factData => factData.fact);
 ---
 <html>


### PR DESCRIPTION


There is a naming error in the code section of the topic Including Promise Directly.

After the fetch request in .then method, response was catched using `resp` variable but then its usage was done with `response` variable.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
