### PR TITLE
Mention shikiji in Markdown & MDX page

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -570,7 +570,7 @@ export default defineConfig({
 
 ### Syntax Highlighting
 
-Astro comes with built-in support for [Shiki](https://shiki.matsu.io/) and [Prism](https://prismjs.com/). This provides syntax highlighting for:
+Astro comes with built-in support for [Shiki](https://shiki.matsu.io/) (via [Shikiji](https://github.com/antfu/shikiji)) and [Prism](https://prismjs.com/). This provides syntax highlighting for:
 
 - all code fences (\`\`\`) used in a Markdown or MDX file.
 - content within the [built-in `<Code />` component](/en/reference/api-reference/#code-) (powered by Shiki).


### PR DESCRIPTION
Mention shikiji in *Markdown & MDX* page, because astro uses shikiji since pull [#8502](https://github.com/withastro/astro/pull/8502)
