### PR TITLE
Strip `prettier-ignore` comments when building integration docs

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -127,7 +127,8 @@ class IntegrationPagesBuilder {
 			.use(relativeLinks, { base: `https://docs.astro.build/` })
 			.use(githubVideos)
 			.use(replaceAsides)
-			.use(closeUnclosedLinebreaks);
+			.use(closeUnclosedLinebreaks)
+			.use(stripPrettierIgnoreComments);
 		readme = (await processor.process(readme)).toString();
 		readme =
 			`---
@@ -207,6 +208,15 @@ function closeUnclosedLinebreaks() {
 	return function transform(tree: Root) {
 		visit(tree, 'html', function htmlVisitor(node) {
 			node.value = node.value.replaceAll(/<br>/gi, '<br/>');
+		});
+	};
+}
+
+/** Remove `<!-- prettier-ignore -->` comments. */
+function stripPrettierIgnoreComments() {
+	return function transform(tree: Root) {
+		visit(tree, 'html', function htmlVisitor(node) {
+			node.value = node.value.replaceAll(/<!--\s*prettier-ignore(-[\w-]+)?\s*-->/gi, '');
 		});
 	};
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Updates our remark pipeline that pulls in integration READMEs from the Astro repo to remove any `<!-- prettier-ignore -->` we might want to use there.

Other kinds of HTML comments could still cause errors, but because remark treats HTML comments as just part of a generic HTML node, which we manipulate with a regular expression, I’m hesitant to commit to a blanket “strip comments” plugin. If we can get CI running so these problems get caught in `astro`, I don’t think failing on an unexpected HTML comment is too bad. Then we can evaluate if the comment is needed and if so, update this code again to handle it.

This only applies to the integration page docgen. We build Markdown ourselves for the configuration and error reference, so don’t think we’ll see the same issue.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
