### PR TITLE
Add first-time contributor action

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/first-interaction@main
+      - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           pr-message: |

--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -1,0 +1,32 @@
+name: WelcomeBot
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome:
+    name: Welcome First Time Contributors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/first-interaction@main
+        with:
+          repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          pr-message: |
+            Hello! Thank you for opening your **first PR** to Astro’s Docs! 🎉
+
+            Here’s what will happen next:
+
+            1. Our GitHub bots will run to check your changes.
+               If they spot any broken links you will see some error messages on this PR.
+               Don’t hesitate to ask any questions if you’re not sure what these mean!
+            
+            2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
+            
+            3. One or more of our maintainers will take a look and may ask you to make changes.
+               We try to be responsive, but don’t worry if this takes a few days.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Something else!

#### Description

- This PR adds a GitHub action, which comments on PRs from first-time contributors to welcome them.
- Comments with a message based on our current “Next Steps” section in the PR template, which we’re removing in #4946 
- Tested in a test repo during Talking & Doc’ing! Comments look something like this:
<img width="844" alt="Message from a bot account welcoming first-time contributor" src="https://github.com/withastro/docs/assets/357379/a1f6c0c5-8fa4-4c33-b044-efb73fcc1863">

