### PR TITLE
Simplify robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,5 +1,0 @@
-export function GET() {
-	return {
-		body: 'User-agent: *\nAllow: /',
-	};
-}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`robots.txt` can be a simple file in `/public` rather than an endpoint. This also unblocks https://github.com/withastro/astro/pull/9181 which we'll be removing support for returning simple objects from endpoints. 

#### Related issues & labels (optional)

- Closes n/a
- Suggested label: n/a


