### PR TITLE
i18n(ko) typescript.mdx link heading fix

### DIFF
--- a/src/content/docs/ko/guides/typescript.mdx
+++ b/src/content/docs/ko/guides/typescript.mdx
@@ -7,7 +7,7 @@ i18nReady: true
 import Since from '~/components/Since.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Astro는 [TypeScript](https://www.typescriptlang.org/)에 대한 기본 지원을 제공합니다. Astro 프로젝트에 `.ts` 및 `.tsx` 파일을 가져올 수 있으며, [Astro 컴포넌트](/ko/core-concepts/astro-components/#컴포넌트-스크립트)에서 직접 TypeScript 코드를 작성할 수도 있습니다. 원한다면 [`astro.config.ts`](/ko/guides/configuring-astro/#the-astro-config-file) 파일을 사용해 구성 파일을 TypeScript로 작성할 수도 있습니다.
+Astro는 [TypeScript](https://www.typescriptlang.org/)에 대한 기본 지원을 제공합니다. Astro 프로젝트에 `.ts` 및 `.tsx` 파일을 가져올 수 있으며, [Astro 컴포넌트](/ko/core-concepts/astro-components/#컴포넌트-스크립트)에서 직접 TypeScript 코드를 작성할 수도 있습니다. 원한다면 [`astro.config.ts`](/ko/guides/configuring-astro/#astro-구성-파일) 파일을 사용해 구성 파일을 TypeScript로 작성할 수도 있습니다.
 
 TypeScript를 사용해 객체와 컴포넌트의 형태를 정의하여 런타임 오류를 방지할 수 있습니다. 예를 들어 TypeScript로 [컴포넌트 props 타입을 정의](#컴포넌트-props)하면 컴포넌트가 허용하지 않는 props를 전달했을 때 편집기에서 오류가 발생합니다.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Corrects a link pointing to an English heading instead of a translated one.

If I'm right, all the link checks should pass.

#### Related issues & labels (optional)
