### PR TITLE
Fix Link Color Issue

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/3.mdx
+++ b/src/content/docs/en/tutorial/6-islands/3.mdx
@@ -72,10 +72,6 @@ Continue with our [guide to migrate this project to content collections](/en/gui
 Congratulations on completing the Astro blog tutorial! Share your achievement with the world and let everyone know you're an Astronaut now!
 
 <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-  <Button href='https://twitter.com/intent/tweet?text=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!%20Check%20it%20out%20at%20https://docs.astro.build/%0Avia%20%40astrodotbuild'>
-    Share on Twitter
-  </Button> 
-  <Button href='https://www.reddit.com/submit?url=https://docs.astro.build/&title=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!'>
-    Share on Reddit
-  </Button>
+  <Button href='https://twitter.com/intent/tweet?text=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!%20Check%20it%20out%20at%20https://docs.astro.build/%0Avia%20%40astrodotbuild'>Share on Twitter</Button>
+  <Button href='https://www.reddit.com/submit?url=https://docs.astro.build/&title=Just%20finished%20learning%20how%20to%20build%20my%20first%20Astro%20blog!'>Share on Reddit</Button>
 </div>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)
- Changes to the docs site code

#### Description

- This PR fixes the issue with the links not being clear in light mode in the tutorial share section.

This is the changed output

## I am taking part in **Hacktoberfest**

![image](https://github.com/withastro/docs/assets/78465651/8bc43e89-834a-4db7-a27e-67815f7ebef1)