### PR TITLE
Use Fragments

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -78,17 +78,26 @@ Use the `create astro` command for your package manager to launch Astro's CLI wi
 ### Add integrations and dependencies
 Add the React integration using the `astro add` command for your package manager. If your app uses Tailwind or MDX, you can add multiple Astro integrations using the same command:
 
-```sh
-# Using NPM
-npx astro add react
-npx astro add react tailwind mdx
-# Using Yarn
-yarn astro add react
-yarn astro add react tailwind mdx
-# Using PNPM
-pnpm astro add react
-pnpm astro add react tailwind mdx
-```
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add react
+  npx astro add react tailwind mdx
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm astro add react
+  pnpm astro add react tailwind mdx
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add react
+  yarn astro add react tailwind mdx
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 If your CRA requires any dependencies (e.g. NPM packages), then install them individually using the command line or by adding them to your new Astro project's `package.json` manually and then running an install command. Note that many, but not all, React dependencies will work in Astro. 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
- Changes to the docs site code

#### Description

* Changed the `Add integrations and dependencies` section to use Fragments like the previous section. 
* This should also automatically change all tabs/fragments to the same package manager