### PR TITLE
Fix broken import statement in server-side-rendering.mdx

### DIFF
--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -171,7 +171,7 @@ For example, to install the Vercel adapter manually:
     ```js ins={3,7} {6}
     // astro.config.mjs
     import { defineConfig } from 'astro/config';
-    import vercel from '@astrojs/vercel';
+    import vercel from '@astrojs/vercel/serverless';
 
     export default defineConfig({
       output: 'server',


### PR DESCRIPTION
#### Description

This PR fixes the broken import statement in the [Manual Install](https://docs.astro.build/en/guides/server-side-rendering/#manual-install) section of [On⁠-⁠demand Rendering Adapters](https://docs.astro.build/en/guides/server-side-rendering).

It causes an error when starting the development server.

```
[astro] Unable to load your Astro config

 error   Failed to resolve entry for package "@astrojs/vercel". The package may have incorrect main/module/exports specified in its package.json: Missing "." specifier in "@astrojs/vercel" package
```

#### Related issues & labels

- Suggested label: code snippet update
