### PR TITLE
Avoiding undefined initial state in theme hook

### DIFF
--- a/src/components/Header/ThemeToggleButton.tsx
+++ b/src/components/Header/ThemeToggleButton.tsx
@@ -41,7 +41,7 @@ const icons = [
 ];
 
 const ThemeToggle = ({ labels, isInsideHeader }: Props) => {
-	const [theme, setTheme] = useState<'light' | 'dark'>();
+	const [theme, setTheme] = useState<'light' | 'dark'>('light'); 
 
 	useEffect(() => {
 		setTheme(document.documentElement.classList.contains('theme-dark') ? 'dark' : 'light');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

Quick follow-up to #4594

Turns out TypeScript wasn't screaming about a type mismatch in the `useState` hook :eyes:

I would have expected an error here when a default value of `light` or `dark` isn't provided, I could see that being super tricky to properly type with generics though!

This updates the `useState` call to default to the light theme, avoiding the state where the theme value was `undefined` and accidentally triggering a flash of dark mode

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
