### PR TITLE
Document `--outDir` CLI flag

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -221,7 +221,7 @@ Builds your site for deployment. By default, this will generate static files and
 
 <h3>Flags</h3>
 
-Use these flags to customize your build. For flags shared with other Astro commands, see [common flags](#common-flags) below.
+See [common flags](#common-flags) below for flags shared with other Astro commands.
 
 ## `astro preview`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -219,9 +219,7 @@ Do not use the `--host` flag to expose the dev server in a production environmen
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If [SSR is enabled](/en/guides/server-side-rendering/), this will generate the necessary server files to serve your site.
 
-<h3>Flags</h3>
-
-See [common flags](#common-flags) below for flags shared with other Astro commands.
+Can be combined with the [common flags](#common-flags) documented below.
 
 ## `astro preview`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -339,6 +339,12 @@ Specifies the path to the config file relative to the project root. Defaults to 
 astro --config config/astro.config.mjs dev
 ```
 
+### `--outDir <path>`
+
+<Since v="3.3.0" />
+
+Configures the [`outDir`](/en/reference/configuration-reference/#outdir) for your project. Passing this flag will override the `outDir` value in your `astro.config.mjs` file, if one exists.
+
 ### `--site <url>`
 
 Configures the [`site`](/en/reference/configuration-reference/#site) for your project. Passing this flag will override the `site` value in your `astro.config.mjs` file, if one exists.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- This PR updates the CLI reference to mention the new `--outDir` CLI flag added in https://github.com/withastro/astro/pull/8808
- While there, I also removed the flags subsection under `astro build`, which was left in a slightly odd shape when the `--drafts` flag was removed. It now links to common flags with the same style as the docs for `astro preview` do.
 

#### For Astro version: `3.3.0`. See astro PR [#8808](https://github.com/withastro/astro/pull/8808).
