### PR TITLE
Add `env.d.ts` changes to  V3 `@astrojs/image` migration 

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -659,23 +659,23 @@ If you were using the image integration in Astro v2.x, complete the following st
 
 2. Update types (if required).
 
-  If you had special types configured for `@astrojs/image` in `src/env.d.ts`, you may need to change them back to the default Astro types if your upgrade to v3 did not complete this step for you.
+		If you had special types configured for `@astrojs/image` in `src/env.d.ts`, you may need to change them back to the default Astro types if your upgrade to v3 did not complete this step for you.
 
-  ```ts title="drc/env.d.ts" del={1} ins={2}
-  /// <reference types="@astrojs/image/client" />
-  /// <reference types="astro/client" />
-  ```
+		```ts title="drc/env.d.ts" del={1} ins={2}
+		 /// <reference types="@astrojs/image/client" />
+		 /// <reference types="astro/client" />
+		```
 
-  Similarly, update `tsconfig.json` if necessary:
+		Similarly, update `tsconfig.json` if necessary:
 
-  ```json title="tsconfig.json" del={3} ins={4}
-  {
-    "compilerOptions": {
-      "types": ["@astrojs/image/client"]
-      "types": ["astro/client"]
-    }
-  }
-  ```
+		```json title="tsconfig.json" del={3} ins={4}
+		{
+			"compilerOptions": {
+			  "types": ["@astrojs/image/client"]
+			  "types": ["astro/client"]
+			}
+		}
+		```
 
 3. Migrate any existing `<Image />` components.
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -657,31 +657,25 @@ If you were using the image integration in Astro v2.x, complete the following st
     })
     ```
 
-2. Update types
+2. Update types (if required).
 
-  In some projects, `@astrojs/image` had special types set up. If you have these, you need to change them back to the default Astro types.
-  
-  You need to update the `src/env.d.ts` file if you have one.
+  If you had special types configured for `@astrojs/image` in `src/env.d.ts`, you may need to change them back to the default Astro types if your upgrade to v3 did not complete this step for you.
 
-  ```ts
-  // src/env.d.ts
-  - /// <reference types="@astrojs/image/client" />
-  + /// <reference types="astro/client" />
+  ```ts title="drc/env.d.ts" del={1} ins={2}
+  /// <reference types="@astrojs/image/client" />
+  /// <reference types="astro/client" />
   ```
 
-  Alternatively, if you have types set in your `tsconfig.json`, update it like so.
+  Similarly, update `tsconfig.json` if necessary:
 
-  ```json
-  // tsconfig.json
+  ```json title="tsconfig.json" del={3} ins={4}
   {
     "compilerOptions": {
-      - "types": ["@astrojs/image/client"]
-      + "types": ["astro/client"]
+      "types": ["@astrojs/image/client"]
+      "types": ["astro/client"]
     }
   }
   ```
-
-  If you can't find `@astrojs/image/client` in either of these files, don't worry: not everyone has them. You can safely continue.
 
 3. Migrate any existing `<Image />` components.
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -657,7 +657,33 @@ If you were using the image integration in Astro v2.x, complete the following st
     })
     ```
 
-2. Migrate any existing `<Image />` components.
+2. Update types
+
+  In some projects, `@astrojs/image` had special types set up. If you have these, you need to change them back to the default Astro types.
+  
+  You need to update the `src/env.d.ts` file if you have one.
+
+  ```ts
+  // src/env.d.ts
+  - /// <reference types="@astrojs/image/client" />
+  + /// <reference types="astro/client" />
+  ```
+
+  Alternatively, if you have types set in your `tsconfig.json`, update it like so.
+
+  ```json
+  // tsconfig.json
+  {
+    "compilerOptions": {
+      - "types": ["@astrojs/image/client"]
+      + "types": ["astro/client"]
+    }
+  }
+  ```
+
+  If you can't find `@astrojs/image/client` in either of these files, don't worry: not everyone has them. You can safely continue.
+
+3. Migrate any existing `<Image />` components.
 
     Change all `import` statements from `@astrojs/image/components` to `astro:assets` in order to use the new built-in `<Image />` component.
 
@@ -681,13 +707,13 @@ If you were using the image integration in Astro v2.x, complete the following st
       />
       ```
 
-3. Remove any existing `<Picture />` components.
+4. Remove any existing `<Picture />` components.
 
     Currently, the built-in assets feature does not include a `<Picture />` component.
 
     Instead, you can use the HTML image attributes `srcset` and `sizes` or the `<picture>` tag [for art direction or to create responsive images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#art_direction).
 
-4. Choose a default image service.
+5. Choose a default image service.
 
     [Sharp](https://github.com/lovell/sharp) is now the default image service used for `astro:assets`. If you would like to use Sharp, no configuration is required.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

- Adds an extra step for updating the `env.d.ts` file or the `tsconfig.json` file, which had special `@astrojs/image` types in them some of the time. You can see a reference to them in the old [integration readme](https://github.com/withastro/astro/blob/670ef109dbbc07f53c7758bad6098186719fdeb2/packages/integrations/image/README.md#update-envdts).

I was just upgrading an old project to Astro 3 and ran into this missing step, so I figured it should add it (hopefully this PR doesn't rot for months this time... 😅).

Also, I'm not entirely sure how the code block diff highlighting works, so please feel free to fix it if I did it wrong. 