### PR TITLE
fix: broken link in `reference/image-service-reference`

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -62,7 +62,7 @@ export default service;
 
 ### Local Services
 
-To create your own local service, you can point to the [built-in endpoint](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/image-endpoint.ts) (`/_image`), or you can additionally create your own endpoint that can call the service's methods.
+To create your own local service, you can point to the [built-in endpoint](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/endpoint/generic.ts) (`/_image`), or you can additionally create your own endpoint that can call the service's methods.
 
 ```js
 import type { LocalImageService, AstroConfig } from "astro";


### PR DESCRIPTION
### Description

Hi, [this section](https://docs.astro.build/en/reference/image-service-reference/#local-services) links to a file that was moved in this [PR](https://github.com/withastro/astro/commit/47ea310f01d06ed1562c790bec348718a2fa8277#diff-21b2586f5098a49b303cfb11dc00fb9ba1083168994d488f6bac1243b8d29253)


broken url:
https://github.com/withastro/astro/blob/main/packages/astro/src/assets/image-endpoint.ts

new url:
https://github.com/withastro/astro/blob/main/packages/astro/src/assets/endpoint/generic.ts



