### PR TITLE
Remove Netlify edge functions adapter

### DIFF
--- a/src/content/docs/en/guides/deploy/netlify.mdx
+++ b/src/content/docs/en/guides/deploy/netlify.mdx
@@ -45,19 +45,6 @@ If you prefer to install the adapter manually instead, complete the following tw
       adapter: netlify(),
     });
     ```
- 
-    To render your project using [Netlify's experimental Edge Functions](https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/#app) instead, change the `netlify/functions` import in the Astro config file to use `netlify/edge-functions`.
-      ```js title="astro.config.mjs" ins={3} del={2}
-      import { defineConfig } from 'astro/config';
-      import netlify from '@astrojs/netlify/functions';
-      import netlify from '@astrojs/netlify/edge-functions';
-
-      export default defineConfig({
-        output: 'server',
-        adapter: netlify(),
-      });
-      ```
-
 ## How to deploy
 
 You can deploy to Netlify through the website UI or using Netlify’s CLI (command line interface). The process is the same for both static and SSR Astro sites.


### PR DESCRIPTION

#### Description (required)
Remove netlify edge functions adapter

Astro 3.0 removed this adapter https://github.com/withastro/adapters/blob/main/packages/netlify/CHANGELOG.md#major-changes
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
