### PR TITLE
i18n(ja): Remove <StackblitzIntro> from tutorial

### DIFF
--- a/src/content/docs/ja/tutorial/2-pages/index.mdx
+++ b/src/content/docs/ja/tutorial/2-pages/index.mdx
@@ -10,14 +10,15 @@ i18nReady: true
 import Checklist from '~/components/Checklist.astro';
 import Badge from '~/components/Badge.astro';
 import Box from '~/components/tutorial/Box.astro';
-import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 
 
 ウェブ上で動作するサイトができたところで、ページと投稿を追加しましょう！
 
 ## 今立っている場所
 
-<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-2/start"/>
+チュートリアルのこの段階でのコードは、[GitHub](https://github.com/withastro/blog-tutorial-demo/tree/unit-2/start)または[StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/unit-2/start?file=src/pages/index.astro)で確認できます。
+
+あなたのコードを上の例と比較してみてください。また、チュートリアルを始めたばかりであれば、StackBlitzでフォークして、ここからブラウザ上でコーディングを始めてください。
 
 ## これから向かう場所
 

--- a/src/content/docs/ja/tutorial/3-components/index.mdx
+++ b/src/content/docs/ja/tutorial/3-components/index.mdx
@@ -12,14 +12,15 @@ import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';
 import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
 import Option from '~/components/tutorial/Option.astro';
-import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 
 
 `.astro`ファイルと`.md`ファイルによりウェブサイトのページ全体を生成できるようになったので、AstroコンポーネントでHTMLの小さな部品を作成して再利用しましょう！
 
 ## 今立っている場所
 
-<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-3/start"/>
+チュートリアルのこの段階でのコードは、[GitHub](https://github.com/withastro/blog-tutorial-demo/tree/unit-3/start)または[StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/unit-3/start?file=src/pages/index.astro)で確認できます。
+
+あなたのコードを上の例と比較してみてください。また、チュートリアルを始めたばかりであれば、StackBlitzでフォークして、ここからブラウザ上でコーディングを始めてください。
 
 ## これから向かう場所
 

--- a/src/content/docs/ja/tutorial/4-layouts/index.mdx
+++ b/src/content/docs/ja/tutorial/4-layouts/index.mdx
@@ -10,14 +10,15 @@ i18nReady: true
 import Badge from '~/components/Badge.astro';
 import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';
-import StackblitzIntro from '~/components/tutorial/StackblitzIntro.astro';
 
 
 コンポーネントを使用できるようになったところで、カスタムレイアウトを作成しましょう！
 
 ## 今立っている場所
 
-<StackblitzIntro tree="withastro/blog-tutorial-demo/tree/unit-4/start"/>
+チュートリアルのこの段階でのコードは、[GitHub](https://github.com/withastro/blog-tutorial-demo/tree/unit-4/start)または[StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/unit-4/start?file=src/pages/index.astro)で確認できます。
+
+あなたのコードを上の例と比較してみてください。また、チュートリアルを始めたばかりであれば、StackBlitzでフォークして、ここからブラウザ上でコーディングを始めてください。
 
 ## これから向かう場所
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Translated content

#### Description

- Remove `<StackblitzIntro>` (https://github.com/withastro/docs/pull/3770).
  - Need to wait for the review result of https://github.com/withastro/docs/pull/3738 before merging.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
