### PR TITLE
[WIP] Add translators face pile

### DIFF
--- a/src/components/TranslatorList.astro
+++ b/src/components/TranslatorList.astro
@@ -1,0 +1,188 @@
+---
+import { cachedFetch } from '../util-server';
+import { getLanguageFromURL } from '../util';
+
+export interface Props {
+	githubRepo?: `${string}/${string}`;
+}
+
+interface Commit {
+	author: {
+		login: string;
+		id: number;
+	};
+	commit: {
+		message: string;
+	};
+}
+
+interface Contributor {
+	login: string;
+	id: number;
+	contributions: number;
+}
+
+const { githubRepo = 'withastro/docs' } = Astro.props as Props;
+const lang = getLanguageFromURL(Astro.url.pathname);
+
+const printError = (e: Error) =>
+	console.warn(`[error]  /src/components/TranslatorList.astro\n         ${e?.message ?? e}`);
+
+async function getCommitsByPath(path: string, repo: string, page = 1): Promise<Commit[]> {
+	try {
+		const pageSize = 100;
+		const url = `https://api.github.com/repos/${repo}/commits?path=${path}&per_page=${pageSize}&page=${page}`;
+
+		const token = import.meta.env.PUBLIC_GITHUB_TOKEN;
+
+		const res = await cachedFetch(
+			url,
+			{
+				method: 'GET',
+				headers: {
+					Authorization:
+						token && `Basic ${Buffer.from(token, 'binary').toString('base64')}`,
+					'User-Agent': 'astro-docs/1.0',
+				},
+			},
+			{ duration: '15m' }
+		);
+
+		const data = await res.json();
+
+		if (!res.ok) {
+			throw new Error(
+				`Request to fetch commits failed. Reason: ${res.statusText}
+         Message: ${data?.message}`
+			);
+		}
+
+		// Fetch more commits recursively if there are more than GitHub’s per-page response limit.
+		if (data.length === pageSize) {
+			const rest = await getCommitsByPath(path, repo, page + 1);
+			data.push(...rest);
+		}
+
+		return data;
+	} catch (e: any) {
+		printError(e);
+		return new Array();
+	}
+}
+
+function getTranslationContributors(contributions: Commit[]) {
+	const ignoredCommitKeywords = /(en-only|typo|broken link|i18nReady|i18nIgnore)/i;
+	const contributors: Contributor[] = [];
+
+	for (const { author, commit } of contributions) {
+		if (ignoredCommitKeywords.test(commit.message) || !author) continue;
+
+		const contributorIndex = contributors.findIndex(
+			(contributor) => contributor.id === author.id
+		);
+
+		if (contributorIndex < 0) {
+			contributors.push({
+				id: author.id,
+				login: author.login,
+				contributions: 1,
+			});
+			continue;
+		}
+
+		contributors[contributorIndex].contributions += 1;
+	}
+
+	return contributors.sort((a, b) => b.contributions - a.contributions);
+}
+
+const pagesContributions = await getCommitsByPath(`src/content/docs/${lang}/`, githubRepo);
+const labelsContributions = await getCommitsByPath(`src/i18n/${lang}/`, githubRepo);
+const legacyContributions = await getCommitsByPath(`src/pages/${lang}/`, githubRepo);
+
+const allContributions = [...pagesContributions, ...labelsContributions, ...legacyContributions];
+const contributors = getTranslationContributors(allContributions);
+console.log(contributors);
+---
+
+{lang !== "en" && (
+	<>
+<slot />
+<!-- Thanks to @5t3ph for https://smolcss.dev/#smol-avatar-list! -->
+<div>
+	<ul class="avatar-list">
+		{
+			contributors.map((item) => (
+				<li>
+					<a href={`https://github.com/${item.login}`}>
+						<img
+							alt={item.login}
+							title={item.login}
+							width="3rem"
+							height="3rem"
+							src={`https://avatars.githubusercontent.com/u/${item.id}?s=64`}
+							loading="lazy"
+						/>
+					</a>
+				</li>
+			))
+		}
+	</ul>
+</div>
+</>
+)}
+
+<style>
+	.avatar-list {
+		--avatar-size: 3rem;
+		--avatar-overlap: -0.125em;
+		--avatar-row-spacing: 0.125em;
+		--avatar-outline-width: 1px;
+		--avatar-outline-offset: 0.08em;
+
+		display: flex;
+		flex-wrap: wrap;
+		list-style: none;
+		padding: var(--avatar-border);
+		font-size: var(--avatar-size);
+	}
+
+	.avatar-list li {
+		--avatar-row-margin: calc(
+			var(--avatar-outline-offset) + var(--avatar-outline-width) + var(--avatar-row-spacing) /
+				2
+		);
+		margin: var(--avatar-row-margin) var(--avatar-overlap) var(--avatar-row-margin) 0;
+	}
+
+	.avatar-list img,
+	.avatar-list a {
+		display: block;
+		border-radius: 50%;
+		width: var(--avatar-size);
+		height: var(--avatar-size);
+		/* Hide alt/title if Avatar image fails to load. */
+		text-decoration: none;
+		color: transparent;
+	}
+
+	.avatar-list img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		background-color: var(--theme-bg);
+		box-shadow: 0 0 0 var(--avatar-outline-width) var(--theme-divider),
+			0 0 0 var(--avatar-outline-offset) var(--theme-bg),
+			0 0 0 calc(var(--avatar-outline-offset) + var(--avatar-outline-width))
+				var(--theme-divider),
+			0 0 calc(var(--theme-glow-blur) + var(--avatar-outline-offset))
+				var(--theme-glow-diffuse);
+		/* Indicates the contributor image boundaries for forced colors users, transparent is changed to a solid color */
+		outline: 1px solid transparent;
+	}
+
+	.avatar-list a:focus {
+		outline: 2px solid var(--theme-accent);
+		outline-offset: var(--avatar-outline-offset);
+	}
+</style>

--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -4,6 +4,7 @@ description: A basic intro to Astro.
 i18nReady: true
 ---
 import Button from '~/components/Button.astro'
+import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
@@ -101,6 +102,12 @@ Join us in the [Astro Discord](https://astro.build/chat/) to share with and get 
 [Astro Blog](https://astro.build/blog/)
 
 [Astro changelog](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)
+
+<TranslatorList githubRepo="withastro/docs">
+## Translate
+
+These docs translation are brought to you by all these amazing people. [Help us with translations!](https://github.com/withastro/docs/blob/main/contributor-guides/translating-astro-docs.md)
+</TranslatorList>
 
 ## Contribute
 

--- a/src/content/docs/es/getting-started.mdx
+++ b/src/content/docs/es/getting-started.mdx
@@ -4,6 +4,7 @@ description: Introducción básica a Astro.
 i18nReady: true
 ---
 import Button from '~/components/Button.astro'
+import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
@@ -99,7 +100,11 @@ Nuestra [guía de instalación](/es/install/auto/) tiene instrucciones completas
 
 [Historial de cambios de Astro](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)
 
+<TranslatorList githubRepo="withastro/docs">
+## Translate
 
+These docs translation are brought to you by all these amazing people. [Help us with translations!](https://github.com/withastro/docs/blob/main/contributor-guides/translating-astro-docs.md)
+</TranslatorList>
 
 ## Contribuye
 

--- a/src/content/docs/pt-br/getting-started.mdx
+++ b/src/content/docs/pt-br/getting-started.mdx
@@ -4,6 +4,7 @@ description: Uma básica introdução ao Astro.
 i18nReady: true
 ---
 import Button from '~/components/Button.astro'
+import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
@@ -106,6 +107,11 @@ Junte-se a nós no [Discord do Astro](https://astro.build/chat) para compartilha
 
 [Histórico de alterações do Astro](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)
 
+<TranslatorList githubRepo="withastro/docs">
+## Traduza
+
+Essa tradução da documentação é trazida até você por todas essas pessoas incríveis. [Nos ajude a traduzir!](https://github.com/withastro/docs/blob/main/contributor-guides/translating-astro-docs.md)
+</TranslatorList>
 
 ## Contribua
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR adds a new face pile for our translators in Getting Started! 🥳

The contributors shown are for the entirety of the docs, not only for the current page. The component isn't rendered in the English Getting Started page, therefore I inserted the base text for translation as a slot prop. 

We're pushing contributions from 3 paths, the main content one (`src/content/docs/language/`), the i18n labels one (`src/i18n/language/`), and the pre-CC one (`src/pages/language/`).

Note that the current design is based on the current "all contributors" face pile. We need to better explore and see how we want to make it unique.

Below are a few examples.

**Spanish:**
![image](https://github.com/withastro/docs/assets/61414485/bc763e2f-582d-49b4-b74f-61dc0c472737)

**Portuguese:**
![image](https://github.com/withastro/docs/assets/61414485/5a17b4fd-285f-4b03-9831-89c216fdad06)

