### PR TITLE
Update Consistency of FileTree Element Border Radius

### DIFF
--- a/src/components/FileTree.astro
+++ b/src/components/FileTree.astro
@@ -29,7 +29,7 @@ const processedContent = await fileTreeProcessor.process({
 
 		display: block;
 		border: 1px solid var(--theme-divider);
-		border-radius: 0.25rem;
+		border-radius: calc(0.3rem + 1.5px);
 		padding: 1rem 0.5rem;
 		background-color: var(--theme-bg-offset);
 		font-size: var(--theme-text-xs);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
#### Description

- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

The border radii of code blocks and file trees in the documentation are inconsistent with one another. It (to me) looks somewhat visually jarring.
![image](https://github.com/withastro/docs/assets/20650404/20f37b21-9954-4443-9844-fe5a34c586a3)

Here is my small, tiny proposed change.
![image](https://github.com/withastro/docs/assets/20650404/da8e8735-57f2-4c20-b9a9-3cd86c2d1e0c)

**I don't know if this really matters, but I thought I would open a PR anyways!**

