### PR TITLE
docs/bun: Clarify why some commands need the `run`

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -74,12 +74,12 @@ Some integrations might not work as expected. If you find any issues, please [op
 To build and serve your site, Bun has familiar commands:
 
 ```bash
-bun run build
+bun run build # note: it is `bun run` here because `bun build` is an internal bun feature
 ```
 
 Bun's build command will output your site to the `dist/` directory.
 
-Then, you can serve your site using the `preview` command:
+Then, you can serve your site using the astro `preview` command:
 
 ```bash
 bun preview


### PR DESCRIPTION
I stumbled on the fact that only the build was `bun run build` and everything else is just `bun`. I assume this page is the first time using bun for people like it is for me, therefore some basics are good to add.
The solution is simple: Some commands on the page use reserved keywords like `install`, others do not need the run because `bun` defaults to `bun run` whenever it is not a reserved keyword, which is why documenting `bun preview` works. So it is just the `bun run build` which is the outlier here… which is what I tried to clarify in the docs with this PR.

Wording might very well be something to improve.

---

Also ping https://github.com/oven-sh/bun/pull/4756