### PR TITLE
chore: Fix the missing links for `guides/deploy/space.mdx`

### DIFF
--- a/src/content/docs/en/guides/deploy/space.mdx
+++ b/src/content/docs/en/guides/deploy/space.mdx
@@ -87,7 +87,7 @@ This will run the build process and create a new [Space app instance](https://de
 
 By default Space apps are private and are only accessible to you. 
 
-If you want to make your app available to others you can use [Public Routes](https://deta.space/docs/en/use/space-apps/using-apps#private-and-public-routes) to make parts of your app public. Or, you can [create a release](https://deta.space/docs/en/publish/releasing#releases) to let others install your app into their own personal cloud.
+If you want to make your app available to others you can use [Public Routes](https://deta.space/docs/en/reference/spacefile#public_routes) to make parts of your app public. Or, you can [create a release](https://deta.space/docs/en/publish/releasing#releases) to let others install your app into their own personal cloud.
 
 ## Next steps
 

--- a/src/content/docs/en/guides/deploy/space.mdx
+++ b/src/content/docs/en/guides/deploy/space.mdx
@@ -16,7 +16,7 @@ This guide includes step-by-step instructions for building sites in Space. Both 
 To push an Astro site to Space, make sure you first:
 
 - Create a [Space account](https://deta.space).
-- Install the [Space CLI](https://deta.space/docs/en/basics/cli) and log in.
+- Install the [Space CLI](https://deta.space/docs/en/build/reference/cli) and log in.
 
 Create a Space project **inside** the directory of your Astro project. Run the CLI and follow the instructions on the screen.    
 
@@ -83,17 +83,17 @@ Deploy your project with the following command:
 space push
 ```
 
-This will run the build process and create a new [Space app instance](https://deta.space/docs/en/basics/revisions#testing-changes) where you can access your Astro app.
+This will run the build process and create a new [Space app instance](https://deta.space/docs/en/build/fundamentals/development/builder-instance#for-testing) where you can access your Astro app.
 
 By default Space apps are private and are only accessible to you. 
 
-If you want to make your app available to others you can use [Public Routes](https://deta.space/docs/en/reference/spacefile#public_routes) to make parts of your app public. Or, you can [create a release](https://deta.space/docs/en/basics/releases) to let others install your app into their own personal cloud.
+If you want to make your app available to others you can use [Public Routes](https://deta.space/docs/en/use/space-apps/using-apps#private-and-public-routes) to make parts of your app public. Or, you can [create a release](https://deta.space/docs/en/publish/releasing#releases) to let others install your app into their own personal cloud.
 
 ## Next steps
 
-- [Add more compute to your Space project](https://deta.space/docs/en/basics/micros)
-- [Store data for your Space project](https://deta.space/docs/en/basics/data)
-- [Launch your Space app](https://deta.space/docs/en/basics/releases)
+- [Add more compute to your Space project](https://deta.space/docs/en/build/fundamentals/the-space-runtime/micros#adding-a-micro)
+- [Store data for your Space project](https://deta.space/docs/en/build/fundamentals/data-storage#content)
+- [Launch your Space app](https://deta.space/docs/en/publish/releasing#releases)
 
 ## Examples
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- New or updated content

#### Description

I found that the old Space document links are invalid When I translated Chinese version(#4008). So I fix it to make them all be right.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
