### PR TITLE
i18n(fr) Create `astro-glob-no-match.mdx`

### DIFF
--- a/src/content/docs/fr/errors/astro-glob-no-match.mdx
+++ b/src/content/docs/fr/errors/astro-glob-no-match.mdx
@@ -1,5 +1,5 @@
 ---
-title: Astro.glob() did not match any files.
+title: Astro.glob() ne correspond à aucun fichier
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---

--- a/src/content/docs/fr/errors/astro-glob-no-match.mdx
+++ b/src/content/docs/fr/errors/astro-glob-no-match.mdx
@@ -1,0 +1,14 @@
+---
+title: Astro.glob() did not match any files.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+> **AstroGlobNoMatch**: `Astro.glob(GLOB_STR)` did not return any matching files. Check the pattern for typos.
+
+## Qu'est-ce qui n'a pas fonctionné ?
+`Astro.glob()` n'a retourné aucun fichier correspondant. Il se peut qu'il y ait une faute de frappe dans le pattern glob.
+
+**Voir aussi:**
+-  [Astro.glob](/fr/reference/api-reference/#astroglob)


### PR DESCRIPTION
#### Description (required)

Add french translation for astro-glob-no-match.mdx file
