### PR TITLE
Tina CMS: clarify admin folder info

### DIFF
--- a/src/content/docs/en/guides/cms/tina-cms.mdx
+++ b/src/content/docs/en/guides/cms/tina-cms.mdx
@@ -12,7 +12,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 ## Integrating with Astro
 
-To get started, you'll need an existing Astro project. 
+To get started, you'll need an existing Astro project.
 
 1. Run the following command to install Tina into your Astro project.
 
@@ -38,8 +38,8 @@ To get started, you'll need an existing Astro project.
     - When prompted "What framework are you using", choose **Other**.
     - When asked where public assets are stored, press <kbd>Enter</kbd>.
 
-    After this has finished, you should now have a `.tina` folder in the root of your project and an `admin` folder in your public directory. It will also create a Markdown file at `content/posts/hello-world.md`.
- 
+    After this has finished, you should now have a `.tina` folder in the root of your project and a generated `hello-world.md` file at `content/posts`.
+
 2. Change  the `dev` script in `package.json`:
 
     <PackageManagerTabs>
@@ -132,7 +132,7 @@ To get started, you'll need an existing Astro project.
                 name: "body",
                 label: "Body",
                 isBody: true,
-              },  
+              },
             ],
           },
         ],
@@ -148,7 +148,7 @@ To get started, you'll need an existing Astro project.
 
 - [TinaCMS Astro integration guide](https://tina.io/docs/frameworks/astro/).
 
-## Community Resources 
+## Community Resources
 
 - [Astro Tina Starter with visual editing](https://github.com/dawaltconley/tina-astro) by Jeff See + Dylan Awalt-Conley
 - [Astro Tina Starter with basic editing](https://github.com/tombennet/astro-tina-starter/tree/main) by Tom Bennet


### PR DESCRIPTION
#### Description (required)
Before the change, docs in `tina-cms.mdx` stated that after executing `yarn dlx @tinacms/cli@latest init` one should be able to see the `admin` folder in the root of the project - that doesn't happen until execution of the updated `dev` script.

#### Related issues & labels (optional)
- Suggested label: [improve documentation](https://github.com/withastro/docs/labels/improve%20documentation)
