### PR TITLE
Remove experimental badge from the Picture component

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -279,7 +279,7 @@ const {src, ...attrs} = Astro.props;
 
 ### `<Picture />`
 
-<Since v="3.3.0" /> <Badge>Experimental</Badge>
+<Since v="3.3.0" />
 
 Use the built-in `<Picture />` Astro component to display a responsive image with multiple formats and/or sizes.
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1245,7 +1245,7 @@ See more in the [Images Guide](/en/guides/images/#image--astroassets).
 
 ### `<Picture />`
 
-<Since v="3.3.0" /> <Badge>Experimental</Badge>
+<Since v="3.3.0" />
 
 Use the built-in `<Picture />` Astro component to display a responsive image with multiple formats and/or sizes.
 


### PR DESCRIPTION

#### Description (required)

Remove experimental flag from the Picture component.

#### Related issues & labels (optional)

#### For Astro version: `3.6`.
