### PR TITLE
Mark CMS stubs as `i18nReady: false`

### DIFF
--- a/src/content/docs/en/guides/cms/caisy.mdx
+++ b/src/content/docs/en/guides/cms/caisy.mdx
@@ -3,7 +3,7 @@ title: Caisy & Astro
 description: Add content to your Astro project using Caisy as a CMS
 type: cms
 service: Caisy
-i18nReady: true
+i18nReady: false
 stub: true
 ---
 

--- a/src/content/docs/en/guides/cms/cloudcannon.mdx
+++ b/src/content/docs/en/guides/cms/cloudcannon.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using CloudCannon as a CMS
 type: cms
 stub: true
 service: CloudCannon
-i18nReady: true
+i18nReady: false
 ---
 
 [CloudCannon](https://cloudcannon.com) is a Git-based content management system that provides a visual editor for your content.

--- a/src/content/docs/en/guides/cms/crystallize.mdx
+++ b/src/content/docs/en/guides/cms/crystallize.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Crystallize as a CMS
 type: cms
 stub: true
 service: Crystallize
-i18nReady: true
+i18nReady: false
 ---
 [Crystallize](https://crystallize.com/) is a headless content management system for eCommerce that exposes a GraphQL API.
 ## Example

--- a/src/content/docs/en/guides/cms/decap-cms.mdx
+++ b/src/content/docs/en/guides/cms/decap-cms.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Decap as a CMS
 type: cms
 stub: true
 service: Decap CMS
-i18nReady: true
+i18nReady: false
 ---
 
 [Decap CMS](https://www.decapcms.org/) (formerly Netlify CMS) is an open-source, Git-based content management system.

--- a/src/content/docs/en/guides/cms/directus.mdx
+++ b/src/content/docs/en/guides/cms/directus.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Directus as a CMS
 type: cms
 stub: true
 service: Directus
-i18nReady: true
+i18nReady: false
 ---
 
 [Directus](https://directus.io/) is a backend-as-a-service which can be used to host data and content for your Astro project.

--- a/src/content/docs/en/guides/cms/keystonejs.mdx
+++ b/src/content/docs/en/guides/cms/keystonejs.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using KeystoneJS as a CMS
 type: cms
 stub: true
 service: KeystoneJS
-i18nReady: true
+i18nReady: false
 ---
 
 [KeystoneJS](https://keystonejs.com/) is an open source, headless content-management system that allows you to describe the structure of your schema.

--- a/src/content/docs/en/guides/cms/microcms.mdx
+++ b/src/content/docs/en/guides/cms/microcms.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using microCMS
 type: cms
 stub: true
 service: microCMS
-i18nReady: true
+i18nReady: false
 ---
 
 [microCMS](https://microcms.io/) is an API-based headless CMS that lets you define content using schemas, and manage it using the dashboard.

--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Payload as a CMS
 type: cms
 stub: true
 service: Payload CMS
-i18nReady: true
+i18nReady: false
 ---
 
 [PayloadCMS](https://payloadcms.com/) is a headless open-source content management system that can be used to provide content for your Astro project.

--- a/src/content/docs/en/guides/cms/prismic.mdx
+++ b/src/content/docs/en/guides/cms/prismic.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Prismic as a CMS
 type: cms
 stub: true
 service: Prismic
-i18nReady: true
+i18nReady: false
 ---
 
 [Prismic](https://prismic.io/) is a headless content management system.

--- a/src/content/docs/en/guides/cms/sanity.mdx
+++ b/src/content/docs/en/guides/cms/sanity.mdx
@@ -4,7 +4,7 @@ description: Add content to your Astro project using Sanity as a CMS
 type: cms
 stub: true
 service: Sanity
-i18nReady: true
+i18nReady: false
 ---
 
 [Sanity](http://sanity.io) is a headless content management system that focuses on [structured content](https://www.sanity.io/structured-content-platform).

--- a/src/content/docs/en/guides/cms/spinal.mdx
+++ b/src/content/docs/en/guides/cms/spinal.mdx
@@ -4,7 +4,7 @@ description: Add content to your project using Spinal as your CMS.
 type: cms
 stub: true
 service: Spinal
-i18nReady: true
+i18nReady: false
 ---
 
 [Spinal](https://spinalcms.com/cms-for-astro/) is a commercial, SaaS-focused, Git-based CMS.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Marks short CMS stubs as not ready for translation.
- I used [a GitHub search](https://github.com/search?q=repo%3Awithastro%2Fdocs+path%3Aen%2F**%2F*.mdx+%22i18nReady%3A+true%22+%22stub%3A+true%22&type=code&ref=advsearch) to find pages with `stub: true` and `i18nReady: true`
- There are a few migration guide “stubs” marked as translation-ready, but I left these as they’re bigger pages with more content that could be actually useful to translate.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
