### PR TITLE
Fix Strapi guide image loading

### DIFF
--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -191,7 +191,7 @@ You can modify this interface, or create multiple interfaces, to correspond to y
   import type Article from '../interfaces/article';
 
   const articles = await fetchApi<Article[]>({
-    endpoint: 'articles',
+    endpoint: 'articles?populate=image',
     wrappedByKey: 'data',
   });
   ---

--- a/src/content/docs/es/guides/cms/strapi.mdx
+++ b/src/content/docs/es/guides/cms/strapi.mdx
@@ -191,7 +191,7 @@ Puedes modificar esta interfaz o crear múltiples interfaces para que se corresp
   import type Article from '../interfaces/article';
 
   const articles = await fetchApi<Article[]>({
-    endpoint: 'articles',
+    endpoint: 'articles?populate=image',
     wrappedByKey: 'data',
   });
   ---


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description

This change fixes an error when trying to display the article image following the Strapi guide. Looks like by default media is not sideloaded when fetching a list of records.

[Relevant Strapi docs](https://docs.strapi.io/dev-docs/api/rest#relations-population)

The error in question:
![CleanShot 2023-06-30 at 09 46 11@2x](https://github.com/withastro/docs/assets/411554/ebd7cf4a-2bef-49a7-bff1-bf51d8c0c67a)