### PR TITLE
Add Bun package manager to docs

### DIFF
--- a/src/components/tabs/PackageManagerTabs.astro
+++ b/src/components/tabs/PackageManagerTabs.astro
@@ -3,21 +3,21 @@ import Tabs from './Tabs';
 ---
 
 <Tabs client:visible sharedStore="package-managers">
-  <Fragment slot="tab.npm">npm</Fragment>
-  <Fragment slot="tab.pnpm">pnpm</Fragment>
-  <Fragment slot="tab.yarn">Yarn</Fragment>
-  <Fragment slot="tab.bun">Bun</Fragment>
+	<Fragment slot="tab.npm">npm</Fragment>
+	<Fragment slot="tab.pnpm">pnpm</Fragment>
+	<Fragment slot="tab.yarn">Yarn</Fragment>
+	<Fragment slot="tab.bun">Bun</Fragment>
 
-  <Fragment slot="panel.npm">
-    <slot name="npm" />
-  </Fragment>
-  <Fragment slot="panel.pnpm">
-    <slot name="pnpm" />
-  </Fragment>
-  <Fragment slot="panel.yarn">
-    <slot name="yarn" />
-  </Fragment>
-  <Fragment slot="panel.bun">
-    <slot name="bun" />
-  </Fragment>
+	<Fragment slot="panel.npm">
+		<slot name="npm" />
+	</Fragment>
+	<Fragment slot="panel.pnpm">
+		<slot name="pnpm" />
+	</Fragment>
+	<Fragment slot="panel.yarn">
+		<slot name="yarn" />
+	</Fragment>
+	<Fragment slot="panel.bun">
+		<slot name="bun" />
+	</Fragment>
 </Tabs>

--- a/src/components/tabs/PackageManagerTabs.astro
+++ b/src/components/tabs/PackageManagerTabs.astro
@@ -3,17 +3,21 @@ import Tabs from './Tabs';
 ---
 
 <Tabs client:visible sharedStore="package-managers">
-	<Fragment slot="tab.npm">npm</Fragment>
-	<Fragment slot="tab.pnpm">pnpm</Fragment>
-	<Fragment slot="tab.yarn">Yarn</Fragment>
+  <Fragment slot="tab.npm">npm</Fragment>
+  <Fragment slot="tab.pnpm">pnpm</Fragment>
+  <Fragment slot="tab.yarn">Yarn</Fragment>
+  <Fragment slot="tab.bun">Bun</Fragment>
 
-	<Fragment slot="panel.npm">
-		<slot name="npm" />
-	</Fragment>
-	<Fragment slot="panel.pnpm">
-		<slot name="pnpm" />
-	</Fragment>
-	<Fragment slot="panel.yarn">
-		<slot name="yarn" />
-	</Fragment>
+  <Fragment slot="panel.npm">
+    <slot name="npm" />
+  </Fragment>
+  <Fragment slot="panel.pnpm">
+    <slot name="pnpm" />
+  </Fragment>
+  <Fragment slot="panel.yarn">
+    <slot name="yarn" />
+  </Fragment>
+  <Fragment slot="panel.bun">
+    <slot name="bun" />
+  </Fragment>
 </Tabs>

--- a/src/components/tabs/PackageManagerTabs.astro
+++ b/src/components/tabs/PackageManagerTabs.astro
@@ -3,21 +3,21 @@ import Tabs from './Tabs';
 ---
 
 <Tabs client:visible sharedStore="package-managers">
-	<Fragment slot="tab.npm">npm</Fragment>
-	<Fragment slot="tab.pnpm">pnpm</Fragment>
-	<Fragment slot="tab.yarn">Yarn</Fragment>
-	<Fragment slot="tab.bun">Bun</Fragment>
+		<Fragment slot="tab.npm">npm</Fragment>
+		<Fragment slot="tab.pnpm">pnpm</Fragment>
+		<Fragment slot="tab.yarn">Yarn</Fragment>
+		<Fragment slot="tab.bun">Bun</Fragment>
 
-	<Fragment slot="panel.npm">
-		<slot name="npm" />
-	</Fragment>
-	<Fragment slot="panel.pnpm">
-		<slot name="pnpm" />
-	</Fragment>
-	<Fragment slot="panel.yarn">
-		<slot name="yarn" />
-	</Fragment>
-	<Fragment slot="panel.bun">
-		<slot name="bun" />
-	</Fragment>
+		<Fragment slot="panel.npm">
+			<slot name="npm" />
+		</Fragment>
+		<Fragment slot="panel.pnpm">
+			<slot name="pnpm" />
+		</Fragment>
+		<Fragment slot="panel.yarn">
+			<slot name="yarn" />
+		</Fragment>
+		<Fragment slot="panel.bun">
+			<slot name="bun" />
+		</Fragment>
 </Tabs>

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -36,10 +36,24 @@ type Props = {
 	sharedStore?: string;
 };
 
+const tabOrdering = {
+	npm: 0,
+	pnpm: 1,
+	yarn: 2,
+	bun: 3,
+};
+
 export default function Tabs({ sharedStore, ...slots }: Props) {
 	const tabId = genTabId();
-	const tabs = Object.entries(slots).filter(isTabSlotEntry);
-	const panels = Object.entries(slots).filter(isPanelSlotEntry);
+	// npm then pnpm then yarn then bun
+	const sortedSlots = Object.entries(slots).sort(([a], [b]) => {
+		const aName = a.split('.')[1];
+		const bName = b.split('.')[1];
+		return tabOrdering[aName] - tabOrdering[bName];
+	});
+
+	const tabs = sortedSlots.filter(isTabSlotEntry);
+	const panels = sortedSlots.filter(isPanelSlotEntry);
 	/** Used to focus next and previous tab on arrow key press */
 	const tabButtonRefs = useRef<Record<TabSlot, HTMLButtonElement | null>>({});
 	const scrollToTabRef = useRef<HTMLButtonElement | null>(null);

--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -83,6 +83,11 @@ To get started, first install Prettier and the plugin:
   yarn add --dev prettier prettier-plugin-astro
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add --dev prettier prettier-plugin-astro
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Prettier will then automatically detect the plugin and use it to process `.astro` files when you run it:

--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -56,6 +56,12 @@ Get a new Astro project up and running locally with our helpful `create astro` C
   yarn create astro
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # create a new project with Bun
+  bunx create-astro
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Our [Installation Guide](/en/install/auto/) has full, step-by-step instructions for installing Astro using our CLI wizard, creating a new project from an existing Astro GitHub repository, and for installing Astro manually.

--- a/src/content/docs/en/guides/assets.mdx
+++ b/src/content/docs/en/guides/assets.mdx
@@ -356,6 +356,11 @@ If you're building a static site or deploying an SSR site to a Node environment,
   yarn add sharp
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add sharp
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Then, enable Astro's sharp image service in your config:

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -100,6 +100,11 @@ To connect Astro with Firebase, install the following packages using the single 
   yarn install firebase firebase-admin
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add firebase firebase-admin
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Next, create a folder named `firebase` in the `src/` directory and add two new files to this folder: `client.ts` and `server.ts`.

--- a/src/content/docs/en/guides/cms/buttercms.mdx
+++ b/src/content/docs/en/guides/cms/buttercms.mdx
@@ -55,6 +55,11 @@ Read more about [using environment variables](/en/guides/environment-variables/)
   yarn add buttercms
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add buttercms
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 3. Create a `buttercms.js` file in a new `src/lib/` directory in your project:

--- a/src/content/docs/en/guides/cms/contentful.mdx
+++ b/src/content/docs/en/guides/cms/contentful.mdx
@@ -87,6 +87,11 @@ To connect with your Contentful space, install both of the following using the s
   yarn add contentful @contentful/rich-text-html-renderer
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add contentful @contentful/rich-text-html-renderer
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Next, create a new file called `contentful.ts` in the `src/lib/` directory of your project.

--- a/src/content/docs/en/guides/cms/ghost.mdx
+++ b/src/content/docs/en/guides/cms/ghost.mdx
@@ -76,6 +76,11 @@ To connect with Ghost, install the official content API wrapper [`@tryghost/cont
   yarn add @tryghost/content-api
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add @tryghost/content-api
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 ## Making a blog with Astro and Ghost

--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -66,6 +66,11 @@ To connect Astro with your Storyblok space, install the official [Storyblok inte
   yarn add @storyblok/astro vite
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add @storyblok/astro vite
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 ### Configuring Storyblok

--- a/src/content/docs/en/guides/cms/tina-cms.mdx
+++ b/src/content/docs/en/guides/cms/tina-cms.mdx
@@ -32,6 +32,11 @@ To get started, you'll need an existing Astro project.
       yarn dlx @tinacms/cli@latest init
       ```
       </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      bunx @tinacms/cli@latest init
+      ```
+      </Fragment>
     </PackageManagerTabs>
 
     - When prompted for a Cloud ID, press <kbd>Enter</kbd> to skip. You'll generate one later if you want to use Tina Cloud.
@@ -66,6 +71,17 @@ To get started, you'll need an existing Astro project.
       ```
       </Fragment>
       <Fragment slot="yarn">
+      ```json del={4} ins={5}
+      // package.json
+      {
+          "scripts": {
+              "dev": "astro dev",
+              "dev": "tinacms dev -c 'astro dev'"
+          }
+      }
+      ```
+      </Fragment>
+      <Fragment slot="bun">
       ```json del={4} ins={5}
       // package.json
       {

--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -90,7 +90,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
     :::
     
     :::caution
-    The official Astro [action](https://github.com/withastro/action) scans for a lockfile to detect your preferred package manager (`npm`, `yarn`, or `pnpm`). You should commit your package manager's automatically generated `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml` file to your repository.
+    The official Astro [action](https://github.com/withastro/action) scans for a lockfile to detect your preferred package manager (`npm`, `yarn`, `pnpm`, or `bun`). You should commit your package manager's automatically generated `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file to your repository.
     :::
 
 3. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -68,6 +68,11 @@ You can also add environment variables as you run your project:
     POKEAPI=https://pokeapi.co/api/v2 pnpm run dev
     ```
  </Fragment>
+ <Fragment slot="bun">
+    ```shell
+    POKEAPI=https://pokeapi.co/api/v2 bun run dev
+    ```
+ </Fragment>
 </PackageManagerTabs>
 
 :::caution

--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -68,6 +68,11 @@ The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts 
       yarn add @fontsource/twinkle-star
       ```
       </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      bun add @fontsource/twinkle-star
+      ```
+      </Fragment>
     </PackageManagerTabs>
 
     :::tip

--- a/src/content/docs/en/guides/integrations-guide.mdx
+++ b/src/content/docs/en/guides/integrations-guide.mdx
@@ -42,6 +42,11 @@ Run the `astro add` command using the package manager of your choice and our aut
   yarn astro add react
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx astro add react
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 It's even possible to add multiple integrations at the same time!
@@ -60,6 +65,11 @@ It's even possible to add multiple integrations at the same time!
   <Fragment slot="yarn">
   ```shell
   yarn astro add react tailwind partytown
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx astro add react tailwind partytown
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -137,6 +147,11 @@ To remove an integration, first uninstall the integration from your project
   <Fragment slot="yarn">
   ```shell
   yarn remove @astrojs/image
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun remove @astrojs/image
   ```
   </Fragment>
 </PackageManagerTabs>

--- a/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
@@ -36,6 +36,8 @@ npx astro add alpinejs
 yarn astro add alpinejs
 # Using PNPM
 pnpm astro add alpinejs
+# Using Bun
+bunx astro add alpinejs
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -34,6 +34,8 @@ npx astro add cloudflare
 yarn astro add cloudflare
 # Using PNPM
 pnpm astro add cloudflare
+# Using Bun
+bunx astro add cloudflare
 ```
 
 If you prefer to install the adapter manually instead, complete the following two steps:

--- a/src/content/docs/en/guides/integrations-guide/deno.mdx
+++ b/src/content/docs/en/guides/integrations-guide/deno.mdx
@@ -44,6 +44,8 @@ npx astro add deno
 yarn astro add deno
 # Using PNPM
 pnpm astro add deno
+# Using Bun
+bunx astro add deno
 ```
 
 If you prefer to install the adapter manually instead, complete the following two steps:

--- a/src/content/docs/en/guides/integrations-guide/image.mdx
+++ b/src/content/docs/en/guides/integrations-guide/image.mdx
@@ -60,6 +60,8 @@ npx astro add image
 yarn astro add image
 # Using PNPM
 pnpm astro add image
+# Using Bun
+bunx astro add image
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -43,6 +43,8 @@ npx astro add lit
 yarn astro add lit
 # Using PNPM
 pnpm astro add lit
+# Using Bun
+bunx astro add lit
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -40,6 +40,8 @@ npx astro add markdoc
 yarn astro add markdoc
 # Using PNPM
 pnpm astro add markdoc
+# Using Bun
+bunx astro add markdoc
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -40,6 +40,8 @@ npx astro add mdx
 yarn astro add mdx
 # Using PNPM
 pnpm astro add mdx
+# Using Bun
+bunx astro add mdx
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -44,6 +44,8 @@ npx astro add netlify
 yarn astro add netlify
 # Using PNPM
 pnpm astro add netlify
+# Using Bun
+bunx astro add netlify
 ```
 
 If you prefer to install the adapter manually instead, complete the following two steps:

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -42,6 +42,8 @@ npx astro add node
 yarn astro add node
 # Using PNPM
 pnpm astro add node
+# Using Bun
+bunx astro add node
 ```
 
 If you prefer to install the adapter manually instead, complete the following two steps:

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -44,6 +44,8 @@ npx astro add partytown
 yarn astro add partytown
 # Using PNPM
 pnpm astro add partytown
+# Using Bun
+bunx astro add partytown
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -45,6 +45,8 @@ npx astro add preact
 yarn astro add preact
 # Using PNPM
 pnpm astro add preact
+# Using Bun
+bunx astro add preact
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/prefetch.mdx
+++ b/src/content/docs/en/guides/integrations-guide/prefetch.mdx
@@ -40,6 +40,8 @@ npx astro add prefetch
 yarn astro add prefetch
 # Using PNPM
 pnpm astro add prefetch
+# Using Bun
+bunx astro add prefetch
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -43,6 +43,8 @@ npx astro add react
 yarn astro add react
 # Using PNPM
 pnpm astro add react
+# Using Bun
+bunx astro add react
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -46,6 +46,8 @@ npx astro add sitemap
 yarn astro add sitemap
 # Using PNPM
 pnpm astro add sitemap
+# Using Bun
+bunx astro add sitemap
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -43,6 +43,8 @@ npx astro add solid
 yarn astro add solid
 # Using PNPM
 pnpm astro add solid
+# Using Bun
+bunx astro add solid
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/en/guides/integrations-guide/svelte.mdx
@@ -43,6 +43,8 @@ npx astro add svelte
 yarn astro add svelte
 # Using PNPM
 pnpm astro add svelte
+# Using Bun
+bunx astro add svelte
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -48,6 +48,8 @@ npx astro add tailwind
 yarn astro add tailwind
 # Using PNPM
 pnpm astro add tailwind
+# Using Bun
+bunx astro add tailwind
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -44,6 +44,8 @@ npx astro add vercel
 yarn astro add vercel
 # Using PNPM
 pnpm astro add vercel
+# Using Bun
+bunx astro add vercel
 ```
 
 If you prefer to install the adapter manually instead, complete the following two steps:

--- a/src/content/docs/en/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vue.mdx
@@ -43,6 +43,8 @@ npx astro add vue
 yarn astro add vue
 # Using PNPM
 pnpm astro add vue
+# Using Bun
+bunx astro add vue
 ```
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.

--- a/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -62,6 +62,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template starlight
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template starlight
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-eleventy.mdx
@@ -55,6 +55,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
  Bring your existing Markdown (or MDX, with our optional integration) files as content to [create Markdown or MDX pages](/en/guides/markdown-content/).

--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -73,6 +73,15 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro@latest --template <example-name>
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    # launch the Astro CLI Wizard 
+    bunx create-astro@latest
+
+    # create a new project with an official example
+    bunx create-astro@latest --template <example-name>
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Then, copy your existing Gatsby project files over to your new Astro project into a separate folder outside of `src`.

--- a/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gitbook.mdx
@@ -53,6 +53,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template starlight
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template starlight
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Once you have a new Astro project, you can sync your existing GitBook content to your new Astro project. GitBook has a [Git Sync feature](https://docs.gitbook.com/product-tour/git-sync) that will automatically sync your GitBook content to a GitHub/GitLab repository. 

--- a/src/content/docs/en/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gridsome.mdx
@@ -55,6 +55,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown (or MDX, with our optional integration) files as content to [create Markdown or MDX pages](/en/guides/markdown-content/).

--- a/src/content/docs/en/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-hugo.mdx
@@ -55,6 +55,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown (or MDX, with our optional integration) files as content to [create Markdown or MDX pages](/en/guides/markdown-content/). You may need to convert your frontmatter to YAML, since Astro only allows YAML frontmatter in these files.

--- a/src/content/docs/en/guides/migrate-to-astro/from-jekyll.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-jekyll.mdx
@@ -53,6 +53,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown files as content to [create Markdown pages](/en/guides/markdown-content/), using an [Astro Markdown layout](/en/core-concepts/layouts/#markdownmdx-layouts) instead of a Liquid template. 

--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -69,6 +69,15 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro@latest --template <example-name>
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    # launch the Astro CLI Wizard 
+    bunx create-astro@latest
+
+    # create a new project with an official example
+    bunx create-astro@latest --template <example-name>
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Then, copy your existing Next project files over to your new Astro project in a separate folder outside of `src`.

--- a/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -71,6 +71,15 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro@latest --template <example-name>
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    # launch the Astro CLI Wizard 
+    bunx create-astro@latest
+
+    # create a new project with an official example
+    bunx create-astro@latest --template <example-name>
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Then, copy your existing Nuxt project files over to your new Astro project in a separate folder outside of `src`.

--- a/src/content/docs/en/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-pelican.mdx
@@ -51,6 +51,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template starlight
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template starlight
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown content files to [create Markdown pages](/en/guides/markdown-content/). You can still take advantage of [file-based routing](/en/core-concepts/routing/) by copying these documents from Pelican's `content/` folder into `src/pages/` in Astro. You may wish to read about [Astro's project structure](/en/core-concepts/project-structure/) to learn where files should be located.

--- a/src/content/docs/en/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-sveltekit.mdx
@@ -58,6 +58,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown (or MDX, with our optional integration) files as content to [create Markdown or MDX pages](/en/guides/markdown-content/).

--- a/src/content/docs/en/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-vuepress.mdx
@@ -53,6 +53,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template starlight
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template starlight
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 Bring your existing Markdown content files to [create Markdown pages](/en/guides/markdown-content/). You can still take advantage of [file-based routing](/en/core-concepts/routing/) by moving these documents from `docs` in VuePress to `src/pages/` in Astro. Create folders with names that correspond to your existing VuePress project, and you should be able to keep your existing URLs. 

--- a/src/content/docs/en/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-wordpress.mdx
@@ -55,6 +55,11 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     yarn create astro --template blog
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bunx create-astro --template blog
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 You can continue to [use your existing WordPress blog as your CMS for Astro](/en/guides/cms/wordpress/), which means you will keep using your WordPress dashboard for writing your posts. Your content will be managed at WordPress, but all other aspects of your Astro site will be built in your code editing environment, and you will [deploy your Astro site](/en/guides/deploy/) separately from your WordPress site. (Be sure to update your domain at your host to keep the same website URL!)

--- a/src/content/docs/en/guides/rss.mdx
+++ b/src/content/docs/en/guides/rss.mdx
@@ -32,6 +32,11 @@ The package [`@astrojs/rss`](https://github.com/withastro/astro/tree/main/packag
   yarn add @astrojs/rss
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add @astrojs/rss
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 :::tip

--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -96,6 +96,11 @@ You can add any of the official adapters with the following `astro add` command.
   yarn astro add netlify
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx astro add netlify
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 #### Manual Install
@@ -118,6 +123,11 @@ You can also add an adapter manually by installing the package and updating `ast
      <Fragment slot="yarn">
      ```shell
      yarn add @astrojs/my-adapter
+     ```
+     </Fragment>
+     <Fragment slot="bun">
+     ```shell
+     bun add @astrojs/my-adapter
      ```
      </Fragment>
    </PackageManagerTabs>

--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -442,6 +442,8 @@ npx astro add tailwind
 yarn astro add tailwind
 # Using PNPM
 pnpm astro add tailwind
+# Using Bun
+bunx astro add tailwind
 ```
 
 📚 See the [Integrations Guide](/en/guides/integrations-guide/) for instructions on installing, importing and configuring Astro integrations.

--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -42,6 +42,11 @@ You can install Cypress using the package manager of your choice.
   yarn add cypress --dev
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add --development cypress
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 ### Configuration
@@ -166,6 +171,11 @@ Alternatively, you can install Playwright within your Astro project using the pa
   <Fragment slot="yarn">
   ```shell
   yarn create playwright
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx create-playwright
   ```
   </Fragment>
 </PackageManagerTabs>

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -53,6 +53,11 @@ If you are not using VSCode, you can install the [Astro TypeScript plugin](https
   yarn add @astrojs/ts-plugin
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add @astrojs/ts-plugin
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Then, add the following to your `tsconfig.json`:

--- a/src/content/docs/en/guides/upgrade-to/v1.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v1.mdx
@@ -35,6 +35,14 @@ You can update your project's version of Astro to the latest version using your 
   yarn upgrade
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # updates the astro dependency:
+  bun update astro
+  # or, to update all dependencies:
+  bun update
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 

--- a/src/content/docs/en/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v2.mdx
@@ -43,6 +43,15 @@ Update your project's version of Astro to the latest version using your package 
   yarn add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # Upgrade to Astro v2.x
+  bun update astro@latest
+  
+  # Example: upgrade React and Tailwind integrations
+  bun add @astrojs/react@latest @astrojs/tailwind@latest
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 ## Astro v2.0 Breaking Changes

--- a/src/content/docs/en/install/auto.mdx
+++ b/src/content/docs/en/install/auto.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Astro with the Automatic CLI
-description: 'How to install Astro with NPM, PNPM, or Yarn via the create-astro CLI tool.'
+description: 'How to install Astro with NPM, PNPM, Yarn, or Bun via the create-astro CLI tool.'
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
@@ -48,6 +48,12 @@ Run the following command in your terminal to start our handy install wizard:
   yarn create astro
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # create a new project with Bun
+  bunx create-astro
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 You can run `create astro` anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
@@ -76,6 +82,11 @@ Every starter template comes with a pre-configured script that will run `astro d
   <Fragment slot="yarn">
   ```shell
   yarn run dev
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun run dev
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -117,6 +128,15 @@ You can also start a new astro project based on an [official example](https://gi
   
   # create a new project based on a GitHub repository’s main branch
   yarn create astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # create a new project with an official example
+  bunx create-astro --template <example-name>
+  
+  # create a new project based on a GitHub repository’s main branch
+  bunx create-astro --template <github-username>/<github-repo>
   ```
   </Fragment>
 </PackageManagerTabs>

--- a/src/content/docs/en/install/manual.mdx
+++ b/src/content/docs/en/install/manual.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Astro manually
-description: 'How to install Astro manually with NPM, PNPM, or Yarn.'
+description: 'How to install Astro manually with NPM, PNPM, Yarn, or Bun.'
 i18nReady: true
 ---
 import Button from '~/components/Button.astro'
@@ -51,6 +51,11 @@ Once you are in your new directory, create your project `package.json` file. Thi
   yarn init --yes
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun init --yes
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 
@@ -77,6 +82,11 @@ Astro must be installed locally, not globally. Make sure you are *not* running `
   <Fragment slot="yarn">
   ```shell
   yarn add astro
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add astro
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -188,7 +198,7 @@ If you have followed the steps above, your project directory should now look lik
     - index.astro
   - env.d.ts
 - astro.config.mjs
-- package-lock.json or `yarn.lock`, `pnpm-lock.yaml`, etc.
+- package-lock.json or `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, etc.
 - package.json
 - tsconfig.json
 </FileTree>

--- a/src/content/docs/en/integrations/integrations.mdx
+++ b/src/content/docs/en/integrations/integrations.mdx
@@ -67,6 +67,11 @@ You can start a new astro project based on an existing github repostory by passi
   yarn create astro --template <github-username>/<github-repo>
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx create-astro --template <github-username>/<github-repo>
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 [delucis/astro-netlify-cms](https://github.com/delucis/astro-netlify-cms) - Astro Starter Template with Netlify CMS

--- a/src/content/docs/en/recipes/build-forms-api.mdx
+++ b/src/content/docs/en/recipes/build-forms-api.mdx
@@ -396,6 +396,11 @@ This recipe shows you how to send form data to an API endpoint and handle that d
           yarn add zod zod-form-data
         ```
       </Fragment>
+      <Fragment slot="bun">
+        ```shell
+          bun add zod zod-form-data
+        ```
+      </Fragment>
     </PackageManagerTabs>
 
 2. In your API Route file, declare your schema using `zfd.formData` and export it. */}

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -33,6 +33,11 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
    yarn add reading-time mdast-util-to-string
      ```
      </Fragment>
+     <Fragment slot="bun">
+     ```shell
+   bun add reading-time mdast-util-to-string
+     ```
+     </Fragment>
    </PackageManagerTabs>
 
 2. Create a remark plugin.

--- a/src/content/docs/en/recipes/sharing-state.mdx
+++ b/src/content/docs/en/recipes/sharing-state.mdx
@@ -33,6 +33,11 @@ When building an Astro website, you may need to share state across components. A
     yarn add nanostores
     ```
     </Fragment>
+    <Fragment slot="bun">
+    ```shell
+    bun add nanostores
+    ```
+    </Fragment>
   </PackageManagerTabs>
 
 2. Create a store. In this example, the store tracks whether a dialog is open or not:

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1091,6 +1091,11 @@ To use the `Prism` highlighter component, first **install** the `@astrojs/prism`
   yarn add @astrojs/prism
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bun add @astrojs/prism
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 ```astro

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -34,6 +34,12 @@ One of the commands you'll use most often is `astro dev`. This command starts th
   yarn astro dev
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # start the development server
+  bunx astro dev
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 You can type `astro --help` in your terminal to display a list of all available commands:
@@ -52,6 +58,11 @@ You can type `astro --help` in your terminal to display a list of all available 
   <Fragment slot="yarn">
   ```shell
   yarn astro --help
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx astro --help
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -134,6 +145,15 @@ You will often use these `astro` commands, or the scripts that run them, without
   yarn build --drafts
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # run the dev server on port 8080 using the `start` script in `package.json`
+  bun run start --port 8080
+
+  # build your site including draft pages using the `build` script in `package.json`
+  bun run build --drafts
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 {/* 
@@ -162,6 +182,11 @@ In most cases you will use the CLI via your package manager:
   yarn astro dev --port 8080
   ```
   </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  bunx astro dev --port 8080
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 If you started your project using [the `create astro` wizard](/en/install/auto/#1-run-the-setup-wizard), you can also use the scripts in `package.json` for a shorter version of these commands. See the `README.md` in your project for details of which commands are available.
@@ -184,6 +209,12 @@ If you started your project using [the `create astro` wizard](/en/install/auto/#
   ```shell
   # run the dev server on port 8080 using the `start` script in `package.json`
   yarn start --port 8080
+  ```
+  </Fragment>
+  <Fragment slot="bun">
+  ```shell
+  # run the dev server on port 8080 using the `start` script in `package.json`
+  bun run start --port 8080
   ```
   </Fragment>
 </PackageManagerTabs>

--- a/src/content/docs/en/reference/publish-to-npm.mdx
+++ b/src/content/docs/en/reference/publish-to-npm.mdx
@@ -26,6 +26,8 @@ npm create astro@latest my-new-component-directory -- --template component
 yarn create astro my-new-component-directory --template component
 # pnpm
 pnpm create astro@latest my-new-component-directory -- --template component
+# Bun
+bunx create-astro@latest my-new-component-directory -- --template component
 ```
 
 ## Creating a package
@@ -72,6 +74,8 @@ npm create astro@latest demo -- --template minimal
 yarn create astro demo --template minimal
 # pnpm
 pnpm create astro@latest demo -- --template minimal
+# bun
+bunx create-astro@latest demo -- --template minimal
 ```
 
 There are two initial files that will make up your individual package: `package.json` and `index.js`.

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -46,6 +46,12 @@ The preferred way to create a new Astro site is through our `create astro` setup
       yarn create astro
       ```
       </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      # create a new project with Bun
+      bunx create-astro
+      ```
+      </Fragment>
     </PackageManagerTabs>
 
 2. Confirm `y` to install `create-astro`
@@ -108,6 +114,11 @@ In order to preview your project files _as a website_ while you work, you will n
       <Fragment slot="yarn">
       ```shell
       yarn run dev
+      ```
+      </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      bun run dev
       ```
       </Fragment>
     </PackageManagerTabs>

--- a/src/content/docs/en/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/4.mdx
@@ -46,6 +46,11 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
       yarn add @astrojs/rss
       ```
       </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      bun add @astrojs/rss
+      ```
+      </Fragment>
     </PackageManagerTabs>
 
 2. Restart the dev server to begin working on your Astro project again.
@@ -64,6 +69,11 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
       <Fragment slot="yarn">
       ```shell
       yarn run dev
+      ```
+      </Fragment>
+      <Fragment slot="bun">
+      ```shell
+      bun run dev
       ```
       </Fragment>
     </PackageManagerTabs>
@@ -111,6 +121,12 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
       yarn run build
 
       yarn run preview
+      ```
+      </Fragment>
+      ```shell
+      bun run build
+
+      bun run preview
       ```
       </Fragment>
     </PackageManagerTabs>

--- a/src/content/docs/en/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/4.mdx
@@ -123,6 +123,7 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
       yarn run preview
       ```
       </Fragment>
+      <Fragment slot="bun">
       ```shell
       bun run build
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Where relevant, this adds tabs for the `bun` package manager and `bunx` package runner alongside npm/yarn/pnpm. (Bun can be used a [standalone package manager](https://bun.sh/package-manager) in any project, regardless of whether it uses Node.js or Bun as a runtime.)