### PR TITLE
[images] updates Default Image Service section

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -681,13 +681,11 @@ If your [adapter for `server` or `hybrid` mode](https://astro.build/integrations
 Configure the no-op image service to avoid both Squoosh and Sharp image processing:
 
 ```js title="astro.config.mjs" ins={4-8}
-import { defineConfig } from 'astro/config';
+import { defineConfig, passthroughImageService } from 'astro/config';
 
 export default defineConfig({
   image: {
-    service: {
-      entrypoint: 'astro/assets/services/noop'
-    }
+    service: passthroughImageService()
   }
 });
 ```

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -652,6 +652,16 @@ If the image is merely decorative (i.e. doesn’t contribute to the understandin
 
 [Sharp](https://github.com/lovell/sharp) is the default image service used for `astro:assets`.
 
+:::note
+When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
+
+```bash
+pnpm install sharp
+```
+:::
+
+### Configure Squoosh
+
 If you would prefer to use [Squoosh](https://github.com/GoogleChromeLabs/squoosh) to transform your images, update your config with the following:
 
 ```js title="astro.config.mjs" ins={4-6}
@@ -664,13 +674,23 @@ export default defineConfig({
 });
 ```
 
-:::note
-When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
+### Configure no-op passthrough service
 
-```bash
-pnpm install sharp
+If your [adapter for `server` or `hybrid` mode](https://astro.build/integrations/?search=&categories%5B%5D=adapters) does not support Astro's built-in Squoosh and Sharp image optimization (e.g. Deno, Cloudflare), you can configure a no-op image service to allow you to use the `<Image />` and `<Picture />` components. Note that Astro does not perform any image transformation and processing in these environments. However, you can still enjoy the other benefits of using `astro:assets`, including no Cumulative Layout Shift (CLS), the enforced `alt` attribute, and a consistent authoring experience.
+
+Configure the no-op image service to avoid both Squoosh and Sharp image processing:
+
+```js title="astro.config.mjs" ins={4-8}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  image: {
+    service: {
+      entrypoint: 'astro/assets/services/noop'
+    }
+  }
+});
 ```
-:::
 
 ## Community Integrations
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -678,9 +678,9 @@ export default defineConfig({
 
 If your [adapter for `server` or `hybrid` mode](https://astro.build/integrations/?search=&categories%5B%5D=adapters) does not support Astro's built-in Squoosh and Sharp image optimization (e.g. Deno, Cloudflare), you can configure a no-op image service to allow you to use the `<Image />` and `<Picture />` components. Note that Astro does not perform any image transformation and processing in these environments. However, you can still enjoy the other benefits of using `astro:assets`, including no Cumulative Layout Shift (CLS), the enforced `alt` attribute, and a consistent authoring experience.
 
-Configure the no-op image service to avoid both Squoosh and Sharp image processing:
+Configure the `passthroughImageService()` to avoid both Squoosh and Sharp image processing:
 
-```js title="astro.config.mjs" ins={4-8}
+```js title="astro.config.mjs" ins={4-6} "passthroughImageService"
 import { defineConfig, passthroughImageService } from 'astro/config';
 
 export default defineConfig({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the Default Image Service section in our Images guide:

- Adds h3s for discoverability now that there are two sub-sections: Squoosh and noop
- The only place we had documented configuring a noop service for an environment/adapter that did not support it was in the upgrade from v2 section, so this moves it to docs proper

Should be checked and vetted to make sure advice is still appropriate (e.g. used to refer to Vercel and Netlify edge environments; is the pnpm warning still appropriate?).

Direct preview link: https://deploy-preview-5189--astro-docs-2.netlify.app/en/guides/images/#default-image-service
