### PR TITLE
Fix labeler not labeling i18n PRs properly

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,5 +3,8 @@
 '🚨 action':
 - .github/workflows/**
 
+# Note: The "any" logic requires ANY file of the PR to match ALL (!) of the globs in the array,
+# so to match files in multiple different paths, we also need multiple "any" arrays.
 i18n:
-- any: ['src/content/docs/**/*.mdx', '!src/content/docs/en/**/*', 'src/i18n/**/*', '!src/i18n/en/*' ]
+- any: ['src/content/docs/**/*.mdx', '!src/content/docs/en/**/*']
+- any: ['src/i18n/**/*', '!src/i18n/en/*']


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Changes to the docs site code

#### Description

- Fixes a labeler issue that prevented any i18n PRs from being labeled.
- Bug was accidentally introduced in https://github.com/withastro/docs/pull/4609 due to a misunderstanding of how the "any" logic works. I checked the action's source code to debug the issue and found this solution.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
