### PR TITLE
Add glob matching to `@tracker-major` directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@nanostores/preact": "^0.1.3",
     "canvas-confetti": "^1.6.0",
     "jsdoc-api": "^7.1.1",
+    "minimatch": "^9.0.3",
     "nanostores": "^0.5.13",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-slug": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@fontsource/ibm-plex-mono':
     specifier: ^4.5.10
@@ -13,6 +17,9 @@ dependencies:
   jsdoc-api:
     specifier: ^7.1.1
     version: 7.1.1
+  minimatch:
+    specifier: ^9.0.3
+    version: 9.0.3
   nanostores:
     specifier: ^0.5.13
     version: 0.5.13
@@ -1899,7 +1906,7 @@ packages:
     resolution: {integrity: sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==}
     dependencies:
       fast-glob: 3.3.0
-      minimatch: 5.1.0
+      minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
     dev: true
@@ -2683,7 +2690,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -5716,19 +5722,19 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
-  /minimatch@5.1.0:
-    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /mkdirp2@1.0.5:
     resolution: {integrity: sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==}
@@ -7858,7 +7864,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/scripts/lib/translation-status/builder.ts
+++ b/scripts/lib/translation-status/builder.ts
@@ -354,6 +354,9 @@ export class TranslationStatusBuilder {
 		`en/astro-components.mdx`, `en/astro-pages.mdx`, `en/astro-syntax.mdx`
 
 		Will mark only `en/astro-components.mdx` & `en/astro-pages.mdx` as major changes.
+
+		See minimatch docs for examples on glob patterns:
+		https://github.com/isaacs/minimatch/blob/main/README.md
 		
 	*/
 	isValidMajor(entry: DefaultLogFields & ListLogLine, filePath: string) {

--- a/scripts/lib/translation-status/builder.ts
+++ b/scripts/lib/translation-status/builder.ts
@@ -18,6 +18,7 @@ import type {
 	PageTranslationStatus,
 } from '../../lib/translation-status/types';
 import { toUtcString, tryGetFrontMatterBlock } from '../../lib/translation-status/utils.js';
+import { minimatch } from 'minimatch';
 
 type NestedRecord = { [k: string]: string | NestedRecord };
 
@@ -343,19 +344,27 @@ export class TranslationStatusBuilder {
 		Also works when there's no English pages! The translated files will be marked as 
 		updated, but the same pages from other languages won't be affected by it, keeping
 		their old state.
+
+		You can also use glob matching!
+
+		Example usage:
+		@tracker-major:./src/content/docs/en/core-concepts/+(astro-components|astro-pages).mdx
+
+		Pages changed:
+		`en/astro-components.mdx`, `en/astro-pages.mdx`, `en/astro-syntax.mdx`
+
+		Will mark only `en/astro-components.mdx` & `en/astro-pages.mdx` as major changes.
 		
 	*/
 	isValidMajor(entry: DefaultLogFields & ListLogLine, filePath: string) {
-		if (entry.message.match(COMMIT_IGNORE)) return false;
-
 		const trackerDirectiveMatch = entry.body.match(TRACKER_DIRECTIVE);
 
-		if (trackerDirectiveMatch) {
-			const filePaths = trackerDirectiveMatch[0].replace('@tracker-major:', '').split(';');
-			return filePaths.includes(filePath);
-		}
+		if (entry.message.match(COMMIT_IGNORE)) return false;
+		if (!trackerDirectiveMatch) return true;
 
-		return true;
+		const globsOrPaths = trackerDirectiveMatch[0].replace('@tracker-major:', '').split(';');
+
+		return globsOrPaths.find(globOrPath => minimatch(filePath, globOrPath)) ? true : false;
 	}
 
 	getTranslationStatusByPage(pages: PageIndex): PageTranslationStatus[] {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Translated content


#### Description

Now the directive also accepts glob patterns! Which will come in handy to deal with the 3.0 docs.

See the comment added to code plus the base PR for this feature for me instructions on how to test: https://github.com/withastro/docs/pull/4267

Note that minimatch glob syntax is a bit different from some other libraries, so check their docs first to be sure!