### PR TITLE
Adds me as an author for an article that was already listed

### DIFF
--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -175,8 +175,8 @@ To deploy your site visit our [deployment guides](/en/guides/deploy/) and follow
 
 - [Building An Astro Website With WordPress As A Headless CMS](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/) by Chris Bongers.
 - [Building with Astro x WordPress](https://www.youtube.com/watch?v=Jstqgklvfnc) on Ben Holmes's stream.
-- [Building a Headless WordPress Site with Astro](https://developers.wpengine.com/blog/building-a-headless-wordpress-site-with-astro) by Jeff Everhart
-- [Astro and WordPress as an API](https://darko.io/posts/wp-as-an-api/)
+- [Building a Headless WordPress Site with Astro](https://developers.wpengine.com/blog/building-a-headless-wordpress-site-with-astro) by Jeff Everhart.
+- [Astro and WordPress as an API](https://darko.io/posts/wp-as-an-api/) by Darko Bozhinovski.
 
 ## Production Sites
 


### PR DESCRIPTION
Adds my name to resources, as it wasn't listed

#### Description (required)
Added my name to an article listed in WordPress resources that I wrote, but I wasn't mentioned by name (every other resource has its author mentioned by name).

