### PR TITLE
Remove Markdoc from `i18nNotReady` in docgen script

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -38,7 +38,7 @@ class IntegrationPagesBuilder {
 	readonly #sourceBranch: string;
 	readonly #sourceRepo: string;
 	readonly #deprecatedIntegrations = new Set(['turbolinks']);
-	readonly #i18nNotReadyIntegrations = new Set(['markdoc']);
+	readonly #i18nNotReadyIntegrations = new Set<string>([]);
 
 	constructor(opts: { githubToken?: string; sourceBranch: string; sourceRepo: string }) {
 		this.#githubToken = opts.githubToken;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Removes the Markdoc integration from the set of pages not ready for i18n in the generator script for integration READMEs.

#3578 changed this manually but we need this change to make sure the CI bot doesn’t try to flip it back every day.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
