### PR TITLE
Add warning about named slot usage

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -251,6 +251,10 @@ import Wrapper from '../components/Wrapper.astro';
 
 Use a `slot="my-slot"` attribute on the child element that you want to pass through to a matching `<slot name="my-slot" />` placeholder in your component.
 
+:::caution
+Named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
+:::
+
 :::tip
 Named slots can also be passed to [UI framework components](/en/core-concepts/framework-components/)!
 :::

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -251,9 +251,7 @@ import Wrapper from '../components/Wrapper.astro';
 
 Use a `slot="my-slot"` attribute on the child element that you want to pass through to a matching `<slot name="my-slot" />` placeholder in your component.
 
-:::caution
-Named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
-:::
+Note that named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
 
 :::tip
 Named slots can also be passed to [UI framework components](/en/core-concepts/framework-components/)!


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content
- Translated content
- Changes to the docs site code
- Something else!

#### Description

- What does this PR change? Adds a warning to specify that usage of named slots has to be top-level.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
