### PR TITLE
Add note about cropping support to assets.mdx

### DIFF
--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -105,6 +105,12 @@ Your existing images in `public/` and remote images are still valid but are not 
 
 **Built-in asset support is incompatible with the `@astrojs/image` integration.**
 
+:::note
+  Please note that the Assets API doesn't yet support cropping (the current behaviour is to resize images to fit).
+  
+  For now, please continue using the `@astrojs/image` integration if you need support for cropping images. Alternatively you can use the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property to achieve a similar result. 
+:::
+
 To avoid errors in your project, complete the following steps:
 
 1. Remove the `@astrojs/image` integration.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- New or updated content 

#### Description

- The experimental assets api doesn't yet support cropping images, which might confuse users when moving from the `@astro/image` integration.
- This PR adds an aside to the assets page in the [properties section](https://docs.astro.build/en/guides/assets/#properties)

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
