### PR TITLE
Description: Controlling history entries during view transitions

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -241,7 +241,7 @@ Once you have enabled client-side routing on a page by adding the `<ViewTransiti
 
 In these cases, you can opt out of client-side routing on a per-link basis using the `data-astro-reload` attribute like so:
 
-```astro
+```html
 <a href="/quarterly-earnings.pdf" data-astro-reload>
 ```
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -253,7 +253,7 @@ Normally, each navigation will push a new entry to the browser's history. This a
 
 It is also possible to prevent a new entry from being written to the browser history by overriding the current entry. This is useful for pages that are not meant to be navigated back to, such as a login page. You do this by adding a `data-astro-history='replace'` attribute to an anchor like so:
 
-```html
+```astro
 <a href="/main" data-astro-history="replace">
 ```
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -247,6 +247,18 @@ In these cases, you can opt out of client-side routing on a per-link basis using
 
 These links will be ignored by the router and a full page navigation will occur.
 
+## Replace entries in the browser history
+
+Normally, each navigation will push a new entry to the browser's history. This allows navigation between pages using the browser's back and forward buttons. 
+
+It is also possible to prevent a new entry from being written to the browser history by overriding the current entry. This is useful for pages that are not meant to be navigated back to, such as a login page. You do this by adding a `data-astro-history='replace'` attribute to an anchor like so:
+
+```html
+<a href="/main" data-astro-history="replace">
+```
+
+This will replace the current entry in the browser's history with the `/main` page. Valid values for `data-astro-history` are `"replace"`, and `"push"`. The default value is `"push"`, which pushes a new entry into the browser history.
+
 ## Fallback control
 
 The `<ViewTransitions />` router works best in browsers that support View Transitions (i.e. Chromium browsers), but also includes default fallback support for other browsers. Even if the browser does not support the View Transitions API, Astro will still provide in-browser navigation using one of the fallback options for a comparable experience.

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -241,7 +241,7 @@ Once you have enabled client-side routing on a page by adding the `<ViewTransiti
 
 In these cases, you can opt out of client-side routing on a per-link basis using the `data-astro-reload` attribute like so:
 
-```html
+```astro
 <a href="/quarterly-earnings.pdf" data-astro-reload>
 ```
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -249,15 +249,17 @@ These links will be ignored by the router and a full page navigation will occur.
 
 ## Replace entries in the browser history
 
-Normally, each navigation will push a new entry to the browser's history. This allows navigation between pages using the browser's back and forward buttons. 
+Normally, each time you navigate, a new entry is written to the browser's history. This allows navigation between pages using the browser's `back` and `forward` buttons. For view transitions, it is possible to suppress history entries by using the `data-astro-history` attribute with the `replace` value on normal anchors. This is useful for pages that should not be navigated back to, such as a confirmation page. 
 
-It is also possible to prevent a new entry from being written to the browser history by overriding the current entry. This is useful for pages that are not meant to be navigated back to, such as a login page. You do this by adding a `data-astro-history='replace'` attribute to an anchor like so:
+The following example navigates to the `/main` page, but does not add a new entry to the browsing history. Instead, it reuses the current entry in the history and overwrites it.
 
-```astro
+```astro title="/confirmation.astro"
 <a href="/main" data-astro-history="replace">
 ```
 
-This will replace the current entry in the browser's history with the `/main` page. Valid values for `data-astro-history` are `"replace"`, and `"push"`. The default value is `"push"`, which pushes a new entry into the browser history.
+This has the effect that if you go back from the `/main` page, the browser will not display the `/confirmation' page, but the page before it.
+
+The values (`auto`, `push`, `replace`) and behavior of the `data-astro-history` attribute are the same as for the [`history` option of the `navigate()` function](#trigger-navigation). `auto` is the default if the `data-astro-history` attribute is omitted. 
 
 ## Fallback control
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- New or updated content

#### Description

View transitions: description of the new `data-astro-history` attribute. 

#### Related Issue / Implementation PR

#### For Astro version: `3.2`. See ~~[Astro PR #8644](https://github.com/withastro/astro/pull/8644).~~ [Astro PR #8571](https://github.com/withastro/astro/pull/8571)
