### PR TITLE
Add title and adjust highlight in configured redirects code samples

### DIFF
--- a/src/content/docs/en/core-concepts/routing.mdx
+++ b/src/content/docs/en/core-concepts/routing.mdx
@@ -231,7 +231,7 @@ You can define rules to [redirect users to permanently-moved pages](#configured-
 
 You can specify a mapping of permanent redirects in your Astro config with the `redirects` value. For most redirects, this is a mapping of an old route to the new route:
 
-```js title="astro.config.mjs" {5, 7-9}
+```js title="astro.config.mjs" {5}
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
@@ -251,7 +251,7 @@ These redirects follow the same rules as file-based routes. Dynamic routes are a
 
 Using SSR or a static adapter, you can also provide an object as the value, allowing you to specify the `status` code in addition to the new `destination`:
 
-```js
+```js title="astro.config.mjs" {5-8}
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- No issue but addresses [request from @sarah11918](https://github.com/withastro/docs/issues/2042#issuecomment-1658196170)
- Adds a title missing from the third code snippet in the [Configured Redirects](https://docs.astro.build/en/core-concepts/routing/#configured-redirects) section of the Routing page. In addition, I adjusted the highlights in the first and third code snippets so that they mark the code being described in the text. In the current version, the first code snippet highlights the final line and two lines that don't exist (7-9).

Before:
<img width="618" alt="current code samples in configured redirects section linked above" src="https://github.com/withastro/docs/assets/7365296/916a67c1-f280-4b8b-8961-729378b93b8c">

After:
<img width="615" alt="same code sample, now both showing config.astro.mjs as the title and with only the redirect configuration code highlighted" src="https://github.com/withastro/docs/assets/7365296/6a162ee1-47e8-4500-974e-20edbd48b523">



<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
