### PR TITLE
i18n(es): Fix typo in `tutorial`

### DIFF
--- a/src/content/docs/es/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/es/tutorial/5-astro-api/2.mdx
@@ -268,7 +268,7 @@ const { posts } = Astro.props;
 
 Ahora, deberías poder visitar cualquiera de tus páginas de etiquetas en la vista previa de tu navegador.
 
-Navega a `http://localhost:4321/tags/community` y verás una lista sólo de las entradas de tu blog con la etiqueta `comunidad`. Del mismo modo, `http://localhost:4321/tags/aprender%20en%20público` debería mostrar una lista de las entradas del blog con la etiqueta `aprender en público`.
+Navega a `http://localhost:4321/tags/comunidad` y verás una lista sólo de las entradas de tu blog con la etiqueta `comunidad`. Del mismo modo, `http://localhost:4321/tags/aprender%20en%20público` debería mostrar una lista de las entradas del blog con la etiqueta `aprender en público`.
 
 En la siguiente sección, crearás enlaces de navegación a estas páginas.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In the translation of the tags the link would be pointing to a non-existent page. To solve this I have translated the URL tag.


