### PR TITLE
i18n(es): Fixed highlighted part

### DIFF
--- a/src/content/docs/es/core-concepts/astro-components.mdx
+++ b/src/content/docs/es/core-concepts/astro-components.mdx
@@ -285,6 +285,7 @@ Los slots pueden ser transferidos a otros componentes. Por ejemplo, cuando se cr
 // src/layouts/BaseLayout.astro
 ---
 ---
+
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
@@ -304,6 +305,7 @@ Los slots pueden ser transferidos a otros componentes. Por ejemplo, cuando se cr
 ---
 import BaseLayout from "./BaseLayout.astro";
 ---
+
 <BaseLayout>
   <slot name="head" slot="head"/>
   <slot />


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Instead of highlighting the desired code, which is `<slot name="head"/>` and `<slot />`, the `</head>` and `</body>` code sections are being highlighted incorrectly. Because of simple spacing.


