### PR TITLE
Fix typo in installing tailwind typography and trim tail spaces

### DIFF
--- a/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
+++ b/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
@@ -13,9 +13,9 @@ This recipe will teach you how to create a reusable Astro component to style you
 
 ## Prerequisites
 
-An Astro project that:  
+An Astro project that:
 
-	- has [Astro's Tailwind integration](/en/guides/integrations-guide/tailwind/) installed.  
+	- has [Astro's Tailwind integration](/en/guides/integrations-guide/tailwind/) installed.
 	- uses Astro's [content collections](/en/guides/content-collections/).
 
 ## Setting Up `@tailwindcss/typography`
@@ -30,7 +30,7 @@ First, install `@tailwindcss/typography` using your preferred package manager.
 	</Fragment>
   	<Fragment slot="pnpm">
 	```shell 
-	pnpm install -D @tailwindcss/typography
+	pnpm add -D @tailwindcss/typography
 	```
 	</Fragment>
   	<Fragment slot="yarn">
@@ -59,7 +59,7 @@ export default {
 
 ## Recipe
 
-1. Create a `<Prose /> ` component to provide a wrapping `<div>` with a `<slot />` for your rendered Markdown. Add the style class `prose` alongside any desired [Tailwind element modifiers](https://tailwindcss.com/docs/typography-plugin#element-modifiers) in the parent element.   
+1. Create a `<Prose /> ` component to provide a wrapping `<div>` with a `<slot />` for your rendered Markdown. Add the style class `prose` alongside any desired [Tailwind element modifiers](https://tailwindcss.com/docs/typography-plugin#element-modifiers) in the parent element.
 
     ```astro title="src/components/Prose.astro"
     ---


### PR DESCRIPTION
#### Description (required)

- fix `pnpm install -D` to `pnpm add -D`
- trim some tail spaces

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
