### PR TITLE
[en-only] Make cli-reference page cleaner

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -13,29 +13,6 @@ You can use the Command-Line Interface (CLI) provided by Astro to develop, build
 
 Use the CLI by running one of the **commands** documented on this page with your preferred package manager, optionally followed by any **flags**. Flags customize the behavior of a command.
 
-One of the commands you'll use most often is `astro dev`. This command starts the development server and gives you a live, updating preview of your site in a browser as you work:
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```shell
-  # start the development server
-  npx astro dev
-  ```
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```shell
-  # start the development server
-  pnpm astro dev
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```shell
-  # start the development server
-  yarn astro dev
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
 You can type `astro --help` in your terminal to display a list of all available commands:
 
 <PackageManagerTabs>
@@ -61,7 +38,7 @@ The following message will display in your terminal:
 ```bash
 astro [command] [...flags]
 
-Commands 
+Commands
               add  Add an integration.
             build  Build your project and write it to disk.
             check  Check your project for errors.
@@ -72,7 +49,7 @@ Commands
              sync  Generate content collection types.
         telemetry  Configure telemetry settings.
 
-Global Flags 
+Global Flags
   --config <path>  Specify your config file.
     --root <path>  Specify your project root folder.
      --site <url>  Specify your project site.
@@ -83,6 +60,14 @@ Global Flags
            --open  Open the app in the browser on server start.
            --help  Show this help message.
 ```
+
+:::note
+Passing `--base <pathname>` will override the base value in your astro.config.mjs file, if one exists.
+
+`--config <path>` defaults to `astro.config.mjs`. Use this if you use a different name for your configuration file or have your config file in another folder.
+
+Passing `--site <url>` will override the site value in your astro.config.mjs file, if one exists.
+:::
 
 ### `package.json` scripts
 
@@ -103,40 +88,7 @@ When you follow the instructions to [install Astro manually](/en/install/manual/
 }
 ```
 
-You will often use these `astro` commands, or the scripts that run them, without any flags. Add flags to the command when you want to customize the command's behavior. For example, you may wish to start the development server on a different port, or build your site with verbose logs for debugging. 
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
-  npm run start -- --port 8080
-
-  # build your site with verbose logs using the `build` script in `package.json`
-  npm run build -- --verbose
-  ```
-  (The extra `--` before the `--port` flag is necessary for `npm` to pass your flags to the `astro` command.)
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
-  pnpm start --port 8080
-
-  # build your site with verbose logs using the `build` script in `package.json`
-  pnpm build --verbose
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
-  yarn start --port 8080
-
-  # build your site with verbose logs using the `build` script in `package.json`
-  yarn build --verbose
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
-{/* 
+{/*
 
 ORIGINAL CONTENT That We Can Always revert to if new stuff is too friendly
 
@@ -194,32 +146,58 @@ If you started your project using [the `create astro` wizard](/en/install/auto/#
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
-<h3>Flags</h3>
+You can type `astro dev --help` in your terminal to display a list of all available commands:
 
-Use these flags to customize the behavior of the Astro dev server. For flags shared with other Astro commands, see [common flags](#common-flags) below.
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro dev --help
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm astro dev --help
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro dev --help
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-#### `--port <number>`
+The following message will display in your terminal:
 
-Specifies which port to run on. Defaults to `4321`.
+```bash
+astro dev [...flags]
 
-#### `--host [optional host address]`
-
-Sets which network IP addresses the dev server should listen on (i.e. non-localhost IPs). This can be useful for testing your project on local devices like a mobile phone during development.
-
-- `--host` — listen on all addresses, including LAN and public addresses
-- `--host <custom-address>` — expose on a network IP address at `<custom-address>`
+Flags
+        --port <number>  Specify which port to run on. Defaults to 4321.
+                 --host  Listen on all addresses, including LAN and public addresses.
+--host <custom-address>  Expose on a network IP address at <custom-address>.
+                 --open  Automatically open the app in the browser on server start.
+                 --help  See all available flags.
+```
 
 :::caution
 Do not use the `--host` flag to expose the dev server in a production environment. The dev server is designed for local use while developing your site only.
 :::
 
+Can be combined with these common flags `--root <path>`, `--config <path>`, `--site <url>`, `--base <pathname>`, `--verbose`, `--silent`.
+
 ## `astro build`
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If [SSR is enabled](/en/guides/server-side-rendering/), this will generate the necessary server files to serve your site.
 
-<h3>Flags</h3>
+```bash
+astro build [...flags]
 
-Use these flags to customize your build. For flags shared with other Astro commands, see [common flags](#common-flags) below.
+Flags
+--drafts  Include Markdown draft pages in the build.
+--help    See all available flags.
+```
+
+Can be combined with these common flags `--root <path>`, `--config <path>`, `--site <url>`, `--base <pathname>`, `--verbose`, `--silent`.
 
 ## `astro preview`
 
@@ -229,7 +207,15 @@ This command is useful for previewing your build locally, before deploying it. I
 
 Since Astro 1.5.0, `astro preview` also works for SSR builds if you use an adapter that supports it. Currently, only the [Node adapter](/en/guides/integrations-guide/node/) supports `astro preview`.
 
-Can be combined with the [common flags](#common-flags) documented below.
+```bash
+astro preview [...flags]
+
+Flags
+--open  Automatically open the app in the browser on server start.
+--help  See all available flags.
+```
+
+Can be combined with these common flags `--root <path>`, `--config <path>`, `--site <url>`, `--base <pathname>`, `--verbose`, `--silent`.
 
 ## `astro check`
 
@@ -237,16 +223,15 @@ Runs diagnostics (such as type-checking within `.astro` files) against your proj
 
 This command is intended to be used in CI workflows.
 
-<h3>Flags</h3>
+```bash
+astro check [...flags]
 
-Use these flags to customize the behavior of the command.
-
-#### `--watch`
-
-The command will watch for any changes to `.astro` files, and will report any errors.
+Flags
+--watch  Watch for any changes to `.astro` files, and will report any errors.
+```
 
 :::note
-This command only checks types within `.astro` files.  
+This command only checks types within `.astro` files.
 :::
 
 📚 Read more about [TypeScript support in Astro](/en/guides/typescript/).
@@ -266,6 +251,38 @@ Generates TypeScript types for all Astro modules. This sets up a [`src/env.d.ts`
 ## `astro add`
 
 Adds an integration to your configuration. Read more in [the integrations guide](/en/guides/integrations-guide/#automatic-integration-setup).
+
+```bash
+astro add [...integrations] [...adapters]
+
+Flags:
+           --yes  Accept all prompts.
+          --help  Show this help message.
+
+UI Frameworks:
+         react  astro add react
+        preact  astro add preact
+           vue  astro add vue
+        svelte  astro add svelte
+      solid-js  astro add solid-js
+           lit  astro add lit
+      alpinejs  astro add alpinejs
+
+SSR Adapters:
+       netlify  astro add netlify
+        vercel  astro add vercel
+          deno  astro add deno
+    cloudflare  astro add cloudflare
+          node  astro add node
+
+Others:
+      tailwind  astro add tailwind
+         image  astro add image
+           mdx  astro add mdx
+     partytown  astro add partytown
+       sitemap  astro add sitemap
+      prefetch  astro add prefetch
+```
 
 ## `astro docs`
 
@@ -306,73 +323,19 @@ Telemetry can later be re-enabled with:
 astro telemetry enable
 ```
 
-The `clear` command resets the telemetry data:
+Telemetry can be reset with:
 
 ```shell
-astro telemetry clear
+astro telemetry reset
 ```
 
 :::tip[Want to disable telemetry in CI environments?]
 Add the `astro telemetry disable` command to your CI scripts or set the `ASTRO_TELEMETRY_DISABLED` environment variable.
 :::
 
-## Common flags
-
-### `--root <path>`
-
-Specifies the path to the project root. If not specified, the current working directory is assumed to be the root.
-
-The root is used for finding the Astro configuration file.
-
-```shell
-astro --root myRootFolder/myProjectFolder dev
-```
-
-### `--config <path>`
-
-Specifies the path to the config file relative to the project root. Defaults to `astro.config.mjs`. Use this if you use a different name for your configuration file or have your config file in another folder.
-
-```shell
-astro --config config/astro.config.mjs dev
-```
-
-### `--site <url>`
-
-Configures the [`site`](/en/reference/configuration-reference/#site) for your project. Passing this flag will override the `site` value in your `astro.config.mjs` file, if one exists.
-
-### `--base <pathname>`
-
-<Since v="1.4.1" />
-
-Configures the [`base`](/en/reference/configuration-reference/#base) for your project. Passing this flag will override the `base` value in your `astro.config.mjs` file, if one exists.
-
-### `--verbose`
-
-Enables verbose logging, which is helpful when debugging an issue.
-
-### `--silent`
-
-Enables silent logging, which will run the server without any console output.
-
-## Global flags
-
-Use these flags to get information about the `astro` CLI.
-
-### `--version`
-
-Prints the Astro version number and exits.
-
-### `--open`
-
-Automatically opens the app in the browser on server start.
-
-### `--help`
-
-Prints the help message and exits.
-
 ## Advanced APIs (Experimental)
 
-If you need more control when running Astro, the `"astro"` package also exports APIs to programmatically run the CLI commands. 
+If you need more control when running Astro, the `"astro"` package also exports APIs to programmatically run the CLI commands.
 
 These APIs are experimental and their API signature may change. Any updates will be mentioned in the [Astro changelog](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md) and the information below will always show the current, up-to-date information.
 
@@ -396,7 +359,7 @@ interface AstroInlineConfig extends AstroUserConfig {
 **Default:** `undefined`
 </p>
 
-A custom path to the Astro config file. 
+A custom path to the Astro config file.
 
 If this value is undefined (default) or unset, Astro will search for an `astro.config.(js,mjs,ts)` file relative to the `root` and load the config file if found.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

- Updated all the command sections to display their available flags
- Replaced the common flags sections by turning them into a list
- Removed the global flags section as the description is already provided at the top of the page

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
