### PR TITLE
fix(errors): Fix error formatting not properly handling angle brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "remark-smartypants": "^2.0.0",
     "sass": "^1.54.3"
   },
-  "packageManager": "pnpm@8.2.0",
+  "packageManager": "pnpm@8.6.12",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/scripts/error-docgen.mjs
+++ b/scripts/error-docgen.mjs
@@ -216,30 +216,31 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 function extractStringFromFunction(func) {
 	const arrowIndex = func.indexOf('=>') + '=>'.length;
 
-	return escapeHtml(func.slice(arrowIndex).trim().slice(1, -1));
+	return expressionToText(func.slice(arrowIndex).trim().slice(1, -1));
 
-	function escapeHtml(unsafe) {
+	// Turn the following syntax: `{componentName}` into this result: `COMPONENT_NAME`
+	function expressionToText(text) {
 		return sanitizeString(
-			unsafe
-				.replaceAll(
-					/\${([^}]+)}/gm,
-					(str, match1) =>
-						`${match1
-							.split(/\.?(?=[A-Z])/)
-							.join('_')
-							.toUpperCase()}`
-				)
-				.replaceAll('\\`', '`')
+			text.replaceAll(
+				/\${([^}]+)}/gm,
+				(_, match1) =>
+					`${match1
+						.split(/\.?(?=[A-Z])/)
+						.join('_')
+						.toUpperCase()}`
+			)
 		);
 	}
 }
 
 /**
- * MDX doesn't like some characters, so we need to sanitize the messages regarding the usage of client directives and HTML tags
+ * MDX doesn't like some characters, so we need to sanitize the messages regarding the usage of client directives and HTML tags.
+ * Also remove unnecessary backslashes for inline code and replace newlines with `<br/>`
  * @param {string} message
  */
 function sanitizeString(message) {
 	return message
+		.replaceAll(/\\`/gm, '`')
 		.replaceAll(/`?(client:[\w]+(="\(.+\)")?)`?/g, '`$1`')
 		.replaceAll(/([^`\\])</gm, `$1\\<`)
 		.replaceAll(/>([^`\\])/gm, '\\$1>')

--- a/scripts/error-docgen.mjs
+++ b/scripts/error-docgen.mjs
@@ -8,7 +8,7 @@ const sourceRepo = process.env.SOURCE_REPO || 'withastro/astro';
 
 const errorURL = `https://raw.githubusercontent.com/${sourceRepo}/${sourceBranch}/packages/astro/src/core/errors/errors-data.ts`;
 
-// Fill this in to test a response locally, with fetching.
+// Fill this in to test a response locally, without fetching.
 const STUB = undefined; // fs.readFileSync('../astro/packages/astro/src/core/errors/errors-data.ts', {encoding: 'utf-8',});
 
 const HEADER = `---
@@ -116,7 +116,7 @@ export async function run() {
 			resultMessage = `> ${cleanMessage}`;
 		} else if (message) {
 			if (typeof message === 'string') {
-				resultMessage = `> **${errorName}**: ${message}`;
+				resultMessage = `> **${errorName}**: ${sanitizeString(message)}`;
 			} else {
 				resultMessage = `> **${errorName}**: ${String.raw({
 					raw: extractStringFromFunction(message.toString()),
@@ -219,36 +219,31 @@ function extractStringFromFunction(func) {
 	return escapeHtml(func.slice(arrowIndex).trim().slice(1, -1));
 
 	function escapeHtml(unsafe) {
-		return unsafe
-			.replaceAll(
-				/\${([^}]+)}/gm,
-				(str, match1) =>
-					`${match1
-						.split(/\.?(?=[A-Z])/)
-						.join('_')
-						.toUpperCase()}`
-			)
-			.replaceAll('\\`', '`')
-			.replaceAll(/`?(client:[\w]+(="\(.+\)")?)`?/g, '`$1`')
-			.replaceAll(/&/g, '&amp;')
-			.replaceAll(/</g, '&lt;')
-			.replaceAll(/>/g, '&gt;');
+		return sanitizeString(
+			unsafe
+				.replaceAll(
+					/\${([^}]+)}/gm,
+					(str, match1) =>
+						`${match1
+							.split(/\.?(?=[A-Z])/)
+							.join('_')
+							.toUpperCase()}`
+				)
+				.replaceAll('\\`', '`')
+		);
 	}
 }
 
 /**
- * Make sure client directives are wrapped in backticks to avoid a docs bug
+ * MDX doesn't like some characters, so we need to sanitize the messages regarding the usage of client directives and HTML tags
  * @param {string} message
  */
 function sanitizeString(message) {
-	return message.replaceAll(/`?(client:[\w]+(="\(.+\)")?)`?/g, '`$1`');
-}
-
-/**
- * @param {number} code
- */
-function padCode(code) {
-	return code.toString().padStart(5, '0');
+	return message
+		.replaceAll(/`?(client:[\w]+(="\(.+\)")?)`?/g, '`$1`')
+		.replaceAll(/([^`\\])</gm, `$1\\<`)
+		.replaceAll(/>([^`\\])/gm, '\\$1>')
+		.replaceAll('\\n', '<br/>');
 }
 
 run();

--- a/src/content/docs/en/reference/errors/expected-image.mdx
+++ b/src/content/docs/en/reference/errors/expected-image.mdx
@@ -13,7 +13,7 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **ExpectedImage**: Expected `src` property for `getImage` or `<Image />` to be either an ESM imported image or a string with the path of a remote image. Received `SRC` (type: `TYPEOF_OPTIONS`). Full serialized options received: `FULL_OPTIONS`.
+> **ExpectedImage**: Expected `src` property for `getImage` or `<Image />` to be either an ESM imported image or a string with the path of a remote image. Received `SRC` (type: `TYPEOF_OPTIONS`).<br/><br/>Full serialized options received: `FULL_OPTIONS`.
 
 ## What went wrong?
 An image's `src` property is not valid. The Image component requires the `src` attribute to be either an image that has been ESM imported or a string. This is also true for the first parameter of `getImage()`.

--- a/src/content/docs/en/reference/errors/unsupported-config-transform-error.mdx
+++ b/src/content/docs/en/reference/errors/unsupported-config-transform-error.mdx
@@ -13,7 +13,7 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 <DontEditWarning />
 
 
-> **UnsupportedConfigTransformError**: `transform()` functions in your content config must return valid JSON, or data types compatible with the devalue library (including Dates, Maps, and Sets).\nFull error: PARSE_ERROR
+> **UnsupportedConfigTransformError**: `transform()` functions in your content config must return valid JSON, or data types compatible with the devalue library (including Dates, Maps, and Sets).<br/>Full error: PARSE_ERROR
 
 ## What went wrong?
 `transform()` functions in your content config must return valid JSON, or data types compatible with the devalue library (including Dates, Maps, and Sets).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

With the new image component, we're adding more errors that have angle brackets in them (ex: `<Image />`). MDX doesn't like this, so we escaped them previously and it'd all work nicely, but then it seems like something changed and now it doesn't work. Not sure. This fixes everything, though.

This PR also updates the `packageManager` field, the old version of `pnpm` used didn't support Node 20.