### PR TITLE
[i18nIgnore] chore: remove non-existent link

### DIFF
--- a/src/content/docs/en/guides/cms/directus.mdx
+++ b/src/content/docs/en/guides/cms/directus.mdx
@@ -10,7 +10,7 @@ i18nReady: false
 [Directus](https://directus.io/) is a backend-as-a-service which can be used to host data and content for your Astro project.
 
 ## Official Resources
-- Check out the official guide, [Get Started Building an Astro Website with Directus](https://directus.io/guides/get-started-building-an-astro-website-with-directus/).
+
 - Directus provides an [example Astro blog template](https://github.com/directus/examples/tree/main/astro).
 
 ## Community Resources 

--- a/src/content/docs/es/guides/cms/directus.mdx
+++ b/src/content/docs/es/guides/cms/directus.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 [Directus](https://directus.io/) es un backend como servicio que se puede utilizar para alojar datos y contenido para tu proyecto de Astro.
 
 ## Recursos oficiales
-- Consulta la guía oficial, [Comienza a construir un sitio web de Astro con Directus](https://directus.io/guides/get-started-building-an-astro-website-with-directus/).
+
 - Directus proporciona una [plantilla de blog de Astro de ejemplo](https://github.com/directus/examples/tree/main/astro).
 
 ## Recursos de la comunidad

--- a/src/content/docs/zh-cn/guides/cms/directus.mdx
+++ b/src/content/docs/zh-cn/guides/cms/directus.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 [Directus](https://directus.io/) 是一个 BaaS（后端即服务），可用于为你的 Astro 项目托管数据和内容。
 
 ## 官方资源
-- 查看官方指南：[使用 Directus 开始构建 Astro 网站](https://directus.io/guides/get-started-building-an-astro-website-with-directus/)。
+
 - Directus 提供了一个[示例 Astro 博客模板](https://github.com/directus/examples/tree/main/astro)。
 
 ## 社区资源


### PR DESCRIPTION
#### Description (required)

The link for the guide doesn't exist anymore on the Directus website. The example still does.
