### PR TITLE
guides/import: Add `.src` to `src={imgReference.src} `

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -133,7 +133,7 @@ import svgReference from './image.svg'; // svgReference === '/src/image.svg'
 import txtReference from './words.txt'; // txtReference === '/src/words.txt'
 
 // This example uses JSX, but you can use import references with any framework.
-<img src={imgReference} alt="image description" />;
+<img src={imgReference.src} alt="image description" />;
 ```
 
 All other assets not explicitly mentioned above can be imported via ESM `import` and will return a URL reference to the final built asset. This can be useful for referencing non-JS assets by URL, like creating an image element with a `src` attribute pointing to that image.


### PR DESCRIPTION
Without this change, I get the following error:

```
Type 'ImageMetadata' is not assignable to type 'string'.ts(2322)
astro-jsx.d.ts(701, 3): The expected type comes from property 'src' which is declared here on type 'ImgHTMLAttributes'
```

It is also how it is documented in https://docs.astro.build/en/guides/images/#images-in-astro-files