### PR TITLE
Fix typo in code example

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -574,7 +574,7 @@ See also: [Astro.site](#astrosite)
 ```ts title="src/pages/site-info.json.ts"
 import type { APIContext } from 'astro';
 
-export function GET{ generator, site }: APIContext) {
+export function GET({ generator, site }: APIContext) {
   const body = JSON.stringify({ generator, site });
   return new Response(body);
 }


### PR DESCRIPTION
#### Description (required)

Add the missing '(' in function definition on code example.