### PR TITLE
transferring slots

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -281,6 +281,59 @@ const { title } = Astro.props
 </div>
 ```
 
+### Transferring slots
+
+Slots can be transfered to other components. For example, when creating nested layouts:
+
+```astro {11,14}
+// src/layouts/BaseLayout.astro
+---
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+    <slot name="head"/>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>
+```
+
+```astro {7, 8}
+// src/layouts/HomeLayout.astro
+---
+import BaseLayout from "./BaseLayout.astro";
+---
+
+<BaseLayout>
+  <slot name="head" slot="head"/>
+  <slot />
+</BaseLayout>
+```
+
+:::note
+Named slots can be transfered to another component using both the `name` and `slot` attributes on a `<slot />` tag
+:::
+
+Now, the default and `head` slots passed to `HomeLayout` will be transferred to the `BaseLayout` parent
+
+```astro
+// src/pages/index.astro
+---
+import HomeLayout from "../layouts/HomeLayout.astro";
+---
+
+<HomeLayout>
+	<title slot="head">Astro</title>
+	<h1>Astro</h1>
+</HomeLayout>
+```
+
 
 ## HTML Components
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Adds example on how to transfer slots from one component to another using a `<slot name="name" slot="name""/>` tag

- Closes: https://github.com/withastro/docs/issues/4034
- https://deploy-preview-4045--astro-docs-2.netlify.app/en/core-concepts/astro-components/#transferring-slots

Let me know if any of this could be worded better, I originally called this pattern "slot drilling" but I think "slot transferring" is a better word for explaining what is happening.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
