### PR TITLE
Add the missing `PackageManagerTabs` for integrations

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -29,14 +30,26 @@ This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinej
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add alpinejs
-# Using Yarn
-yarn astro add alpinejs
-# Using PNPM
-pnpm astro add alpinejs
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add alpinejs  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add alpinejs
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -27,14 +28,26 @@ An SSR adapter for use with Cloudflare Pages Functions targets. Write your code 
 
 Add the Cloudflare adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add cloudflare
-# Using Yarn
-yarn astro add cloudflare
-# Using PNPM
-pnpm astro add cloudflare
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add cloudflare  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add cloudflare
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you prefer to install the adapter manually instead, complete the following two steps:
 

--- a/src/content/docs/en/guides/integrations-guide/deno.mdx
+++ b/src/content/docs/en/guides/integrations-guide/deno.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -37,14 +38,26 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 Add the Deno adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add deno
-# Using Yarn
-yarn astro add deno
-# Using PNPM
-pnpm astro add deno
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add deno  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add deno
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you prefer to install the adapter manually instead, complete the following two steps:
 

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -36,14 +37,26 @@ Astro includes a CLI tool for adding first party integrations: `astro add`. This
 
 To install `@astrojs/lit`, run the following from your project directory and follow the prompts:
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add lit
-# Using Yarn
-yarn astro add lit
-# Using PNPM
-pnpm astro add lit
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add lit  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add lit
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -33,14 +34,26 @@ Markdoc allows you to enhance your Markdown with [Astro components][astro-compon
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add markdoc
-# Using Yarn
-yarn astro add markdoc
-# Using PNPM
-pnpm astro add markdoc
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add markdoc  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add markdoc
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -33,14 +34,26 @@ MDX allows you to [use variables, JSX expressions and components within Markdown
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add mdx
-# Using Yarn
-yarn astro add mdx
-# Using PNPM
-pnpm astro add mdx
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add mdx  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add mdx
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -37,14 +38,26 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 Add the Netlify adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add netlify
-# Using Yarn
-yarn astro add netlify
-# Using PNPM
-pnpm astro add netlify
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add netlify  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add netlify
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### Add dependencies manually
 

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -35,14 +36,26 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 Add the Node adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add node
-# Using Yarn
-yarn astro add node
-# Using PNPM
-pnpm astro add node
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add node  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add node
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### Add dependencies manually
 

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -37,14 +38,26 @@ The Astro Partytown integration installs Partytown for you and makes sure it's e
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add partytown
-# Using Yarn
-yarn astro add partytown
-# Using PNPM
-pnpm astro add partytown
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add partytown  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add partytown
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -38,14 +39,26 @@ Check out [“Learn Preact in 10 minutes”](https://preactjs.com/tutorial), an 
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add preact
-# Using Yarn
-yarn astro add preact
-# Using PNPM
-pnpm astro add preact
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add preact  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add preact
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/prefetch.mdx
+++ b/src/content/docs/en/guides/integrations-guide/prefetch.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -33,14 +34,26 @@ To further improve the experience, especially on similar pages, stylesheets are 
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add prefetch
-# Using Yarn
-yarn astro add prefetch
-# Using PNPM
-pnpm astro add prefetch
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add prefetch  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add prefetch
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -36,14 +37,26 @@ Astro includes a CLI tool for adding first party integrations: `astro add`. This
 
 To install `@astrojs/react`, run the following from your project directory and follow the prompts:
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add react
-# Using Yarn
-yarn astro add react
-# Using PNPM
-pnpm astro add react
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add react  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add react
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -39,14 +40,26 @@ This integration cannot generate sitemap entries for dynamic routes in [SSR mode
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add sitemap
-# Using Yarn
-yarn astro add sitemap
-# Using PNPM
-pnpm astro add sitemap
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add sitemap  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add sitemap
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -36,14 +37,26 @@ Astro includes a CLI tool for adding first party integrations: `astro add`. This
 
 To install `@astrojs/solid-js`, run the following from your project directory and follow the prompts:
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add solid
-# Using Yarn
-yarn astro add solid
-# Using PNPM
-pnpm astro add solid
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add solid  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add solid
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/en/guides/integrations-guide/svelte.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -36,14 +37,26 @@ Astro includes a CLI tool for adding first party integrations: `astro add`. This
 
 To install `@astrojs/svelte`, run the following from your project directory and follow the prompts:
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add svelte
-# Using Yarn
-yarn astro add svelte
-# Using PNPM
-pnpm astro add svelte
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add svelte  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add svelte
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -41,14 +42,26 @@ Note: it's generally discouraged to use both Tailwind and another styling method
 
 The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add tailwind
-# Using Yarn
-yarn astro add tailwind
-# Using PNPM
-pnpm astro add tailwind
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add tailwind  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add tailwind
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -18,6 +18,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 <DontEditWarning/>
 
@@ -37,14 +38,26 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 Add the Vercel adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add vercel
-# Using Yarn
-yarn astro add vercel
-# Using PNPM
-pnpm astro add vercel
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add vercel  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add vercel
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### Add dependencies manually
 

--- a/src/content/docs/en/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vue.mdx
@@ -36,14 +36,26 @@ Astro includes a CLI tool for adding first party integrations: `astro add`. This
 
 To install `@astrojs/vue`, run the following from your project directory and follow the prompts:
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add vue
-# Using Yarn
-yarn astro add vue
-# Using PNPM
-pnpm astro add vue
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add vue  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add vue
+```
+</Fragment>
+</PackageManagerTabs>
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/alpinejs.mdx
@@ -8,6 +8,7 @@ category: renderer
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 这个 **[Astro集成][astro-integration]** 将 [Alpine.js](https://alpinejs.dev/) 添加到你的项目中，这样你就可以在页面的任何位置使用 Alpine.js。
 
@@ -17,14 +18,26 @@ i18nReady: true
 
 `astro add` 命令行工具可以自动化安装。在新的终端窗口中运行以下命令之一（如果不确定你使用的是哪个包管理器，请运行第一个命令）。然后，按照提示，在终端中输入 "y"（表示 "yes"）确认每个提示。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add alpinejs
-# 使用 Yarn
-yarn astro add alpinejs
-# 使用 PNPM
-pnpm astro add alpinejs
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add alpinejs  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add alpinejs
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)，并尝试以下手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/cloudflare.mdx
@@ -10,6 +10,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 @astrojs/cloudflare 是一个与 Cloudflare Pages Functions 目标一起使用的 SSR 适配器。你可以使用 Astro/Javascript 编写代码，并将其部署到 Cloudflare Pages。
 
@@ -17,14 +18,26 @@ import DontEditWarning from '~/components/DontEditWarning.astro';
 
 通过以下 `astro add` 命令将 Cloudflare 适配器添加到你的 Astro 项目中，以启用 SSR。这将安装适配器，并在这一步之内对 `astro.config.mjs` 文件进行相应的更改。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add cloudflare
-# 使用 Yarn
-yarn astro add cloudflare
-# 使用 PNPM
-pnpm astro add cloudflare
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add cloudflare  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add cloudflare
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你更喜欢手动安装适配器，请完成以下两个步骤：
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/deno.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/deno.mdx
@@ -8,6 +8,8 @@ category: adapter
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 此适配器允许 Astro 将你的 SSR 站点部署到 Deno。
 
 在我们的 [Deno Deploy 部署指南](/zh-cn/guides/deploy/deno/) 中学习如何部署你的 Astro 站点。
@@ -24,14 +26,26 @@ i18nReady: true
 
 使用以下 `astro add` 命令将 Deno 适配器添加到你的 Astro 项目中，以启用 SSR。这将在一步中安装适配器并对你的 `astro.config.mjs` 文件进行适当的更改。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add deno
-# 使用 Yarn
-yarn astro add deno
-# 使用 PNPM
-pnpm astro add deno
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add deno  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add deno
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你更喜欢手动安装适配器，请完成以下两个步骤：
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/lit.mdx
@@ -8,6 +8,8 @@ category: renderer
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 这个 **[Astro 集成][astro-integration]** 为你的 [Lit](https://lit.dev/) 自定义元素提供了服务端渲染和客户端水合。
 
 ## 安装
@@ -23,14 +25,26 @@ Astro 包含一个用于添加第一方集成的 CLI 工具：`astro add`。这�
 
 要安装 `@astrojs/lit`，请从项目目录运行以下命令并按照提示操作：
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add lit
-# 使用 Yarn
-yarn astro add lit
-# 使用 PNPM
-pnpm astro add lit
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add lit  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add lit
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues) 并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/markdoc.mdx
@@ -8,6 +8,8 @@ category: other
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 这个 **[Astro 集成][astro-integration]** 允许使用 [Markdoc](https://markdoc.dev/) 来创建组件、页面和内容集合条目。
 
 ## 为什么是 Markdoc？
@@ -20,14 +22,26 @@ Markdoc 允许你使用 [Astro 组件][astro-components] 增强 Markdown。如�
 
 `astro add` 命令行工具可以自动为你安装。在新的终端窗口中运行以下命令之一。（如果你不确定你使用的是哪个包管理器，请运行第一个命令。）然后，按照提示操作，在终端中输入 "y"（意思是 "yes"）。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add markdoc
-# 使用 Yarn
-yarn astro add markdoc
-# 使用 PNPM
-pnpm astro add markdoc
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add markdoc  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add markdoc
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)，并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/mdx.mdx
@@ -8,6 +8,7 @@ category: other
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 此 **[Astro 集成][astro-integration]** 能够使用 [MDX](https://mdxjs.com/) 组件，并允许你通过 `.mdx` 文件创建页面。
 
@@ -21,14 +22,26 @@ MDX 允许你在 Astro 项目的 [Markdown 内容中使用变量、JSX 表达式
 
 `astro add` 命令行工具为你自动进行安装。在一个新的终端窗口中运行下列其中一个命令。（如果你不确定你使用的是哪个包管理器，请运行第一个命令）。然后按照提示，在终端中输入“y”（意思是“是”），每一条都是如此。
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add mdx
-# Using Yarn
-yarn astro add mdx
-# Using PNPM
-pnpm astro add mdx
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add mdx  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add mdx
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/netlify.mdx
@@ -8,6 +8,8 @@ category: adapter
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 此适配器允许 Astro 部署 SSR 网站到 [Netlify](https://www.netlify.com/)。
 
 在我们的 [Netlify 部署指南](/zh-cn/guides/deploy/netlify/) 中学习如何部署你的 Astro 网站。
@@ -24,14 +26,26 @@ i18nReady: true
 
 添加 Netlify 适配器以在 Astro 项目中启用 SSR，使用以下 `astro add` 命令。这将在一步中安装适配器并对 `astro.config.mjs` 文件进行适当的更改。
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add netlify
-# Using Yarn
-yarn astro add netlify
-# Using PNPM
-pnpm astro add netlify
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add netlify  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add netlify
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### 手动添加依赖
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/node.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/node.mdx
@@ -9,6 +9,7 @@ i18nReady: true
 ---
 
 import Video from '~/components/Video.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 此适配器允许 Astro 将你的 SSR 站点部署到 Node 目标。
 
@@ -24,14 +25,26 @@ import Video from '~/components/Video.astro';
 
 使用以下 `astro add` 命令添加 node 适配器，以在 Astro 项目中启用 SSR。这个命令将安装适配器并一步对你的 `astro.config.mjs` 文件进行适当的更改。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add node
-# 使用 Yarn
-yarn astro add node
-# 使用 PNPM
-pnpm astro add node
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add node  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add node
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### 手动添加依赖
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/partytown.mdx
@@ -8,6 +8,7 @@ category: other
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 此 **[Astro 集成][astro-integration]** 允许你在Astro项目中启用 [Partytown](https://partytown.builder.io/)。
 
@@ -25,14 +26,26 @@ Astro Partytown 集成会为你安装 Partytown 并确保它在所有页面上�
 
 `astro add` 命令行工具为你自动进行安装。在一个新的终端窗口中运行下列其中一条命令（如果你不确定你使用的是哪个包管理器，请运行第一个命令）。然后按照提示，在终端中输入“y”（意思是“是”），每一条都是如此。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add partytown
-# 使用 Yarn
-yarn astro add partytown
-# 使用 PNPM
-pnpm astro add partytown
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add partytown  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add partytown
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/preact.mdx
@@ -10,6 +10,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 这个 **[Astro 集成][astro-integration]** 可以为你的 [Preact](https://preactjs.com/) 组件提供服务器端渲染和客户端水合（hydration）功能。
 
@@ -28,14 +29,26 @@ Preact 是一个允许你构建适用于网络的交互式 UI 组件的库。如
 
 `astro add `命令行工具可以自动化为你安装。在新的终端窗口中运行以下命令之一。（如果你不确定你正在使用哪个包管理器，运行第一个命令。）然后，按照提示操作，在终端中输入 “y”（表示 "yes"）来确认每一个步骤。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add preact
-# 使用 Yarn
-yarn astro add preact
-# 使用 PNPM
-pnpm astro add preact
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add preact  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add preact
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果遇到任何问题，[请随时在 GitHub 留言](https://github.com/withastro/astro/issues) 并尝试以下的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/prefetch.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/prefetch.mdx
@@ -8,6 +8,8 @@ category: other
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 ## 什么是预请求？
 
 页面加载时间对于网站的可用性和整体体验起着至关重要的作用。通过在屏幕上可见时预请求页面链接，此集成将近乎即时的页面导航的优点带到了你的多页应用程序（MPA）中。
@@ -20,14 +22,26 @@ i18nReady: true
 
 `astro add` 命令行工具可以自动为你安装。在新的终端窗口中运行以下命令之一。（如果你不确定正在使用哪个包管理器，请运行第一个命令。）然后，跟随提示，在终端中输入“y”（表示“是”）来确认每个命令。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add prefetch
-# 使用 Yarn
-yarn astro add prefetch
-# 使用 PNPM
-pnpm astro add prefetch
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add prefetch  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add prefetch
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)，并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/react.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/react.mdx
@@ -9,6 +9,7 @@ i18nReady: true
 ---
 
 import Video from '~/components/Video.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 
 **[Astro 集成][astro-integration]** 为你的 [React](https://react.dev/) 组件实现服务器端渲染和客户端水合。
@@ -26,14 +27,26 @@ Astro 包括一个 CLI 工具用于添加第一方的集成： `astro add` ，�
 
 要安装 `@astrojs/react`，请在你的项目目录下运行以下命令并根据提示操作：
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add react
-# 使用 Yarn
-yarn astro add react
-# 使用 PNPM
-pnpm astro add react
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add react  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add react
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在 GitHub 上向我们报告](https://github.com/withastro/astro/issues)并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/sitemap.mdx
@@ -10,6 +10,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 此 **[Astro 集成][astro-integration]** 在构建你的 Astro 项目时，会根据你的页面生成一个 网站地图（Sitemap）。
 
@@ -29,14 +30,26 @@ import DontEditWarning from '~/components/DontEditWarning.astro';
 
 `astro add` 命令行工具会自动化安装过程。在新的终端窗口中运行以下命令之一（如果不确定使用哪个包管理器，请运行第一个命令）。然后按照提示，在终端中输入 "y"（表示 "yes"）确认每个提示。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add sitemap
-# 使用 Yarn
-yarn astro add sitemap
-# 使用 PNPM
-pnpm astro add sitemap
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add sitemap  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add sitemap
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果遇到任何问题，[请随时向我们报告](https://github.com/withastro/astro/issues)，并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/solid-js.mdx
@@ -8,6 +8,8 @@ category: renderer
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 此 **[Astro 集成][astro-integration]** 为你的 [SolidJS](https://www.solidjs.com/) 组件启用服务器端渲染和客户端水合。
 
 ## 安装
@@ -23,14 +25,26 @@ Astro 包含一个 CLI 工具来提供一等集成支持，`astro add` 这个命
 
 要安装 `@astrojs/solid-js`，需要在你的项目工程中依次运行以下命令：
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add solid
-# 使用 Yarn
-yarn astro add solid
-# 使用 PNPM
-pnpm astro add solid
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add solid  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add solid
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你有任何问题, [欢迎随时在 GitHub 上开个 issue 来向我们报告](https://github.com/withastro/astro/issues) 然后尝试执行以下的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/svelte.mdx
@@ -10,6 +10,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 此 **[Astro 集成][astro-integration]** 为你的 [Svelte](https://svelte.dev/) 组件启用服务器端渲染和客户端注入。
 
@@ -26,14 +27,26 @@ Astro 包含来一个 CLI 工具来提供一等集成支持，`astro add` 这个
 
 安装 `@astrojs/svelte`，需要在你的项目工程中依次运行以下命令：
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add svelte
-# 使用 Yarn
-yarn astro add svelte
-# 使用 PNPM
-pnpm astro add svelte
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add svelte  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add svelte
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你有任何问题, [欢迎随时在 GitHub 上开个 issue 来向我们报告](https://github.com/withastro/astro/issues) 然后尝试执行以下的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/tailwind.mdx
@@ -9,6 +9,7 @@ i18nReady: true
 ---
 
 import Video from '~/components/Video.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 **[Astro 集成][astro-integration]** 为你项目中的每一个 `.astro` 文件和 [框架组件](/zh-cn/core-concepts/framework-components/) 带来 [Tailwind](https://tailwindcss.com/) 的实用 CSS 类，同时支持 Tailwind 配置文件。
 
@@ -30,14 +31,26 @@ Tailwind也是为 React、Preact 或 Solid 组件添加样式的不错选择，�
 
 `astro add` 命令行工具为你自动进行安装。在一个新的终端窗口中运行下列其中一条命令（如果你不确定你使用的是哪个包管理器，请运行第一个命令）。然后按照提示，在终端中输入“y”（意思是“是”），每一条都是如此。
 
-```sh
-# Using NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add tailwind
-# Using Yarn
-yarn astro add tailwind
-# Using PNPM
-pnpm astro add tailwind
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add tailwind  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add tailwind
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你遇到任何问题，[请随时在GitHub上向我们报告](https://github.com/withastro/astro/issues)并尝试下面的手动安装步骤。
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/vercel.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 
 import Video from '~/components/Video.astro';
 import DontEditWarning from '~/components/DontEditWarning.astro';
-
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 这个适配器允许 Astro 将你的SSR站点部署到 [Vercel](https://www.vercel.com/) 。
 
@@ -28,14 +28,26 @@ import DontEditWarning from '~/components/DontEditWarning.astro';
 
 通过以下 `astro add` 命令，将 Vercel 适配器添加到你的Astro项目中以启用SSR。这将在一个步骤中安装适配器并对你的 `astro.config.mjs` 文件进行适当的更改。
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add vercel
-# 使用 Yarn
-yarn astro add vercel
-# 使用 PNPM
-pnpm astro add vercel
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add vercel  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add vercel
+```
+</Fragment>
+</PackageManagerTabs>
 
 ### 手动添加依赖
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/vue.mdx
@@ -8,6 +8,8 @@ category: renderer
 i18nReady: true
 ---
 
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
 此 **[Astro 集成][astro-integration]** 为你的 [Vue 3](https://vuejs.org/) 组件启用服务器端渲染和客户端水合。
 
 ## 安装
@@ -23,14 +25,26 @@ Astro 包含一个 CLI 工具来提供一等集成支持，`astro add` 这个命
 
 安装 `@astrojs/vue`，需要在你的项目工程中依次运行以下命令：
 
-```sh
-# 使用 NPM
+<PackageManagerTabs>
+
+<Fragment slot="npm">
+```shell
 npx astro add vue
-# 使用 Yarn
-yarn astro add vue
-# 使用 PNPM
-pnpm astro add vue
 ```
+</Fragment>
+
+<Fragment slot="pnpm">
+```shell
+pnpm astro add vue  
+```
+</Fragment>
+
+<Fragment slot="yarn">
+```shell
+yarn astro add vue
+```
+</Fragment>
+</PackageManagerTabs>
 
 如果你有任何问题, [欢迎随时在 GitHub 上开个 issue 来向我们报告](https://github.com/withastro/astro/issues) 然后尝试执行以下的手动安装步骤。
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

Use `PackageManagerTabs` component to replace many installation snippets with single code block.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
