### PR TITLE
Update WordPress.mdx to describe how to get smaller image sizes

### DIFF
--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -157,7 +157,11 @@ let [post] = await res.json();
 
 The `_embedded['wp:featuredmedia']['0'].source_url` property is returned, and can be used to display the featured image on each dinosuar page. 
 
-As written, this will return the full sized image which may be too large for your use. If you need one of the smaller sizes created by WordPress, you can retrieve it like this: `_embedded['wp:featuredmedia']['0'].media_details.sizes.[SIZE].source_url` where [SIZE] is one of the image sizes created by WordPress. For example, `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` will return the medium image size.
+As written, this will return the full sized image which may be too large for your use. If you need one of the smaller sizes created by WordPress, you can retrieve it like this:
+
+`_embedded['wp:featuredmedia']['0'].media_details.sizes.[SIZE].source_url` 
+
+where [SIZE] is one of the image sizes created by WordPress. For example, `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` will return the medium image size.
 
 ```astro title="/src/pages/dinos/[slug].astro" {3}
 <Layout title={post.title.rendered}>

--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -155,7 +155,9 @@ let [post] = await res.json();
 ---
 ```
 
-The `_embedded['wp:featuredmedia']['0'].source_url` property is returned, and can be used to display the featured image on each dinosuar page.
+The `_embedded['wp:featuredmedia']['0'].source_url` property is returned, and can be used to display the featured image on each dinosuar page. 
+
+As written, this will return the full sized image which may be too large for your use. If you need one of the smaller sizes created by WordPress, you can retrieve it like this: `_embedded['wp:featuredmedia']['0'].media_details.sizes.[SIZE].source_url` where [SIZE] is one of the image sizes created by WordPress. For example, `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` will return the medium image size.
 
 ```astro title="/src/pages/dinos/[slug].astro" {3}
 <Layout title={post.title.rendered}>

--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -160,7 +160,7 @@ The `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` p
 ```astro title="/src/pages/dinos/[slug].astro" {3}
 <Layout title={post.title.rendered}>
   <article>
-    <img src={post._embedded['wp:featuredmedia']['0'].source_url} />
+    <img src={post._embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url} />
     <h1 set:html={post.title.rendered} />
     <Fragment set:html={post.content.rendered} />
   </article>

--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -155,13 +155,7 @@ let [post] = await res.json();
 ---
 ```
 
-The `_embedded['wp:featuredmedia']['0'].source_url` property is returned, and can be used to display the featured image on each dinosuar page. 
-
-As written, this will return the full sized image which may be too large for your use. If you need one of the smaller sizes created by WordPress, you can retrieve it like this:
-
-`_embedded['wp:featuredmedia']['0'].media_details.sizes.[SIZE].source_url` 
-
-where [SIZE] is one of the image sizes created by WordPress. For example, `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` will return the medium image size.
+The `_embedded['wp:featuredmedia']['0'].media_details.sizes.medium.source_url` property is returned, and can be used to display the featured image on each dinosuar page. (Replace `medium` with your desired image size.)
 
 ```astro title="/src/pages/dinos/[slug].astro" {3}
 <Layout title={post.title.rendered}>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

 
- New or updated content
 
#### Description
_Added a couple of sentences to the section on embeddable content with information on how get smaller sizes of the featured image (the code that is there gets the full size image which is often too large)._


<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
