### PR TITLE
[en-only] Fix broken URL reference in testing docs

### DIFF
--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -265,4 +265,4 @@ Here is an example of the configuration and commands required when using npm:
 More information about Playwright can be found in the links below:
 
 - [Getting started with Playwright](https://playwright.dev/docs/intro)
-- [Use a development server](https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests)
+- [Use a development server](https://playwright.dev/docs/test-webserver#configuring-a-web-server)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
The older link reference returns a 404 if JavaScript is disabled (as was in my case), or redirects you to a resource which _still_ does not directly mention how to use a development server with Playwright. I found an updated—and IMO, better—resource for the same.

- Did you change something visual? A before/after screenshot can be helpful.
N/A

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->

__PS__: Since this is simply a change in the URL ref, LMK if it’s OK for me to update it in the other languages too, in which case I’ll also update the PR title. I didn’t want to cause any unnecessary trouble for the translators.

💖
