### PR TITLE
Explain how to get environment variables in SSR mode

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -93,7 +93,7 @@ Because Vite statically replaces `import.meta.env`, you cannot access it with dy
 :::
 
 In SSR mode the environment variables can be accessed at runtime based on the SSR adapter. For most adapters you can access environment variables with `process.env`. With the Deno adapter you can get them with `Deno.env.get()`.
-Cloudflare also has its [own way](en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. Astro will first check the server environment for variables and if they don't exist it will try to look for them in .env files.
+Cloudflare also has its [own way](/en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. Astro will first check the server environment for variables and if they don't exist it will try to look for them in .env files.
 
 ## IntelliSense for TypeScript
 

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -92,8 +92,8 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
 
-In SSR mode the environment variables can be accessed at runtime based on the SSR adapter. For most adapters you can access environment variables with `process.env`. With the Deno adapter you can get them with `Deno.env.get()`.
-Cloudflare also has its [own way](/en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. Astro will first check the server environment for variables and if they don't exist it will try to look for them in .env files.
+When using SSR, environment variables can be accessed at runtime based on the SSR adapter being used. With most adapters you can access environment variables with `process.env`, for the Deno adapter you have to use `Deno.env.get()`. Cloudflare has its [own way](/en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. 
+Astro will check the server environment for variables, if they don't exist, Astro will look for them in .env files.
 
 ## IntelliSense for TypeScript
 

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -73,6 +73,7 @@ You can also add environment variables as you run your project:
 :::caution
 Variables set this way will be available everywhere within your project, including on the client.
 :::
+
 ## Getting environment variables
 
 Instead of using `process.env`, with Vite you use `import.meta.env`, which uses the `import.meta` feature added in ES2020.
@@ -90,6 +91,9 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 :::caution
 Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
+
+In SSR mode the environment variables can be accessed at runtime based on the SSR adapter. For most adapters you can access environment variables with `process.env`, but with the Deno adapter you can get them with `Deno.env.get()`.
+Cloudflare also has its [own way](en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. Astro will first check the server environment for variables and if they don't exist it will try to look for them in .env files.
 
 ## IntelliSense for TypeScript
 

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -92,7 +92,7 @@ const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 Because Vite statically replaces `import.meta.env`, you cannot access it with dynamic keys like `import.meta.env[key]`.
 :::
 
-In SSR mode the environment variables can be accessed at runtime based on the SSR adapter. For most adapters you can access environment variables with `process.env`, but with the Deno adapter you can get them with `Deno.env.get()`.
+In SSR mode the environment variables can be accessed at runtime based on the SSR adapter. For most adapters you can access environment variables with `process.env`. With the Deno adapter you can get them with `Deno.env.get()`.
 Cloudflare also has its [own way](en/guides/integrations-guide/cloudflare/#environment-variables) of handling environment variables. Astro will first check the server environment for variables and if they don't exist it will try to look for them in .env files.
 
 ## IntelliSense for TypeScript


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes #3049

This Pull request explains how to access environment variables in SSR mode. Feel free to add sugggestions, maybe we also should have a section on environment variables in the Deno adapter guide? 

Here's a complete list of how we can use environment variables in different adapters:

| Adapter | Usage |
| --- | --- |
| Node | `process.env` |
| Netlify | `process.env` |
| Vercel | `process.env` |
| Cloudflare | `import.meta.env` |
| Deno | `Deno.env.get` |

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
