### PR TITLE
Fix import meta env reference in configuring-astro.mdx

### DIFF
--- a/src/content/docs/en/guides/configuring-astro.mdx
+++ b/src/content/docs/en/guides/configuring-astro.mdx
@@ -115,7 +115,8 @@ export default defineConfig({
 ```
 
 :::note
-Vite-specific `import.meta` properties, like `import.meta.env` or `import.meta.glob`, are _not_ accessible from your configuration file. We recommend alternatives like [dotenv](https://github.com/motdotla/dotenv) or [fast-glob](https://github.com/mrmlnc/fast-glob) for these respective use cases.
+{/* Need to use <code> here because Vite does an auto-replace on import-meta-env that breaks rendering */}
+Vite-specific `import.meta` properties, like <code>{'import.meta.env'}</code> or `import.meta.glob`, are _not_ accessible from your configuration file. We recommend alternatives like [dotenv](https://github.com/motdotla/dotenv) or [fast-glob](https://github.com/mrmlnc/fast-glob) for these respective use cases.
 :::
 
 ## Customising Output Filenames


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fix import meta env reference in configuring-astro.mdx

Fix https://github.com/withastro/docs/issues/4110

#### Related issues & labels (optional)

- Closes #4110
- https://github.com/withastro/docs/pull/5222

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
