### PR TITLE
Fix number cannot be assigned to string issue in script example

### DIFF
--- a/src/content/docs/en/guides/client-side-scripts.mdx
+++ b/src/content/docs/en/guides/client-side-scripts.mdx
@@ -163,7 +163,7 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
       // Each time the button is clicked, update the count.
 			heartButton.addEventListener('click', () => {
         count++;
-        countSpan.textContent = count;
+        countSpan.textContent = count.toString();
       });
 		}
   }


### PR DESCRIPTION
Fix type issue number cannot be assigned to string.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Fix minor type issue.
<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
