### PR TITLE
i18n(zh-CN): improve translation for `reading-time.mdx`

### DIFF
--- a/src/content/docs/zh-cn/recipes/reading-time.mdx
+++ b/src/content/docs/zh-cn/recipes/reading-time.mdx
@@ -1,21 +1,21 @@
 ---
 title: 添加阅读时间
-description: 构建一个 remark 插件并将其添加到你的 Markdown 或 MDX 文件中。
+description: 编写一个在你的 Markdown 和 MDX 文件里添加阅读所需时间的 remark 插件。
 i18nReady: true
 type: recipe
 ---
 
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-创建一个 [remark 插件](https://github.com/remarkjs/remark) ，它可以将阅读时间属性添加到 Markdown 或 MDX 文件的 frontmatter 中，然后你就可以使用该属性来为每个页面显示所需的阅读时间。
+创建一个在你的 Markdown 或 MDX 文件的 frontmatter 中添加阅读所需时间的 [remark 插件](https://github.com/remarkjs/remark)。使用该属性来为每个页面显示所需的阅读时间。
 
 ## 操作步骤
 
-1. 安装辅助工具包
+1. 安装辅助包
 
-   安装如下两个辅助工具包：
+   安装如下两个辅助包：
    - [`reading-time`](https://www.npmjs.com/package/reading-time) 用于计算阅读分钟数
-   - [`mdast-util-to-string`](https://www.npmjs.com/package/mdast-util-to-string) 用于从你的 Markdown 文件中提取所有文本内容
+   - [`mdast-util-to-string`](https://www.npmjs.com/package/mdast-util-to-string) 用于从你的 Markdown 中提取所有文本
 
    <PackageManagerTabs>
      <Fragment slot="npm">
@@ -37,7 +37,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 2. 创建一个 remark 插件
 
-  该插件使用 `mdast-util-to-string` 包来获取 Markdown 文件的文本内容，然后将文本传递给 `reading-time` 包以计算阅读时间（以分钟为单位）。 
+  该插件使用 `mdast-util-to-string` 包来获取 Markdown 文件的文本内容，然后将文本传递给 `reading-time` 包以计算阅读所需的分钟数。
 
    ```js title="remark-reading-time.mjs"
    import getReadingTime from 'reading-time';
@@ -47,7 +47,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
      return function (tree, { data }) {
        const textOnPage = toString(tree);
        const readingTime = getReadingTime(textOnPage);
-       // readingTime.text 会以友好的字符串形式给出阅读时间，例如 3 分钟。
+       // readingTime.text 会以友好的字符串形式给出阅读时间，例如 "3 min read"。
        data.astro.frontmatter.minutesRead = readingTime.text;
      };
    }
@@ -66,11 +66,11 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
    });
    ```
 
-   现在，所有的 Markdown 文档都会在其 frontmatter 中包含一个计算后的 `minutesRead` 属性。
+   现在所有的 Markdown 文档的 frontmatter 中都会有一个计算出来的 `minutesRead` 属性。
 
-4. 展示阅读时间
+4. 显示阅读时间
 
-   如果你的博客文章存储在 [内容集合](/zh-cn/guides/content-collections/) 中，那么也可以从 `entry.render()` 函数访问 `remarkPluginFrontmatter`，然后在模板中根据需要来决定渲染 `minutesRead` 属性的位置。
+   如果你的博客文章存储在[内容集合](/zh-cn/guides/content-collections/)中，通过 `entry.render()` 函数获取 `remarkPluginFrontmatter`，然后在模板中你喜欢的位置渲染 `minutesRead`。
 
    ```astro title="src/pages/posts/[slug].astro" "const { Content, remarkPluginFrontmatter } = await entry.render();" "<p>{remarkPluginFrontmatter.minutesRead}</p>"
    ---
@@ -98,7 +98,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
    </html>
    ```
 
-   如果你正在使用 [Markdown 布局](/zh-cn/guides/markdown-content/#markdown-和-mdx-页面)，那么在布局模板中也可以直接通过 `Astro.props` 来获取 frontmatter 中的 `minutesRead` 属性。
+   如果你使用的是 [Markdown 布局](/zh-cn/guides/markdown-content/#markdown-和-mdx-页面)，在布局模板中通过 `Astro.props` 来获取 frontmatter 中的 `minutesRead` 属性。
 
    ```astro title="src/layouts/BlogLayout.astro" "const { minutesRead } = Astro.props.frontmatter;" "<p>{minutesRead}</p>"
    ---


### PR DESCRIPTION
#### Description (required)

Mostly rewording and restructuring sentences.
Source: https://github.com/withastro/docs/blob/main/src/content/docs/en/recipes/reading-time.mdx

While doing the translation I found the npm package `reading-time` does not seems to output a `text` property, maybe this doc is outdated? I was checking if their `text` output is translated or not since it was translated in this page.