### PR TITLE
i18n(es): Updated `content-schema-contains-slug-error.mdx`

### DIFF
--- a/src/content/docs/es/reference/errors/content-schema-contains-slug-error.mdx
+++ b/src/content/docs/es/reference/errors/content-schema-contains-slug-error.mdx
@@ -7,7 +7,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 > **ContentSchemaContainsSlugError**: Un esquema de colección de contenido no debe contener el `slug` ya que está reservado para la generación de slugs. Elimina esto de tu esquema de colección de contenido. (E09003)
 
 ## ¿Qué salió mal?
-Un esquema de colección de contenido no debe contener la propiedad `slug`. Esto está reservado por Astro para generar slugs. Elimine el campo `slug` de su esquema o elija un nombre diferente.
+Un esquema de colección de contenido no debe contener la propiedad `slug`. Esto está reservado por Astro para generar slugs. Elimina `slug` de tu esquema. Aún puedes usar slugs personalizados en tu frontmatter.
 
 **Ver también:**
--  [La propiedad reservada `slug`](/es/guides/content-collections/)
+-  [La propiedad reservada `slug`](/es/guides/content-collections/#defining-custom-slugs)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Updated `content-schema-contains-slug-error.mdx` based on this commit 772051ff623275c954eee95ed94dab3fa8980cf2