### PR TITLE
Reference:  `getEntries()` would return `Array<CollectionEntry>` - not a single entry

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -922,8 +922,8 @@ See the `Content Collections` guide for examples of [querying collection entries
 
 **Types:**
 
-- `(Array<{ collection: string, id: string }>) => CollectionEntry<collection>`
-- `(Array<{ collection: string, slug: string }>) => CollectionEntry<collection>`
+- `(Array<{ collection: string, id: string }>) => Array<CollectionEntry<collection>>`
+- `(Array<{ collection: string, slug: string }>) => Array<CollectionEntry<collection>>`
 
 `getEntries()` is a function that retrieves multiple collection entries from the same collection. This is useful for [returning an array of referenced entries](/en/guides/content-collections/#defining-collection-references) to access their associated `data`, `body`, and `render()` properties.
 


### PR DESCRIPTION
#### Description
<!-- Please describe the change you are proposing, and why -->

Fixing a minor inconsistency in reference docs, so that `getEntries()` returns `Array<CollectionEntry>` - not a single entry.