### PR TITLE
fix: Steps numbers in `deploy/deno` are only marked as 1.

### DIFF
--- a/src/content/docs/en/guides/deploy/deno.mdx
+++ b/src/content/docs/en/guides/deploy/deno.mdx
@@ -79,12 +79,9 @@ You can deploy to Deno Deploy through GitHub Actions or using Deno Deploy’s CL
 If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno.com/) will guide you through setting up GitHub Actions to deploy your Astro site.
 
 1. Push your code to a public or private GitHub repository.
-
-1. Sign in on [Deno Deploy](https://dash.deno.com/) with your GitHub account, and click on [New Project](https://dash.deno.com).
-
-1. Select your repository, the branch you want to deploy from, and select **GitHub Action** mode. (Your Astro site requires a build step, and cannot use Automatic mode.)
-   
-1. In your Astro project, create a new file at `.github/workflows/deploy.yml` and paste in the YAML below. This is similar to the YAML given by Deno Deploy, with the additional steps needed for your Astro site.
+2. Sign in on [Deno Deploy](https://dash.deno.com/) with your GitHub account, and click on [New Project](https://dash.deno.com).
+3. Select your repository, the branch you want to deploy from, and select **GitHub Action** mode. (Your Astro site requires a build step, and cannot use Automatic mode.)
+4. In your Astro project, create a new file at `.github/workflows/deploy.yml` and paste in the YAML below. This is similar to the YAML given by Deno Deploy, with the additional steps needed for your Astro site.
 
     ```yaml
     name: Deploy
@@ -118,7 +115,7 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
               root: dist
     ```
 
-1. After committing this YAML file, and pushing to GitHub on your configured deploy branch, the deploy should begin automatically!
+5. After committing this YAML file, and pushing to GitHub on your configured deploy branch, the deploy should begin automatically!
 
    You can track the progress using the "Actions" tab on your GitHub repository page, or on [Deno Deploy](https://dash.deno.com).
 
@@ -131,13 +128,13 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
     deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
     ```
 
-1. Run your Astro build step.
+2. Run your Astro build step.
 
     ```bash
     npm run build
     ```
 
-1. Run `deployctl` to deploy!
+3. Run `deployctl` to deploy!
 
    In the command below, replace `<ACCESS-TOKEN>` with your [Personal Access Token](https://dash.deno.com/user/access-tokens) and `<MY-DENO-PROJECT>` with your Deno Deploy project name.
 
@@ -147,7 +144,7 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
     
     You can track all your deploys on [Deno Deploy](https://dash.deno.com).
 
-1. (Optional) To simplify the build and deploy into one command, add a `deploy-deno` script in `package.json`.
+4. (Optional) To simplify the build and deploy into one command, add a `deploy-deno` script in `package.json`.
 
     ```json ins={9}
     // package.json


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
<!-- Please describe the change you are proposing, and why -->
Fix a little error with steps numbers in `deploy/deno` in the original file (in English).

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->

I am participating in the Hacktoberfest!

- [fix: Steps numbers in deploy/deno are only marked as 1.](https://github.com/withastro/docs/commit/47efa9faadf9a378d97924dd9fd1ee827d4e73fb)

#### Related issues & labels (optional)
Seen this error when I translated in French language #4970.