### PR TITLE
i18n(es): Update `typescript` & `view-transitions`

### DIFF
--- a/src/content/docs/es/guides/typescript.mdx
+++ b/src/content/docs/es/guides/typescript.mdx
@@ -273,6 +273,7 @@ Para ver errores de tipos en tu editor, asegúrate de tener instalada la [extens
 :::
 
 📚 Lee más sobre las [importaciones de archivos `.ts`](/es/guides/imports/#typescript) en Astro.
+
 📚 Lee más sobre la [configuración de TypeScript](https://www.typescriptlang.org/tsconfig/).
 
 ## Solución de problemas

--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -451,9 +451,9 @@ Puedes usar este evento para ejecutar código en cada navegación de página, o 
 
 ### `astro:after-swap`
 
-Un evento que se dispara inmediatamente después de que la nueva página reemplace la página antigua. Puedes escuchar este evento en el `document`.
+Un evento que se dispara inmediatamente después de que la nueva página reemplace la página antigua. Puedes escuchar este evento en el `document` y desencadenar acciones que ocurrirán antes de que se rendericen los elementos DOM de la nueva página y se ejecuten los scripts.
 
-Este evento es útil para restaurar cualquier estado en el DOM que necesite transferirse a la nueva página.
+Este evento, cuando se escucha en la **página saliente**, es útil para pasar y restaurar cualquier estado en el DOM que necesite transferirse a la nueva página.
 
 Por ejemplo, si estás implementando el soporte de modo oscuro, este evento se puede usar para restaurar el estado en las cargas de página:
 


### PR DESCRIPTION
#### Description (required)

Update `typescript` & `view-transitions` based on these commits:
- f8fcfaeacbafff860342e4958f4ee26cf595ebea
- 55ee62997eb6b86e197c8f81c8a015634b5faadf

#### Related issues & labels (optional)

- Suggested label: i18n