### PR TITLE
fix: correct way to type `Locals`

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -71,15 +71,13 @@ To type the information inside `Astro.locals`, which gives you autocompletion in
 
 ```ts title="src/env.d.ts"
 /// <reference types="astro/client" />
-declare global {
-    namespace App {
-        interface Locals {
-            user: {
-                name: string
-            },
-            welcomeTitle: () => String,
-            orders: Map<string, object>
-        }
+declare namespace App {
+    interface Locals {
+        user: {
+            name: string
+        },
+        welcomeTitle: () => String,
+        orders: Map<string, object>
     }
 }
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

The correct way to type the `Locals` object was changed, and we forgot to update doc site. In fact, the `examples/` folder in the main repo is different:

https://github.com/withastro/astro/blob/3f1cb6b1a001fb03419a313f72c9f4846b890fe0/examples/middleware/src/env.d.ts#L2-L9

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
