### PR TITLE
fix: show where client directives should be added

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -154,12 +154,19 @@ Note that directive entrypoints are only bundled through esbuild and should be k
 
 Example usage:
 
-```js
-// Create a `client:click` directive
-addClientDirective({
-  name: 'click',
-  entrypoint: 'astro-click-directive/click.js' 
-})
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [
+    // Create a `client:click` directive
+    addClientDirective({
+      name: 'click',
+      entrypoint: 'astro-click-directive/click.js' 
+    })
+  ],
+});
 ```
 
 ```js title="astro-click-directive/click.js"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Adds information about where client directives should be registered. This wasn't clear to me when reading the docs, had to find the original RFC for reference. Hope this helps!

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
