### PR TITLE
typo: missing word in astro-pages.mdx en-only

### DIFF
--- a/src/content/docs/en/core-concepts/astro-pages.mdx
+++ b/src/content/docs/en/core-concepts/astro-pages.mdx
@@ -88,7 +88,7 @@ This is my page, written in **Markdown.**
 
 ## HTML Pages
 
-Files with the `.html` file extension can be placed in the `src/pages/` and used directly as pages on your site. Note that some key Astro features are not supported in [HTML Components](/en/core-concepts/astro-components/#html-components).
+Files with the `.html` file extension can be placed in the `src/pages/` directory and used directly as pages on your site. Note that some key Astro features are not supported in [HTML Components](/en/core-concepts/astro-components/#html-components).
 
 ## Custom 404 Error Page
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- Added missing word `directory`. Alternatively, the word `the` could be removed.