### PR TITLE
i18n(es): Fix typos in some pages

### DIFF
--- a/src/content/docs/es/recipes/bun.mdx
+++ b/src/content/docs/es/recipes/bun.mdx
@@ -13,7 +13,7 @@ Bun lanzó recientemente su primera versión estable. Sin embargo, al usar Bun c
 Si tienes algún problema utilizando Bun, por favor [abre un problema en GitHub directamente en el repositorio de Bun](https://github.com/oven-sh/bun/issues/new/choose).
 :::
 
-## Prerrequesitos
+## Prerrequisitos
 
 - Tener Bun instalado localmente en tu máquina. Consulta las [instrucciones de instalación](https://bun.sh/docs/installation) en la documentación oficial de Bun.
 

--- a/src/content/docs/es/reference/cli-reference.mdx
+++ b/src/content/docs/es/reference/cli-reference.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 import Since from '~/components/Since.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-Puredes usar la Interfaz de Línea de Comandos (CLI) proporcionada por Astro para desarrollar, construir y previsualizar tu proyecto desde una ventana de la terminal.
+Puedes usar la Interfaz de Línea de Comandos (CLI) proporcionada por Astro para desarrollar, construir y previsualizar tu proyecto desde una ventana de la terminal.
 
 ### Comandos `astro`
 
@@ -86,7 +86,7 @@ También puedes usar scripts en el `package.json` para versiones más cortas de 
 
 El siguiente script para los comandos más comunes de `astro` (`astro dev`, `astro build` y `astro preview`) se agrega automáticamente cuando creas un proyecto usando [el asistente `create astro`](/es/install/auto/#1-ejecuta-el-asistente-de-configuración).
 
-Cunado sigues las instrucciones para [instalar Astro manualmente](/es/install/manual/#2-instala-astro), se te indica que agregues estos scripts tú mismo. También puedes agregar más scripts a esta lista manualmente para cualquier comando que uses con frecuencia.
+Cuando sigues las instrucciones para [instalar Astro manualmente](/es/install/manual/#2-instala-astro), se te indica que agregues estos scripts tú mismo. También puedes agregar más scripts a esta lista manualmente para cualquier comando que uses con frecuencia.
 
 ```json title="package.json"
 {


### PR DESCRIPTION
**What kind of changes does this PR include?**

Fix typos

**Description**

Fix typos in the following pages:

- src/content/docs/es/recipes/bun.mdx
- src/content/docs/es/reference/cli-reference.mdx