### PR TITLE
i18n(en): Fix typo in `react-integration`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -101,7 +101,7 @@ import ReactComponent from './ReactComponent';
 </ReactComponent>
 ```
 
-If you are using a library that *expects* more than one child element element to be passed, for example so that it can slot certain elements in different places, you might find this to be a blocker.
+If you are using a library that *expects* more than one child element to be passed, for example so that it can slot certain elements in different places, you might find this to be a blocker.
 
 You can set the experimental flag `experimentalReactChildren` to tell Astro to always pass children to React as React vnodes. There is some runtime cost to this, but it can help with compatibility.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Minor content fixes (broken links, typos, etc.)

#### Description
- What does this PR change? Give us a brief description.
  - This fixes a type in the page [react-integration](https://docs.astro.build/en/guides/integrations-guide/react/)
- Did you change something visual? A before/after screenshot can be helpful.
  - N/A

- Are these docs for an upcoming Astro release?
  - No