### PR TITLE
Add missing `sizes` attribute to Image's widths example

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -193,7 +193,12 @@ Widths that are larger than the original image will be ignored to avoid upscalin
 import { Image } from 'astro:assets';
 import myImage from "../assets/my_image.png"; // Image is 1600x900
 ---
-<Image src={myImage} widths={[240, 540, 720, myImage.width]} alt="A description of my image." />
+<Image
+  src={myImage}
+  widths={[240, 540, 720, myImage.width]}
+  sizes={`(max-width: 360px) 240px, (max-width: 720px) 540px, (max-width: 1600px) 720px, ${myImage.width}px`}
+  alt="A description of my image."
+/>
 ```
 
 ```html
@@ -204,6 +209,12 @@ import myImage from "../assets/my_image.png"; // Image is 1600x900
     /_astro/my_image.hash.webp 540w,
     /_astro/my_image.hash.webp 720w,
 		/_astro/my_image.hash.webp 1600w
+  "
+  sizes="
+    (max-width: 360px) 240px,
+    (max-width: 720px) 540px,
+    (max-width: 1600px) 720px,
+    1600px
   "
   alt="A description of my image."
   width="1600"


### PR DESCRIPTION
#### Description

This PR adds the missing `sizes` attribute to Image's widths example.

#### Related issues & labels

- Closes #5473
- Suggested label: code snippet update
