### PR TITLE
i18n(zh-CN): Update `view-transitions.mdx`, `cloudflare.mdx`

### DIFF
--- a/src/content/docs/zh-cn/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/zh-cn/guides/deploy/cloudflare.mdx
@@ -40,7 +40,7 @@ i18nReady: true
 1. 安装 [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/)。
 2. 使用 `wrangler login` 在 Wrangler 登陆 Cloudflare 账户并授权。
 3. 运行你的构建命令（比如 `npm run build`）。
-4. 使用 `npx wrangler pages publish dist` 进行部署。
+4. 使用 `npx wrangler pages deploy dist` 进行部署。
 
 ```bash
 # 安装 Wrangler CLI（命令行）
@@ -50,7 +50,7 @@ wrangler login
 # 运行你的构建命令
 npm run build
 # 创建新的部署
-npx wrangler pages publish dist
+npx wrangler pages deploy dist
 ```
 
 上传完所有的文件后，Wrangler 将为你提供一个预览 URL 以检查你的站点。当你登录 Cloudflare Pages 仪表板时，你将看到你的新项目。

--- a/src/content/docs/zh-cn/guides/view-transitions.mdx
+++ b/src/content/docs/zh-cn/guides/view-transitions.mdx
@@ -272,7 +272,7 @@ const myFade = {
 ```astro title="src/components/form.astro"
 <script>
     import { navigate } from 'astro:transitions/client';
-    // Navigate to the selected option automatically.
+    // 自动导航到所选选项
     document.querySelector('select').onchange = (ev) => {
         let href = ev.target.value;
         navigate(href);

--- a/src/content/docs/zh-cn/guides/view-transitions.mdx
+++ b/src/content/docs/zh-cn/guides/view-transitions.mdx
@@ -266,18 +266,70 @@ const myFade = {
 
 ### 触发导航
 
-你还可以使用 `navigate` 方法在通常不被 `<ViewTransitions />` 路由器监听的事件里触发客户端导航。该方法来自于 `astro:transitions/client` 模块，可以在任何客户端脚本或客户端组件中使用。
+你还可以使用 `navigate` 方法在通常不被 `<ViewTransitions />` 路由器监听的事件里触发客户端导航。该函数来自于 `astro:transitions/client` 模块，可以在任何客户端脚本和通过[客户端指令](/zh-cn/reference/directives-reference/#客户端指令)激活了的客户端组件中使用。
 
-以下示例展示了使用站点访客选择的选项来触发导航：
+下面的示例展示了一个当访客选择菜单中的选项时导航到另一个页面的 Astro 组件：
+```astro title="src/components/form.astro"
+<script>
+    import { navigate } from 'astro:transitions/client';
+    // Navigate to the selected option automatically.
+    document.querySelector('select').onchange = (ev) => {
+        let href = ev.target.value;
+        navigate(href);
+    };
+</script>
+<select>
+    <option value="/play">Play</option>
+    <option value="/blog">Blog</option>
+    <option value="/about">About</option>
+    <option value="/contact">Contact</option>
+</select>
+```
+```astro title="src/pages/index.astro"
+---
+import Form from "../components/form.astro"
+import { ViewTransitions } from "astro:transitions";
+---
+<html>
+	<head>
+		<ViewTransitions />
+	</head>
+	<body>
+		<Form />
+	</body>
+</html>
+```
 
-```js title="form.js" "navigate(href)"
+下面的示例在一个 React 的 `<Form />` 组件中使用 `navigate()` 实现了相同的功能：
+
+```js title="src/components/form.jsx"
+import React from 'react';
 import { navigate } from 'astro:transitions/client';
 
-// 自动导航到所选选项
-document.querySelector('select').onchange = (ev) => {
-  let href = ev.target.value;
-  navigate(href);
-};
+export default function ClickToNavigate({ to }) {
+  return <select onChange={(ev) => navigate(e.target.value)}>
+    <option value="/play">Play</option>
+    <option value="/blog">Blog</option>
+    <option value="/about">About</option>
+    <option value="/contact">Contact</option>
+  </select>;
+}
+```
+这个 `<Form />` 组件可以在使用 `<ViewTransitions />` 路由器的 Astro 页面上带着客户端指令渲染：
+
+```astro title="src/pages/index.astro"
+---
+import Form from "../components/form.jsx"
+import { ViewTransitions } from "astro:transitions";
+---
+<html>
+	<head>
+		<ViewTransitions />
+	</head>
+	<body>
+		<Form client:load />
+	</body>
+</html>
 ```
 
 `navigate` 方法接受以下参数：
@@ -289,7 +341,7 @@ document.querySelector('select').onchange = (ev) => {
 		- `'replace'`: 路由器将使用 `history.replaceState` 更新 URL，而不向导航添加新条目。
 		- `'auto'`（默认）: 路由器将尝试使用 `history.pushState`，但如果无法转换到指定的 URL，则当前 URL 将保持不变，浏览器历史不会发生变化。
 
-要想通过浏览器的历史记录进行后退和前进导航，你可以将 `navigate()` 与浏览器内置的 `history.back()`、`history.forward()` 和 `history.go()` 等函数结合使用。
+要想通过浏览器的历史记录进行后退和前进导航，你可以将 `navigate()` 与浏览器内置的 `history.back()`、`history.forward()` 和 `history.go()` 等函数结合使用。如果 `navigate()` 在服务器渲染时被调用，它不会有任何效果。
 
 ### 替换浏览器历史条目
 


### PR DESCRIPTION
#### Description (required)

Updated translation based on source texts at [9049c78](https://github.com/withastro/docs/tree/9049c78bf535b132d706a8b534f040c27958988d).

| File | Source | Source Diff | Other Links |
| --- | --- | --- | --- |
| `guides/deploy/cloudflare.mdx` | [source@`9049c78`](https://github.com/withastro/docs/blob/9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/deploy/cloudflare.mdx) | [`57d124a..9049c78`](https://i18n-tools.genteure.com/diff#withastro/docs/57d124a0451093fc8382f024f556dc9821783b7b..9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/deploy/cloudflare.mdx) | [blame@`9049c78`](https://github.com/withastro/docs/blame/9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/deploy/cloudflare.mdx) <br> [blame@`main`](https://github.com/withastro/docs/blame/main/src/content/docs/en/guides/deploy/cloudflare.mdx) <br> [history@`main`](https://github.com/withastro/docs/commits/main/src/content/docs/en/guides/deploy/cloudflare.mdx) |
| `guides/view-transitions.mdx` | [source@`9049c78`](https://github.com/withastro/docs/blob/9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/view-transitions.mdx) | [`57d124a..9049c78`](https://i18n-tools.genteure.com/diff#withastro/docs/57d124a0451093fc8382f024f556dc9821783b7b..9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/view-transitions.mdx) | [blame@`9049c78`](https://github.com/withastro/docs/blame/9049c78bf535b132d706a8b534f040c27958988d/src/content/docs/en/guides/view-transitions.mdx) <br> [blame@`main`](https://github.com/withastro/docs/blame/main/src/content/docs/en/guides/view-transitions.mdx) <br> [history@`main`](https://github.com/withastro/docs/commits/main/src/content/docs/en/guides/view-transitions.mdx) |
