### PR TITLE
Fix Incorrect content collection config path in upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v3.mdx
@@ -200,7 +200,7 @@ Astro v3.0 removes this export entirely.
 
 If you are using the deprecated `image()` from `astro:content`, remove it as this no longer exists. Validate images through [the `image` helper from `schema`](/en/guides/images/#update-content-collections-schemas) instead:
 
- ```ts title="astro.config.mjs" del={1} ins={2} "({ image })"
+ ```ts title="src/content/config.ts" del={1} ins={2} "({ image })"
 import { defineCollection, z, image } from "astro:content";
 import { defineCollection, z } from "astro:content";
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)


#### Description

I updated the content collection config path from `astro.config.mjs` to `src/content/config.ts` for the code example for this [page](https://deploy-preview-4898--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#what-should-i-do-6)



#### Before
<img width="536" alt="Screenshot 2023-09-30 at 8 43 43 PM" src="https://github.com/withastro/docs/assets/67210629/b46f1a86-6355-41aa-b715-8f612180131d">


#### After
<img width="450" alt="Screenshot 2023-09-30 at 8 43 55 PM" src="https://github.com/withastro/docs/assets/67210629/bf6b3b76-ca81-4df4-90d0-25d730b762cf">


<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

#### Related Issue / Implementation PR

- Closes #4875 

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!-- Next Steps

Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
