### PR TITLE
fix: `astro check` watches all files, not just Astro files

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -245,7 +245,7 @@ Use these flags to customize the behavior of the command.
 
 The command will watch for any changes in your project, and will report any errors.
 
-📚 Read more about [TypeScript support in Astro](/en/guides/typescript/).
+📚 Read more about [type checking in Astro](/en/guides/typescript/#type-checking).
 
 ## `astro sync`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -243,11 +243,7 @@ Use these flags to customize the behavior of the command.
 
 #### `--watch`
 
-The command will watch for any changes to `.astro` files, and will report any errors.
-
-:::note
-This command only checks types within `.astro` files.
-:::
+The command will watch for any changes in your project, and will report any errors.
 
 📚 Read more about [TypeScript support in Astro](/en/guides/typescript/).
 


### PR DESCRIPTION
#### Description (required)

What the title says, the reference was outdated for Astro 3

