### PR TITLE
i18n(zh-cn): translate the rest sections of `Reference/Error Reference/Content Colletion Errors` into Chinese(Simplified)

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/collection-does-not-exist-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/collection-does-not-exist-error.mdx
@@ -1,0 +1,11 @@
+---
+title: Collection does not exist
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> 通过 `getCollection()` 查询的集合不存在。
+
+## 哪里发生了错误？
+
+当查询集合时，请确保 `src/content/` 下存在一个和请求名称同名的集合目录。

--- a/src/content/docs/zh-cn/reference/errors/content-collection-type-mismatch-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/content-collection-type-mismatch-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Collection contains entries of a different type.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` 包含 `ACTUAL_TYPE` 类型的条目，但却配置为 `EXPECTED_TYPE` 集合。
+
+## 哪里发生了错误？
+
+内容集合必须包含所配置的类型。默认类型为 `type: 'content'`。试着为数据集合添加 `type: 'data'` 的类型。
+
+**请参阅：**
+
+- [定义内容集合](/zh-cn/guides/content-collections/#defining-collections)

--- a/src/content/docs/zh-cn/reference/errors/data-collection-entry-parse-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/data-collection-entry-parse-error.mdx
@@ -1,0 +1,11 @@
+---
+title: Data collection entry failed to parse.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_ENTRY_NAME` 解析失败。
+
+## 哪里发生了错误？
+
+`type: 'data'` 的集合条目必须返回一个包含有效 JSON（对于 `.json` 条目）或 YAML（对于 `.yaml` 条目）的对象。

--- a/src/content/docs/zh-cn/reference/errors/duplicate-content-entry-slug-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/duplicate-content-entry-slug-error.mdx
@@ -1,0 +1,11 @@
+---
+title: Duplicate content entry slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` 包含多个相同的 `SLUG` 条目。Slug 必须是唯一的。
+
+## 哪里发生了错误？
+
+内容集合条目必须具有唯一的 slug。通常是由 `slug` frontmatter 属性引起的重复。

--- a/src/content/docs/zh-cn/reference/errors/mixed-content-data-collection-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/mixed-content-data-collection-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Content and data cannot be in same collection.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` 同时包含了内容和数据条目。所有条目必须是相同的类型。
+
+## 哪里发生了错误？
+
+一个内容集合不能同时包含内容和数据条目。必须按类型将条目存储在单独的集合中。
+
+**请参阅：**
+
+- [定义内容集合](/zh-cn/guides/content-collections/#defining-collections)

--- a/src/content/docs/zh-cn/reference/errors/unsupported-config-transform-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/unsupported-config-transform-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Unsupported transform in content config.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnsupportedConfigTransformError**: 内容配置中的 `transform()` 函数必须返回有效的 JSON，或者与 devalue 库兼容的数据类型（包括 Dates、Maps 和 Sets）。\n完整错误：PARSE_ERROR
+
+## 哪里发生了错误？
+
+内容配置中的 `transform()` 函数必须返回有效的 JSON，或者与 devalue 库兼容的数据类型（包括 Dates、Maps 和 Sets）。
+
+**请参阅：**
+
+- [devalue 库](https://github.com/rich-harris/devalue)


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content
- Translated content

#### Description

Translate the following sections into Chinese(Simplified):
- [CollectionDoesNotExistError](https://docs.astro.build/en/reference/errors/collection-does-not-exist-error/)
- [MixedContentDataCollectionError](https://docs.astro.build/en/reference/errors/mixed-content-data-collection-error/)
- [ContentCollectionTypeMismatchError](https://docs.astro.build/en/reference/errors/content-collection-type-mismatch-error/)
- [DataCollectionEntryParseError](https://docs.astro.build/en/reference/errors/data-collection-entry-parse-error/)
- [DuplicateContentEntrySlugError](https://docs.astro.build/en/reference/errors/duplicate-content-entry-slug-error/)
- [UnsupportedConfigTransformError](https://docs.astro.build/en/reference/errors/unsupported-config-transform-error/)