### PR TITLE
Use status 404 instead of redirect

### DIFF
--- a/src/content/docs/en/core-concepts/routing.mdx
+++ b/src/content/docs/en/core-concepts/routing.mdx
@@ -206,7 +206,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -752,7 +752,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -760,7 +760,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;
@@ -820,7 +820,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -828,7 +828,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;

--- a/src/content/docs/en/guides/cms/contentful.mdx
+++ b/src/content/docs/en/guides/cms/contentful.mdx
@@ -461,7 +461,7 @@ try {
     "fields.slug": slug,
   });
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -490,7 +490,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -518,7 +518,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 <html lang="en">

--- a/src/content/docs/en/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/en/guides/cms/kontent-ai.mdx
@@ -463,7 +463,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 ```
@@ -498,7 +498,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -468,7 +468,7 @@ try {
   });
   content = data.story.content
 } catch (error) {
-  return Astro.redirect('/404')
+  return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -341,7 +341,7 @@ try {
     },
   });
 } catch (error) {
-  return Astro.redirect('/404');
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -529,7 +529,7 @@ if (slug === undefined) {
 const entry = await getEntry("blog", slug);
 // 3. Redirect if the entry does not exist
 if (entry === undefined) {
-	return Astro.redirect("/404");
+	return new Response(null, { status: 404, statusText: 'Not found' });
 }
 // 4. (Optional) Render the entry to HTML in the template
 const { Content } = await entry.render();

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -142,7 +142,7 @@ If you prefer the default language to not be visible in the URL unlike other lan
         const page = await getEntryBySlug('blog', `${lang}/${slug}`);
 
         if (!page) {
-          return Astro.redirect('/404');
+          return new Response(null, { status: 404, statusText: 'Not found' });
         }
 
         const formattedDate = page.data.date.toLocaleString(lang);

--- a/src/content/docs/es/core-concepts/routing.mdx
+++ b/src/content/docs/es/core-concepts/routing.mdx
@@ -206,7 +206,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/es/guides/backend/google-firebase.mdx
+++ b/src/content/docs/es/guides/backend/google-firebase.mdx
@@ -752,7 +752,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -760,7 +760,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;
@@ -820,7 +820,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -828,7 +828,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;

--- a/src/content/docs/es/guides/cms/contentful.mdx
+++ b/src/content/docs/es/guides/cms/contentful.mdx
@@ -463,7 +463,7 @@ try {
     "fields.slug": slug,
   });
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -492,7 +492,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -520,7 +520,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 <html lang="en">

--- a/src/content/docs/es/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/es/guides/cms/kontent-ai.mdx
@@ -466,7 +466,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 ```
@@ -501,7 +501,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/es/guides/cms/storyblok.mdx
+++ b/src/content/docs/es/guides/cms/storyblok.mdx
@@ -470,7 +470,7 @@ try {
   });
   content = data.story.content
 } catch (error) {
-  return Astro.redirect('/404')
+  return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/es/guides/cms/strapi.mdx
+++ b/src/content/docs/es/guides/cms/strapi.mdx
@@ -341,7 +341,7 @@ try {
     },
   });
 } catch (error) {
-  return Astro.redirect('/404');
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 

--- a/src/content/docs/es/guides/content-collections.mdx
+++ b/src/content/docs/es/guides/content-collections.mdx
@@ -530,7 +530,7 @@ if (slug === undefined) {
 const entry = await getEntry("blog", slug);
 // 3. Redirige si la entrada no existe
 if (entry === undefined) {
-	return Astro.redirect("/404");
+	return new Response(null, { status: 404, statusText: 'Not found' });
 }
 // 4. (Opcional) Renderiza la entrada a HTML en la plantilla
 const { Content } = await entry.render();

--- a/src/content/docs/es/recipes/i18n.mdx
+++ b/src/content/docs/es/recipes/i18n.mdx
@@ -143,7 +143,7 @@ Si prefieres que el idioma predeterminado no sea visible en la URL, a diferencia
         const page = await getEntryBySlug('blog', `${lang}/${slug}`);
 
         if (!page) {
-          return Astro.redirect('/404');
+          return new Response(null, { status: 404, statusText: 'Not found' });
         }
 
         const formattedDate = page.data.date.toLocaleString(lang);

--- a/src/content/docs/fr/core-concepts/routing.mdx
+++ b/src/content/docs/fr/core-concepts/routing.mdx
@@ -205,7 +205,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/it/core-concepts/routing.mdx
+++ b/src/content/docs/it/core-concepts/routing.mdx
@@ -205,7 +205,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/it/guides/backend/google-firebase.mdx
+++ b/src/content/docs/it/guides/backend/google-firebase.mdx
@@ -751,7 +751,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -759,7 +759,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;
@@ -819,7 +819,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -827,7 +827,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;

--- a/src/content/docs/ja/core-concepts/routing.mdx
+++ b/src/content/docs/ja/core-concepts/routing.mdx
@@ -210,7 +210,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/ja/guides/cms/contentful.mdx
+++ b/src/content/docs/ja/guides/cms/contentful.mdx
@@ -458,7 +458,7 @@ try {
     "fields.slug": slug,
   });
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -488,7 +488,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -516,7 +516,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 <html lang="en">

--- a/src/content/docs/ja/guides/cms/storyblok.mdx
+++ b/src/content/docs/ja/guides/cms/storyblok.mdx
@@ -428,7 +428,7 @@ try {
   });
   content = data.story.content
 } catch (error) {
-  return Astro.redirect('/404')
+  return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/ja/guides/content-collections.mdx
+++ b/src/content/docs/ja/guides/content-collections.mdx
@@ -522,7 +522,7 @@ if (slug === undefined) {
 const entry = await getEntry("blog", slug);
 // 3. エントリーが存在しない場合はリダイレクト
 if (entry === undefined) {
-	return Astro.redirect("/404");
+	return new Response(null, { status: 404, statusText: 'Not found' });
 }
 // 4. (オプション) テンプレート内でエントリーをHTMLにレンダリング
 const { Content } = await entry.render();

--- a/src/content/docs/pt-br/core-concepts/routing.mdx
+++ b/src/content/docs/pt-br/core-concepts/routing.mdx
@@ -206,7 +206,7 @@ const paginas = [
 
 const { slug } = Astro.params;
 const pagina = paginas.find((pagina) => pagina.slug === slug);
-if (!pagina) return Astro.redirect("/404");
+if (!pagina) return new Response(null, { status: 404, statusText: 'Not found' });
 const { titulo, texto } = pagina;
 ---
 <html>

--- a/src/content/docs/pt-br/guides/content-collections.mdx
+++ b/src/content/docs/pt-br/guides/content-collections.mdx
@@ -530,7 +530,7 @@ if (slug === undefined) {
 const entrada = await getEntry("blog", slug);
 // 3. Redireciona se a entrada não existir
 if (entrada === undefined) {
-	return Astro.redirect("/404");
+	return new Response(null, { status: 404, statusText: 'Not found' });
 }
 // 4. (Opcional) Renderiza a entrada para HTML no template
 const { Content } = await entrada.render();

--- a/src/content/docs/pt-br/recipes/i18n.mdx
+++ b/src/content/docs/pt-br/recipes/i18n.mdx
@@ -141,7 +141,7 @@ Se você prefere que a língua padrão não seja visível na URL ao contrário d
         const pagina = await getEntryBySlug('blog', `${lang}/${slug}`);
 
         if (!pagina) {
-          return Astro.redirect('/404');
+          return new Response(null, { status: 404, statusText: 'Not found' });
         }
 
         const dataFormatada = page.data.data.toLocaleString(lang);

--- a/src/content/docs/ru/core-concepts/routing.mdx
+++ b/src/content/docs/ru/core-concepts/routing.mdx
@@ -206,7 +206,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/zh-cn/core-concepts/routing.mdx
+++ b/src/content/docs/zh-cn/core-concepts/routing.mdx
@@ -211,7 +211,7 @@ const pages = [
 
 const { slug } = Astro.params;
 const page = pages.find((page) => page.slug === slug);
-if (!page) return Astro.redirect("/404");
+if (!page) return new Response(null, { status: 404, statusText: 'Not found' });
 const { title, text } = page;
 ---
 <html>

--- a/src/content/docs/zh-cn/guides/backend/google-firebase.mdx
+++ b/src/content/docs/zh-cn/guides/backend/google-firebase.mdx
@@ -749,7 +749,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -757,7 +757,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;
@@ -817,7 +817,7 @@ interface Friend {
 const { id } = Astro.params;
 
 if (!id) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const db = getFirestore(app);
@@ -825,7 +825,7 @@ const friendsRef = db.collection("friends");
 const friendSnapshot = await friendsRef.doc(id).get();
 
 if (!friendSnapshot.exists) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 
 const friend = friendSnapshot.data() as Friend;

--- a/src/content/docs/zh-cn/guides/cms/contentful.mdx
+++ b/src/content/docs/zh-cn/guides/cms/contentful.mdx
@@ -458,7 +458,7 @@ try {
     "fields.slug": slug,
   });
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -486,7 +486,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 ```
@@ -514,7 +514,7 @@ try {
     content: documentToHtmlString(content),
   };
 } catch (error) {
-  return Astro.redirect("/404");
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 <html lang="en">

--- a/src/content/docs/zh-cn/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/zh-cn/guides/cms/kontent-ai.mdx
@@ -463,7 +463,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 ```
@@ -498,7 +498,7 @@ try {
         .toPromise()
     blogPost = data.data.items[0]
 } catch (error) {
-    return Astro.redirect('/404')
+    return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/zh-cn/guides/cms/storyblok.mdx
+++ b/src/content/docs/zh-cn/guides/cms/storyblok.mdx
@@ -468,7 +468,7 @@ try {
   });
   content = data.story.content
 } catch (error) {
-  return Astro.redirect('/404')
+  return new Response(null, { status: 404, statusText: 'Not found' })
 }
 ---
 <html lang="en">

--- a/src/content/docs/zh-cn/guides/cms/strapi.mdx
+++ b/src/content/docs/zh-cn/guides/cms/strapi.mdx
@@ -342,7 +342,7 @@ try {
     },
   });
 } catch (error) {
-  return Astro.redirect('/404');
+  return new Response(null, { status: 404, statusText: 'Not found' });
 }
 ---
 

--- a/src/content/docs/zh-cn/guides/content-collections.mdx
+++ b/src/content/docs/zh-cn/guides/content-collections.mdx
@@ -531,7 +531,7 @@ if (slug === undefined) {
 const entry = await getEntry('blog', slug);
 // 3. 如果条目不存在，则重定向到 404
 if (entry === undefined) {
-	return Astro.redirect("/404");
+	return new Response(null, { status: 404, statusText: 'Not found' });
 }
 // 4. (可选)在模板中将条目呈现为 HTML
 const { Content } = await entry.render();

--- a/src/content/docs/zh-cn/recipes/i18n.mdx
+++ b/src/content/docs/zh-cn/recipes/i18n.mdx
@@ -141,7 +141,7 @@ import StaticSsrTabs from '~/components/tabs/StaticSsrTabs.astro'
         const page = await getEntryBySlug('blog', `${lang}/${slug}`);
 
         if (!page) {
-          return Astro.redirect('/404');
+          return new Response(null, { status: 404, statusText: 'Not found' });
         }
 
         const formattedDate = page.data.date.toLocaleString(lang);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- New or updated content

#### Description

This PR changes multiple places in the documentation to return the Response object with 404 status instead of redirecting to the `/404` URL. The previous approach has downsides of losing the information the user has provided, among others, making it impossible for the user to correct a typo in the URL.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->


<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!-- Next Steps

Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
