### PR TITLE
fix(integration pages ci): ignore private packages

### DIFF
--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -123,7 +123,7 @@ class IntegrationPagesBuilder {
 				})
 		);
 
-		return integrationData.filter(package => package.isPrivate === false)
+		return integrationData.filter(pkg => pkg.isPrivate === false)
 	}
 
 	/**

--- a/scripts/generate-integration-pages.ts
+++ b/scripts/generate-integration-pages.ts
@@ -25,6 +25,7 @@ interface IntegrationData {
 	readme: string;
 	srcdir: string;
 	i18nReady: string;
+	isPrivate: boolean;
 }
 
 const prettyCategoryDescription: Record<string, unknown> = {
@@ -78,7 +79,7 @@ class IntegrationPagesBuilder {
 		pkgJsonURL: string;
 		readmeURL: string;
 	}): Promise<IntegrationData> {
-		const { name, keywords } = await githubGet({
+		const { name, keywords, private: isPrivate = false } = await githubGet({
 			url: pkgJsonURL,
 			githubToken: this.#githubToken,
 		});
@@ -89,7 +90,7 @@ class IntegrationPagesBuilder {
 			: 'other';
 		const i18nReady = (!this.#i18nNotReadyIntegrations.has(packageName)).toString();
 		const readme = await (await fetch(readmeURL)).text();
-		return { name, category, readme, srcdir: packageName, i18nReady };
+		return { name, category, readme, srcdir: packageName, i18nReady, isPrivate };
 	}
 
 	/**
@@ -102,7 +103,7 @@ class IntegrationPagesBuilder {
 		}?ref=${this.#sourceBranch}`;
 		const packages: { name: string }[] = await githubGet({ url, githubToken: this.#githubToken });
 
-		return await Promise.all(
+		const integrationData = await Promise.all(
 			packages
 				.filter((pkg) => !this.#deprecatedIntegrations.has(pkg.name))
 
@@ -121,6 +122,8 @@ class IntegrationPagesBuilder {
 					});
 				})
 		);
+
+		return integrationData.filter(package => package.isPrivate === false)
 	}
 
 	/**


### PR DESCRIPTION
#### Description (required)
The adapters repo is introducing a private package for testing that does not need to be processed by docs.
Currently, smoke tests are failing because `generate-integration-pages.ts` attempts to create a markdown file for the internal test-utils package.

#### Related issues & labels (optional)
None