### PR TITLE
I18n(es): Updating some pages translation

### DIFF
--- a/src/content/docs/es/reference/error-reference.mdx
+++ b/src/content/docs/es/reference/error-reference.mdx
@@ -46,7 +46,7 @@ La siguiente referencia es una lista completa de los errores que puedes encontra
 - [**ResponseSentError**](/es/reference/errors/response-sent-error/)<br/>Unable to set response.
 - [**MiddlewareNoDataOrNextCalled**](/es/reference/errors/middleware-no-data-or-next-called/)<br/>The middleware didn't return a response or call `next`.
 - [**MiddlewareNotAResponse**](/es/reference/errors/middleware-not-aresponse/)<br/>The middleware returned something that is not a `Response` object.
-- [**LocalImageUsedWrongly**](/es/reference/errors/local-image-used-wrongly/)<br/>ESM imported images must be passed as-is.
+- [**LocalImageUsedWrongly**](/es/reference/errors/local-image-used-wrongly/)<br/>Local images must be imported.
 - [**LocalsNotAnObject**](/es/reference/errors/locals-not-an-object/)<br/>Value assigned to `locals` is not accepted.
 - [**AstroGlobUsedOutside**](/es/reference/errors/astro-glob-used-outside/)<br/>Astro.glob() used outside of an Astro file.
 - [**AstroGlobNoMatch**](/es/reference/errors/astro-glob-no-match/)<br/>Astro.glob() did not match any files.

--- a/src/content/docs/es/reference/errors/expected-image.mdx
+++ b/src/content/docs/es/reference/errors/expected-image.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **ExpectedImage**: Se esperaba que la propiedad `src` fuera una imagen importada como ESM o una cadena de texto con la ruta de una imagen remota. Se recibieron `OPTIONS`.
+> **ExpectedImage**: Se esperaba que la propiedad `src` de `getImage` o `<Image />` fuera o bien una imagen importada como ESM o una cadena de texto con la ruta de una imagen remota. Se recibió `SRC` (tipo: `TYPEOF_OPTIONS`). Opciones completamente serializadas recibidas: `FULL_OPTIONS`.
 
 ## ¿Qué salió mal?
 La propiedad `src` de la imagen no es válida. El componente Image requiere que el atributo `src` sea una imagen que se haya importado con ESM o una cadena de texto. Esto también es válido para el primer parámetro de `getImage()`.

--- a/src/content/docs/es/reference/errors/expected-image.mdx
+++ b/src/content/docs/es/reference/errors/expected-image.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **ExpectedImage**: Se esperaba que la propiedad `src` de `getImage` o `<Image />` fuera o bien una imagen importada como ESM o una cadena de texto con la ruta de una imagen remota. Se recibió `SRC` (tipo: `TYPEOF_OPTIONS`). Opciones completamente serializadas recibidas: `FULL_OPTIONS`.
+> **ExpectedImage**: Se esperaba que la propiedad `src` de `getImage` o `<Image />` fuera o bien una imagen importada como ESM o una cadena de texto con la ruta de una imagen remota. Se recibió `SRC` (tipo: `TYPEOF_OPTIONS`). Se recibieron todas las opciones serializadas: `FULL_OPTIONS`.
 
 ## ¿Qué salió mal?
 La propiedad `src` de la imagen no es válida. El componente Image requiere que el atributo `src` sea una imagen que se haya importado con ESM o una cadena de texto. Esto también es válido para el primer parámetro de `getImage()`.

--- a/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
+++ b/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
@@ -27,7 +27,7 @@ import myImage from "../my_image.png";
 <Image src={myImage.src} alt="Cool image" />
 
 <!-- MAL: `src` es una cadena de caracteres con una ruta de archivo. -->
-<Image src="../my_image.png" alt="Cool image" />
+<Image src="../my_image.png" alt="Imagen genial" />
 ```
 
 **Ver también:**

--- a/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
+++ b/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
@@ -21,7 +21,7 @@ import myImage from "../my_image.png";
 <Image src={myImage} alt="Cool image" />
 
 <!-- BIEN: `src` es una URL. -->
-<Image src="https://example.com/my_image.png" alt="Cool image" />
+<Image src="https://example.com/my_image.png" alt="Imagen genial" />
 
 <!-- MAL: `src` es la ruta `src` de la imagen en lugar de la imagen completa. -->
 <Image src={myImage.src} alt="Cool image" />

--- a/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
+++ b/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **LocalImageUsedWrongly**: El parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser un una cadena de caracteres con la ruta de archivo. Se recibió `IMAGE_FILE_PATH`.
+> **LocalImageUsedWrongly**: El parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser una cadena de caracteres con la ruta de archivo. Se recibió `IMAGE_FILE_PATH`.
 
 ## ¿Qué salió mal?
 Cuando se utilizan los servicios de imagen predeterminados, el parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser una cadena de caracteres con una ruta de archivo.

--- a/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
+++ b/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
@@ -18,13 +18,13 @@ import myImage from "../my_image.png";
 ---
 
 <!-- BIEN: `src` es la imagen completa importada. -->
-<Image src={myImage} alt="Cool image" />
+<Image src={myImage} alt="Imagen genial" />
 
 <!-- BIEN: `src` es una URL. -->
 <Image src="https://example.com/my_image.png" alt="Imagen genial" />
 
 <!-- MAL: `src` es la ruta `src` de la imagen en lugar de la imagen completa. -->
-<Image src={myImage.src} alt="Cool image" />
+<Image src={myImage.src} alt="Imagen genial" />
 
 <!-- MAL: `src` es una cadena de caracteres con una ruta de archivo. -->
 <Image src="../my_image.png" alt="Imagen genial" />

--- a/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
+++ b/src/content/docs/es/reference/errors/local-image-used-wrongly.mdx
@@ -1,13 +1,15 @@
 ---
-title: ESM imported images must be passed as-is.
+title: Local images must be imported.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **LocalImageUsedWrongly**: El parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser una ruta de archivo. Se recibió `IMAGE_FILE_PATH`.
+> **LocalImageUsedWrongly**: El parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser un una cadena de caracteres con la ruta de archivo. Se recibió `IMAGE_FILE_PATH`.
 
 ## ¿Qué salió mal?
-Cuando se utilizan los servicios de imagen predeterminados, el parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser una ruta de archivo.
+Cuando se utilizan los servicios de imagen predeterminados, el parámetro `src` de `Image` y `getImage` debe ser una imagen importada o una URL, no puede ser una cadena de caracteres con una ruta de archivo.
+
+Para imágenes locales de colecciones de contenido, puedes usar el [helper de esquema image()](/es/guides/images/#imágenes-en-colecciones-de-contenido) para resolver las imágenes.
 
 ```astro
 ---
@@ -18,8 +20,14 @@ import myImage from "../my_image.png";
 <!-- BIEN: `src` es la imagen completa importada. -->
 <Image src={myImage} alt="Cool image" />
 
+<!-- BIEN: `src` es una URL. -->
+<Image src="https://example.com/my_image.png" alt="Cool image" />
+
 <!-- MAL: `src` es la ruta `src` de la imagen en lugar de la imagen completa. -->
 <Image src={myImage.src} alt="Cool image" />
+
+<!-- MAL: `src` es una cadena de caracteres con una ruta de archivo. -->
+<Image src="../my_image.png" alt="Cool image" />
 ```
 
 **Ver también:**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content
- Translated content

#### Description

- What does this PR change? Give us a brief description.
Updating `error-reference.mdx`, `local-image-used-wrongly.mdx` and `expected-image.mdx` pages translation from this commit: https://github.com/withastro/docs/commit/106bdf93ebc68c885850e043a2310779011d6b1e.

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
