### PR TITLE
Remove outdated shiki pnpm note

### DIFF
--- a/src/content/docs/de/reference/api-reference.mdx
+++ b/src/content/docs/de/reference/api-reference.mdx
@@ -888,14 +888,6 @@ import { Code } from 'astro/components';
 
 Diese Komponente bietet Syntax-Highlighting für Codeblöcke zum Zeitpunkt der Erstellung (kein clientseitiges JavaScript enthalten). Die Komponente wird intern von Shiki betrieben und unterstützt alle gängigen [Themen](https://github.com/shikijs/shiki/blob/main/docs/themes.md) und [Sprachen](https://github.com/shikijs/shiki/blob/main/docs/languages.md). Außerdem kannst du deine eigenen Themes und Sprachen hinzufügen, indem du sie an `theme` bzw. `lang` übergibst.
 
-:::note
-Wenn du einen [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) wie `pnpm` verwendest, musst du eventuell auch Shiki installieren, damit es während des Builds funktioniert:
-
-```bash
-pnpm install shiki
-```
-:::
-
 ### `<Prism />`
 
 Um die Textmarker-Komponente `Prism` zu verwenden, musst du zuerst das Paket `@astrojs/prism` **installieren**:

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1116,14 +1116,6 @@ import { Code } from 'astro:components';
 
 This component provides syntax highlighting for code blocks at build time (no client-side JavaScript included). The component is powered internally by Shiki and it supports all popular [themes](https://github.com/shikijs/shiki/blob/main/docs/themes.md) and [languages](https://github.com/shikijs/shiki/blob/main/docs/languages.md). Plus, you can add your custom themes and languages by passing them to `theme` and `lang` respectively.
 
-:::note
-When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may also need to install Shiki so it works during build:
-
-```bash
-pnpm install shiki
-```
-:::
-
 ### `<Prism />`
 
 To use the `Prism` highlighter component, first **install** the `@astrojs/prism` package:

--- a/src/content/docs/es/reference/api-reference.mdx
+++ b/src/content/docs/es/reference/api-reference.mdx
@@ -1094,14 +1094,6 @@ import { Code } from 'astro:components';
 
 Este componente proporciona resaltado de sintaxis para bloques de código en el momento de la compilación (no incluye JavaScript del lado del cliente). El componente funciona internamente con Shiki y es compatible con todos los [temas populares](https://github.com/shikijs/shiki/blob/main/docs/themes.md) y [lenguajes de programación](https://github.com/shikijs/shiki/blob/main/docs/languages.md). Además, puedes agregar temas y lenguajes de programación personalizados modificando `theme` y `lang` respectivamente.
 
-:::note
-Cuando uses un [gestor de paquetes estricto](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como `pnpm`, también es posible que necesites instalar Shiki para que funcione durante la compilación:
-
-```bash
-pnpm install shiki
-```
-:::
-
 ### `<Prism />`
 
 Para usar el componente resaltador `Prism`, primero **instala** el paquete `@astrojs/prism`:

--- a/src/content/docs/pt-br/reference/api-reference.mdx
+++ b/src/content/docs/pt-br/reference/api-reference.mdx
@@ -1067,14 +1067,6 @@ import { Code } from 'astro:components';
 
 Este componente providencia syntax highlighting para blocos de código em tempo de build (sem JavaScript no lado do cliente). O componente é viabilizado internamente por Shiki e suporta todos os [temas](https://github.com/shikijs/shiki/blob/main/docs/themes.md) e [linguagens](https://github.com/shikijs/shiki/blob/main/docs/languages.md) populares. Além disso, você pode adicionar temas e linguagens customizadas as passando para `theme` e `lang` respectivamente.
 
-:::note
-Ao utilizar um [gerenciador de pacotes estrito](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como o `pnpm`, você pode também precisar instalar o Shiki para que ele funcione durante a build:
-
-```bash
-pnpm install shiki
-```
-:::
-
 ### `<Prism />`
 
 Para usar o componente highlighter `Prism`, primeiro **instale** o pacote `@astrojs/prism`:

--- a/src/content/docs/zh-cn/reference/api-reference.mdx
+++ b/src/content/docs/zh-cn/reference/api-reference.mdx
@@ -1124,14 +1124,6 @@ import { Code } from 'astro:components';
 
 该组件在构建时为代码块提供语法高亮（不包括客户端 JavaScript）。该组件由 Shiki 驱动，它支持所有流行的[主题](https://github.com/shikijs/shiki/blob/main/docs/themes.md)和[语言](https://github.com/shikijs/shiki/blob/main/docs/languages.md)。另外，你可以通过给 `theme` 和 `lang` 传递自定义主题和语言分别添加它们。
 
-:::note
-当使用像 `pnpm` 这样的[严格包管理器](https://pnpm.io/pnpm-vs-npm#npms-flat-tree)时，您还可能需要安装 Shiki，以便在构建期间正常工作：
-
-```bash
-pnpm install shiki
-```
-:::
-
 ### `<Prism />`
 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Remove note where `shiki` might need to be installed in your project when using pnpm. This is no longer the case since Astro 3.3 (releasing today). The PR (https://github.com/withastro/astro/pull/8502) switches to shikiji which doesn't have this caveat anymore.

#### Related issues & labels (optional)

#### For Astro version: `3.3`. See astro PR [#8502](https://github.com/withastro/astro/pull/8502)
