### PR TITLE
Fix: Flash of Dark Theme

### DIFF
--- a/src/components/Header/ThemeToggleButton.tsx
+++ b/src/components/Header/ThemeToggleButton.tsx
@@ -51,7 +51,7 @@ const ThemeToggle = ({ labels, isInsideHeader }: Props) => {
 		const root = document.documentElement;
 		if (theme === 'light') {
 			root.classList.remove('theme-dark');
-		} else {
+		} else if (theme === 'dark') {
 			root.classList.add('theme-dark');
 		}
 	}, [theme]);


### PR DESCRIPTION
**Note:** This PR is a temporary fix until the issue with `setTheme` is fixed. 

**Current Status:** 

- On first load or when refreshing the browser, `setTheme` isn't setting the `theme` value.
- This leads to `theme` being 'undefined', causing the `.theme-dark` class to be added. 
- This PR doesn't solve the `setTheme` problem directly. Instead, it checks to ensure the theme is set to either "dark" or "light". 

- ![CleanShot 2023-09-08 at 08 50 46@2x](https://github.com/withastro/docs/assets/20273871/58b01e23-d0ab-4091-8cc9-85cbec40fae1) 
- ![CleanShot 2023-09-08 at 08 51 29@2x](https://github.com/withastro/docs/assets/20273871/a9fd3625-68e6-4033-af01-ed5e0165c2f6)
 
#### What kind of changes does this PR include?

- Something else:
    - Minor tweak to prevent the flash of the dark theme. 
    
#### Description: 

- Added a check to ensure the theme value is 'light' or 'dark', providing a temporary solution to the `setTheme` issue in `useEffect`.

#### Before / After 

- Did you change something visual

**Before:**


https://github.com/withastro/docs/assets/20273871/9006143e-c79f-40f5-822d-8308e706551e

https://github.com/withastro/docs/assets/20273871/a77536e8-7661-48d4-bdde-1161aa5807fa

https://github.com/withastro/docs/assets/20273871/41b08978-ab47-49b0-a02a-a96e7cfdab54

https://github.com/withastro/docs/assets/20273871/26235901-6412-48e4-9b48-2d363d9f0a05

https://github.com/withastro/docs/assets/20273871/65f64f15-21a1-40ed-9bdc-2774907182a0


**After:**

https://github.com/withastro/docs/assets/20273871/627849e7-7d14-4511-aaab-7dcdb8181c1d


