### PR TITLE
Update bun.mdx

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -23,13 +23,13 @@ curl -fsSL https://bun.sh/install | bash
 Create a new Astro project with Bun using the following `create astro` command:
 
 ```bash
-bunx create-astro@latest my-astro-project-using-bun
+bun x create-astro@latest my-astro-project-using-bun
 ```
 
 :::tip[Tip]
 You can also [create a new Astro project from any existing Astro GitHub repository](/en/install/auto/#starter-templates) using the `--template` flag:
 ```bash
-bunx create-astro@latest my-astro-project-using-bun --template eliancodes/brutal
+bun x create-astro@latest my-astro-project-using-bun --template eliancodes/brutal
 ```
 :::
 
@@ -60,7 +60,7 @@ Use the full command `bun run dev` to start your Astro development server. The c
 You can also use any of the official Astro integrations with Bun and the `astro add` command:
 
 ```bash
-bunx astro add react
+bun x astro add react
 ```
 
 This will work exactly the same as if you were using NPM, but with the added benefit of using Bun's blazing fast runtime.


### PR DESCRIPTION
As of bun 1.0 calling bunx doesn't seem to work. Calling bun x  works.

After installing bun 1.0 on on Windows 10 WSL 2 Ubuntu 20.04:

```sh
$ bunx create-astro@latest my-astro-project-using-bun
bunx: command not found
```

![image](https://github.com/withastro/docs/assets/657249/1ddb6dd1-a7bf-41cb-b794-525d3ff7b517)

```sh
$ bun x create-astro@latest my-astro-project-using-bun
```

![image](https://github.com/withastro/docs/assets/657249/840f6c8e-27a0-4b07-b2d5-4b00b331ffe3)


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

This updates the docs to work with the latest bun 1.0

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
