### PR TITLE
Remove markdown draft reference

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -395,6 +395,16 @@ const publishedBlogEntries = await getCollection('blog', ({ data }) => {
 });
 ```
 
+You can also create draft pages that are available when running the dev server, but not built in production:
+
+```js
+// Example: Filter out content entries with `draft: true` only when building for production
+import { getCollection } from 'astro:content';
+const blogEntries = await getCollection('blog', ({ data }) => {
+  return import.meta.env.PROD ? data.draft !== true : true;
+});
+```
+
 The filter argument also supports filtering by nested directories within a collection. Since the `id` includes the full nested path, you can filter by the start of each `id` to only return items from a specific nested directory:
 
 ```js

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -60,60 +60,6 @@ It probably isn't styled much, but Markdown does support:
 
 📚 Read more about Astro's [file-based routing](/en/core-concepts/routing/) or options for creating [dynamic routes](/en/core-concepts/routing/#dynamic-routes).
 
-### Draft Pages
-
-`draft: true` is an optional frontmatter value that will mark an individual Markdown or MDX page or post as "unpublished." By default, this page will be:
--  excluded from the site build (**no page will be built**)
-- returned by [`Astro.glob()`](/en/reference/api-reference/#astroglob) (**visible in lists of posts**)
-
-```markdown {5}
----
-# src/pages/post/blog-post.md
-layout: ../../layouts/BaseLayout.astro
-title: My Blog Post
-draft: true
----
-
-This is my in-progress blog post.
-
-No page will be built for this post.
-
-To build and publish this post:
-
-- update the frontmatter to `draft: false` or
-- remove the `draft` property entirely.
-
-But, this page _will_ be returned by any matching `Astro.glob()` request.
-```
-
-To exclude draft posts from being included in a post archive, or list of most recent posts, you can filter the results returned by `Astro.glob()`:
-
-```js
-const posts = await Astro.glob('../pages/post/*.md');
-const nonDraftPosts = posts.filter((post) => !post.frontmatter.draft);
-```
-
-#### Enable building draft pages
-
-To enable building draft pages by default, update `astro.config.mjs` by adding `drafts: true` to `markdown` or to the `mdx` integration:
-
-```js title="astro.config.mjs" ins={5, 8}
-import { defineConfig } from 'astro/config';
-
-export default defineConfig({
-  markdown: {
-    drafts: true,
-  },
-  integrations: [mdx({
-    drafts: true,
-  })],
-});
-```
-
-:::tip
-You can also pass the `--drafts` flag when running `astro build` to build draft pages!
-:::
-
 ## Markdown Features
 
 Astro provides some extra, built-in Markdown features available when using Markdown and MDX files.
@@ -183,7 +129,7 @@ For example, to prevent `<` being interpreted as the beginning of an HTML elemen
 
 Adding the Astro [MDX integration](/en/guides/integrations-guide/mdx/) enhances your Markdown authoring with JSX variables, expressions and components. 
 
-It also adds extra features to standard MDX, including support for [Markdown-style frontmatter in MDX](https://mdxjs.com/guides/frontmatter/). This allows you to use most of Astro's built-in Markdown features like a [frontmatter `layout`](#frontmatter-layout) property and a setting for [draft pages](#draft-pages).
+It also adds extra features to standard MDX, including support for [Markdown-style frontmatter in MDX](https://mdxjs.com/guides/frontmatter/). This allows you to use most of Astro's built-in Markdown features like a [frontmatter `layout`](#frontmatter-layout) property.
 
 `.mdx` files must be written in [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) rather than Astro’s HTML-like syntax.
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -103,7 +103,7 @@ When you follow the instructions to [install Astro manually](/en/install/manual/
 }
 ```
 
-You will often use these `astro` commands, or the scripts that run them, without any flags. Add flags to the command when you want to customize the command's behavior. For example, you may wish to start the development server on a different port, or build your site including draft pages. 
+You will often use these `astro` commands, or the scripts that run them, without any flags. Add flags to the command when you want to customize the command's behavior. For example, you may wish to start the development server on a different port, or build your site with verbose logs for debugging. 
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -111,8 +111,8 @@ You will often use these `astro` commands, or the scripts that run them, without
   # run the dev server on port 8080 using the `start` script in `package.json`
   npm run start -- --port 8080
 
-  # build your site including draft pages using the `build` script in `package.json`
-  npm run build -- --drafts
+  # build your site with verbose logs using the `build` script in `package.json`
+  npm run build -- --verbose
   ```
   (The extra `--` before the `--port` flag is necessary for `npm` to pass your flags to the `astro` command.)
   </Fragment>
@@ -121,8 +121,8 @@ You will often use these `astro` commands, or the scripts that run them, without
   # run the dev server on port 8080 using the `start` script in `package.json`
   pnpm start --port 8080
 
-  # build your site including draft pages using the `build` script in `package.json`
-  pnpm build --drafts
+  # build your site with verbose logs using the `build` script in `package.json`
+  pnpm build --verbose
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -130,8 +130,8 @@ You will often use these `astro` commands, or the scripts that run them, without
   # run the dev server on port 8080 using the `start` script in `package.json`
   yarn start --port 8080
 
-  # build your site including draft pages using the `build` script in `package.json`
-  yarn build --drafts
+  # build your site with verbose logs using the `build` script in `package.json`
+  yarn build --verbose
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -220,10 +220,6 @@ Builds your site for deployment. By default, this will generate static files and
 <h3>Flags</h3>
 
 Use these flags to customize your build. For flags shared with other Astro commands, see [common flags](#common-flags) below.
-
-#### `--drafts`
-
-Includes [Markdown draft pages](/en/guides/markdown-content/#draft-pages) in the build.
 
 ## `astro preview`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Close https://github.com/withastro/docs/issues/4318
- Remove references of markdown and MDX draft features.
- Add a new small paragraph about content collections draft filtering where it's available in dev, but not in prod.


<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
