### PR TITLE
Support using specific branch when running `docgen` scripts

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -40,10 +40,12 @@ const FOOTER = ``;
  * source file directly.  It uses the default parser configuration.
  */
 export async function run() {
+	const sourceBranch = process.env.SOURCE_BRANCH || 'main';
+	const sourceRepo = process.env.SOURCE_REPO || 'withastro/astro';
 	const inputBuffer =
 		STUB ||
 		(await fetch(
-			'https://raw.githubusercontent.com/withastro/astro/main/packages/astro/src/%40types/astro.ts'
+			`https://raw.githubusercontent.com/${sourceRepo}/${sourceBranch}/packages/astro/src/%40types/astro.ts`
 		).then((r) => r.text()));
 
 	// Get all `@docs` JSDoc comments in the file.

--- a/scripts/error-docgen.mjs
+++ b/scripts/error-docgen.mjs
@@ -3,8 +3,10 @@ import jsdoc from 'jsdoc-api';
 import fetch from 'node-fetch';
 import ts from 'typescript';
 
-const errorURL =
-	'https://raw.githubusercontent.com/withastro/astro/main/packages/astro/src/core/errors/errors-data.ts';
+const sourceBranch = process.env.SOURCE_BRANCH || 'main';
+const sourceRepo = process.env.SOURCE_REPO || 'withastro/astro';
+
+const errorURL = `https://raw.githubusercontent.com/${sourceRepo}/${sourceBranch}/packages/astro/src/core/errors/errors-data.ts`;
 
 // Fill this in to test a response locally, with fetching.
 const STUB = undefined; // fs.readFileSync('../astro/packages/astro/src/core/errors/errors-data.ts', {encoding: 'utf-8',});


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

Currently, our documentation generation scripts fetch data from the `witastro/astro#main` to build our integration pages, configuration reference, and error pages.

This PR updates the configuration reference and error reference docgen scripts to use `SOURCE_REPO` and `SOURCE_BRANCH` environment variables if set, in line with how the integration page generator already works.

This will unlock testing in the main Astro repo as we can set those environment variables there and be able to test `astro` PR changes in `astro` rather than waiting for builds to fail in the docs repo.

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
