### PR TITLE
i18n(fr): Add new `google-firebase.mdx` translation

### DIFF
--- a/src/content/docs/fr/guides/backend/google-firebase.mdx
+++ b/src/content/docs/fr/guides/backend/google-firebase.mdx
@@ -1,0 +1,4 @@
+---
+title:
+description:
+---

--- a/src/content/docs/fr/guides/backend/google-firebase.mdx
+++ b/src/content/docs/fr/guides/backend/google-firebase.mdx
@@ -1,4 +1,39 @@
 ---
-title:
-description:
+title: Déployez votre site Astro sur l'hébergement Firebase de Google
+description: Comment déployer votre site Astro sur le web en utilisant l'hébergement Firebase de Google.
+type: deploy
+i18nReady: true
 ---
+
+[L'hébergement Firebase](https://firebase.google.com/products/hosting) est un service fourni par la plateforme de développement d'applications [Firebase](https://firebase.google.com/) de Google, qui peut être utilisé pour déployer un site Astro.
+
+Consultez notre guide séparé pour [ajouter des services backend Firebase](/fr/guides/backend/google-firebase/) tels que les bases de données, l'authentification et le stockage.
+
+## Comment déployer
+
+1. Assurez-vous d'avoir [firebase-tools](https://www.npmjs.com/package/firebase-tools) installé.
+
+2. Créez `firebase.json` et `.firebaserc` à la racine de votre projet avec le contenu suivant:
+
+   `firebase.json`:
+
+   ```json
+   {
+     "hosting": {
+       "public": "dist",
+       "ignore": []
+     }
+   }
+   ```
+
+   `.firebaserc`:
+
+   ```json
+   {
+     "projects": {
+       "default": "<VOTRE_ID_FIREBASE>"
+     }
+   }
+   ```
+
+3. Après avoir exécuté `npm run build`, déployez en utilisant la commande `firebase deploy`.


### PR DESCRIPTION
## Addition of French Translation for Firebase Deployment Guide

- New or updated content
- Translated content

#### Description
This pull request adds a French translation of the guide for deploying on Google's Firebase hosting. This will make it easier for our French-speaking users to understand how to deploy their Astro site on Firebase.

Key points covered in this translation include:
- A brief description of Firebase hosting and its use for deploying an Astro site.
- A step-by-step guide on how to deploy the site, including creating specific configuration files and running the appropriate deployment commands.
With this translation, I hope to make the documentation more accessible to Astro's french community. Any feedback and suggestions for improving this translation are welcome.
