### PR TITLE
Fix for incorrect navigation CSS in chapter 3 of the blog tutorial - en-only

### DIFF
--- a/src/content/docs/en/tutorial/3-components/3.mdx
+++ b/src/content/docs/en/tutorial/3-components/3.mdx
@@ -145,7 +145,7 @@ Since your site will be viewed on different devices, let's create a page navigat
       top: 5rem;
       left: 48px;
       background-color: #ff9776;
-      display: none;
+      display: block;
       margin: 0;
     }
 
@@ -170,7 +170,6 @@ Since your site will be viewed on different devices, let's create a page navigat
     @media screen and (min-width: 636px) {
       .nav-links {
         margin-left: 5em;
-        display: block;
         position: static;
         width: auto;
         background: none;


### PR DESCRIPTION
#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code


#### Description

While working through the Blog tutorial, I noticed an issue with the CSS in chapter 3 - Build and design with Astro UI components.

In globals.css, .nav-links is given `display:none;` styling by default. The navigation is completely hidden until we hit the 636px media query, at which point the styling is given `display:block;` and updated for larger screen sizes.

This is confusing as the tutorial encourages readers to play around with the screen size and also has a content tip for mobile-first design. So this does not seem like intended behaviour.



Screenshots given:

Before:
![image](https://github.com/withastro/docs/assets/16520455/2b18a36a-d529-4a00-9dbe-f1d548651629)


After:
![image](https://github.com/withastro/docs/assets/16520455/4cd636cf-d549-4610-9a8b-a92d017d6514)


This is a simple fix of replacing `display:none` with `display:block` and also removing duplicate styling from the media query.

