### PR TITLE
docs/bun: Add link to external installation guide

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -11,7 +11,7 @@ Using Bun with Astro still is experimental. Some integrations may not work as ex
 
 ## Installing Bun
 
-Use the following command to install Bun:
+Use the following command to [install Bun](https://bun.sh/docs/installation):
 
 
 ```bash


### PR DESCRIPTION
This makes it easy to look for the homebrew installation steps for example.