### PR TITLE
Updating outdated information for astro check documentation for Astro 3 

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -270,15 +270,15 @@ const { title } = Astro.props;
 
 To see type errors in your editor, please make sure that you have the [Astro VS Code extension](/en/editor-setup/) installed. Please note that the `astro start` and `astro build` commands will transpile the code with esbuild, but will not run any type checking. To prevent your code from building if it contains TypeScript errors, change your "build" script in `package.json` to the following:
 
-```json title="package.json" del={2} ins={3} ins="astro check && tsc --noEmit && "
+```json title="package.json" del={2} ins={3} ins="astro check &&"
   "scripts": {
     "build": "astro build",
-    "build": "astro check && tsc --noEmit && astro build",
+    "build": "astro check && astro build",
   },
 ```
 
 :::note
-`astro check` only checks types within `.astro` files, and `tsc --noEmit` only checks types within `.ts` and `.tsx` files. To check types within Svelte and Vue files, you can use the [`svelte-check`](https://www.npmjs.com/package/svelte-check) and the [`vue-tsc`](https://www.npmjs.com/package/vue-tsc) packages respectively.
+`astro check` checks all the files included in your TypeScript project. To check types within Svelte and Vue files, you can use the [`svelte-check`](https://www.npmjs.com/package/svelte-check) and the [`vue-tsc`](https://www.npmjs.com/package/vue-tsc) packages respectively.
 :::
 
 📚 Read more about [`.ts` file imports](/en/guides/imports/#typescript) in Astro.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content


#### Description

This PR removes the mention of `tsc --noEmit` in both the `package.json` example and note for astro check docs in the Type Checking section for astro 3. 

[Link to page with the fix](https://deploy-preview-4899--astro-docs-2.netlify.app/en/guides/typescript/#type-checking)

#### Before
<img width="605" alt="Screenshot 2023-09-30 at 9 28 39 PM" src="https://github.com/withastro/docs/assets/67210629/b07fbc5a-6013-4ac7-ba0d-ae9ce2b12c6f">


#### After
<img width="788" alt="Screenshot 2023-09-30 at 9 29 43 PM" src="https://github.com/withastro/docs/assets/67210629/68f87bc4-8a5c-42c4-b269-e426d760f3c9">

#### Related Issue / Implementation PR

- Closes #4789 



