### PR TITLE
Add share links at the end of the tutorial

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/3.mdx
+++ b/src/content/docs/en/tutorial/6-islands/3.mdx
@@ -69,11 +69,13 @@ Continue with our [guide to migrate this project to content collections](/en/gui
 
 ## Share your achievement!
 
-Congratulations on completing the Astro blog tutorial! Share your achievement with the world and let everyone know you're an 🧑‍🚀Astronaut now!
+Congratulations on completing the Astro blog tutorial! Share your achievement with the world and let everyone know you're an Astronaut now!
 
-<Button href='https://twitter.com/intent/tweet?text=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!%20Check%20it%20out%20at%20https://docs.astro.build/%0Avia%20%40astrodotbuild'>
-  Share on Twitter
-</Button> 
-<Button href='https://www.reddit.com/submit?url=https://docs.astro.build/&title=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!'>
-  Share on Reddit
-</Button>
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
+  <Button href='https://twitter.com/intent/tweet?text=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!%20Check%20it%20out%20at%20https://docs.astro.build/%0Avia%20%40astrodotbuild'>
+    Share on Twitter
+  </Button> 
+  <Button href='https://www.reddit.com/submit?url=https://docs.astro.build/&title=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!'>
+    Share on Reddit
+  </Button>
+</div>

--- a/src/content/docs/en/tutorial/6-islands/3.mdx
+++ b/src/content/docs/en/tutorial/6-islands/3.mdx
@@ -13,6 +13,7 @@ import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';
 import CompletionConfetti from '~/components/tutorial/CompletionConfetti.astro';
 import PreCheck from '~/components/tutorial/PreCheck.astro';
+import Button from '~/components/Button.astro';
 
 
 There's one more edit to make...
@@ -65,3 +66,14 @@ Continue with our [guide to migrate this project to content collections](/en/gui
 [Join us on Discord](https://astro.build/chat)
 
 <CompletionConfetti />
+
+## Share your achievement!
+
+Congratulations on completing the Astro blog tutorial! Share your achievement with the world and let everyone know you're an 🧑‍🚀Astronaut now!
+
+<Button href='https://twitter.com/intent/tweet?text=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!%20Check%20it%20out%20at%20https://docs.astro.build/%0Avia%20%40astrodotbuild'>
+  Share on Twitter
+</Button> 
+<Button href='https://www.reddit.com/submit?url=https://docs.astro.build/&title=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!'>
+  Share on Reddit
+</Button>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to the docs site code

#### Description

This adds two simple buttons to the end of tutorial. No external styles or anything, just imports the standard button component and passing in the share links with the following text URL encoded

```text
Just finished learning how to build my first Astro blog! 

Check it out at https://docs.astro.build/!
```

Here's a screenshot of the website
![image](https://github.com/withastro/docs/assets/78465651/48fee9c3-fbe8-4e9b-87d7-62653331c65d)

I took the creative liberty of adding the text to invite the user to share, please do tell me if you want me to change it, but I think it's fun 😄 

>Congratulations on completing the Astro blog tutorial! Share your achievement with the world and let everyone know you’re an 🧑‍🚀Astronaut now!

#### Related Issue / Implementation PR

- Closes Issue #4044 