### PR TITLE
i18n(zh-cn): fix some typos in `guides/deploy.mdx`

### DIFF
--- a/src/content/docs/zh-cn/guides/deploy.mdx
+++ b/src/content/docs/zh-cn/guides/deploy.mdx
@@ -26,7 +26,7 @@ import DeployGuidesNav from '~/components/DeployGuidesNav.astro';
 
     :::note[部署设置]
     - **构建命令：** `astro build` 或 `npm run build`。
-    - **发布目录：** `dist'。
+    - **发布目录：** `dist`。
     :::
 
 1. 点击 `Deploy`，你的新网站将在该服务商所提供的唯一链接上创建好了（例如：`new-astro-site.netlify.app`）。
@@ -48,11 +48,11 @@ import DeployGuidesNav from '~/components/DeployGuidesNav.astro';
 
 1. 构建站点并部署到服务商
 
-    许多服务商会帮你构建和部署站点。它们通常也能识别出你的项目是 Astro 站点，会选择相应的配置设置进行构建和部署，就像下面一一。（如果不是，那么这些设置也可以进行修改）
+    许多服务商会帮你构建和部署站点。它们通常也能识别出你的项目是 Astro 站点，会选择相应的配置设置进行构建和部署，就像下面一样。（如果不是，那么这些设置也可以进行修改）
 
     :::note[部署设置]
-    - **构建命令:** `astro build` 或 `npm run build`
-    - **发布目录:** `dist`
+    - **构建命令：** `astro build` 或 `npm run build`。
+    - **发布目录：** `dist`。
     :::
 
 
@@ -70,7 +70,7 @@ import DeployGuidesNav from '~/components/DeployGuidesNav.astro';
 npm run build
 ```
 
-默认情况下，构建输出将会被放在 `dist/`. 你可以修改 [`outDir` 配置项](/zh-cn/reference/configuration-reference/#outdir)改变存储位置。
+默认情况下，构建输出将会被放在 `dist/`。你可以修改 [`outDir` 配置项](/zh-cn/reference/configuration-reference/#outdir)改变存储位置。
 
 ## 添加 SSR 适配器
 


### PR DESCRIPTION
#### Description (required)

fix some typos in `guides/deploy.mdx`

#### Related issues & labels (optional)

None
