### PR TITLE
Clarify that file-based routes supersede redirects per priority level

### DIFF
--- a/src/content/docs/en/core-concepts/routing.mdx
+++ b/src/content/docs/en/core-concepts/routing.mdx
@@ -321,7 +321,7 @@ Given the example above, here are a few examples of how the rules will match a r
 - `pages/posts/[pid].astro` - Will build `/posts/1`, `/posts/abc`, etc. But not `/posts/create`
 - `pages/posts/[...slug].astro` - Will build `/posts/1/2`, `/posts/a/b/c`, etc. But not `/posts/create`, `/posts/1`, `/posts/abc`
 
-Redirects also follow the same rules, but are prioritized *last*; if there is a file-based route and a redirect with the same route rule, the file-based route is chosen.
+Redirects also follow the same rules, but are prioritized *last*; if there is a file-based route and a redirect with the same route priority level, the file-based route is chosen.
 
 ## Pagination
 


### PR DESCRIPTION
Since the list of route priority levels immediately precedes this, this language might make it clearer that file-based routes take precedence over redirects at the same route priority level.

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

A change to docs text for clarity relating to route priority levels and redirects 