### PR TITLE
[migrate-to-astro] Note suggesting experimental assets

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -321,6 +321,12 @@ See more about [Styling in Astro](/en/guides/styling/).
 
 ### Gatsby Image Plugin to Astro
 
+:::note
+Astro v3.0 will include a new `astro:assets` module and will deprecate the existing `@astrojs/image` integration.
+
+Access to `astro:assets` is currently available under an experimental flag, and is the recommended way to begin a new Astro project. If you are migrating to Astro pre-v3.0, we recommend [enabling the experimental flag to use assets](/en/guides/assets/) as an image solution.
+:::
+
 Convert Gatsby's `<StaticImage />` and `<GatsbyImage />` components with [Astro's own image integration components](/en/guides/images/#astros-image-integration), or with a standard HTML `<img>` / JSX `<img />` tag as appropriate.
 
 ```astro title="src/pages/index.astro"

--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -419,6 +419,12 @@ See more about [Styling in Astro](/en/guides/styling/).
 
 ### Next Image Plugin to Astro
 
+:::note
+Astro v3.0 will include a new `astro:assets` module and will deprecate the existing `@astrojs/image` integration.
+
+Access to `astro:assets` is currently available under an experimental flag, and is the recommended way to begin a new Astro project. If you are migrating to Astro pre-v3.0, we recommend [enabling the experimental flag to use assets](/en/guides/assets/) as an image solution.
+:::
+
 Convert any Next `<Image />` components with [Astro's own image integration components](/en/guides/images/#astros-image-integration), or with a standard HTML `<img>`. See a [full list of component attributes](/en/guides/integrations-guide/image/#usage) available for Astro's `<Image />` and `<Picture />` components, and note that several will differ from Next's attributes. 
 
 ```astro title="src/pages/index.astro"

--- a/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -489,6 +489,12 @@ See more about [Styling in Astro](/en/guides/styling/).
 
 ### Nuxt Image Plugin to Astro
 
+:::note
+Astro v3.0 will include a new `astro:assets` module and will deprecate the existing `@astrojs/image` integration.
+
+Access to `astro:assets` is currently available under an experimental flag, and is the recommended way to begin a new Astro project. If you are migrating to Astro pre-v3.0, we recommend [enabling the experimental flag to use assets](/en/guides/assets/) as an image solution.
+:::
+
 Convert any [Nuxt `<nuxt-img/>` or `<nuxt-picture/>` components](https://image.nuxtjs.org/components/nuxt-img) to [Astro's own image integration components](/en/guides/images/#astros-image-integration), or to a standard HTML `<img>` tag. 
 
 See a [full list of component attributes](/en/guides/integrations-guide/image/#usage) available for Astro's `<Image />` and `<Picture />` components, and note that several will differ from Nuxt's attributes. 


### PR DESCRIPTION
The existing "Migrate to Astro" *full* guides (Gatsby, Next and Nuxt) all include a section on how to convert their respective Image components to Astro's image integration component.

This PR adds a note to the top of that section in all three guides suggesting that if you are converting/starting a new project *now*, we recommend using the experimental assets flag in prep for v3.

![Screenshot from 2023-07-17 10-45-14](https://github.com/withastro/docs/assets/5098874/70cd3173-5da2-41a3-b137-de055c609fe1)

Note: these sections will be fully updated as part of the v3 Image / Assets docs updates when Assets is no longer experimental. This is only adding a note now to provide guidance in the interim.


