### PR TITLE
Refactor Configuration Reference docgen script

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import fs from 'fs';
 import jsdoc from 'jsdoc-api';
 import fetch from 'node-fetch';
@@ -42,24 +44,28 @@ const FOOTER = ``;
 export async function run() {
 	const sourceBranch = process.env.SOURCE_BRANCH || 'main';
 	const sourceRepo = process.env.SOURCE_REPO || 'withastro/astro';
+
+	let task = 'Fetch `@types/astro.ts` from ' + sourceRepo + '#' + sourceBranch;
+	console.time(task);
+
 	const inputBuffer =
 		STUB ||
 		(await fetch(
 			`https://raw.githubusercontent.com/${sourceRepo}/${sourceBranch}/packages/astro/src/%40types/astro.ts`
 		).then((r) => r.text()));
 
+	console.timeEnd(task);
+	task = 'Parse types and generate configuration reference';
+	console.time(task);
+
 	// Get all `@docs` JSDoc comments in the file.
 	const allComments = [
-		...inputBuffer.matchAll(/\/\*\*\s*\n([^\*]|\*[^\/])*@docs([^\*]|\*[^\/])*\*\//g),
+		...inputBuffer.matchAll(/\/\*\*\s*\n([^*]|\*[^/])*@docs([^*]|\*[^/])*\*\//g),
 	];
 	const allCommentsInput = allComments
 		.map((m) => m[0])
 		.filter((c) => c.includes('* @docs'))
 		.join('\n\n');
-
-	console.log(jsdoc);
-	console.log(allCommentsInput);
-	console.log(jsdoc.explainSync({ source: allCommentsInput }));
 
 	const allParsedComments = jsdoc
 		.explainSync({ source: allCommentsInput })
@@ -68,60 +74,67 @@ export async function run() {
 	let result = ``;
 
 	for (const comment of allParsedComments) {
-		if (comment.kind === 'heading') {
-			result += `## ${comment.name}\n\n`;
-			if (comment.description) {
-				result += comment.description.trim() + '\n\n';
-			}
-			continue;
-		}
-		const cliFlag = comment.tags.find((f) => f.title === 'cli');
-		const typerawFlag = comment.tags.find((f) => f.title === 'typeraw');
 		if (!comment.name) {
 			throw new Error(`Missing @docs JSDoc tag: @name`);
 		}
-		if (!comment.type && !typerawFlag) {
-			throw new Error(`Missing @docs JSDoc tag: @type or @typeraw`);
-		}
-		const typesFormatted = typerawFlag
-			? typerawFlag.text.replace(/\{(.*)\}/, '$1')
-			: comment.type.names.join(' | ');
+
 		result += [
-			`### ${comment.longname}`,
-			``,
+			getHeading(comment),
 			getDeprecatedAside(comment.deprecated),
-			`<p>`,
-			``,
-			[
-				`**Type:** \`${typesFormatted}\``,
-				cliFlag ? `**CLI:** \`${cliFlag.text}\`` : undefined,
-				comment.defaultvalue ? `**Default:** ${comment.defaultvalue}` : undefined,
-				comment.version ? `<Since v="${comment.version}" />` : undefined,
-			]
-				.filter((l) => l !== undefined)
-				.join('<br />\n'),
-			`</p>`,
-			``,
-			comment.description && comment.description.trim(),
+			getCommentProperties(comment),
+			comment.description?.trim() || undefined,
 			comment.see
 				? `**See Also:**\n${comment.see.map((s) => `- ${s}`.trim()).join('\n')}`
 				: undefined,
-			`\n\n`,
+			`\n`,
 		]
 			.filter((l) => l !== undefined)
 			.join('\n');
 	}
 
+	// Make any links to docs relative instead of absolute.
 	result = result.replace(/https:\/\/docs\.astro\.build\//g, '/');
 
-	console.log(result);
+	console.timeEnd(task);
+	task = 'Update configuration-reference.mdx';
+	console.time(task);
+
 	fs.writeFileSync(
 		'src/content/docs/en/reference/configuration-reference.mdx',
 		HEADER + result + FOOTER,
 		'utf8'
 	);
+
+	console.timeEnd(task);
 }
 
+/**
+ * Create a string of ### to create a Markdown heading for the given level.
+ * @param {number} headingLevel
+ */
+function h(headingLevel) {
+	return Array.from({ length: headingLevel }).fill('#').join('');
+}
+
+/**
+ * Get a Markdown heading of the correct level for this comment.
+ * @param {{ kind: string | undefined; longname: string }} comment
+ */
+function getHeading(comment) {
+	let headingLevel = 3;
+	const headingMatches = /^h(1|2|3|4|5|6)$/.exec(comment.kind || '');
+	if (headingMatches) {
+		headingLevel = parseInt(headingMatches[1]);
+	} else if (comment.kind === 'heading') {
+		headingLevel = 2;
+	}
+	return `${h(headingLevel)} ${comment.longname}\n`;
+}
+
+/**
+ * Get a `:::caution` block if the passed tag is deprecated.
+ * @param {string | undefined} tag
+ */
 function getDeprecatedAside(tag) {
 	if (!tag) return undefined;
 	return [
@@ -131,6 +144,33 @@ function getDeprecatedAside(tag) {
 		':::',
 		'',
 	].join('\n');
+}
+
+/**
+ * Get block of type, CLI command, default value, and version added in for the current comment.
+ * @param {{ tags: { title: string; text: string }[]; kind: string; type?: { names: string [] }; defaultvalue?: string; version?: string }} comment
+ */
+function getCommentProperties(comment) {
+	const cliFlag = comment.tags.find((f) => f.title === 'cli');
+	const typerawFlag = comment.tags.find((f) => f.title === 'typeraw');
+
+	if (comment.kind !== 'heading' && !comment.type && !typerawFlag) {
+		throw new Error(`Missing @docs JSDoc tag: @type or @typeraw`);
+	}
+	const typesFormatted = typerawFlag
+		? typerawFlag.text.replace(/\{(.*)\}/, '$1')
+		: comment.type?.names.join(' | ');
+
+	const properties = [
+		typesFormatted ? `**Type:** \`${typesFormatted}\`` : undefined,
+		cliFlag ? `**CLI:** \`${cliFlag.text}\`` : undefined,
+		comment.defaultvalue ? `**Default:** ${comment.defaultvalue}` : undefined,
+		comment.version ? `<Since v="${comment.version}" />` : undefined,
+	]
+		.filter((l) => l !== undefined)
+		.join('<br />\n');
+
+	return properties.length ? ['<p>', '', properties, '</p>', ''].join('\n') : undefined;
 }
 
 run();

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -26,6 +26,7 @@ export default defineConfig({
 ```
 ## Top-Level Options
 
+
 ### root
 
 <p>
@@ -50,7 +51,6 @@ If you provide a relative path (ex: `--root: './my-project'`) Astro will resolve
 $ astro build --root ./my-project-directory
 ```
 
-
 ### srcDir
 
 <p>
@@ -69,7 +69,6 @@ The value can be either an absolute file system path or a path relative to the p
 }
 ```
 
-
 ### publicDir
 
 <p>
@@ -87,7 +86,6 @@ The value can be either an absolute file system path or a path relative to the p
   publicDir: './my-custom-publicDir-directory'
 }
 ```
-
 
 ### outDir
 
@@ -109,7 +107,6 @@ The value can be either an absolute file system path or a path relative to the p
 **See Also:**
 - build.server
 
-
 ### cacheDir
 
 <p>
@@ -127,7 +124,6 @@ The value can be either an absolute file system path or a path relative to the p
   cacheDir: './my-custom-cache-directory'
 }
 ```
-
 
 ### redirects
 
@@ -175,73 +171,6 @@ You can customize the [redirection status code](https://developer.mozilla.org/en
 }
 ```
 
-
-### prefetch
-
-<p>
-
-**Type:** `boolean | object`
-</p>
-
-Enable prefetching for links on your site to provide faster page transitions.
-(Enabled by default on pages using the `<ViewTransitions />` router. Set `prefetch: false` to opt out of this behaviour.)
-
-This configuration automatically adds a prefetch script to every page in the project
-giving you access to the `data-astro-prefetch` attribute.
-Add this attribute to any `<a />` link on your page to enable prefetching for that page.
-
-```html
-<a href="/about" data-astro-prefetch>About</a>
-```
-Further customize the default prefetching behavior using the [`prefetch.defaultStrategy`](#prefetchdefaultstrategy) and [`prefetch.prefetchAll`](#prefetchprefetchall) options.
-
-See the [Prefetch guide](/en/guides/prefetch/) for more information.
-
-
-### prefetch.prefetchAll
-
-<p>
-
-**Type:** `boolean`
-</p>
-
-Enable prefetching for all links, including those without the `data-astro-prefetch` attribute.
-This value defaults to `true` when using the `<ViewTransitions />` router. Otherwise, the default value is `false`.
-
-```js
-prefetch: {
-	prefetchAll: true
-}
-```
-
-When set to `true`, you can disable prefetching individually by setting `data-astro-prefetch="false"` on any individual links.
-
-```html
-<a href="/about" data-astro-prefetch="false">About</a>
-```
-
-
-### prefetch.defaultStrategy
-
-<p>
-
-**Type:** `'tap' | 'hover' | 'viewport'`<br />
-**Default:** `'hover'`
-</p>
-
-The default prefetch strategy to use when the `data-astro-prefetch` attribute is set on a link with no value.
-
-- `'tap'`: Prefetch just before you click on the link.
-- `'hover'`: Prefetch when you hover over or focus on the link. (default)
-- `'viewport'`: Prefetch as the links enter the viewport.
-
-You can override this default value and select a different strategy for any individual link by setting a value on the attribute.
-
-```html
-<a href="/about" data-astro-prefetch="viewport">About</a>
-```
-
-
 ### site
 
 <p>
@@ -256,7 +185,6 @@ Your final, deployed URL. Astro uses this full URL to generate your sitemap and 
   site: 'https://www.my-site.dev'
 }
 ```
-
 
 ### compressHTML
 
@@ -274,7 +202,6 @@ To disable HTML compression, set the `compressHTML` flag to `false`.
   compressHTML: false
 }
 ```
-
 
 ### base
 
@@ -318,7 +245,6 @@ In the example below, the values of `import.meta.env.BASE_URL` and `config.base`
 }
 ```
 
-
 ### trailingSlash
 
 <p>
@@ -345,7 +271,6 @@ You can also set this if you prefer to be more strict yourself, so that URLs wit
 **See Also:**
 - build.format
 
-
 ### scopedStyleStrategy
 
 <p>
@@ -363,7 +288,6 @@ Specify the strategy used for scoping styles within Astro components. Choose fro
 Using `'class'` is helpful when you want to ensure that element selectors within an Astro component override global style defaults (e.g. from a global stylesheet).
 Using `'where'` gives you more control over specificity, but requires that you use higher-specificity selectors, layers, and other tools to control which selectors are applied.
 Using `'attribute'` is useful when you are manipulating the `class` attribute of elements and need to avoid conflicts between your own styling logic and Astro's application of styles.
-
 
 ### adapter
 
@@ -385,7 +309,6 @@ import netlify from '@astrojs/netlify/functions';
 ```
 **See Also:**
 - output
-
 
 ### output
 
@@ -411,8 +334,8 @@ export default defineConfig({
 **See Also:**
 - adapter
 
-
 ## Build Options
+
 
 ### build.format
 
@@ -446,7 +369,6 @@ To prevent inconsistencies with trailing slash behaviour in dev, you can restric
 - `directory` - Set `trailingSlash: 'always'`
 - `file` - Set `trailingSlash: 'never'`
 
-
 ### build.client
 
 <p>
@@ -469,7 +391,6 @@ This value is relative to the `outDir`.
 }
 ```
 
-
 ### build.server
 
 <p>
@@ -489,7 +410,6 @@ This value is relative to the `outDir`.
   }
 }
 ```
-
 
 ### build.assets
 
@@ -511,7 +431,6 @@ Specifies the directory in the build output where Astro-generated assets (bundle
 ```
 **See Also:**
 - outDir
-
 
 ### build.assetsPrefix
 
@@ -537,7 +456,6 @@ To rename the `_astro` path, specify a new directory in `build.assets`.
 }
 ```
 
-
 ### build.serverEntry
 
 <p>
@@ -560,7 +478,6 @@ detects that the file is a JavaScript module.
   }
 }
 ```
-
 
 ### build.redirects
 
@@ -586,7 +503,6 @@ configuration files for redirects and do not need/want HTML based redirects.
 }
 ```
 
-
 ### build.inlineStylesheets
 
 <p>
@@ -609,7 +525,6 @@ Control whether project styles are sent to the browser in a separate css file or
 }
 ```
 
-
 ### build.split
 
 
@@ -626,7 +541,6 @@ Deprecated since version 3.0.
 The build config option `build.split` has been replaced by the adapter configuration option [`functionPerRoute`](/en/reference/adapter-reference/#functionperroute).
 
 Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `functionPerRoute` to define how your SSR code is bundled.
-
 
 ### build.excludeMiddleware
 
@@ -645,6 +559,68 @@ The build config option `build.excludeMiddleware` has been replaced by the adapt
 
 Please see your [SSR adapter's documentation](/en/guides/integrations-guide/#official-integrations) for using `edgeMiddleware` to define whether or not any SSR middleware code will be bundled when built.
 
+## Prefetch Options
+
+<p>
+
+**Type:** `boolean | object`
+</p>
+
+Enable prefetching for links on your site to provide faster page transitions.
+(Enabled by default on pages using the `<ViewTransitions />` router. Set `prefetch: false` to opt out of this behaviour.)
+
+This configuration automatically adds a prefetch script to every page in the project
+giving you access to the `data-astro-prefetch` attribute.
+Add this attribute to any `<a />` link on your page to enable prefetching for that page.
+
+```html
+<a href="/about" data-astro-prefetch>About</a>
+```
+Further customize the default prefetching behavior using the [`prefetch.defaultStrategy`](#prefetchdefaultstrategy) and [`prefetch.prefetchAll`](#prefetchprefetchall) options.
+
+See the [Prefetch guide](/en/guides/prefetch/) for more information.
+
+### prefetch.prefetchAll
+
+<p>
+
+**Type:** `boolean`
+</p>
+
+Enable prefetching for all links, including those without the `data-astro-prefetch` attribute.
+This value defaults to `true` when using the `<ViewTransitions />` router. Otherwise, the default value is `false`.
+
+```js
+prefetch: {
+	prefetchAll: true
+}
+```
+
+When set to `true`, you can disable prefetching individually by setting `data-astro-prefetch="false"` on any individual links.
+
+```html
+<a href="/about" data-astro-prefetch="false">About</a>
+```
+
+### prefetch.defaultStrategy
+
+<p>
+
+**Type:** `'tap' | 'hover' | 'viewport'`<br />
+**Default:** `'hover'`
+</p>
+
+The default prefetch strategy to use when the `data-astro-prefetch` attribute is set on a link with no value.
+
+- `'tap'`: Prefetch just before you click on the link.
+- `'hover'`: Prefetch when you hover over or focus on the link. (default)
+- `'viewport'`: Prefetch as the links enter the viewport.
+
+You can override this default value and select a different strategy for any individual link by setting a value on the attribute.
+
+```html
+<a href="/about" data-astro-prefetch="viewport">About</a>
+```
 
 ## Server Options
 
@@ -679,7 +655,6 @@ Set which network IP addresses the server should listen on (i.e. non-localhost I
 - `true` - listen on all addresses, including LAN and public addresses
 - `[custom-address]` - expose on a network IP address at `[custom-address]` (ex: `192.168.0.1`)
 
-
 ### server.port
 
 <p>
@@ -698,7 +673,6 @@ If the given port is already in use, Astro will automatically try the next avail
 }
 ```
 
-
 ### server.headers
 
 <p>
@@ -710,8 +684,8 @@ If the given port is already in use, Astro will automatically try the next avail
 
 Set custom HTTP response headers to be sent in `astro dev` and `astro preview`.
 
-
 ## Image Options
+
 
 ### image.endpoint
 
@@ -734,7 +708,6 @@ The endpoint will always be injected at `/_image`.
   },
 }
 ```
-
 
 ### image.service
 
@@ -760,7 +733,6 @@ The service entrypoint can be either one of the included services, or a third-pa
 }
 ```
 
-
 ### image.domains
 
 <p>
@@ -783,7 +755,6 @@ This option requires an array of individual domain names as strings. Wildcards a
   },
 }
 ```
-
 
 ### image.remotePatterns
 
@@ -823,8 +794,8 @@ You can use wildcards to define the permitted `hostname` and `pathname` values a
   - End with '/**' to allow all sub-routes ('startsWith').
   - End with '/*' to allow only one level of sub-route.
 
-
 ## Markdown Options
+
 
 ### markdown.drafts
 
@@ -852,7 +823,6 @@ A Markdown page is considered a draft if it includes `draft: true` in its frontm
 }
 ```
 
-
 ### markdown.shikiConfig
 
 <p>
@@ -861,7 +831,6 @@ A Markdown page is considered a draft if it includes `draft: true` in its frontm
 </p>
 
 Shiki configuration options. See [the Markdown configuration docs](/en/guides/markdown-content/#shiki-configuration) for usage.
-
 
 ### markdown.syntaxHighlight
 
@@ -885,7 +854,6 @@ Which syntax highlighter to use, if any.
 }
 ```
 
-
 ### markdown.remarkPlugins
 
 <p>
@@ -904,7 +872,6 @@ import remarkToc from 'remark-toc';
 }
 ```
 
-
 ### markdown.rehypePlugins
 
 <p>
@@ -922,7 +889,6 @@ import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
   }
 }
 ```
-
 
 ### markdown.gfm
 
@@ -943,7 +909,6 @@ Astro uses [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) by
 }
 ```
 
-
 ### markdown.smartypants
 
 <p>
@@ -963,7 +928,6 @@ Astro uses the [SmartyPants formatter](https://daringfireball.net/projects/smart
 }
 ```
 
-
 ### markdown.remarkRehype
 
 <p>
@@ -981,7 +945,6 @@ Pass options to [remark-rehype](https://github.com/remarkjs/remark-rehype#api).
   },
 };
 ```
-
 
 ## Integrations
 
@@ -1059,7 +1022,6 @@ Enable hoisted script analysis optimization by adding the experimental flag:
 }
 ```
 
-
 ### experimental.devOverlay
 
 <p>
@@ -1079,7 +1041,6 @@ Enable a dev overlay in development mode. This overlay allows you to inspect you
 }
 ```
 
-
 ### experimental.i18n
 
 <p>
@@ -1092,8 +1053,7 @@ Configures experimental i18n routing and allows you to specify some customizatio
 
 See our guide for more information on [internationalization in Astro](/en/guides/internationalization/)
 
-
-### experimental.i18n.defaultLocale
+#### experimental.i18n.defaultLocale
 
 <p>
 
@@ -1105,8 +1065,7 @@ The default locale of your website/application. This is a required field.
 
 No particular language format or syntax is enforced, but we suggest using lower-case and hyphens as needed (e.g. "es", "pt-br") for greatest compatibility.
 
-
-### experimental.i18n.locales
+#### experimental.i18n.locales
 
 <p>
 
@@ -1118,8 +1077,7 @@ A list of all locales supported by the website (e.g. `['en', 'es', 'pt-br']`). T
 
 No particular language format or syntax is enforced, but your folder structure must match exactly the locales in the list.
 
-
-### experimental.i18n.fallback
+#### experimental.i18n.fallback
 
 <p>
 
@@ -1150,8 +1108,7 @@ export defualt defineConfig({
 })
 ```
 
-
-### experimental.i18n.routingStrategy
+#### experimental.i18n.routingStrategy
 
 <p>
 
@@ -1168,7 +1125,6 @@ Controls the routing strategy to determine your site URLs. Set this based on you
  - `prefix-always`: All URLs will display a language prefix.
    URLs will be of the form `example.com/[locale]/content/` for every route, including the default language.
    Localized folders are used for every language, including the default.
-
 
 ### experimental.contentCollectionCache
 
@@ -1188,5 +1144,4 @@ Enables a persistent cache for content collections when building in static mode.
 	},
 }
 ```
-
 


### PR DESCRIPTION
#### Description (required)

- Updates our configuration reference generation script to add support for `@kind h4` (and other heading levels) in addition to our existing `@kind heading` support.
- Accompanies https://github.com/withastro/astro/pull/9052 and already includes a preview of what those updates would look like with this new version of the script.
- Also refactored this script a bunch because it was kind of gnarly how some of that was written.
