### PR TITLE
Fix typo in font usage guide for Spanish documentation

### DIFF
--- a/src/content/docs/es/guides/fonts.mdx
+++ b/src/content/docs/es/guides/fonts.mdx
@@ -94,7 +94,7 @@ El proyecto [Fontsource](https://fontsource.org/) simplifica el uso de Google Fo
 
 ## Registrando fuentes con Tailwind
 
-Si estás usando la [integración de Tailwind](/es/guides/integrations-guide/tailwind/), puedes usar cualquiera de los métodos anteriores en esta página para instalar tu fuente, con algunas modificaciones. Puedes añadir una [declaración`@font-face` para una fuente local](#usando-un-archivo-de-fuente-local) para una fuente local o usar [la estrategia `import` de Fontsource](#usando-fontsource) para instalar tu fuente.
+Si estás usando la [integración de Tailwind](/es/guides/integrations-guide/tailwind/), puedes usar cualquiera de los métodos anteriores en esta página para instalar tu fuente, con algunas modificaciones. Puedes añadir una [declaración`@font-face` para una fuente local](#usando-un-archivo-de-fuente-local) o usar [la estrategia `import` de Fontsource](#usando-fontsource) para instalar tu fuente.
 
 Para registrar tu fuente en Tailwind:
 


### PR DESCRIPTION
#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
- What does this PR change? Fixed a typographical error in the font usage guide in the Spanish documentation.
- Did you change something visual? No, it's a text correction.

#### Changes Made

- Corrected a grammatical error in the font usage guide of the Spanish documentation by removing redundant phrasing. The phrase "para una fuente local para una fuente local" was revised to "para una fuente local" to improve clarity and readability.
- Modified the content in the section related to using local font files.
