### PR TITLE
Fix(rehype-autolink-config.ts): Typo in the xmlns svg element attribute

### DIFF
--- a/plugins/rehype-autolink-config.ts
+++ b/plugins/rehype-autolink-config.ts
@@ -14,7 +14,7 @@ const AnchorLinkIcon = h(
 			height: 16,
 			version: 1.1,
 			viewBox: '0 0 16 16',
-			xlmns: 'http://www.w3.org/2000/svg',
+			xmlns: 'http://www.w3.org/2000/svg',
 		},
 		h('path', {
 			fillRule: 'evenodd',


### PR DESCRIPTION
#### Description (required)

- Fixes a typo in the spelling of the `xmlns` attribute of the generated svg element. The attribute was spelled `xlmns`. Fixed to the proper `xmlns`.
