### PR TITLE
Add insert on import

### DIFF
--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -26,7 +26,7 @@ To enable SSR features for production deployments, update your `output` configur
 
 - __`output: 'server'`__: Server-rendered by default. Use this when most or all of your site should be server-rendered. Any individual page or endpoint can *opt-in* to pre-rendering.
 
-  ```js ins={6,7}
+  ```js ins={2,6,7}
   // astro.config.mjs
   import { defineConfig } from 'astro/config';
   import nodejs from '@astrojs/node';


### PR DESCRIPTION
#### Description (required)
In the documentation for SSR, the first example about adding `nodejs` to your Astro config is not highlighted as an import, whereas the second example (converting a static site) highlights `nodejs` as an import. This PR fixes that.
