### PR TITLE
i18n(es): Updated `publish-to-npm.mdx` & `server-side-rendering.mdx`

### DIFF
--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -7,11 +7,20 @@ import FileTree from '~/components/FileTree.astro';
 import Since from '~/components/Since.astro';
 
 
-**Renderizado en el servidor**, también conocido como SSR (server side rendering), se puede habilitar en Astro. Cuando habilitas SSR puedes:
+El renderizado en el lado del servidor (SSR) se refiere a la generación de páginas HTML en el servidor bajo demanda y enviarlas al cliente.
 
+SSR te permite:
 - Implementar sesiones para iniciar sesión en su aplicación.
 - Renderizar datos desde una llamada de API dinámicamente con `fetch`. 
 - Desplegar su sitio en un servidor usando un *adaptador*.
+
+Considera habilitar el renderizado en el lado del servidor (SSR) en tu proyecto de Astro si necesitas lo siguiente:
+
+- **Endpoints de API**: SSR te permite crear páginas específicas que funcionan como endpoints de API para tareas como el acceso a bases de datos, la autenticación y la autorización, al tiempo que mantienen oculta la información confidencial del cliente.
+
+- **Páginas protegidas**: Si necesitas restringir el acceso a una página según los privilegios del usuario, puedes habilitar SSR para manejar el acceso del usuario en el servidor.
+
+- **Contenido que cambia con frecuencia**: Habilitar SSR te permite generar páginas individuales sin necesidad de reconstruir estáticamente todo tu sitio. Esto es útil cuando el contenido de una página se actualiza con frecuencia.
 
 ## Habilitando SSR en su proyecto
 

--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -356,7 +356,7 @@ import RandomFact from '../components/RandomFact.astro'
 
 #### Incluyendo promesas directamente
 
-También puedes incluir promesas directamente en la plantilla. En lugar de bloquear todo el componente, solo bloqueará el marcado que viene después de él.
+También puedes incluir promesas directamente en la plantilla. En lugar de bloquear todo el componente, se resolverá la promesa en paralelo y solo se bloqueará el marcado que viene después de ella.
 
 ```astro title="src/pages/index.astro"
 ---
@@ -380,7 +380,9 @@ const factPromise = fetch('https://catfact.ninja/fact')
 </html>
 ```
 
-En este ejemplo, `A name` se renderizará mientras se carga `personPromise`. En ese momento, aparecerá `A fact` mientras se carga `factPromise`.
+En este ejemplo, `A name` se renderizará mientras se cargan `personPromise` y `factPromise`.
+
+Una vez que `personPromise` se haya resuelto, aparecerá `A fact` y `factPromise` se mostrará cuando haya terminado de cargarse.
 
 ### Dividir la compilación SSR en varios archivos
 

--- a/src/content/docs/es/reference/publish-to-npm.mdx
+++ b/src/content/docs/es/reference/publish-to-npm.mdx
@@ -17,7 +17,7 @@ Consulta nuestra [plantilla de componente de Astro](https://github.com/astro-com
 
 ## Inicio rápido
 
-Para comenzar a desarrollar tus componentes rápidamente, tenemos una plantilla configurada para ti.
+Para comenzar a desarrollar tu componente rápidamente, puedes utilizar una plantilla que ya está configurada para ti.
 
 ```bash
 # Inicializar la plantilla de componentes de Astro en una nueva carpeta
@@ -39,7 +39,7 @@ Antes de empezar, será útil tener una comprensión básica de:
 - [Workspaces](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#workspaces)
 :::
 
-Para crear un nuevo paquete, recomendamos configurar tu entorno de desarrollo para utilizar **Workspaces** dentro de tu proyecto. Esto te permitirá desarrollar tu componente junto con una copia funcional de Astro.
+Para crear un nuevo paquete, configura tu entorno de desarrollo para utilizar **Workspaces** dentro de tu proyecto. Esto te permitirá desarrollar tu componente junto con una copia funcional de Astro.
 
 <FileTree>
 - my-new-component-directory/
@@ -53,9 +53,9 @@ Para crear un nuevo paquete, recomendamos configurar tu entorno de desarrollo pa
       - ... additional files used by the package
 </FileTree>
 
-En este ejemplo, llamado `mi-proyecto`, creamos un proyecto con un solo paquete, llamado `mi-componente`, y un directorio `demo/` para probar y demostrar el componente.
+Este ejemplo, llamado `mi-proyecto`, crea un proyecto con un solo paquete, llamado `mi-componente`, y un directorio `demo/` para probar y demostrar el componente.
 
-Esto se configura en el archivo `package.json` de la raíz del proyecto.
+Esto se configura en el archivo `package.json` de la raíz del proyecto:
 
 ```json
 {
@@ -118,7 +118,7 @@ El formato del módulo utilizado por Node.js y Astro para interpretar tus archiv
 }
 ```
 
-Recomendamos usar `"type": "module"` para que `index.js` se pueda usar como un punto de entrada con `import` y `export`.
+Utiliza `"type": "module"` para que `index.js` se pueda usar como un punto de entrada con `import` y `export`.
 
 #### `homepage`
 
@@ -150,7 +150,7 @@ En este ejemplo, importar `my-component` usaría `index.js`, mientras que import
 
 #### `files`
 
-Esta es una optimización opcional para excluir archivos innecesarios del paquete enviado a los usuarios a través de npm. Ten en cuenta que **solo los archivos enumerados aquí se incluirán en tu paquete**, por lo que, si agregas o cambias los archivos necesarios para que tu paquete funcione, debes actualizar esta lista en consecuencia.
+Una optimización opcional para excluir archivos innecesarios del paquete enviado a los usuarios a través de npm. Ten en cuenta que **solo los archivos enumerados aquí se incluirán en tu paquete**, por lo que, si agregas o cambias los archivos necesarios para que tu paquete funcione, debes actualizar esta lista en consecuencia.
 
 ```json
 {
@@ -160,9 +160,9 @@ Esta es una optimización opcional para excluir archivos innecesarios del paquet
 
 #### `keywords`
 
-Una serie de palabras clave relevantes para tu componente que se utilizarán para ayudar a otros usuarios a [encontrar tu componente en npm](https://www.npmjs.com/search?q=keywords:astro-component,withastro) y en cualquier otro catálogo de búsqueda.
+Una serie de palabras clave relevantes para tu componente, utilizado para ayudar a otros usuarios a [encontrar tu componente en npm](https://www.npmjs.com/search?q=keywords:astro-component,withastro) y en cualquier otro catálogo de búsqueda.
 
-Recomendamos agregar `astro-component` o `withastro` como palabra clave especial para maximizar su descubrimiento en el ecosistema de Astro.
+Agrega `astro-component` o `withastro` como palabra clave especial para maximizar su descubrimiento en el ecosistema de Astro.
 
 ```json
 {
@@ -230,7 +230,7 @@ Si estás extrayendo componentes de un proyecto existente, puedes incluso contin
 
 ## Probando tus componentes
 
-Astro actualmente no envía un test runner. Esto es algo que nos gustaría abordar. _(Si estás interesado en ayudar, [¡únete a nosotros en Discord!](https://astro.build/chat/))_
+Astro actualmente no incluye un test runner. Esto es algo que nos gustaría abordar. _(Si estás interesado en ayudar con esto, [¡únete a nosotros en Discord!](https://astro.build/chat/))_
 
 Mientras tanto, nuestra recomendación actual para las pruebas es:
 
@@ -248,13 +248,11 @@ my-project/demo/src/pages/__fixtures__/
 
 ## Publicando tu componente
 
-Una vez que tengas tu paquete listo, ¡puedes publicarlo en npm!
+Una vez que tengas tu paquete listo, puedes publicarlo en npm utiliza el comando `npm publish` para publicar tu paquete. Si falla, asegúrate de haber iniciado sesión con `npm login` y de que tu archivo `package.json` esté correcto. Si tiene éxito, ¡has terminado!
 
-Para publicar un paquete en npm, utiliza el comando `npm publish`. Si eso falla, asegúrate de haber iniciado sesión a través de `npm login` y que tu `package.json` sea correcto. Si tienes éxito, ¡ya está!
+Es importante destacar que no hay un paso de "build" para los paquetes de Astro. Cualquier tipo de archivo que Astro admita de forma nativa, como `.astro`, `.ts`, `.jsx` y `.css`, puede ser publicado directamente sin necesidad de un paso de construcción adicional.
 
-Ten en cuenta que no hay un paso de `compilación` para los paquetes de Astro. Cualquier tipo de archivo compatible con Astro se puede publicar directamente sin un paso de compilación, porque sabemos que Astro es compatible con ellos de forma nativa. Esto incluye todos los archivos con extensiones como `.astro`, `.ts`, `.jsx` y `.css`.
-
-Si necesitas algún otro tipo de archivo que Astro no admita de forma nativa, puedes agregar un paso de compilación a tu paquete. Este caso avanzado depende de ti.
+Si necesitas agregar otro tipo de archivo que no sea admitido de forma nativa por Astro, deberás agregar un paso de construcción a tu paquete. Este ejercicio avanzado queda a tu cargo y dependerá de tus necesidades específicas.
 
 ## Biblioteca de integraciones
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Updated `publish-to-npm.mdx` & `server-side-rendering.mdx`

`publish-to-npm.mdx`
* [`f079d91`](https://github.com/withastro/docs/commit/f079d91844071800d53bd32191bd1fedb3baf5ce)

`server-side-rendering.mdx`
* [`c9e4190`](https://github.com/withastro/docs/commit/c9e4190b93eddcae595c2498e67257161c0de4df)
* [`326dd21`](https://github.com/withastro/docs/commit/326dd2188d6ee9eeff87bd44d67f08453b9bd5fa)