### PR TITLE
fix(assets): Fix outdated image service page

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -31,10 +31,12 @@ Both types of services can provide `getHTMLAttributes()` to determine the other 
 An external service points to a remote URL to be used as the `src` attribute of the final `<img>` tag. This remote URL is responsible for downloading, transforming, and returning the image.
 
 ```js
-import type { ExternalImageService } from "astro";
+import type { ExternalImageService, ImageTransform, AstroConfig } from "astro";
 
 const service: ExternalImageService = {
-  validateOptions(options: ImageTransform, serviceConfig: Record<string, any>) {
+  validateOptions(options: ImageTransform, imageConfig: AstroConfig['image']) {
+    const serviceConfig = imageConfig.service.config;
+
     // Enforce the user set max width.
     if (options.width > serviceConfig.maxWidth) {
       console.warn(`Image width ${options.width} exceeds max width ${serviceConfig.maxWidth}. Falling back to max width.`);
@@ -43,10 +45,10 @@ const service: ExternalImageService = {
 
     return options;
   },
-  getURL(options, serviceConfig) {
+  getURL(options, imageConfig) {
     return `https://mysupercdn.com/${options.src}?q=${options.quality}&w=${options.width}&h=${options.height}`;
   },
-  getHTMLAttributes(options, serviceConfig) {
+  getHTMLAttributes(options, imageConfig) {
     const { src, format, quality, ...attributes } = options;
 		return {
 			...attributes,
@@ -65,9 +67,10 @@ export default service;
 To create your own local service, you can point to the [built-in endpoint](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/image-endpoint.ts) (`/_image`), or you can additionally create your own endpoint that can call the service's methods.
 
 ```js
-import type { LocalImageService } from "astro";
+import type { LocalImageService, AstroConfig } from "astro";
+
 const service: LocalImageService = {
-  getURL(options: ImageTransform, serviceConfig: Record<string, any>) {
+  getURL(options: ImageTransform, imageConfig: AstroConfig['image']) {
     const searchParams = new URLSearchParams();
 		searchParams.append('href', typeof options.src === "string" ? options.src : options.src.src);
 		options.width && searchParams.append('w', options.width.toString());
@@ -78,7 +81,7 @@ const service: LocalImageService = {
     // Or use the built-in endpoint, which will call your parseURL and transform functions:
     // return `/_image?${searchParams}`;
   },
-  parseURL(url: URL, serviceConfig) {
+  parseURL(url: URL, imageConfig) {
     return {
       src: params.get('href')!,
       width: params.has('w') ? parseInt(params.get('w')!) : undefined,
@@ -87,14 +90,14 @@ const service: LocalImageService = {
       quality: params.get('q'),
     };
   },
-  transform(buffer: Buffer, options: { src: string, [key: string]: any }, serviceConfig): { data: Buffer, format: OutputFormat } {
+  transform(buffer: Buffer, options: { src: string, [key: string]: any }, imageConfig): { data: Buffer, format: OutputFormat } {
     const { buffer } = mySuperLibraryThatEncodesImages(options);
     return {
       data: buffer,
       format: options.format,
     };
   },
-  getHTMLAttributes(options, serviceConfig) {
+  getHTMLAttributes(options, imageConfig) {
 		let targetWidth = options.width;
 		let targetHeight = options.height;
 		if (typeof options.src === "object") {
@@ -125,20 +128,22 @@ At build time for static sites and pre-rendered routes, both `<Image />` and `ge
 
 In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
 
-#### getConfiguredImageService & imageServiceConfig
+#### getConfiguredImageService & imageConfig
 
-If you implement your own endpoint as an Astro endpoint, you can use `getConfiguredImageService` and `imageServiceConfig` to call your service's `parseURL` and `transform` methods and provide the service's config object.
+If you implement your own endpoint as an Astro endpoint, you can use `getConfiguredImageService` and `imageConfg` to call your service's `parseURL` and `transform` methods and provide the image config.
+
+To access the image service config ([`image.service.config`](/en/reference/configuration-reference/#imageservice-experimental)), you can use `imageConfig.service.config`.
 
 ```ts title="src/api/my_custom_endpoint_that_transforms_images.ts"
 import type { APIRoute } from "astro";
-import { getConfiguredImageService, imageServiceConfig } from 'astro:assets';
+import { getConfiguredImageService, imageConfig } from 'astro:assets';
 
 export const get: APIRoute = async ({ request }) => {
   const imageService = await getConfiguredImageService();
 
-  const imageTransform = imageService.parseURL(new URL(request.url), imageServiceConfig);
+  const imageTransform = imageService.parseURL(new URL(request.url), imageConfig);
   // ... fetch the image from imageTransform.src and store it in inputBuffer
-  const { data, format } = await imageService.transform(inputBuffer, imageTransform, imageServiceConfig);
+  const { data, format } = await imageService.transform(inputBuffer, imageTransform, imageConfig);
   return new Response(data, {
 			status: 200,
 			headers: {
@@ -158,7 +163,7 @@ export const get: APIRoute = async ({ request }) => {
 
 **Required for local and external services**
 
-`getURL(options: ImageTransform, imageServiceConfig: Record<string, any>): string`
+`getURL(options: ImageTransform, imageConfig: AstroConfig['image']): string`
 
 For local services, this hook returns the URL of the endpoint that generates your image (in SSR and dev mode). It is unused during build. The local endpoint that `getURL()` points to may call both `parseURL()` and `transform()`.
 
@@ -169,7 +174,7 @@ For both types of services, `options` are the properties passed by the user as a
 ```ts
 export type ImageTransform = {
     // ESM imported images | remote/public image paths
-    src: ImageAsset | string;
+    src: ImageMetadata | string;
     width?: number;
     height?: number;
     quality?: ImageQuality;
@@ -184,7 +189,7 @@ export type ImageTransform = {
 
 **Required for local services; unavailable for external services**
 
-`parseURL(url: URL, imageServiceConfig: Record<string, any>): { src: string, [key: string]: any}`
+`parseURL(url: URL, imageConfig: AstroConfig['image']): { src: string, [key: string]: any}`
 
 This hook parses the generated URLs by `getURL()` back into an object with the different properties to be used by `transform` (in SSR and dev mode). It is unused during build.
 
@@ -192,7 +197,7 @@ This hook parses the generated URLs by `getURL()` back into an object with the d
 
 **Required for local services only; unavailable for external services**
 
-`transform(buffer: Buffer, options: { src: string, [key: string]: any }, imageServiceConfig: Record<string, any>): { data: Buffer, format: OutputFormat }`
+`transform(buffer: Buffer, options: { src: string, [key: string]: any }, imageConfig: AstroConfig['image']): { data: Buffer, format: OutputFormat }`
 
 This hook transforms and returns the image and is called during the build to create the final asset files.
 
@@ -202,7 +207,7 @@ You must return a `format` to ensure that the proper MIME type is served to user
 
 **Optional for both local and external services**
 
-`getHTMLAttributes(options: ImageTransform, imageServiceConfig: Record<string, any>): Record<string, any>`
+`getHTMLAttributes(options: ImageTransform, imageConfig: AstroConfig['image']): Record<string, any>`
 
 This hook returns all additional attributes used to render the image as HTML, based on the parameters passed by the user (`options`).
 
@@ -210,7 +215,7 @@ This hook returns all additional attributes used to render the image as HTML, ba
 
 **Optional for both local and external services**
 
-`validateOptions(options: ImageTransform, imageServiceConfig: Record<string, any>): ImageTransform`
+`validateOptions(options: ImageTransform, imageConfig: AstroConfig['image']): ImageTransform`
 
 This hook allows you to validate and augment the options passed by the user. This is useful for setting default options, or telling the user that a parameter is required.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

After the recent update to allow remote images, the Image Service reference page ended up being outdated. Notably, we now pass the entire `image` config to hooks instead of just the service config, so that they can access `domains` and `remotePatterns`. Some misc fixes were also included