### PR TITLE
Remove Unused Import "h" from Tutorial 6-1

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/1.mdx
+++ b/src/content/docs/en/tutorial/6-islands/1.mdx
@@ -46,7 +46,6 @@ This component will take an array of greeting messages as a prop and randomly se
 2. Add the following code to `Greeting.jsx`:
 
     ```jsx title="src/components/Greeting.jsx"
-    import { h } from 'preact';
     import { useState } from 'preact/hooks';
 
     export default function Greeting({messages}) {

--- a/src/content/docs/es/tutorial/6-islands/1.mdx
+++ b/src/content/docs/es/tutorial/6-islands/1.mdx
@@ -46,7 +46,6 @@ Este componente tomará un array de mensajes de bienvenida como props y seleccio
 2. Añade el siguiente código a `Greeting.jsx`:
 
     ```jsx title="src/components/Greeting.jsx"
-    import { h } from 'preact';
     import { useState } from 'preact/hooks';
 
     export default function Greeting({messages}) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

I found an unused import in the tutorial code in 6-1 that looks like could be removed. Thank you!

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change?
Removes unused import from tutorial code 6-1.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
