### PR TITLE
Fix dev overlay UI Toolkit component names

### DIFF
--- a/src/content/docs/en/reference/dev-overlay-plugin-reference.mdx
+++ b/src/content/docs/en/reference/dev-overlay-plugin-reference.mdx
@@ -223,7 +223,7 @@ Shows a card with optionally an [`icon`](#icons). Optionally, if a `link` is pas
 The slot of the component will be used as the content of the card.
 
 ```html
-<astro-overlay-card icon="astro:logo" link="https://github.com/withastro/astro/issues/new/choose">Report an issue</astro-overlay-card>
+<astro-dev-overlay-card icon="astro:logo" link="https://github.com/withastro/astro/issues/new/choose">Report an issue</astro-dev-overlay-card>
 ```
 
 ### `astro-dev-overlay-highlight`
@@ -239,7 +239,7 @@ Can be used to highlight an element on the page. In most cases, you'll want to p
 const elementToHighlight = document.querySelector('h1');
 const rect = elementToHighlight.getBoundingClientRect();
 
-const highlight = document.createElement('astro-overlay-highlight');
+const highlight = document.createElement('astro-dev-overlay-highlight');
 
 highlight.style.top = `${Math.max(rect.top + window.scrollY - 10, 0)}px`;
 highlight.style.left = `${Math.max(rect.left + window.scrollX - 10, 0)}px`;
@@ -282,7 +282,7 @@ tooltip.sections = [{
 This component is often combined with the `astro-dev-overlay-highlight` component to show a tooltip when hovering a highlighted element:
 
 ```ts
-const highlight = document.createElement('astro-overlay-highlight');
+const highlight = document.createElement('astro-dev-overlay-highlight');
 
 // Position the highlight...
 
@@ -309,5 +309,5 @@ Currently, the following icons are available and can be used in any component th
 In addition to these included icons, you can also pass a string containing the SVG markup of the icon you want to use.
 
 ```html
-<astro-overlay-card icon="<svg>...</svg>" link="https://docs.astro.build">Read more in the Astro Docs!</astro-overlay-card>
+<astro-dev-overlay-card icon="<svg>...</svg>" link="https://docs.astro.build">Read more in the Astro Docs!</astro-dev-overlay-card>
 ```


### PR DESCRIPTION
#### Description (required)

This PR is a follow-up to an [Astro PR](https://github.com/withastro/astro/pull/8928) which fixes some name discrepancies between the code and the docs for various dev overlay UI Toolkit component names.

For example, the docs mention [`astro-dev-overlay-window`](https://docs.astro.build/en/reference/dev-overlay-plugin-reference/#astro-dev-overlay-window) but the component was registered as `astro-overlay-window`. The [Astro PR](https://github.com/withastro/astro/pull/8928) fixes the component names to always include the `-dev` portion (checked [on Discord](https://discord.com/channels/830184174198718474/845430950191038464/1167141643305091102) first) which is mostly used in the docs but not all the time.

This PR fixes the docs to always use the `-dev` portion in the component names.

#### Related issues & labels (optional)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->

See astro PR [#8928](https://github.com/withastro/astro/pull/8928).