### PR TITLE
i18n(ja): Update translation for `ui.ts`

### DIFF
--- a/src/i18n/ja/ui.ts
+++ b/src/i18n/ja/ui.ts
@@ -15,7 +15,7 @@ export default UIDictionary({
 	'leftSidebar.learnTab': '学習',
 	'leftSidebar.referenceTab': 'リファレンス',
 	'leftSidebar.viewInEnglish': '英語版で見る',
-	'leftSidebar.sponsoredBy': 'スポンサー：',
+	'leftSidebar.sponsoredBy': 'スポンサー',
 	// Right Sidebar
 	'rightSidebar.a11yTitle': '目次',
 	'rightSidebar.onThisPage': '目次',


### PR DESCRIPTION
#### Description (required)

Removed the colon in `leftSidebar.sponsoredBy`. The English text does not have a colon.

https://github.com/withastro/docs/blob/ad0a45f8c966ea74b3a60f3afe0c220e9af66c39/src/i18n/en/ui.ts#L16

#### Related issues & labels (optional)
