### PR TITLE
i18n(es): Translate `unsupported-image-conversion`

### DIFF
--- a/src/content/docs/es/reference/errors/unsupported-image-conversion.mdx
+++ b/src/content/docs/es/reference/errors/unsupported-image-conversion.mdx
@@ -4,10 +4,10 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **UnsupportedImageConversion**: Convertir entre imágenes vectoriales (como SVG) y de mapa de bits (como PNG y JPEG) no es compatible actualmente.
+> **UnsupportedImageConversion**: La conversión entre imágenes vectoriales (como SVGs) y raster (como PNGs y JPEGs) no está soportada actualmente.
 
 ## ¿Qué salió mal?
-Astro no admite actualmente la conversión entre imágenes vectoriales (como SVG) y de mapa de bits (como PNG y JPEG).
+Astro no admite actualmente la conversión entre imágenes vectoriales (como SVG) y raster (como PNG y JPEG).
 
 **Ver también:**
 -  [Imágenes](/es/guides/images/)

--- a/src/content/docs/es/reference/errors/unsupported-image-conversion.mdx
+++ b/src/content/docs/es/reference/errors/unsupported-image-conversion.mdx
@@ -1,0 +1,15 @@
+---
+title: Unsupported image conversion
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnsupportedImageConversion**: Convertir entre imágenes vectoriales (como SVG) y de mapa de bits (como PNG y JPEG) no es compatible actualmente.
+
+## ¿Qué salió mal?
+Astro no admite actualmente la conversión entre imágenes vectoriales (como SVG) y de mapa de bits (como PNG y JPEG).
+
+**Ver también:**
+-  [Imágenes](/es/guides/images/)
+
+


### PR DESCRIPTION
#### Description (required)

Translated `unsupported-image-conversion` error to spanish.

#### Related issues & labels (optional)

- Suggested label: i18n