### PR TITLE
swap client-side routing with view transitions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -80,6 +80,10 @@
     to = "/:lang/guides/deploy/edgio"
 
   [[redirects]]
+    from = "/:lang/guides/client-side-routing"
+    to = "/:lang/guides/view-transitions"
+
+  [[redirects]]
     from = "/:lang/migration/0.21.0"
     to = "/:lang/guides/upgrade-to/v1"
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -1,13 +1,13 @@
 ---
-title: Client-side routing (Experimental)
+title: View Transitions (Experimental)
 description: >-
-  How to enable experimental support for client-side routing in your Astro site.
+  How to enable experimental support for view transitions in your Astro site.
 i18nReady: true
 ---
 
-Support for **opt-in, per-page, client-side routing** in Astro projects can be enabled behind an experimental flag. Client-side routing updates your page content without the browser's normal, full-page navigation refresh and provides seamless animations between pages. 
+Support for **opt-in, per-page, view transitions** in Astro projects can be enabled behind an experimental flag. View transitions update your page content without the browser's normal, full-page navigation refresh and provides seamless animations between pages. 
 
-Astro provides a `<ViewTransitions />` routing component that can be added to a single page's `<head>` to control page transitions as you navigate away to another page. Add this component to a reusable `.astro` component, such as a common head or layout, for client-side routing across your entire site (SPA mode).
+Astro provides a `<ViewTransitions />` routing component that can be added to a single page's `<head>` to control page transitions as you navigate away to another page, an effect traditionally only possible with client-side routing. Add this component to a reusable `.astro` component, such as a common head or layout, for animated page transitions across your entire site (SPA mode).
 
 Astro's view transitions support is powered by the new [View Transitions](https://developer.chrome.com/docs/web-platform/view-transitions/) browser API and also includes:
 
@@ -17,12 +17,12 @@ Astro's view transitions support is powered by the new [View Transitions](https:
 - [Control over fallback behavior](#fallback-control) for browsers that do not yet support the View Transition APIs.
 
 :::caution
-Client-side routing is an experimental feature enabled in Astro 2.9. The API is subject to change before it is marked as stable.
+View transitions is an experimental feature enabled in Astro 2.9. The API is subject to change before it is marked as stable.
 :::
 
-## Enabling Client-side Routing in your Project
+## Enabling View Transitions in your Project
 
-You can enable support for client-side routing through the experimental `viewTransitions` flag in your Astro config:
+You can enable support for animated page transitions through the experimental `viewTransitions` flag in your Astro config:
 
 ```js title="astro.config.mjs" ins={4-6}
 import { defineConfig } from 'astro/config';
@@ -37,14 +37,14 @@ export default defineConfig({
 :::note
 Enabling view transitions support does not automatically convert your entire site into a SPA (Single-page App). By default, every page will still use regular, full-page, browser navigation.
 
-Use client-side routing in Astro with the `<ViewTransitions />` routing component and transition directives on a per-page basis, or site-wide.
+Add page transitions in Astro with the `<ViewTransitions />` routing component and transition directives on a per-page basis, or site-wide.
 :::
 
-## Client-side Routing on a Page
+## View transitions a page
 
-Import the `<ViewTransitions />` component and place it inside of a page's `<head>` to opt that page in to client-side routing on a per-page basis. You can then control the animation of page elements during navigation with [transition directives](#transition-directives):
+Import the `<ViewTransitions />` component and place it inside of a page's `<head>` to opt that page in to use the routing component on a per-page basis. You can then control the animation of page elements during navigation with [transition directives](#transition-directives):
 
-```astro title="src/pages/MyClientSideRoutingPage.astro"
+```astro title="src/pages/MyPageWithTransitions.astro"
 ---
 import { ViewTransitions } from 'astro:transitions';
 ---
@@ -59,11 +59,11 @@ import { ViewTransitions } from 'astro:transitions';
 </html>
 ```
 
-## Full site client-side routing (SPA mode)
+## Full site view transitions (SPA mode)
 
-To enable client-side routing on multiple pages, or your entire site, import and use `<ViewTransitions />` in a reused component, such as a layout component.
+To enable page transitions on multiple pages, or your entire site, import and use `<ViewTransitions />` in a reused component, such as a layout component.
 
-The example below shows adding client-side routing site-wide by importing and adding this component to a `<CommonHead />` Astro component:
+The example below shows adding animated page transitions site-wide by importing and adding this component to a `<CommonHead />` Astro component:
 
 ```astro title="components/CommonHead.astro" ins={2,12}
 ---
@@ -203,7 +203,7 @@ Control fallback support by setting the `fallback` property on the `<ViewTransit
 
 - `animate` (default) - Astro will simulate view transitions using custom attributes before updating page content.
 - `swap` - Astro will not attempt to animate the page. Instead, the old page will be immediately replaced by the new one.
-- `none` - Astro will not do client-side routing at all. Instead, you will get full page navigation in non-supporting browsers.
+- `none` - Astro will not do any animated page transitions at all. Instead, you will get full page navigation in non-supporting browsers.
 
 ```astro
 ---

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -901,7 +901,7 @@ To enable this feature, set `experimental.assets` to `true` in your Astro config
 </p>
 
 Enable experimental support for the `<ViewTransitions / >` component. With this enabled
-you can opt-in to  [client-side routing](/en/guides/client-side-routing/) on a per-page basis using this component
+you can opt-in to [view transitions](/en/guides/view-transitions/) on a per-page basis using this component
 and enable animations with the `transition:animate` directive.
 
 ```js

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -84,7 +84,7 @@ export default [
 	{ text: 'Middleware', slug: 'guides/middleware', key: 'guides/middleware' },
 	{ text: 'Testing', slug: 'guides/testing', key: 'guides/testing' },
 	{
-		text: 'Client-side Routing (Experimental)',
+		text: 'View Transitions (Experimental)',
 		slug: 'guides/client-side-routing',
 		key: 'guides/client-side-routing',
 	},

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -85,8 +85,8 @@ export default [
 	{ text: 'Testing', slug: 'guides/testing', key: 'guides/testing' },
 	{
 		text: 'View Transitions (Experimental)',
-		slug: 'guides/client-side-routing',
-		key: 'guides/client-side-routing',
+		slug: 'guides/view-transitions',
+		key: 'guides/view-transitions',
 	},
 	{ text: 'Troubleshooting', slug: 'guides/troubleshooting', key: 'guides/troubleshooting' },
 


### PR DESCRIPTION
Renames the main page and tweaks some wording throughout to hit "View Transitions" harder than "Client-side routing" for 2.9.

This also updates the config reference locally, which I'll also do at the source in a separate PR to match.