### PR TITLE
Fix typo from drc to src

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -661,7 +661,7 @@ If you were using the image integration in Astro v2.x, complete the following st
 
 		If you had special types configured for `@astrojs/image` in `src/env.d.ts`, you may need to change them back to the default Astro types if your upgrade to v3 did not complete this step for you.
 
-		```ts title="drc/env.d.ts" del={1} ins={2}
+		```ts title="src/env.d.ts" del={1} ins={2}
 		 /// <reference types="@astrojs/image/client" />
 		 /// <reference types="astro/client" />
 		```

--- a/src/content/docs/es/guides/images.mdx
+++ b/src/content/docs/es/guides/images.mdx
@@ -658,7 +658,7 @@ Si estabas utilizando la integración de imágenes en Astro v2.x, completa los s
 
 		Si tenías tipos especiales configurados para `@astrojs/image` en `src/env.d.ts`, es posible que necesites cambiarlos de nuevo a los tipos predeterminados de Astro si la actualización a la versión 3 no completó este paso por ti.
 
-		```ts title="drc/env.d.ts" del={1} ins={2}
+		```ts title="src/env.d.ts" del={1} ins={2}
 		 /// <reference types="@astrojs/image/client" />
 		 /// <reference types="astro/client" />
 		```

--- a/src/content/docs/ja/guides/images.mdx
+++ b/src/content/docs/ja/guides/images.mdx
@@ -662,7 +662,7 @@ Astro v2.xで画像インテグレーションを使用していた場合は、�
 
     `src/env.d.ts`に`@astrojs/image`のための特別な型を設定していた場合、v3へのアップグレードでこのステップが完了していなければ、デフォルトのAstroの型に戻す必要があるかもしれません。
 
-		```ts title="drc/env.d.ts" del={1} ins={2}
+		```ts title="src/env.d.ts" del={1} ins={2}
 		 /// <reference types="@astrojs/image/client" />
 		 /// <reference types="astro/client" />
 		```

--- a/src/content/docs/zh-cn/guides/images.mdx
+++ b/src/content/docs/zh-cn/guides/images.mdx
@@ -657,7 +657,7 @@ import rocket from '../images/rocket.svg';
 
     如果你在 `src/env.d.ts` 中为 `@astrojs/image` 配置了特殊类型，并且如果你的升级到 v3 却没有完成这一步，你可能需要将它们改回 Astro 的默认类型。
 
-		```ts title="drc/env.d.ts" del={1} ins={2}
+		```ts title="src/env.d.ts" del={1} ins={2}
 		 /// <reference types="@astrojs/image/client" />
 		 /// <reference types="astro/client" />
 		```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Fixes the typo in section https://docs.astro.build/de/guides/images/#remove-astrojsimage for langauges:
- English
- Spanish
- Chinese Simplified
- Japanese

I checked all languages and these are my findings:

| Language | Code | Status |
| --- | --- | --- |
English | en | original typo
Deutsch | de | no translation, inherited from EN
Portuguese | pt-br | fixed by the pt-br contributor
Spanish | es | translated but inherited the typo
Chinese Simplified | zh-cn | translated but inherited the typo
Taiwanese Mandarin | zh-tw  | no translation, inherited from EN
French | fr  | no translation, inherited from EN
Hindi | hi  | no translation, inherited from EN
Arabic | ar  | no translation, inherited from EN
Japanese | jp | translated but inherited the typo
Korean | ko | no translation, inherited from EN
Polish | pl  | no translation, inherited from EN
Russian | ru  | no translation, inherited from EN
Italian | it  | no translation, inherited from EN


#### Related Issue / Implementation PR

Implemented in this PR https://github.com/withastro/docs/pull/4724. No issues opened.


<!-- Next Steps

Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
