### PR TITLE
Remove authentication recipe

### DIFF
--- a/src/content/docs/en/recipes.mdx
+++ b/src/content/docs/en/recipes.mdx
@@ -17,7 +17,6 @@ See guided examples of adding features to your Astro project.
 
 Add your own here! See our [recipes contributing guide](https://github.com/withastro/docs/blob/main/contributor-guides/submitting-a-recipe.md) for more info.
 
-- [Add authentication with Prisma and Planetscale](https://www.thomasledoux.be/blog/authentication-astro-prisma-planetscale)
 - [Use a dynamic filename when importing images](https://vaihe.com/blog/astro/astro-dynamic-image-prop/)
 - [Add animated page transitions with Swup](https://navillus.dev/blog/astro-plus-swup)
 - [Use UnoCSS in Astro](https://www.elian.codes/blog/23-02-11-implementing-unocss-in-astro/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Removes [Add authentication with Prisma and Planetscale](https://www.thomasledoux.be/blog/authentication-astro-prisma-planetscale) from the community resources section. It doesn't hash passwords which is a must when implementing password based authentication. 