### PR TITLE
Remove abort when `<Version />` fetch fails

### DIFF
--- a/src/components/Version.astro
+++ b/src/components/Version.astro
@@ -1,5 +1,5 @@
 ---
-import pRetry, { AbortError } from 'p-retry';
+import pRetry from 'p-retry';
 import { cachedFetch } from '../util-server';
 
 export interface Props {
@@ -16,7 +16,7 @@ const packageInfo = await pRetry(
 		const json = await response.json();
 
 		if (!response.ok) {
-			throw new AbortError(
+			throw new Error(
 				`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(
 					json
 				)}`
@@ -25,7 +25,7 @@ const packageInfo = await pRetry(
 
 		return json;
 	},
-	{ retries: 5 }
+	{ retries: 10 }
 );
 
 const { version } = packageInfo;


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description

Turns out adding retrying logic didn't really fix this for us, now I changed the `AbortError` to a normal `Error` so that when it fails it will actually retry. And with +5 retries, to be sure.

From what I understood from Eleventy Fetch docs, it won't cache a failed response, so I guess we're fine in this aspect!