### PR TITLE
upgrade to v2 - future proof link

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v2.mdx
@@ -415,7 +415,7 @@ export default defineConfig({
 These features are now available by default:
 
 - [Content collections](/en/guides/content-collections/) as a way to manage your Markdown and MDX files with type-safety.
-- [Prerendering individual pages to static HTML](/en/guides/server-side-rendering/#configuring-individual-routes) when using SSR to improve speed and cacheability.
+- [Prerendering individual pages to static HTML](/en/guides/server-side-rendering/) when using SSR to improve speed and cacheability.
 - A redesigned error message overlay.
 
 ## Known Issues


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
The link for this very old page (upgrade from v1 to v2) is going to eventually cause problems. This removes the specific heading that will change and simply directs to the page itself.

#### Related issues & labels (optional)
