### PR TITLE
i18n(es): Update `cloudflare`, `sitemap` & `/integrations-guide/netlify`

### DIFF
--- a/src/content/docs/es/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/es/guides/integrations-guide/cloudflare.mdx
@@ -2,7 +2,7 @@
 type: integration
 title: '@astrojs/cloudflare'
 description: Aprende cómo utilizar el adaptador SSR @astrojs/cloudflare para implementar tu proyecto de Astro.
-githubURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
+githubURL: 'https://github.com/withastro/adapters/tree/main/packages/integrations/cloudflare/'
 hasREADME: true
 category: adapter
 i18nReady: true
@@ -199,17 +199,24 @@ export default defineConfig({
 
 ### `runtime`
 
-`runtime: "off" | "local"`
+`runtime: { mode: "off" | "local", persistTo: string }`
 
-por defecto: `"off"`
+por defecto: `{ mode: 'off', persistTo: '' }`
 
 Determina si y como el Runtime de Cloudflare es añadido a `astro dev`.
 
 El Runtime de Cloudflare incluye [Cloudflare Bindings](https://developers.cloudflare.com/pages/platform/functions/bindings), [variables de entorno](https://developers.cloudflare.com/pages/platform/functions/bindings/#environment-variables), y el [objeto cf](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties). Obtén más información sobre [cómo acceder al Runtime de Cloudflare](#runtime-de-cloudflare).
 
-## Acceso al runtime de Cloudflare
+La propiedad `mode` define como el runtime es agregado a `astro dev`:
+
 * `local`: utiliza simulaciones de bindings y placeholders estáticos locales.
 * `off`: no tiene acceso al runtime de Cloudflare usando `astro dev`. Alternativamente, puedes usar [Vista previa con Wrangler](#vista-previa-con-wrangler).
+
+La propiedad `persistTo` define donde el runtime local es persistido cuando se usa `mode: local`. Este valor es un directorio relativo a la ruta de ejecución de `astro dev`.
+
+El valor predeterminado se establece en `.wrangler/state/v3` para que coincida con la ruta predeterminada que utiliza Wrangler. Esto significa que ambas herramientas pueden acceder y utilizar el estado local.
+
+Cualquier directorio que se establezca en `persistTo`, `.wrangler` o tu valor personalizado, debe añadirse a `.gitignore`.
 
 ```diff lang="js"
 // astro.config.mjs

--- a/src/content/docs/es/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/es/guides/integrations-guide/netlify.mdx
@@ -52,7 +52,7 @@ Si prefieres instalar el adaptador manualmente, completa los siguientes dos paso
       // astro.config.mjs
       import { defineConfig } from 'astro/config';
     + import netlify from '@astrojs/netlify/functions';
-      
+
       export default defineConfig({
     +   output: 'server',
     +   adapter: netlify(),

--- a/src/content/docs/es/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/es/guides/integrations-guide/sitemap.mdx
@@ -79,7 +79,7 @@ export default defineConfig({
 
 Ten en cuenta que, a diferencia de otras opciones de configuración, `site` se establece en el objeto `defineConfig` raíz, en lugar de dentro de la llamada a `sitemap()`.
 
-Ahora, [construye tu sitio para producción](/es/reference/cli-reference/#astro-build) utilizando el comando `astro build`. ¡Deberías encontrar tu sitemap en la carpeta `dist/` con los nombres `sitemap-index.xml` y `sitemap-0.xml`!
+Ahora, [construye tu sitio para producción](/es/reference/cli-reference/#astro-build) utilizando el comando `astro build`. Encontrarás `sitemap-index.xml` y `sitemap-0.xml` en la carpeta `dist/` (o tu [directorio de salida](/es/reference/configuration-reference/#outdir) personalizado si está configurado).
 
 :::caution
 Si olvidas agregar la propiedad `site`, recibirás una advertencia amigable al realizar la compilación y el archivo `sitemap-index.xml` no se generará.


### PR DESCRIPTION
#### Description (required)

Updated `cloudflare`, `sitemap` & `/integrations-guide/netlify` based on these commits:
- 4d2d8a1a6dfef7f2acdf28737f656e384ca18c79
- b384847cdbaf16b57f2e67f95a01cef2c660b256

#### Related issues & labels (optional)

- Suggested label: i18n