### PR TITLE
fix: generate rss.xml file by lowercasing get() function

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/4.mdx
@@ -78,7 +78,7 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
 
     import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-    export async function GET() {
+    export async function get() {
       return rss({
         title: 'Astro Learner | Blog',
         description: 'My journey learning Astro',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description

After following the [rss-feed blog tutorial](https://docs.astro.build/en/tutorial/5-astro-api/4/#install-astros-rss-package) I came across an issue.

**Issue:**
When running `npm run build` then `npm run preview`, rss.xml file does not seem to be created, as /rss.xml on local returns a 404.


**Potential solution:**
This issue was solved after lowercasing GET()

from:
`export async function GET() {`
to:
`export async function get() {`

by finding and applying [koba-masa's suggestion on Astro discord channel](https://discord.com/channels/830184174198718474/1147825423594565752/1147825423594565752)

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
