### PR TITLE
Add imports to src/pages/tags/[tag].astro example

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -636,6 +636,10 @@ This guide shows you how to convert an existing Astro project with Markdown file
 
     ```astro title="src/pages/tags/[tag].astro" "post.data" "getCollection(\"posts\")" "post.data.title" "'/posts/' + post.slug"
     ---
+    import { getCollection } from "astro:content";
+    import BaseLayout from "../../layouts/BaseLayout.astro";
+    import BlogPost from "../../components/BlogPost.astro";
+
     export async function getStaticPaths() {
       const allPosts = await getCollection("posts");
       const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())];


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

In the migrating from file based routing guide, the "src/pages/tags/[tag].astro" code example is missing the import statements in the frontmatter. If someone were copying and pasting from the given examples, they would probably get confused as to hwy the build is now broken. This PR just adds the missing import statements in.

