### PR TITLE
i18n(fr): Update `install/manual` in French language

### DIFF
--- a/src/content/docs/fr/install/manual.mdx
+++ b/src/content/docs/fr/install/manual.mdx
@@ -57,6 +57,10 @@ Maintenant que vous êtes dans votre nouveau répertoire, créez votre fichier `
 
 D'abord, installez les dépendances d'Astro dans votre projet.
 
+:::note[Important]
+Astro doit être installé localement, pas globalement. Assurez-vous que vous n'exécutez pas `npm install -g astro` `pnpm add -g astro` ou `yarn add global astro`.
+:::
+
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
<!-- Please describe the change you are proposing, and why -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->


Update `install/manual` in French language. Missed one line : 

```diff
+ :::note[Important]
+ Astro doit être installé localement, pas globalement. Assurez-vous que vous n'exécutez pas `npm install -g astro` `pnpm add -g astro` ou `yarn add global astro`.
+ :::
```
 
I am participating in the Hacktoberfest!

- [i18n(fr): Update install/manual in French language](https://github.com/withastro/docs/commit/95aac997e625a4105e8f68266c9085359445cbe7)

#### Related issues & labels (optional)
hmhm, nope!
