### PR TITLE
feat: add two new breaking things in the migration guide

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -5,7 +5,6 @@ i18nReady: true
 ---
 import Since from '~/components/Since.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
-import Tabs from '~/components/tabs/Tabs'
 
 
 Astro ships with built-in support for [TypeScript](https://www.typescriptlang.org/). You can import `.ts` and `.tsx` files in your Astro project, write TypeScript code directly inside your [Astro component](/en/core-concepts/astro-components/#the-component-script), and even use an [`astro.config.ts`](/en/guides/configuring-astro/#the-astro-config-file) file if you like.
@@ -85,35 +84,15 @@ import type { SomeType } from './script';
 
 This way, you avoid edge cases where Astro's bundler may try to incorrectly bundle your imported types as if they were JavaScript.
 
-You can configure TypeScript to enforce type imports in your `.tsconfig` file.
+You can configure TypeScript to enforce type imports in your `.tsconfig` file. Set [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) to `true`. TypeScript will check your imports and tell you when `import type` should be used. This setting is enabled by default in all our presets.
 
-<Tabs client:visible sharedStore="typescript-version">
-	<Fragment slot="tab.4.9">TypeScript ≤4.9</Fragment>
-	<Fragment slot="tab.5.0">TypeScript ≥5.0</Fragment>
-
-	<Fragment slot="panel.4.9">
-		Set [`importsNotUsedAsValues`](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) to `"error"`. TypeScript will check your imports and tell you when `import type` should be used. This setting is included by default in our `strict` and `strictest` templates.
-
-    ```json title="tsconfig.json" ins={3}
-    {
-      "compilerOptions": {
-        "importsNotUsedAsValues": "error"
-      }
+```json title="tsconfig.json" ins={3}
+  {
+    "compilerOptions": {
+      "verbatimModuleSyntax": true
     }
-    ```
-	</Fragment>
-	<Fragment slot="panel.5.0">
-		Set [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) to `true`. TypeScript will check your imports and tell you when `import type` should be used.
-
-    ```json title="tsconfig.json" ins={3}
-    {
-      "compilerOptions": {
-        "verbatimModuleSyntax": true
-      }
-    }
-    ```
-	</Fragment>
-</Tabs>
+  }
+```
 
 ## Import Aliases
 

--- a/src/content/docs/en/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v3.mdx
@@ -180,6 +180,16 @@ If you are continuing to use v1.x APIs, use the new APIs for each feature instea
 - Deprecated config options: See [the 0.26 migration guide](/en/guides/upgrade-to/v1/#new-configuration-api)
 - Deprecated script/style attribute types: See [the 0.26 migration guide](/en/guides/upgrade-to/v1/#new-default-script-behavior)
 
+### Removed: Partial shims for Web APIs in server code
+
+In Astro v2.x, Astro provided partial shims for Web APIs such as `document` or `localStorage` in server-rendered code. These shims were often incomplete and unreliable.
+
+Astro v3.0 removes these partial shims entirely. Web APIs are no longer available in server-rendered code.
+
+#### What should I do?
+
+If you are using Web APIs in server-rendered components, you will need to either make the usage of those APIs conditional or use the `client:only` client directive.
+
 ### Removed: `image` from `astro:content` in content collections schema
 
 In Astro v2.x, the content collections API deprecated an `image` export from `astro:content` for use in your content collections schemas.
@@ -386,6 +396,32 @@ If you really need to keep the previous format, you can use the `ResponseWithEnc
 export async function GET() {
   return { body: { "title": "Bob's blog" } };
   return new ResponseWithEncoding({ body: { "title": "Bob's blog" }});
+}
+```
+
+### Changed default: `verbatimModuleSyntax` in tsconfig.json presets
+
+In Astro v2.x, the [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) settings was off by default, with its TypeScript 4.x equivalent `importsNotUsedAsValues` being enabled in the `strict` preset.
+
+In Astro v3.0, `verbatimModuleSyntax` is enabled in every preset.
+
+#### What should I do?
+
+This option requires that types are imported using the `import type` syntax.
+
+```astro title="src/components/MyAstroComponent.astro" "type"
+---
+import { type CollectionEntry, getEntry } from "astro:content";
+---
+```
+
+While we recommend keeping it on and properly making your type imports with `type` (as shown above), you can disable it by setting `verbatimModuleSyntax: false` in your `tsconfig.json` file if it causes any issues.
+
+```json title="tsconfig.json" "false"
+{
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
 }
 ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Two breaking things added in 3.0 were not documented in the migration guide. This adds that. Additionally, the typescript page has been updated to remove TypeScript 4.0 code, since it's not supported anymore