### PR TITLE
chore(en): describe more accepted `class:list` value kinds

### DIFF
--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -31,6 +31,7 @@ A template directive is never included directly in the final HTML output of a co
 - `Object`: All truthy keys are added to the element `class`
 - `Array`: flattened
 - `Set`: flattened
+- `false` or `null`: skipped
 
 ```astro
 <!-- This -->


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- (very) minor content fixes (broken links, typos, etc.)

#### Description

Currently, the documentation on `class:list` doesn't mention anything about how it handles false values.
This was an issue when it stringified `false`, diverging in behavior from the `clsx` package the documentation references (https://github.com/withastro/astro/issues/3920);
while that since has since been fixed (https://github.com/withastro/astro/pull/3922), there's still no mention of how it handles such values in the documentation. This PR adds a note of how it handles `false` (as well as `null`) in the docs, as observed in the source code at https://github.com/withastro/astro/blob/main/packages/astro/src/runtime/server/util.ts#L19.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
