### PR TITLE
fix: Two little v3.6 typos

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -492,7 +492,7 @@ An event that fires at the beginning of the preparation phase, after navigation 
 
 This event is used:
 
-- To do something before loading has started, such as showing an a loading spinner.
+- To do something before loading has started, such as showing a loading spinner.
 - To alter loading, such as loading content you've defined in a template rather than from the external URL.
 - To change the `direction` of the navigation (which is usually either `forward` or `backward`) for custom animation.
 
@@ -576,7 +576,7 @@ An event that fires immediately after the new page replaces the old page. You ca
 
 This event, when listened to on the **outgoing page**, is useful to pass along and restore any state on the DOM that needs to transfer over to the new page.
 
-This is the latest point in the lifecyle where it is still safe to, for example, add a dark mode class name (`<html class="dark-mode">`), though you may wish to do so in an earlier event.
+This is the latest point in the lifecycle where it is still safe to, for example, add a dark mode class name (`<html class="dark-mode">`), though you may wish to do so in an earlier event.
 
 The `astro:after-swap` event occurs immediately after the browser history has been updated and the scroll position has been set. 
 Therefore, one use of targeting this event is to override the default scroll restore for history navigation. The following example resets the horizontal and vertical scroll position to the top left corner of the page for each navigation. 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Spotted two small typos in the new View Transitions docs for 3.6! This fixes them.
