### PR TITLE
add: note to direct users to modifiyng frontmatter with remark

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -515,6 +515,10 @@ export default {
 
 ### Modifying frontmatter programmatically
 
+:::note
+If you are using [content collections](/en/guides/content-collections/), you will instead want to read ["Modifying Frontmatter with Remark"](/en/guides/content-collections/#modifying-frontmatter-with-remark)
+:::
+
 You can add frontmatter properties to all of your Markdown and MDX files by using a [remark or rehype plugin](#markdown-plugins).
 
 1. Append a `customProperty` to the `data.astro.frontmatter` property from your plugin's `file` argument:

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -516,7 +516,7 @@ export default {
 ### Modifying frontmatter programmatically
 
 :::note
-If you are using [content collections](/en/guides/content-collections/), you will instead want to read ["Modifying Frontmatter with Remark"](/en/guides/content-collections/#modifying-frontmatter-with-remark)
+If you are using [content collections](/en/guides/content-collections/), please see ["Modifying Frontmatter with Remark"](/en/guides/content-collections/#modifying-frontmatter-with-remark).
 :::
 
 You can add frontmatter properties to all of your Markdown and MDX files by using a [remark or rehype plugin](#markdown-plugins).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

- Closes #3930
- What does this PR change? Give us a brief description.
  - It adds a note `aside` to the `markdown-content` page that warns users that if they are using content collections, they should instead be reading the `content-collections` page if they want to modify their frontmatter programmatically.
<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
