### PR TITLE
Update server-side-rendering.mdx

### DIFF
--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -58,7 +58,9 @@ import { defineConfig } from 'astro/config';
 + import nodejs from '@astrojs/node';
 
 export default defineConfig({
-+ adapter: nodejs(),  
++ adapter: nodejs({
++  mode: 'middleware' // or 'standalone'
++ }),  
 + output: 'hybrid',
 });
 ```


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This commit makes the code example for adapters run when copy-pasted.

The current code example won't work as-is and throws a “Setting the 'mode' option is required.” error without any suggestions for resolution. Readers then must realize that they must go to docs for the nodejs adapter and figure out what `mode` is.
