### PR TITLE
fix Api call for retrieving stories

### DIFF
--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -312,7 +312,7 @@ import { useStoryblokApi } from '@storyblok/astro'
 
 const storyblokApi = useStoryblokApi();
 
-const { data } = await storyblokApi.get('cdn/stories/blog', {
+const { data } = await storyblokApi.get('cdn/stories', {
   version: import.meta.env.DEV ? "draft" : "published",
   content_type: 'blogPost',
 })


### PR DESCRIPTION
For retrieving stories, instead of `cdn/stories/blog`, you need to call `cdn/stories`

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)


#### Description

Fix a typo for calling api