### PR TITLE
fix: revert Node to 18 for CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 18
         cache: pnpm
 
     - name: Install dependencies


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

Revert Node version to 18, since 20 is very buggy

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
