### PR TITLE
fix: missing backticks in code block and indentation in `add-content-collection`

### DIFF
--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -238,7 +238,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
 
 10. Anywhere you have a list of blog posts, like the tutorial's Blog page (`src/pages/blog.astro/`), you will need to replace `Astro.glob()` with [`getCollection()`](/en/reference/api-reference/#getcollection) as the way to fetch content and metadata from your Markdown files.
 
-      ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")" "/posts/${post.slug}/" del={7} ins={2,8}
+    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"posts\")" "/posts/${post.slug}/" del={7} ins={2,8}
     ---
     import { getCollection } from "astro:content";
     import BaseLayout from "../layouts/BaseLayout.astro";
@@ -248,6 +248,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
     const allPosts = await Astro.glob("../pages/posts/*.md");
     const allPosts = await getCollection("posts");
     ---
+    ```
 
 11. You will also need to update references to the data returned for each `post`. You will now find your frontmatter values on the `data` property of each object. Also, when using collections each `post` object will have a page `slug`, not a full URL.
 

--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -382,5 +382,4 @@ The steps below show you how to extend the final product of the Build a Blog tut
       })
     }
     ```
-
 For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-collections) of the tutorial repo.

--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -382,4 +382,5 @@ The steps below show you how to extend the final product of the Build a Blog tut
       })
     }
     ```
+
 For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-collections) of the tutorial repo.


### PR DESCRIPTION
#### Description (required)

Added missing backticks at the end of a code block and fixed identation.

#### Related issues & labels (optional)

- Suggested label: tutorial
