### PR TITLE
i18n(es): Fix typos in `server-side-rendering.mdx`

### DIFF
--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -9,11 +9,11 @@ import Since from '~/components/Since.astro';
 
 **Renderizado en el servidor**, también conocido como SSR (server side rendering), se puede habilitar en Astro. Cuando habilitas SSR puedes:
 
-- Implementar sesiones para iniciar sesión en su aplicación.
+- Implementar sesiones para iniciar sesión en tu aplicación.
 - Renderizar datos desde una llamada de API dinámicamente con `fetch`. 
-- Desplegar su sitio en un servidor usando un *adaptador*.
+- Desplegar tu sitio en un servidor usando un *adaptador*.
 
-## Habilitando SSR en su proyecto
+## Habilitando SSR en tu proyecto
 
 Para hablitar las características SSR para despliegues en producción, actualiza tu configuración `output` a `'server'` o `'hybrid'` (introducido en **v2.6.0**). Ambos modos controlan cuales [páginas](/es/core-concepts/astro-pages/) o [endpoints del servidor](/es/core-concepts/endpoints/#endpoints-del-servidor-rutas-de-api) deben ser renderizados en el servidor. Cada opción de configuración tiene un comportamiento por defecto diferente, y permite que las rutas individuales opten por no utilizar el valor por defecto:
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
Fix typos in `server-side-rendering.mdx`, The use of `usted` has been changed to `tú`.