### PR TITLE
i18n(zh-CN): Update why-astro.mdx, and 10 other pages with link to it

### DIFF
--- a/src/content/docs/zh-cn/concepts/why-astro.mdx
+++ b/src/content/docs/zh-cn/concepts/why-astro.mdx
@@ -1,71 +1,89 @@
 ---
 title: 为什么是 Astro?
-description: Astro 是集多功能于一体的 Web 框架，用于构建快速、以内容为中心的网站。了解更多。
+description: Astro 是最适合构建像博客、营销网站、电子商务网站这样的以内容驱动的网站的 Web 框架。了解为什么 Astro 可能是你下一个网站的好选择。
 i18nReady: true
 ---
 
-Astro 是**集多功能于一体的 Web 框架**，用于构建**快速、以内容为中心的网站**。
+**Astro** 是最适合构建像博客、营销网站、电子商务网站这样的**以内容驱动的网站**的 Web 框架。Astro 以开创了一种新的[前端架构](/zh-cn/concepts/islands/)而闻名，与其他框架相比它减少了 JavaScript 的开销和复杂性。如果你需要一个加载速度快、具有良好 SEO 的网站，那么 Astro 就是你的选择。
 
-为什么选择 Astro 而不是其他的 Web 框架？以下的五个核心设计原则有助于解释我们为什么要构建 Astro，它需要解决的问题以及为什么 Astro 可能是你的项目或团队的最佳选择。
+## 功能
 
-#### Astro 是...
-1. [ **以内容为中心** ](#以内容为中心)：Astro 专为内容丰富的网站而设计。
-2. [ **服务器优先** ](#服务器优先)：网站在服务器上渲染 HTML 时运行速度更快。
-3. [ **默认快速** ](#默认快速)：在 Astro 中构建缓慢的网站是不可能的。
-4. [ **易于使用** ](#易于使用)：你不需要成为专家即可使用 Astro 构建某些内容。
-5. [ **功能齐全且灵活** ](#功能齐全且灵活)：超100多种 Astro 集成可供选择。
+<strong>Astro 是一个集多功能于一体的 Web 框架。</strong>它内置包含了你构建网站所需的一切。还有数百个不同的[集成](https://astro.build/integrations/)和 [API 钩子](/zh-cn/reference/integrations-reference/)可根据你的具体用例和需求定制你的项目。
 
-## 以内容为中心
-**Astro 皆为构建内容丰富的网站。** 这包括大多数营销网站、出版网站、文档网站、博客、个人作品集和一些电子商务网站。
+一些亮点包括：
 
-相比之下，大多数现代 Web框架 都是为构建 Web应用程序 而设计的，这些框架最适合构建更复杂、类似应用程序的体验；管理仪表板、收件箱、社交网络、待办事项列表，甚至是像 [Figma](https://figma.com) 和 [Ping](https://ping.gg/) 这样的体验接近于原生应用的 Web 应用程序。
+- **[群岛](/zh-cn/concepts/islands/)**：一种基于组件的针对内容驱动的网站进行优化的 Web 架构。
+- **[UI 无关](/zh-cn/core-concepts/framework-components/)**：支持 React、Preact、Svelte、Vue、Solid、Lit、HTMX、Web 组件等等。
+- **[服务器优先](/zh-cn/core-concepts/rendering-modes/)**：将沉重的渲染移出访问者的设备。
+- **[默认无 JS](/zh-cn/core-concepts/astro-components/)**：更少减慢你网站速度的客户端 JavaScript。
+- **[内容集合](/zh-cn/guides/content-collections/)**：组织、验证你的 Markdown 内容，并提供 TypeScript 类型安全。
+- **[可定制](/zh-cn/guides/integrations-guide/)**：Tailwind、MDX 和数百个集成可供选择。
 
-这是了解 Astro 最重要的区别之一。 Astro 对内容的独特关注让 Astro 能够做出权衡并提供无与伦比的性能特性，而这些特性对于更多以应用程序为中心的 Web 框架来说是没有意义的。
+## 设计原则
 
-:::tip
-如果你的项目属于第二个“应用”阵营，Astro 可能不是你项目的正确选择... **没关系！** 查看 [Next.js](https://nextjs.org/) 以获得比 Astro 更专注于应用程序的替代方案。
-:::
+以下的五个核心设计原则有助于解释我们为什么做了 Astro，它需要解决的问题以及为什么 Astro 可能是你的项目或团队的最佳选择。
 
-## 服务器优先
+Astro 是…
 
-**Astro 尽可能利用服务器渲染而不是客户端渲染。** 这与传统服务器端框架（PHP、WordPress、Laravel、Ruby on Rails等）使用的方法相同，你不需要学习第二种服务端语言。 Astro 仍然使用 HTML、CSS和JavaScript(或TypeScript)。
+1. **[内容驱动](#内容驱动)**：Astro 专为展示你的内容而设计。
+2. **[服务器优先](#服务器优先)**：网站在服务器上渲染 HTML 时运行速度更快。
+3. **[默认快速](#默认快速)**：在 Astro 中应当不可能做出缓慢的网站。
+4. **[易于使用](#易于使用)**：你不需要是一个专家即可使用 Astro 做点什么。
+5. **[以开发者为中心](#以开发者为中心)**：你应该拥有成功所需的资源。
 
-这种方法与其他现代 JavaScript Web 框架 形成鲜明对比，如 Next.JS、SvelteKit、Nuxt、Remix 等。这些框架需要整个网站的客户端和服务器端渲染，以解决性能问题，这种方法被称为**单页应用程序(SPA)，** 与 Astro 的**多页应用程序（MPA）** 方式形成鲜明对比。
+### 内容驱动
 
-SPA模式有它的优势。然而，这些都是以牺牲额外的复杂性和性能权衡为代价，这些权衡会损坏页面性能——包括[可交互时间(TTI)](https://web.dev/interactive/) 等关键指标——这对于以内容为中心的网站没有多大意义，因为这些网站的首次加载性能至关重要。
+<strong>Astro 专为构建内容丰富的网站而设计。</strong>这包括大多数营销网站、出版网站、文档网站、博客、个人作品集、着陆页、社区网站和电子商务网站。如果你有内容要展示，它需要快速地到达你的读者。
 
-## 默认快速
+相比之下，大多数现代 Web 框架都是为构建 **Web 应用程序**而设计的。这些框架擅长于在浏览器中构建复杂的、类似应用程序的体验：登录后的管理仪表板、收件箱、社交网络、待办事项列表，甚至是像 [Figma](https://figma.com) 和 [Ping](https://ping.gg/) 这样的类原生应用程序。然而随着复杂性的增加，它们在提供内容时可能会遇到性能问题。
 
-良好的性能很重要，对于以内容为中心的网站尤其至关重要。事实证明，糟糕的表现会让您失去参与度、转化率和金钱。列如：
+Astro 从它最初作为静态网站生成器的开始就专注于内容，使得 Astro 可以**合理地扩展到性能强大的动态 Web 应用程序**，同时仍然尊重你的内容和你的受众。Astro 对内容的独特关注让 Astro 能够做出取舍并提供无与伦比的在其他框架中实现起来不合理的性能功能。
+
+### 服务器优先
+
+<strong>Astro 尽可能多地使用[服务器渲染](/zh-cn/core-concepts/rendering-modes/)而不是在浏览器中的客户端渲染。</strong>这与传统的服务器端框架 -- 像 PHP、WordPress、Laravel、Ruby on Rails 等 -- 使用了几十年的方法相同。但你不需要学习第二种服务端语言来解锁它。使用 Astro，一切仍然只是 HTML、CSS 和 JavaScript（或 TypeScript，如果你乐意的话）。
+
+这种方法与其他现代 JavaScript Web 框架形成鲜明对比，如 Next.js、SvelteKit、Nuxt、Remix 等。这些框架是为客户端渲染整个网站而制作的，提供服务器端渲染主要是为了解决性能问题。这种方法被称为**单页应用程序（SPA）**，对比 Astro 的**多页应用程序（MPA）**。
+
+SPA 模式有它的优势。然而，这些都是以牺牲额外的复杂性和性能权衡为代价的。这些取舍损害了页面性能 -- 比如[可交互时间（TTI）](https://web.dev/interactive/)等关键指标 -- 对于以内容为中心的网站没有多大意义，而这种网站的首次加载性能至关重要。
+
+Astro 的服务器优先方法使你可以在且仅在必要的时候选择加入客户端渲染。你可以选择添加在客户端运行的 UI 框架组件。你可以利用 Astro 的[视图过渡路由](/zh-cn/guides/view-transitions/)来更精细地控制选定页面的过渡和动画。Astro 的服务器优先渲染，无论是预渲染还是按需渲染，都提供了可以增强和扩展的高性能默认值。
+
+### 默认快速
+
+好的性能总是重要的，但它对于那些成功取决于展示你的内容的网站来说*尤其*重要。事实已经充分证明糟糕的性能表现会让你失去参与度、转化率和金钱。例如：
 
 - 每快 100ms → 转化率增加 1% ([Mobify](https://web.dev/why-speed-matters/), 收入 +$380,000/年)
 - 每快 50% → 销售额增加 12% ([AutoAnything](https://www.digitalcommerce360.com/2010/08/19/web-accelerator-revs-conversion-and-sales-autoanything/))
 - 每快 20% → 转换率增加 10% ([Furniture Village](https://www.thinkwithgoogle.com/intl/en-gb/marketing-strategies/app-and-mobile/furniture-village-and-greenlight-slash-page-load-times-boosting-user-experience/))
 - 每快 40% → 注册率增加 15% ([Pinterest](https://medium.com/pinterest-engineering/driving-user-growth-with-performance-improvements-cfc50dafadd7))
-- 转换速度提高 850ms → 转化率增加 7% ([COOK](https://web.dev/why-speed-matters/))
-- 每慢1秒 → 减少 10% 的用户 ([BBC](https://www.creativebloq.com/features/how-the-bbc-builds-websites-that-scale))
+- 每快 850ms → 转化率增加 7% ([COOK](https://web.dev/why-speed-matters/))
+- 每慢 1 秒 → 减少 10% 的用户 ([BBC](https://www.creativebloq.com/features/how-the-bbc-builds-websites-that-scale))
 
-在许多 Web框架 中，在开发过程中很容易构建一个看起来很棒的网站，但是在部署后加载速度会非常慢。JavaScript 通常是罪魁祸首，因为用户的手机和低功耗设备很少能与开发人员的电脑速度相匹配。
+在许多 Web 框架中，很容易在开发过程中构建一个看起来很棒的网站，但在部署后加载速度非常慢。JavaScript 通常是罪魁祸首，因为用户的手机和低功耗设备很少能与开发者的电脑速度相匹配。
 
-Astro 的魔力在于它如何将上述两个值（内容焦点于服务器优先的MPA架构）相结合，以做出权衡并提供其他框架无法实现的功能。结果是每个网站都有开箱即用令人惊叹的Web性能。我们的目标：**使用 Astro 构建几乎不可能缓慢的网站。**
+Astro 的魔力在于它如何将上述两个价值 -- 以内容为中心和服务器优先的架构 -- 相结合，做出权衡并提供其他框架无法实现的功能。结果是每个网站都开箱即有令人惊叹的 Web 性能。我们的目标：**使用 Astro 几乎不可能做出缓慢的网站。**
 
-与使用最受欢迎的 React Web框架 构建相同的网站进行比较，Astro 网站的[加载速度快40%，JavaScript减少90%](https://twitter.com/t3dotgg/status/1437195415439360003) 。请对我们的结论半信半疑：观看 Astro 的现场直播 让 Ryan Carniato(Solid.js和Marko的创造者) [无言以对](https://youtu.be/2ZEMb_H-LYE?t=8163)。
+一个 Astro 网站可以比使用最受欢迎的 React Web 框架构建的同一网站[加载速度快 40%，JavaScript 减少 90%](https://twitter.com/t3dotgg/status/1437195415439360003)。但不要直接相信我们的话：看 Astro 的性能让 Ryan Carniato（Solid.js 和 Marko 的创始人）[说不出话来](https://youtu.be/2ZEMb_H-LYE?t=8163)。
 
-## 易于使用
-**Astro 的目标是让每位 Web 开发者都易于理解。** Astro 被设计成熟悉和平易近人的感觉，无论技能水平或过去的 Web 开发经验如何。
+### 易于使用
 
-我们首先确保你可以使用你已经了解的任何喜欢的 UI 组件语言。在 Astro 项目中创建新的 UI 组件时使用 React、Preact、Svelte、Vue、Solid、Lit 和其他一些组件都是被支持的。
+<strong>Astro 的目标是使所有 Web 开发者都对它易于理解。</strong>Astro 被设计成熟悉和平易近人的感觉，无论技能水平或过去的 Web 开发经验如何。
 
-我们为了 Astro 也能有一个很好的内置组件语言，我们创建了自己 `.astro` UI语言。它很大程度上深受 HTML 的影响：任何有效的 HTML 部分都已经是有效的 Astro 组件，它还结合了我们从其他组件中借用的一些功能，如：React 的 JSX 表达式和（像 Svelte 和 Vue 一样的）默认 CSS 作用域。这种与 HTML 的相似性也使得使用渐进式增强和通用可访问性模式变得更加容易，而无需任何开销。
+Astro 的 `.astro` UI 语言是 HTML 的超集：任何有效的 HTML 都是有效的 Astro 模板语法！因此，如果你能编写 HTML，你就可以编写 Astro 组件！但是，它还结合了我们从其他组件语言中借用的一些我们最喜欢的功能，如 JSX 表达式（React）和默认使用 CSS 作用域（Svelte 和 Vue）。这种与 HTML 的相似性也使得使用渐进式增强和常见的可访问性模式变得更加容易而无额外开销。
 
-Astro 的设计比其他UI框架和语言更简单，其中一个重要原因是 Astro 被设计为在服务器上渲染而不是浏览器，这意味着你无需担心：hooks (React)、stale closures (还是 React)、refs (Vue)、observables (Svelte)、atoms、selectors、reactions、或 derivations。服务器上没有响应式，因此这些复杂性都消失了。
+我们然后确保你还可以使用你已经了解的最喜欢的 UI 组件语言，甚至可以复用你可能已经有的组件。React、Preact、Svelte、Vue、Solid、Lit 和其他的，包括 Web components，都被支持在 Astro 项目中编写 UI 组件。
 
-我们最喜欢的说法之一是：**复杂性是可选的。** 我们设计 Astro 是为了尽可能多地从开发人员体验中消除“必须的复杂性”，尤其是你首次加入时。你可以在 Astro 中使用 HTML 和 CSS 构建 “Hello World” 示例网站。然后当你需要构建更强大的功能时，你可以随时获得新功能和 API。
+Astro 的设计比其他 UI 框架和语言更简单。其中一个重要原因是 Astro 被设计为在服务器上渲染，不是在浏览器中。这意味着你无需担心：hooks (React)、stale closures (还是 React)、refs (Vue)、observables (Svelte)、atoms、selectors、reactions、或 derivations。服务器上没有响应式，因此这些复杂性都消失了。
 
-## 功能齐全且灵活
+我们最喜欢的说法之一是：**复杂性是可选的**。我们设计 Astro 是为了尽可能多地从开发者体验中消除“必须的复杂性”，尤其是你首次加入时。你可以在 Astro 中只使用 HTML 和 CSS 构建一个“Hello World”示例网站。然后，当你需要构建更强大的东西时，你随时可以逐渐取用新功能和 API。
 
-**Astro 是集多功能于一体的 Web 框架，提供了构建网站所需的一切** Astro 包括组件语法、基于文件的路由、静态资源处理、构建处理、捆绑、优化、数据获取等。你只使用 Astro 核心功能集就可构建出色的网站。
+### 以开发者为中心
 
-如果你需要更多的控制，你可以通过 [React](https://www.npmjs.com/package/@astrojs/react), [Svelte](https://www.npmjs.com/package/@astrojs/svelte), [Vue](https://www.npmjs.com/package/@astrojs/vue), [Tailwind CSS](https://www.npmjs.com/package/@astrojs/tailwind), [MDX](https://www.npmjs.com/package/@astrojs/mdx) 等[100多个集成](https://astro.build/integrations/)。 扩展 Astro 只需要一个命令 [即可连接你喜欢的 CMS](/zh-cn/guides/cms/) 或 [部署到你喜欢的托管平台](/zh-cn/guides/deploy/)
+我们坚信，只有当人们喜欢使用 Astro 时，Astro 才是一个成功的项目。Astro 有支持你使用 Astro 构建网站所需的一切。
 
-Astro 与 UI 无关，这意味着你可以自带 UI 框架（BYOF）。React、Preact、Solid 、Svelte、Vue 和 Lit 都在 Astro 中得到官方支持。你甚至可以在同一页面上混合和匹配不同的框架，使未来的迁移更容易，并防止项目锁定到单个框架。
+Astro 在开发者工具方面有所投入，例如从你打开终端的那一刻起就有的很棒的 CLI 体验、一个提供语法高亮的官方 VS Code 扩展、TypeScript 和 Intellisense，以及提供 14 种语言由数百名社区贡献者积极维护的文档。
+
+我们友善、尊重和包容的 Discord 社区已准备好提供支持、动力和鼓励。创建一个 `#support` 帖子来获取关于你的项目的帮助。访问我们专门的 `#showcase` 频道，分享你的 Astro 网站、博客文章、视频、甚至是半成品以获得安全的反馈和建设性的批评。参加定期的实时活动，如我们每周的社区会议、“Talking and Doc'ing”、以及 API/bug 修复。
+
+作为一个开源项目，我们欢迎各种经验程度的社区成员以各种类型和规模做出贡献。你被邀请参与路线图讨论以塑造 Astro 的未来，我们也希望你能为核心代码库、编译器、文档、语言工具、网站和其他项目贡献修复和功能。

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-create-react-app.mdx
@@ -47,7 +47,7 @@ import App from '../cra-project/App.jsx'
 
 -  [`.astro` 组件](/zh-cn/core-concepts/astro-components/) 不是作为返回页面模板的导出函数而被构建。相反，你需要将代码分割到一个用于 JavaScript 的“代码围栏”和一个专门用于生成的 HTML 的“body”中。
 
--  [内容优先](/zh-cn/concepts/why-astro/)：Astro 的设计目标是展示你的内容，并允许你在需要时选择性地启用交互。如果现有的 CRA 应用用于构建高级的客户端交互，那么可能需要使用高级的 Astro 技术来让 `.astro` 组件来完成更具挑战性的复制，例如仪表板。
+-  [内容驱动](/zh-cn/concepts/why-astro/#内容驱动)：Astro 的设计目标是展示你的内容，并允许你在需要时选择性地启用交互。如果现有的 CRA 应用用于构建高级的客户端交互，那么可能需要使用高级的 Astro 技术来让 `.astro` 组件来完成更具挑战性的复制，例如仪表板。
 
 ## 将 CRA 添加到 Astro
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-docusaurus.mdx
@@ -15,7 +15,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 Docusaurus 和 Astro 之间有一些相似之处，这将有助于你迁移你的项目：
 
-- Astro 和 Docusaurus 都是现代的、基于 JavaScript（Jamstack）的站点生成器，用于[内容聚焦的网站](/zh-cn/concepts/why-astro/#以内容为中心)，如文档站点。
+- Astro 和 Docusaurus 都是现代的、基于 JavaScript（Jamstack）的站点生成器，用于[内容驱动的网站](/zh-cn/concepts/why-astro/#内容驱动)，如文档站点。
 
 - Astro 和 Docusaurus 都支持[MDX页面](/zh-cn/guides/markdown-content/)。你应该能够将现有的`.mdx`文件用于Astro。
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-eleventy.mdx
@@ -30,7 +30,7 @@ Eleventy (11ty) 和 Astro 有一些相似之处，这将帮助你迁移你的项
 
 - Astro 使用[`public/` 文件夹存储不需要在构建过程中处理或转换的静态资源](/zh-cn/core-concepts/project-structure/#public)。
 
-- 在Eleventy中，必须手动配置 CSS，JavaScript 和其他资产的打包。[Astro 为你提供开箱即用的处理方式](/zh-cn/concepts/why-astro/#易于使用)。
+- 在 Eleventy 中，必须手动配置 CSS，JavaScript 和其他资产的打包。[Astro 为你提供开箱即用的处理方式](/zh-cn/concepts/why-astro/#易于使用)。
 
 ## 从 Eleventy 切换到 Astro
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-hugo.mdx
@@ -15,7 +15,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 Hugo 和 Astro 有一些相似之处，可以帮助你迁移项目：
 
-- Hugo 和 Astro 都是现代静态站点生成器，非常适合于像博客这样以[内容为中心的网站](/zh-cn/concepts/why-astro/#以内容为中心)。
+- Hugo 和 Astro 都是现代静态站点生成器，非常适合于像博客这样以[内容驱动的网站](/zh-cn/concepts/why-astro/#内容驱动)。
 
 - Hugo 和 Astro 都允许你在 [Markdown 中编写内容](/zh-cn/guides/content/#markdown-创作)。然而，Hugo 包含了几个特殊的 frontmatter 属性，并允许你使用 YAML、TOML 或 JSON 编写 frontmatter。尽管许多现有的 Hugo frontmatter 属性在 Astro 中并不生效，但你也可以继续使用现有的 Markdown 文件和 YAML frontmatter 值。
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-nextjs.mdx
@@ -30,7 +30,7 @@ Next.js 和 Astro 有一些相似之处，可以帮助你迁移你的项目：
 
 - [`.astro` 组件](/zh-cn/core-concepts/astro-components/)：不是作为返回页面模板的导出函数去编写的。相反，会把你的代码分成一个 JavaScript 的"代码栅栏"和一个专门用于生成 HTML 的主体。
 
-- [内容优先](/zh-cn/concepts/why-astro/)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。已有的 Next.js 应用程序可能是为重客户端交互性而构建的，并且包含一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
+- [内容驱动](/zh-cn/concepts/why-astro/#内容驱动)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。已有的 Next.js 应用程序可能是为重客户端交互性而构建的，并且包含一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
 
 ## 转换你的 Next.js 项目
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -32,7 +32,7 @@ Nuxt 和 Astro 有一些相似之处，这些相似性能够帮助你完成迁�
 
 - [页面路由](/zh-cn/core-concepts/astro-pages/#基于文件的路由)：Nuxt 使用 `vue-router` 进行 SPA 路由，并且使用 `vue-meta` 来管理 `<head>`。在 Astro 中，你将创建单独的 HTML 页面路由，并直接控制页面的 `<head>`，或者在布局组件中控制。
 
-- [内容优先](/zh-cn/concepts/why-astro/)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。虽然 Nuxt 可以通过 `@nuxt/content` 来制作以内容为中心的网站，但现有的 Nuxt 应用更多是针对客户端的高交互性构建的。Astro 内置有能够处理内容的功能，例如页面生成，但是一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
+- [内容驱动](/zh-cn/concepts/why-astro/#内容驱动)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。Nuxt 应用更多是针对客户端的高交互性构建的。Astro 内置有能够处理内容的功能，例如页面生成，但是一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
 
 ## 转换你的 NuxtJS 项目
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-pelican.mdx
@@ -15,7 +15,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 Pelican 和 Astro 的一些相似点会帮助你完成迁移。
 
-- Pelican 和 Astro 都是静态网站生成器，尤其适合[专注于内容的网站](/zh-cn/concepts/why-astro/#以内容为中心)，例如博客。
+- Pelican 和 Astro 都是静态网站生成器，尤其适合[内容驱动的网站](/zh-cn/concepts/why-astro/#内容驱动)，例如博客。
 
 - Pelican 和 Astro 都内置支持 [Markdown文档](/zh-cn/guides/content/#markdown-创作)，包括页面元数据的 frontmatter YAML 属性。但是 Astro 中预留的 frontmatter 比 Pelican 少得多。尽管很多 Pelican 内生效的 frontmatter 属性在 Astro 中并不会生效，但你仍然可以使用使用 Markdown 和 frontmatter 。
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-sveltekit.mdx
@@ -30,7 +30,7 @@ SvelteKit 和 Astro 有一些相似之处，可以帮助你迁移你的项目：
 
 - [组件](/zh-cn/core-concepts/astro-components/)：SvelteKit 使用 [Svelte](https://svelte.dev)。Astro 页面使用 [`.astro` 组件](/zh-cn/core-concepts/astro-components/) 构建，但也可以支持 [React、Preact、Vue.js、Svelte、SolidJS、AlpineJS、Lit](/zh-cn/core-concepts/framework-components/) 和原始 HTML 模板。
 
-- [内容优先](/zh-cn/concepts/why-astro/)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。现有的 SvelteKit 应用程序可能是为客户端的高交互性而构建的。Astro 内置有能够处理内容的功能，例如页面生成，但是一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
+- [内容驱动](/zh-cn/concepts/why-astro/#内容驱动)：Astro 旨在展示你的内容，并允许你仅在需要时选择加入交互性。现有的 SvelteKit 应用程序可能是为客户端的高交互性而构建的。Astro 内置有能够处理内容的功能，例如页面生成，但是一些使用 `.astro` 组件难以复制、更具挑战性的功能，可能需要高级 Astro 技术来处理，例如仪表盘。
 
 - [Markdown 支持就绪](/zh-cn/guides/markdown-content/)：Astro 包含内置的 Markdown 支持，并且包含用于每个文件的页面模板的一个 [特殊的前置 YAML `layout` 属性](/zh-cn/core-concepts/layouts/#markdownmdx-布局)。如果你正在将 SvelteKit 的基于 Markdown 的博客转换为 Astro，你将不需要安装单独的 Markdown 集成，并且你不需要通过配置文件设置布局。你可以将现有的 Markdown 文件带入，但是你可能需要重新整理下这些文件，因为 Astro 的基于文件的路由不需要为每个页面路由创建一个文件夹。
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-vuepress.mdx
@@ -16,7 +16,7 @@ VuePress 和 Astro 有一些共同的特点，这些相似之处将有助于你�
 
 - VuePress 和 Astro 都是现代的 JavaScript 静态网站生成器，具有类似的项目文件结构。它们都使用 [特殊的`src/pages/`文件夹来进行基于文件的路由](/zh-cn/core-concepts/astro-pages/)。因此，在创建和管理站点页面时，你应该会感到非常熟悉。
 
-- Astro 和 VuePress 都是为 [以内容为中心的网站](/zh-cn/concepts/why-astro/#以内容为中心) 设计的，它们都拥有出色的内置 Markdown 文件支持。因此，在使用 Markdown 编写内容时，你会感到非常熟悉，并且你可以保留现有的内容。
+- Astro 和 VuePress 都是为 [内容驱动的网站](/zh-cn/concepts/why-astro/#内容驱动) 设计的，它们都拥有出色的内置 Markdown 文件支持。因此，在使用 Markdown 编写内容时，你会感到非常熟悉，并且你可以保留现有的内容。
 
 - Astro 提供了 [官方集成的 Vue 组件使用方式](/zh-cn/guides/integrations-guide/vue/) 并且支持 [安装NPM包](/zh-cn/guides/imports/#npm-包)，其中包括一些适用于 Vue 的包。你可以编写 Vue UI 组件，并且可能可以保留你现有的部分或全部 Vue 组件和依赖项。
 

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-wordpress.mdx
@@ -18,7 +18,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 WordPress 和 Astro 在以下方面有一些相似之处，这将有助于你迁移项目：
 
-- 无论是 WordPress 还是 Astro ，都非常适合用于制作 [内容聚焦的网站](/zh-cn/concepts/why-astro/#以内容为中心)，比如博客，并支持使用 Markdown 编写内容（在 WordPress 中需要使用插件）。虽然在 Astro 中添加新内容的过程不同，但如果你已经在 WordPress 编辑器中使用过 Markdown 语法，那么在 Astro 博客中 [编写 Markdown 文件](/zh-cn/guides/markdown-content/)应该会感觉很熟悉。 
+- 无论是 WordPress 还是 Astro，都非常适合用于制作[内容驱动的网站](/zh-cn/concepts/why-astro/#内容驱动)，比如博客，并支持使用 Markdown 编写内容（在 WordPress 中需要使用插件）。虽然在 Astro 中添加新内容的过程不同，但如果你已经在 WordPress 编辑器中使用过 Markdown 语法，那么在 Astro 博客中 [编写 Markdown 文件](/zh-cn/guides/markdown-content/)应该会感觉很熟悉。 
 
 - WordPress 和 Astro 都鼓励 [将网站的设计划分为“模块”](/zh-cn/concepts/islands/) （组件）。在 Astro 中，你可能会更多的 [编写自己的代码来创建这些模块](/zh-cn/core-concepts/astro-components/)，而不是依赖于预先构建的插件。对于网站的各个组成部分以及它们在页面上的呈现方式的思考应该是相似的。
 


### PR DESCRIPTION
#### Description (required)

Update translation based on #5428

`<strong>`s are used in some places because markdown bold syntax are not being rendered correctly in certain cases, example:

**Astro 是一个集多功能于一体的 Web 框架。**它内置包含了你构建网站所需的一切。