### PR TITLE
Fix highlighted lines in code block at Basics -> Components -> Transferring slots

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -290,7 +290,7 @@ const { title } = Astro.props
 
 Slots can be transfered to other components. For example, when creating nested layouts:
 
-```astro title="src/layouts/BaseLayout.astro" {11,14}
+```astro title="src/layouts/BaseLayout.astro" {10,13}
 ---
 ---
 


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The wrong lines of code were highlighted. This fixes it.


<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
