### PR TITLE
add governance/Discord to contribute.mdx

### DIFF
--- a/src/content/docs/en/contribute.mdx
+++ b/src/content/docs/en/contribute.mdx
@@ -8,7 +8,9 @@ import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-We welcome contributions of any size and contributors of any skill level. As an open-source project, we believe in giving back to our contributors. We are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
+We welcome contributions of any size and contributors of any skill level. As an open-source project, we believe in giving back to our contributors. We are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality. 
+
+Want to get even more involved? See our [Governance doc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) for detailed descriptions of different roles, maintainer nomination processes, code review processes, and Code of Conduct enforcement.
 
 ## Ways to Contribute
 
@@ -35,6 +37,8 @@ Visit [Astro's GitHub profile](https://github.com/withastro) to find the reposit
 In addition to contributing your own code or content, you can also make a huge contribution by getting involved by leaving review comments on PRs, adding ideas in existing GitHub Issues and Discussions, and participating in our "Pinned" issue maintenance tasks! 
 
 Every PR, especially translation PRs, needs reviewers! Reviewing PRs and leaving comments, suggestions, or an approving "LGTM!" ("Looks Good To Me!") is a great way to get started in any repository, and to learn more about Astro.
+
+We also have a very active [Discord](https://astro.build/chat) and value the contributions of members who welcome new members, answer support questions, share what they have built with and for Astro! Beyond traditional GitHub contributions, Astro recognizes and supports community members who engage with our community, share Astro in blog posts, videos and conference talks, and help maintain the health of our community.
 
 ## Contributing to Docs
 


### PR DESCRIPTION
Adds two new paragraphs re: contributing to Astro:

- Link to Governance model where people can find more info like Code of Conduct
- Description of support/etc. as contributions, in a "Discord/community" paragraph.