### PR TITLE
Add basic custom Translation Tracker syntax

### DIFF
--- a/scripts/lib/translation-status/builder.ts
+++ b/scripts/lib/translation-status/builder.ts
@@ -348,11 +348,11 @@ export class TranslationStatusBuilder {
 	isValidMajor(entry: DefaultLogFields & ListLogLine, filePath: string) {
 		if (entry.message.match(COMMIT_IGNORE)) return false;
 
-		const trackerDirective = entry.body.match(TRACKER_DIRECTIVE);
+		const trackerDirectiveMatch = entry.body.match(TRACKER_DIRECTIVE);
 
 		if (trackerDirective) {
-			const filePaths = trackerDirective[0].replace('@tracker-major:', '').split(';');
-			return filePaths.indexOf(filePath) > -1;
+			const filePaths = trackerDirectiveMatch[0].replace('@tracker-major:', '').split(';');
+			return filePaths.includes(filePath);
 		}
 
 		return true;

--- a/scripts/lib/translation-status/builder.ts
+++ b/scripts/lib/translation-status/builder.ts
@@ -350,7 +350,7 @@ export class TranslationStatusBuilder {
 
 		const trackerDirectiveMatch = entry.body.match(TRACKER_DIRECTIVE);
 
-		if (trackerDirective) {
+		if (trackerDirectiveMatch) {
 			const filePaths = trackerDirectiveMatch[0].replace('@tracker-major:', '').split(';');
 			return filePaths.includes(filePath);
 		}

--- a/scripts/lib/translation-status/builder.ts
+++ b/scripts/lib/translation-status/builder.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { escape } from 'html-escaper';
 import os from 'os';
 import path from 'path';
-import simpleGit from 'simple-git';
+import simpleGit, { DefaultLogFields, ListLogLine } from 'simple-git';
 import { fileURLToPath } from 'url';
 import type { DocSearchTranslation, UIDict } from '~/i18n/translation-checkers';
 import docsearchTranslations from '../../../src/i18n/en/docsearch';
@@ -22,6 +22,7 @@ import { toUtcString, tryGetFrontMatterBlock } from '../../lib/translation-statu
 type NestedRecord = { [k: string]: string | NestedRecord };
 
 export const COMMIT_IGNORE = /(en-only|typo|broken link|i18nReady|i18nIgnore)/i;
+export const TRACKER_DIRECTIVE = /@tracker-major:.*/i;
 
 interface PullRequest {
 	html_url: string;
@@ -314,7 +315,7 @@ export class TranslationStatusBuilder {
 		// usually do not require translations to be updated
 		const lastMajorCommit =
 			gitLog.all.find((logEntry) => {
-				return !logEntry.message.match(COMMIT_IGNORE);
+				return this.isValidMajor(logEntry, filePath);
 			}) || lastCommit;
 
 		return {
@@ -323,6 +324,38 @@ export class TranslationStatusBuilder {
 			lastMajorCommitMessage: lastMajorCommit.message,
 			lastMajorCommitDate: toUtcString(lastMajorCommit.date),
 		};
+	}
+
+	/* 	
+		Determines if a commit is a valid major. Any commits that include one of the 
+		keywords from `COMMIT_IGNORE` have all their files marked as minor changes.
+		Meanwhile, the `@tracker-major` directive if used in a final squash commit's
+		description, selects specific files to be marked as major changes.
+
+		Example usage:
+		@tracker-major:./src/content/docs/en/concepts/mpa-vs-spa.mdx;./src/content/docs/en/concepts/why-astro.mdx
+
+		Pages changed:
+		`en/mpa-vs-spa.mdx`, `en/why-astro.mdx`, `pt-br/markdown-content.mdx`
+
+		Only `en/mpa-vs-spa.mdx` & `en/why-astro.mdx` are marked as major; translations 
+		to these pages all become outdated and other pages from the commit stay the same. 
+		Also works when there's no English pages! The translated files will be marked as 
+		updated, but the same pages from other languages won't be affected by it, keeping
+		their old state.
+		
+	*/
+	isValidMajor(entry: DefaultLogFields & ListLogLine, filePath: string) {
+		if (entry.message.match(COMMIT_IGNORE)) return false;
+
+		const trackerDirective = entry.body.match(TRACKER_DIRECTIVE);
+
+		if (trackerDirective) {
+			const filePaths = trackerDirective[0].replace('@tracker-major:', '').split(';');
+			return filePaths.indexOf(filePath) > -1;
+		}
+
+		return true;
 	}
 
 	getTranslationStatusByPage(pages: PageIndex): PageTranslationStatus[] {


### PR DESCRIPTION

#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This PR adds a rudimentary version of the custom tracker syntax to help with the 3.0 PRs changing lots of translations to fix links (LOOKING AT YOU 3.0 IMAGE GUIDE).

This allows you to add a `@tracker-major:(list of file paths separated by ;)` to a final squashed commit description (the one you have to confirm before you merge) that makes all changes be considered minor except the ones you have explicitly marked as major.

🚨 **THE FILE PATH HAS TO INCLUDE EVERYTHING (SEE BELOW)** 🚨 


Example:

**PR updates the pages (br/1.mdx, br/2.mdx), but also updates the link to another page that isn't fully updated yet (br/3.mdx).**
Using: `@tracker-major:./src/content/docs/br/1.mdx;./src/content/docs/br/2.mdx`, `br/3.mdx` continues to be marked as outdated.

More info in the code comment!

**How to test it?**
1. Pull the branch
2. Run `pnpm translation-status` (or with your preferred package manager) 
3. Open the `dist/translation-status/index.html` file. (this is the current status in the branch!)
4. Now, make a new commit changing any pages you want, and add the custom syntax to the commit description.
5. Do steps 2 & 3 again.
6. See the changes done in the tracker. Might be helpful to have `i18n.docs.astro.build` side by side, but will be inconsistent the moment the branch isn't 100% updated in relation to main.
 