### PR TITLE
i18n(es): Update `islands`, `contribute` & `client-side-scripts`

### DIFF
--- a/src/content/docs/es/concepts/islands.mdx
+++ b/src/content/docs/es/concepts/islands.mdx
@@ -69,4 +69,4 @@ Aún mejor, puedes decirle a Astro exactamente cómo y cuándo renderizar cada c
 
 En Astro, depende de ti como desarrollador decirle explícitamente a Astro cuáles componentes de la página deben ejecutarse también en el navegador. Astro solo hidratará exactamente lo que se necesita en la página y dejará el resto de tu sitio como HTML estático.
 
-**¡Las Islas son el secreto del rendimiento rápido por defecto de Astro!**
+**¡Las Islas son el secreto del rendimiento rápido por defecto de Astro!** 

--- a/src/content/docs/es/contribute.mdx
+++ b/src/content/docs/es/contribute.mdx
@@ -3,9 +3,7 @@ title: Contribuye a Astro
 description: Cómo involucrarse y contribuir a Astro.
 i18nReady: true
 ---
-import Button from '~/components/Button.astro'
 import ContributorList from '~/components/ContributorList.astro'
-import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
 Aceptamos contribuciones de cualquier tamaño y contribuyentes de todos los niveles de habilidad. Como un proyecto de código abierto, creemos en devolver a nuestros contribuyentes. Estamos encantados de ayudar con orientación sobre PRs, escritura técnica y convertir cualquier idea en realidad.

--- a/src/content/docs/es/guides/client-side-scripts.mdx
+++ b/src/content/docs/es/guides/client-side-scripts.mdx
@@ -41,7 +41,7 @@ En este ejemplo, agregar el componente `<Hello />` a una página registrará un 
 </script>
 ```
 
-### Empaquetado de scripts
+### Procesamiento de scripts
 
 De forma predeterminada, las etiquetas `<script>` son procesadas por Astro.
 
@@ -57,7 +57,18 @@ De forma predeterminada, las etiquetas `<script>` son procesadas por Astro.
 </script>
 ```
 
-Para evitar el empaquetado del script, puedes utilizar la directiva `is:inline`.
+El atributo `type="module"` hace que el navegador trate el script como un módulo de JavaScript. Esto tiene varios beneficios de rendimiento:
+- El renderizado no está bloqueado. El navegador continúa procesando el resto del HTML mientras el script del módulo y sus dependencias se cargan.
+- El navegador espera a que el HTML sea procesado antes de ejecutar los scripts de módulo. No necesitas escuchar el evento "load".
+- Los atributos `async` y `defer` son innecesarios. Los scripts de módulo siempre se diferirán.
+
+:::note
+El atributo `async` es valioso para los scripts normales porque evita que bloqueen el renderizado. Sin embargo, los scripts de módulo ya tienen este comportamiento. Agregar `async` a un script de módulo hará que se ejecute antes de que la página se haya cargado por completo. Probablemente esto no es lo que quieres.
+:::
+
+### Optando por no procesar
+
+Para prevenir que Astro procese un script, agrega la directiva `is:inline`.
 
 ```astro title="src/components/InlineScript.astro" "is:inline"
 <script is:inline>
@@ -68,20 +79,20 @@ Para evitar el empaquetado del script, puedes utilizar la directiva `is:inline`.
 ```
 
 :::note
-El comportamiento por defecto de empaquetado de Astro se desactivará en algunas situaciones. En particular, al agregar `type="module"` o cualquier atributo que no sea `src` a una etiqueta `<script>` hará que Astro trate la etiqueta como si tuviera una directiva `is:inline`. Lo mismo será cierto cuando el script esté escrito en una expresión JSX.
+Astro no procesará tus etiquetas de script en algunas situaciones. En particular, al agregar `type="module"` o cualquier atributo que no sea `src` a una etiqueta `<script>` hará que Astro trate la etiqueta como si tuviera una directiva `is:inline`. Lo mismo será cierto cuando el script esté escrito en una expresión JSX.
 :::
 
 📚 Consulta nuestra página de [referencia de directivas](/es/reference/directives-reference/#directivas-script--style) para obtener más información sobre las directivas disponibles en las etiquetas `<script>`.
 
-## Cargando el script
+## Incluye archivos javascript en tu página
 
 Es posible que quieras escribir tus scripts como archivos separados `.js`/`.ts` o necesites referenciar un script externo. Puedes hacerlo referenciándolos en una etiqueta `<script>` con el atributo `src`.
 
 ### Importando scripts locales
 
-**Cuándo usar esto:** Si tu script se encuentra dentro de `src/`.
+**Cuándo usar esto:** cuando tu script se encuentra dentro de `src/`.
 
-Astro empaquetará, optimizará y agregará estos scripts a la página por ti, siguiendo sus [reglas de empaquetado](#empaquetado-de-scripts).
+Astro empaquetará, optimizará y agregará estos scripts a la página por ti, siguiendo sus [reglas de empaquetado](#procesamiento-de-scripts).
 
 ```astro title="src/components/LocalScripts.astro"
 <!-- ruta relativa al script en `src/scripts/local.js` -->
@@ -93,7 +104,7 @@ Astro empaquetará, optimizará y agregará estos scripts a la página por ti, s
 
 ### Cargando scripts externos
 
-**Cuando usar esto:** Si tu archivo JavaScript se encuentra dentro de `public/` o en un CDN.
+**Cuando usar esto:** cuando tu archivo JavaScript se encuentra dentro de `public/` o en un CDN.
 
 Para cargar scripts fuera del directorio `src/` de tu proyecto, incluye la directiva `is:inline`. Este enfoque omite el procesamiento, agrupación y optimización de JavaScript que proporciona Astro cuando importa scripts como se describe anteriormente.
 


### PR DESCRIPTION
#### Description (required)
Updated `islands`, `contribute` & `client-side-scripts` based on these commits: 
- f51a87b0596b55bcd9075f35f29e983350b2c6fc
- 73b069812db63e744bfa81c98b9eb114af4f12ab
- f355283ad12709251ba7e0cb199ad1a593456dc1

**Note:** There was no need to apply changes in `islands` document, just added an space to trigger the i18n tracker so it can mark it as updated.


#### Related issues & labels (optional)

- Suggested label: i18n
