### PR TITLE
fix: import images inside the custom image component recipe

### DIFF
--- a/src/content/docs/en/recipes/build-custom-img-component.mdx
+++ b/src/content/docs/en/recipes/build-custom-img-component.mdx
@@ -115,11 +115,13 @@ In this recipe, you will use the [`getImage()` function](/en/guides/images/#gene
     ```astro title="src/pages/index.astro" 
     ---
     import MyCustomImageComponent from "../components/MyCustomImageComponent.astro";
+    import mobileImage from "../images/mobile-profile-image.jpg";
+    import desktopImage from "../images/desktop-profile-image.jpg";
     ---
 
     <MyCustomImageComponent
-        mobileImgUrl="/images/mobile-profile-image.jpg"
-        desktopImgUrl="/images/desktop-profile-image.jpg"
+        mobileImgUrl={mobileImage}
+        desktopImgUrl={desktopImage}
         alt="user profile picture"
     />
 


### PR DESCRIPTION
#### Description (required)

Local images have to be imported, we don't support linking to images in `public` like that at the moment
