### PR TITLE
Add note about installing Sharp when using Bun install

### DIFF
--- a/src/content/docs/en/reference/errors/missing-sharp.mdx
+++ b/src/content/docs/en/reference/errors/missing-sharp.mdx
@@ -18,6 +18,8 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 ## What went wrong?
 Sharp is the default image service used for `astro:assets`. When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like pnpm, Sharp must be installed manually into your project in order to use image processing.
 
+When using `bun install` to install your packages, you will have to manually install Sharp using `npm i sharp --no-save` until [this issue](https://github.com/lovell/sharp/issues/3779) is resolved.
+
 If you are not using `astro:assets` for image processing, and do not wish to install Sharp, you can configure the following passthrough image service that does no processing:
 
 ```js


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

Bun cannot currently install sharp properly, so installing Sharp using `npm` is currently necessary. This adds a note documenting what you need to do to get Sharp working when using `bun install` to install your packages.


