### PR TITLE
Revert "changed fontFamily Tailwind configuration"

### DIFF
--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -103,15 +103,17 @@ To register your font in Tailwind:
 
     This example adds `InterVariable` and `Inter` to the sans-serif font stack, with default fallback fonts from Tailwind CSS.
 
-    ```js title="tailwind.config.cjs" ins={1,6-8}
+    ```js title="tailwind.config.cjs" ins={1,7-9}
     const defaultTheme = require("tailwindcss/defaultTheme");
 
     module.exports = {
       // ...
       theme: {
+        extend: {
           fontFamily: {
             sans: ["InterVariable", "Inter", ...defaultTheme.fontFamily.sans],
           },
+        },
       },
       // ...
     };


### PR DESCRIPTION
We later found out the font should yes be extended from Tailwind so that it remains in the Preflight, according to Tailwind docs:
https://tailwindcss.com/docs/font-family#customizing-the-default-font

