### PR TITLE
Fix (Troubleshooting): Poor sentence wording

### DIFF
--- a/src/content/docs/en/guides/troubleshooting.mdx
+++ b/src/content/docs/en/guides/troubleshooting.mdx
@@ -121,7 +121,7 @@ Then check your import statement:
 
 - Does your import have the same name as the imported component? (Check your component name and that it [follows the `.astro` syntax](/en/core-concepts/astro-syntax/#differences-between-astro-and-jsx).)
 
-- Have you included the extension in the import? (Check that your imported file contains an extension. e.g. `.astro`, `.md`, `.vue`, `.svelte`. Note: File extensions are **not** required for `.js(x)` and `.ts(x)` files only.)
+- Have you included the extension in the import? (Check that your imported file contains an extension. e.g. `.astro`, `.md`, `.vue`, `.svelte`. Note: File extensions are **optional** for .js(x) and .ts(x) files.)
 
 ### My component is not interactive
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
_These modifications are clearly optional. I don't speak English extremely well either, so some problems may come from there. In addition, I first spotted the error on a [French translation](https://github.com/withastro/docs/pull/4948), which may have influenced my judgment._

#### Description (required)
<!-- Please describe the change you are proposing, and why -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See .github/hacktoberfest.md in this repo for more details. -->
Let's play a little game. **Don't read the sentence below**, start a chronometer, and the read it. Stop the chronometer when you've finished reading AND understanding the sentence.

`Note: File extensions are not required for .js(x) and .ts(x) files only`.

For my part, I had to read the sentence 4 times to understand it correctly.
In fact, according to some studies on the subject said: "Negative sentences **required longer processing times** and were associated with **higher error rates**. [... A type of evidence] speaks for a **reduced access to conceptual representations** of the negated items; accordingly, reduced activations of the brain circuits involved in conceptual representations are to be expected."
_Source_: https://www.sciencedirect.com/science/article/abs/pii/S1053811908009014

How do we solve this problem?
Simply turn it into affirmative sentences. Let's try the previous game again. Start a chronometer and stop it when you have completely read and understood the sentence.

`Note: File extensions are optional for .js(x) and .ts(x) files.`