### PR TITLE
i18n(es): Update `markdoc`, `mdx` & `vue`

### DIFF
--- a/src/content/docs/es/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/es/guides/integrations-guide/markdoc.mdx
@@ -507,7 +507,7 @@ Cuando uses etiquetas anidadas en Markdoc, puede ser útil indentar el contenido
 ```md
 # Bienvenido a Markdoc con etiquetas indentadas 👋
 
-# Note: Can use either spaces or tabs for indentation
+# Nota: Puedes usar tanto espacios como tabulaciones para la identación
 
 {% custom-tag %}
 {% custom-tag %} ### Las etiquetas pueden ser indentadas para una mejor legibilidad

--- a/src/content/docs/es/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/es/guides/integrations-guide/markdoc.mdx
@@ -486,6 +486,40 @@ Para lograr una experiencia más similar a Markdown, donde los elementos HTML pu
 Cuando `allowHTML` está habilitado, el marcado HTML dentro de los documentos de Markdoc se representará como elementos HTML reales (incluyendo `<script>`), lo que hace posible vectores de ataque como XSS. Asegúrate de que cualquier marcado HTML provenga de fuentes confiables.
 :::
 
+### `ignoreIndentation`
+
+Por defecto, cualquier contenido que esté indentado por cuatro espacios se tratará como un bloque de código. Desafortunadamente, este comportamiento hace que sea difícil usar niveles arbitrarios de indentación para mejorar la legibilidad de los documentos con estructura compleja.
+
+Cuando uses etiquetas anidadas en Markdoc, puede ser útil indentar el contenido dentro de las etiquetas para que el nivel de profundidad sea claro. Para admitir la indentación arbitraria, tenemos que deshabilitar los bloques de código basados en la indentación y modificar varias otras reglas de análisis de markdown-it que tienen en cuenta los bloques de código basados en la indentación. Estos cambios se pueden aplicar habilitando la opción ignoreIndentation.
+
+```diff lang="js" "ignoreIndentation: true"
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
+  import markdoc from '@astrojs/markdoc';
+
+  export default defineConfig({
+    // ...
++   integrations: [markdoc({ ignoreIndentation: true })],
+    //                       ^^^^^^^^^^^^^^^^^^^^^^^
+  });
+```
+
+```md
+# Bienvenido a Markdoc con etiquetas indentadas 👋
+
+# Note: Can use either spaces or tabs for indentation
+
+{% custom-tag %}
+{% custom-tag %} ### Las etiquetas pueden ser indentadas para una mejor legibilidad
+
+    {% another-custom-tag %}
+      Esto es más fácil de seguir cuando hay mucho anidamiento
+    {% /another-custom-tag %}
+
+{% /custom-tag %}
+{% /custom-tag %}
+```
+
 ## Ejemplos
 
 *   La [plantilla de inicio Astro Markdoc](https://github.com/withastro/astro/tree/latest/examples/with-markdoc) muestra como usar archivos Markdoc en tu proyecto Astro.

--- a/src/content/docs/es/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/es/guides/integrations-guide/mdx.mdx
@@ -57,15 +57,9 @@ Luego, aplica esta integración a tu archivo `astro.config.*`  usando la propied
 
 ### Integración del Editor
 
-[VS Code](https://code.visualstudio.com/) admite Markdown de forma predeterminada. Sin embargo, para el soporte del editor MDX, es posible que desees agregar la siguiente configuración en tu archivo de configuración de VSCode. Esto asegura que la autoría de archivos MDX proporcione una experiencia de edición similar a Markdown.
+Para soporte en [VS Code](https://code.visualstudio.com/), instala la [extensión oficial de MDX](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx).
 
-```json title=".vscode/settings.json"
-{
-  "files.associations": {
-    "*.mdx": "markdown"
-  }
-}
-```
+Para otros editores, usa el [servidor de lenguaje MDX](https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server).
 
 ## Uso
 

--- a/src/content/docs/es/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/es/guides/integrations-guide/vue.mdx
@@ -142,7 +142,7 @@ export default (app: App) => {
 
 Puedes usar Vue JSX configurando `jsx: true`.
 
-```js
+```ts
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
 import vue from '@astrojs/vue';


### PR DESCRIPTION
#### Description (required)

Updated `markdoc`, `mdx` & `vue` based on this commit 3a466f740bdf9375d57122e8cba4344467027912

#### Related issues & labels (optional)

- Suggested label: i18n