### PR TITLE
Add `backend/` pages to subpage handling

### DIFF
--- a/src/util/isSubPage.ts
+++ b/src/util/isSubPage.ts
@@ -5,7 +5,8 @@ import { getPageCategory } from './getPageCategory';
 /** Remove the sub-page segment of a URL string */
 export function removeSubPageSegment(path: string) {
 	// Include new pages with sub-pages as part of this regex.
-	const regex = /(?:install|deploy|integrations-guide|tutorial|migrate-to-astro|recipes|cms)\//;
+	const regex =
+		/(?:install|deploy|integrations-guide|tutorial|migrate-to-astro|recipes|cms|backend)\//;
 	const matches = regex.exec(path);
 
 	if (matches) {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code


#### Description

"Add a backend service" subpages were not being marked, so no item would be highlighted in the sidebar when accessing a page like `/backend/google-firebase/`. This PR fixes this behavior.

**Before**
![image](https://github.com/withastro/docs/assets/61414485/3ff5cd46-3abd-4773-9fcd-c52908300bc6)


**After**
![image](https://github.com/withastro/docs/assets/61414485/5d023872-4bb7-4012-90f9-e34ee42c4e02)
