### PR TITLE
Add instructions on how to setup CloudFront Error Pages

### DIFF
--- a/src/content/docs/en/guides/deploy/aws.mdx
+++ b/src/content/docs/en/guides/deploy/aws.mdx
@@ -185,6 +185,26 @@ Unfortunately, CloudFront does not support multi-page `sub-folder/index` routing
         * **Viewer request - Function type:** CloudFront Function.
         * **Viewer request - Function ARN:** Select the function you created in the previous step.
 
+### CloudFront Error Pages setup
+
+By default, S3 returns a 404 error when the file is not found and 403 when the file is private. This causes page visitors to see an ugly XML error page. To fix this, you'll need to add **custom error responses** in your CloudFront distribution's **Settings > Error pages**.
+
+1. Create a custom error response for 404 errors with the following values:
+    * **HTTP error code:** 404: Not Found
+    * **Customize error response:** Yes
+    * **Response page path:** `/index.html`
+    * **HTTP response code:** 200: OK
+
+2. Create a custom error response for 403 errors with the following values:
+    * **HTTP error code:** 403: Forbidden
+    * **Customize error response:** Yes
+    * **Response page path:** `/index.html`
+    * **HTTP response code:** 200: OK
+
+  :::tip
+  For the best user experience, you can create a custom 404 page in your project and set the **Response page path** to `/404.html`.
+  :::
+
 ## Continuous deployment with GitHub Actions
 
 There are many ways to set up continuous deployment for AWS. One possibility for code hosted on GitHub is to use [GitHub Actions](https://github.com/features/actions) to deploy your website every time you push a commit.

--- a/src/content/docs/en/guides/deploy/aws.mdx
+++ b/src/content/docs/en/guides/deploy/aws.mdx
@@ -187,7 +187,9 @@ Unfortunately, CloudFront does not support multi-page `sub-folder/index` routing
 
 ### CloudFront Error Pages setup
 
-By default, S3 returns a 404 error when the file is not found and 403 when the file is private. This causes page visitors to see an ugly XML error page. To fix this, you'll need to add **custom error responses** in your CloudFront distribution's **Settings > Error pages**.
+By default, S3 returns a 404 error when the file is not found, and 403 when the file is private. This causes visitors to see an ugly XML error page in both cases.
+
+To fix this, add **custom error responses** in your CloudFront distribution's **Settings > Error pages**.
 
 1. Create a custom error response for 404 errors with the following values:
     * **HTTP error code:** 404: Not Found
@@ -202,7 +204,7 @@ By default, S3 returns a 404 error when the file is not found and 403 when the f
     * **HTTP response code:** 200: OK
 
   :::tip
-  For the best user experience, you can create a custom 404 page in your project and set the **Response page path** to `/404.html`.
+  For the best user experience, you can [create a custom 404 page](/en/core-concepts/astro-pages/#custom-404-error-page) in your project and set the **Response page path** to `/404.html`.
   :::
 
 ## Continuous deployment with GitHub Actions


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

I have added instructions on how to handle the most common error responses.
By default, CloudFront will show an ugly XML error message saying that the content was not found (when the URL doesn't exist) and a 403 message when the content is private.
These two custom error messages were the ones I encountered when I tried to deploy my Astro blog to AWS following the official docs.

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
