### PR TITLE
[i18nIgnore] Fix pnpm command typos

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -75,7 +75,7 @@ To get started, first install Prettier and the plugin:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -92,7 +92,7 @@ To connect Astro with Firebase, install the following packages using the single 
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install firebase firebase-admin
+  pnpm add firebase firebase-admin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/backend/supabase.mdx
+++ b/src/content/docs/en/guides/backend/supabase.mdx
@@ -69,7 +69,7 @@ To connect to Supabase, you will need to install `@supabase/supabase-js` in your
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @supabase/supabase-js
+  pnpm add @supabase/supabase-js
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/buttercms.mdx
+++ b/src/content/docs/en/guides/cms/buttercms.mdx
@@ -47,7 +47,7 @@ To get started, you will need to have the following:
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install buttercms
+      pnpm add buttercms
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/contentful.mdx
+++ b/src/content/docs/en/guides/cms/contentful.mdx
@@ -79,7 +79,7 @@ To connect with your Contentful space, install both of the following using the s
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install contentful @contentful/rich-text-html-renderer
+  pnpm add contentful @contentful/rich-text-html-renderer
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/ghost.mdx
+++ b/src/content/docs/en/guides/cms/ghost.mdx
@@ -68,7 +68,7 @@ To connect with Ghost, install the official content API wrapper [`@tryghost/cont
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @tryghost/content-api
+  pnpm add @tryghost/content-api
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/keystatic.mdx
+++ b/src/content/docs/en/guides/cms/keystatic.mdx
@@ -75,7 +75,7 @@ You will also need two Keystatic packages:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @keystatic/core @keystatic/astro
+  pnpm add @keystatic/core @keystatic/astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/en/guides/cms/kontent-ai.mdx
@@ -64,7 +64,7 @@ To connect Astro with your Kontent.ai project, install the [Kontent.ai TypeScrip
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/delivery-sdk
+    pnpm add @kontent-ai/delivery-sdk
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -206,7 +206,7 @@ First, install the [Kontent.ai JS model generator](https://github.com/kontent-ai
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/model-generator ts-node dotenv
+    pnpm add @kontent-ai/model-generator ts-node dotenv
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -58,7 +58,7 @@ To connect Astro with your Storyblok space, install the official [Storyblok inte
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @storyblok/astro vite
+  pnpm add @storyblok/astro vite
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/configuring-astro.mdx
+++ b/src/content/docs/en/guides/configuring-astro.mdx
@@ -154,7 +154,7 @@ You can also use [Vite's `loadEnv` helper](https://main.vitejs.dev/config/#using
 :::note
 `pnpm` does not allow you to import modules that are not directly installed in your project. If you are using `pnpm`, you will need to install `vite` to use the `loadEnv` helper.
 ```sh
-pnpm install vite --save-dev
+pnpm add vite --save-dev
 ```
 :::
 

--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -60,7 +60,7 @@ After your assets are uploaded, Wrangler will give you a preview URL to inspect 
 For the preview to work, you must install `wrangler`
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 It's then possible to update the preview script to run `wrangler` instead of Astro’s built-in preview command:

--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -60,7 +60,7 @@ The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts 
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -656,7 +656,7 @@ If the image is merely decorative (i.e. doesn’t contribute to the understandin
 When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -656,7 +656,7 @@ If the image is merely decorative (i.e. doesn’t contribute to the understandin
 When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
 
 ```bash
-pnpm add sharp
+pnpm install sharp
 ```
 :::
 

--- a/src/content/docs/en/guides/rss.mdx
+++ b/src/content/docs/en/guides/rss.mdx
@@ -24,7 +24,7 @@ The package [`@astrojs/rss`](https://github.com/withastro/astro/tree/main/packag
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -111,7 +111,7 @@ You can also add an adapter manually by installing the package and updating `ast
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/my-adapter
+     pnpm add @astrojs/my-adapter
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -44,7 +44,7 @@ If you are not using VSCode, you can install the [Astro TypeScript plugin](https
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/ts-plugin
+  pnpm add @astrojs/ts-plugin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ Update your project's version of Astro to the latest version using your package 
   <Fragment slot="pnpm">
   ```shell
   # Upgrade to Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Example: upgrade React and Tailwind integrations
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ Update your project's version of Astro to the latest version using your package 
   <Fragment slot="pnpm">
   ```shell
   # Upgrade to Astro v3.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Example: upgrade React and Tailwind integrations
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -529,7 +529,7 @@ Astro v3.0 now includes Sharp as the default image processing service and instea
 When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/en/install/manual.mdx
+++ b/src/content/docs/en/install/manual.mdx
@@ -71,7 +71,7 @@ Astro must be installed locally, not globally. Make sure you are *not* running `
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm add astro
+  pnpm install astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/install/manual.mdx
+++ b/src/content/docs/en/install/manual.mdx
@@ -71,7 +71,7 @@ Astro must be installed locally, not globally. Make sure you are *not* running `
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -23,7 +23,7 @@ Learn how to build a [remark plugin](https://github.com/remarkjs/remark) that ad
      </Fragment>
      <Fragment slot="pnpm">
        ```shell
-       pnpm install dayjs
+       pnpm add dayjs
        ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -25,7 +25,7 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-   pnpm install reading-time mdast-util-to-string
+   pnpm add reading-time mdast-util-to-string
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/en/recipes/sharing-state.mdx
+++ b/src/content/docs/en/recipes/sharing-state.mdx
@@ -25,7 +25,7 @@ When building an Astro website, you may need to share state across components. A
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm install nanostores
+    pnpm add nanostores
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1183,7 +1183,7 @@ To use the `Prism` highlighter component, first **install** the `@astrojs/prism`
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/prism
+  pnpm add @astrojs/prism
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/4.mdx
@@ -38,7 +38,7 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -110,10 +110,10 @@ The steps below show you how to extend the final product of the Build a Blog tut
       <Fragment slot="pnpm">
       ```shell
       # Upgrade to Astro v3.x
-      pnpm install astro@latest
+      pnpm add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration
-      pnpm install @astrojs/preact@latest
+      pnpm add @astrojs/preact@latest
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -116,10 +116,10 @@ The steps below show you how to extend the final product of the Build a Blog tut
       <Fragment slot="pnpm">
       ```shell
       # Upgrade to Astro v3.x
-      pnpm install astro@latest
+      pnpm add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration
-      pnpm install @astrojs/preact@latest
+      pnpm add @astrojs/preact@latest
       ```
       </Fragment>
       <Fragment slot="yarn">


### PR DESCRIPTION
#### Description

I found that many package installation snippets use `pnpm install <pkg>` instead of `pnpm add <pkg>`.

According to pnpm's documentation:
- [`pnpm install`](https://pnpm.io/cli/install) is used for installing **all** dependencies for a project
- [`pnpm add <pkg>`](https://pnpm.io/cli/add) is used for installing certain package(s)

This PR changes those to the latter ✍️

#### Related issues & labels

- Suggested label: code snippet update
