### PR TITLE
[i18nIgnore] remove unused import in content collections guide

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -7,7 +7,6 @@ i18nReady: true
 ---
 import FileTree from '~/components/FileTree.astro'
 import Since from '~/components/Since.astro'
-import TypeScriptSettingTabs from '~/components/tabs/TypeScriptSettingTabs.astro'
 import RecipeLinks from "~/components/RecipeLinks.astro"
 import Badge from "~/components/Badge.astro"
 


### PR DESCRIPTION
#### Description (required)

Removed unused import in `content-collections`

#### Related issues & labels (optional)

- Suggested label: i18n