### PR TITLE
Improve `injectRoute` docs

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -208,7 +208,7 @@ injectRoute({
 ```
 
 An integration designed to be installed in other projects should use its package name to refer to the route entrypoint.
-For example, a package published to npm as `@fancy/dashboard`, might inject a dashboard route:
+The following example shows a package published to npm as `@fancy/dashboard` injecting a dashboard route:
 
 ```js
 injectRoute({

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -200,7 +200,7 @@ A callback function to inject routes into an Astro project. Injected routes can 
 
 ```js
 injectRoute({
-  // Use Astro’s syntax for dynamic route syntax.
+  // Use Astro’s pattern syntax for dynamic routes.
   pattern: '/subfolder/[dynamic]',
   // Use relative path syntax for a local route.
   entryPoint: './src/dynamic-page.astro'

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -196,12 +196,24 @@ A callback function to inject routes into an Astro project. Injected routes can 
 - `pattern` - where the route should be output in the browser, for example `/foo/bar`. A `pattern` can use Astro's filepath syntax for denoting dynamic routes, for example `/foo/[bar]` or `/foo/[...bar]`. Note that a file extension is **not** needed in the `pattern`.
 - `entryPoint` - a bare module specifier pointing towards the `.astro` page or `.js`/`.ts` route handler that handles the route denoted in the `pattern`.
 
-Example usage:
+##### Example usage
 
 ```js
 injectRoute({
+  // Use Astro’s syntax for dynamic route syntax.
   pattern: '/foo/[dynamic]',
-  entryPoint: 'foo/dynamic-page.astro'
+  // Use relative path syntax for a local route.
+  entryPoint: './src/foo/dynamic-page.astro'
+});
+```
+
+An integration designed to be installed in other projects should use its package name to refer to the route entrypoint.
+For example, a package published to npm as `@fancy/dashboard`, might inject a dashboard route:
+
+```js
+injectRoute({
+  pattern: '/fancy-dashboard',
+  entryPoint: '@fancy/dashboard/dashboard.astro'
 });
 ```
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -201,9 +201,9 @@ A callback function to inject routes into an Astro project. Injected routes can 
 ```js
 injectRoute({
   // Use Astro’s syntax for dynamic route syntax.
-  pattern: '/foo/[dynamic]',
+  pattern: '/subfolder/[dynamic]',
   // Use relative path syntax for a local route.
-  entryPoint: './src/foo/dynamic-page.astro'
+  entryPoint: './src/dynamic-page.astro'
 });
 ```
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -207,7 +207,7 @@ injectRoute({
 });
 ```
 
-An integration designed to be installed in other projects should use its package name to refer to the route entrypoint.
+For an integration designed to be installed in other projects, use its package name to refer to the route entrypoint.
 The following example shows a package published to npm as `@fancy/dashboard` injecting a dashboard route:
 
 ```js


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes withastro/astro#7642
- Improves docs for the `injectRoute` integration API to clarify how to specify the path to injected entrypoints. The user in the issue above was confused by the current docs and I’ve been repeatedly confused by them too.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
