### PR TITLE
Release the translators!

### DIFF
--- a/src/content/docs/en/core-concepts/astro-syntax.mdx
+++ b/src/content/docs/en/core-concepts/astro-syntax.mdx
@@ -1,7 +1,7 @@
 ---
 title: Astro Syntax
 description: An intro to the .astro component syntax.
-i18nReady: false
+i18nReady: true
 ---
 
 **If you know HTML, you already know enough to write your first Astro component.**

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -3,7 +3,7 @@ title: Firebase & Astro
 description: Add a backend to your project with Firebase
 type: backend
 service: Firebase
-stub: false
+stub: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -4,6 +4,7 @@ description: Add a backend to your project with Firebase
 type: backend
 service: Firebase
 stub: true
+i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -3,7 +3,7 @@ title: Firebase & Astro
 description: Add a backend to your project with Firebase
 type: backend
 service: Firebase
-stub: true
+stub: false
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -3,7 +3,7 @@ title: Xata & Astro
 description: Add a serverless database with full-text search to your project with Xata
 type: backend
 service: Xata
-stub: false
+stub: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -4,6 +4,7 @@ description: Add a serverless database with full-text search to your project wit
 type: backend
 service: Xata
 stub: true
+i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import FileTree from '~/components/FileTree.astro'

--- a/src/content/docs/en/guides/backend/xata.mdx
+++ b/src/content/docs/en/guides/backend/xata.mdx
@@ -3,7 +3,7 @@ title: Xata & Astro
 description: Add a serverless database with full-text search to your project with Xata
 type: backend
 service: Xata
-stub: true
+stub: false
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'

--- a/src/content/docs/en/guides/cms/cloudcannon.mdx
+++ b/src/content/docs/en/guides/cms/cloudcannon.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using CloudCannon as a CMS
 type: cms
 stub: true
 service: CloudCannon
-i18nReady: false
+i18nReady: true
 ---
 
 [CloudCannon](https://cloudcannon.com) is a Git-based content management system that provides a visual editor for your content.

--- a/src/content/docs/en/guides/cms/crystallize.mdx
+++ b/src/content/docs/en/guides/cms/crystallize.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Crystallize as a CMS
 type: cms
 stub: true
 service: Crystallize
-i18nReady: false
+i18nReady: true
 ---
 [Crystallize](https://crystallize.com/) is a headless content management system for eCommerce that exposes a GraphQL API.
 ## Example

--- a/src/content/docs/en/guides/cms/decap-cms.mdx
+++ b/src/content/docs/en/guides/cms/decap-cms.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Decap as a CMS
 type: cms
 stub: true
 service: Decap CMS
-i18nReady: false
+i18nReady: true
 ---
 
 [Decap CMS](https://www.decapcms.org/) (formerly Netlify CMS) is an open-source, Git-based content management system.

--- a/src/content/docs/en/guides/cms/directus.mdx
+++ b/src/content/docs/en/guides/cms/directus.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Directus as a CMS
 type: cms
 stub: true
 service: Directus
-i18nReady: false
+i18nReady: true
 ---
 
 [Directus](https://directus.io/) is a backend-as-a-service which can be used to host data and content for your Astro project.

--- a/src/content/docs/en/guides/cms/frontmatter-cms.mdx
+++ b/src/content/docs/en/guides/cms/frontmatter-cms.mdx
@@ -3,7 +3,7 @@ title: Front Matter CMS & Astro
 description: Add content to your Astro project using Front Matter CMS
 type: cms
 service: Front Matter CMS
-i18nReady: false
+i18nReady: true
 ---
 import FileTree from '~/components/FileTree.astro'
 

--- a/src/content/docs/en/guides/cms/keystonejs.mdx
+++ b/src/content/docs/en/guides/cms/keystonejs.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using KeystoneJS as a CMS
 type: cms
 stub: true
 service: KeystoneJS
-i18nReady: false
+i18nReady: true
 ---
 
 [KeystoneJS](https://keystonejs.com/) is an open source, headless content-management system that allows you to describe the structure of your schema.

--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Payload as a CMS
 type: cms
 stub: true
 service: Payload CMS
-i18nReady: false
+i18nReady: true
 ---
 
 [PayloadCMS](https://payloadcms.com/) is a headless open-source content management system that can be used to provide content for your Astro project.

--- a/src/content/docs/en/guides/cms/prismic.mdx
+++ b/src/content/docs/en/guides/cms/prismic.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Prismic as a CMS
 type: cms
 stub: true
 service: Prismic
-i18nReady: false
+i18nReady: true
 ---
 
 [Prismic](https://prismic.io/) is a headless content management system.

--- a/src/content/docs/en/guides/cms/sanity.mdx
+++ b/src/content/docs/en/guides/cms/sanity.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Sanity as a CMS
 type: cms
 stub: true
 service: Sanity
-i18nReady: false
+i18nReady: true
 ---
 
 [Sanity](http://sanity.io) is a headless content management system that focuses on [structured content](https://www.sanity.io/structured-content-platform).

--- a/src/content/docs/en/guides/cms/spinal.mdx
+++ b/src/content/docs/en/guides/cms/spinal.mdx
@@ -4,7 +4,7 @@ description: Add content to your project using Spinal as your CMS.
 type: cms
 stub: true
 service: Spinal
-i18nReady: false
+i18nReady: true
 ---
 
 [Spinal](https://spinalcms.com/cms-for-astro/) is a commercial, SaaS-focused, Git-based CMS.

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -3,7 +3,7 @@ title: Content Collections
 description: >-
   Content collections help organize your Markdown and type-check your
   frontmatter with schemas.
-i18nReady: false
+i18nReady: true
 ---
 import FileTree from '~/components/FileTree.astro'
 import Since from '~/components/Since.astro'

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -13,7 +13,7 @@ description: Learn how to use the @astrojs/markdoc integration in your Astro pro
 githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/markdoc/'
 hasREADME: true
 category: other
-i18nReady: false
+i18nReady: true
 ---
 
 import Video from '~/components/Video.astro';

--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -1,7 +1,7 @@
 ---
 title: Middleware
 description: Learn how to use middleware in Astro.
-i18nReady: false
+i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
@@ -4,7 +4,7 @@ description: Tips for migrating an existing GitBook project to Astro
 type: migration
 stub: true
 framework: GitBook
-i18nReady: false
+i18nReady: true
 ---
 
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'

--- a/src/content/docs/en/recipes.mdx
+++ b/src/content/docs/en/recipes.mdx
@@ -1,7 +1,7 @@
 ---
 title: More Recipes
 description: See guided examples of building features in Astro.
-i18nReady: false
+i18nReady: true
 ---
 
 import RecipesNav from '~/components/RecipesNav.astro';

--- a/src/content/docs/en/recipes/build-forms-api.mdx
+++ b/src/content/docs/en/recipes/build-forms-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build Forms With API Routes
 description: Learn how to use JavaScript to send form submissions to an API Route
-i18nReady: false
+i18nReady: true
 type: recipe
 ---
 import UIFrameworkTabs from "~/components/tabs/UIFrameworkTabs.astro";

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build HTML Forms in Astro Pages
 description: Learn how to build HTML forms and handle submissions in your frontmatter
-i18nReady: false
+i18nReady: true
 type: recipe
 ---
 

--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -2,7 +2,7 @@
 title: Use Bun with Astro
 description: Learn how to use Bun with your Astro site.
 type: recipe
-i18nReady: false
+i18nReady: true
 ---
 
 [Bun](https://bun.sh/) is a runtime for JavaScript built for speed. See [Bun's documentation](https://bun.sh/docs) for more information.

--- a/src/content/docs/en/recipes/captcha.mdx
+++ b/src/content/docs/en/recipes/captcha.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verify a Captcha
 description: Learn how to create an API route and fetch it from the client.
-i18nReady: false
+i18nReady: true
 type: recipe
 ---
 

--- a/src/content/docs/en/recipes/docker.mdx
+++ b/src/content/docs/en/recipes/docker.mdx
@@ -2,7 +2,7 @@
 title: Build your Astro Site with Docker
 description: Learn how to build your Astro site using Docker.
 type: recipe
-i18nReady: false
+i18nReady: true
 ---
 
 [Docker](https://docker.com) is a tool to build, deploy, and run applications using containers.

--- a/src/content/docs/en/recipes/external-links.mdx
+++ b/src/content/docs/en/recipes/external-links.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add icons to external links
 description: Learn how to install a rehype plugin to add icons to external links in your Markdown files
-i18nReady: false
+i18nReady: true
 type: recipe
 ---
 

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -2,7 +2,7 @@
 title: Add i18n features 
 description: Use dynamic routing and content collections to add internationalization support to your Astro site.
 type: recipe
-i18nReady: false
+i18nReady: true
 ---
 import FileTree from '~/components/FileTree.astro'
 import StaticSsrTabs from '~/components/tabs/StaticSsrTabs.astro'

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add Reading Time
 description: Build a remark plugin to add reading time to your Markdown or MDX files.
-i18nReady: false
+i18nReady: true
 type: recipe
 ---
 

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Image Service API
-i18nReady: false
+i18nReady: true
 ---
 
 Astro [assets](/en/guides/assets/) were designed to make it easy for any image optimization service to build a service on top of Astro.


### PR DESCRIPTION
This marks 27 more pages `i18nReady: true`!

Notably not transated:
- Content Colletions
- Middleware
- Astro Syntax
- Firebase
- All the Recipes!!

Also marks some stubs for translation, which will be great first time PRs for people! (Maybe figure out a way to highlight and guide people toward `stub: true` when searching for ones to translate?)

Notably NOT yet marked:
- Experimental Assets, as this page will need to change significantly for V3 anyway
- Builder.io, as there's an existing full-guide PR being edited right now.