### PR TITLE
typo: incorrect filename in google-firebase.mdx

### DIFF
--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -303,7 +303,7 @@ After creating server endpoints for authentication, your project directory shoul
     - api
       - auth
         - **signin.ts**
-        - **logout.ts**
+        - **signout.ts**
         - **register.ts**
 - .env
 - astro.config.mjs

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -227,7 +227,7 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
 ```
 
 :::note
-This is a basic implementation of the login endpoint. You can add more logic to this endpoint to suit your needs.
+This is a basic implementation of the signin endpoint. You can add more logic to this endpoint to suit your needs.
 :::
 
 `signout.ts` contains the code to log out a user by deleting the session cookie:
@@ -302,7 +302,7 @@ After creating server endpoints for authentication, your project directory shoul
   - pages
     - api
       - auth
-        - **login.ts**
+        - **signin.ts**
         - **logout.ts**
         - **register.ts**
 - .env

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -244,7 +244,7 @@ export const GET: APIRoute = async ({ redirect, cookies }) => {
 ```
 
 :::note
-This is a basic implementation of the logout endpoint. You can add more logic to this endpoint to suit your needs.
+This is a basic implementation of the signout endpoint. You can add more logic to this endpoint to suit your needs.
 :::
 
 `register.ts` contains the code to register a user using Firebase:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- In most places the file and endpoint was called `signin.ts`. Changed the two places that inconsistency referenced `login` and `login.ts`.
- After review by TheOtterlord, changed `logout` to `signout` in two places as well
