### PR TITLE
i18n(es): Fix typos in `tutorial`

### DIFF
--- a/src/content/docs/es/tutorial/2-pages/1.mdx
+++ b/src/content/docs/es/tutorial/2-pages/1.mdx
@@ -75,7 +75,7 @@ A diferencia de muchos frameworks, Astro utiliza elementos HTML estándar `<a>` 
 :::
 
 <Box icon="puzzle-piece">
-## Pruébelo usted mismo - Añadir una página de blog
+## Pruébalo tú mismo - Añadir una página de blog
 
 Añade una tercera página `blog.astro` a tu sitio, siguiendo los [mismos pasos que arriba](#crear-un-nuevo-archivo-astro).
 

--- a/src/content/docs/es/tutorial/2-pages/2.mdx
+++ b/src/content/docs/es/tutorial/2-pages/2.mdx
@@ -78,7 +78,7 @@ Ahora que ya has creado páginas con archivos `.astro`, vamos a crear algunos po
 La información en la parte superior del archivo, dentro de las vallas de código, se llama frontmatter. Estos datos -incluyendo etiquetas y una imagen del post- son información *sobre* tu post que Astro puede usar. No aparece en la página automáticamente, pero accederemos a ella más adelante en el tutorial para mejorar tu sitio. 
 :::
 
-## Enlace a sus posts
+## Enlace a tus posts
 
 1. Enlaza a tu primer post con una etiqueta anchor en `src/pages/blog.astro`:
     ```astro title="src/pages/blog.astro" ins={16-18}

--- a/src/content/docs/es/tutorial/2-pages/4.mdx
+++ b/src/content/docs/es/tutorial/2-pages/4.mdx
@@ -85,7 +85,7 @@ Usando las etiquetas `<style></style>` de Astro, puedes dar estilo a los element
 
   4. Vuelve a visitar tu página Acerca de en tu navegador y comprueba, mediante inspección visual o herramientas de desarrollo, que cada elemento de tu lista de habilidades está ahora en verde y en negrita.
 
-## Utilice su primera variable CSS
+## Utiliza tu primera variable CSS
 La etiqueta Astro `<style>` también puede hacer referencia a cualquier variable de tu script frontmatter usando la directiva `define:vars={ {...} }`. Puedes **definir variables dentro de tu código vallado**, y luego **utilizarlas como variables CSS en tu etiqueta de estilo**.
 
 1. Define una variable `skillColor` añadiéndola al script frontmatter de `src/pages/about.astro` así:


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
Fix typos in `tutorial`, the use of `usted` has been changed to `tú`.