### PR TITLE
Improve description of `locals` on guides/middleware

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -19,11 +19,12 @@ Middleware is available in both SSG and SSR Astro projects.
 
     ```js title="src/middleware.js"
     export function onRequest ({ locals, request }, next) {
-        // intercept response data from a request
-        // optionally, transform the response by modifying `locals`
+        // intercept data from a request
+        // optionally, share data with the rendering process by modifying `locals`
         locals.title = "New title";
 
         // return a Response or the result of calling `next()`
+        // optionally, transform the response by modifying the result
         return next();
     };
     ```
@@ -46,7 +47,7 @@ This is an optional argument passed to `onRequest()` that may contain the `local
 
 ### Storing data in `context.locals`
 
-`context.locals` is an object containing data from a `Response` that can be manipulated inside middleware. 
+`context.locals` is an object that can be manipulated inside the middleware. Adapters _might_ add data to it.
 
 This `locals` object is forwarded across the request handling process and is available as a property to [`APIContext`](/en/reference/api-reference/#contextlocals) and [`AstroGlobal`](/en/reference/api-reference/#astrolocals) . This allows data to be shared between middlewares, API routes, and `.astro` pages. This is useful for storing request-specific data, such as user data, across the rendering step.
 
@@ -54,14 +55,15 @@ You can store any type of data inside `locals`: strings, numbers, and even compl
 
 ```js title="src/middleware.js"
 export function onRequest ({ locals, request }, next) {
-    // intercept response data from a request
-    // optionally, transform the response by modifying `locals`
+    // intercept data from a request
+    // optionally, share data with the rendering process by modifying `locals`
     locals.user.name = "John Wick";
     locals.welcomeTitle = () => {
         return "Welcome back " + locals.user.name;
     };
 
     // return a Response or the result of calling `next()`
+    // optionally, transform the response by modifying the result
     return next();
 };
 ```


### PR DESCRIPTION
#### Description (required)

Change the comments and description of the `locals` object on `guides/middleware`.

#### Related issues & labels (optional)

- Closes #4207 
- Suggested label: `improve documentation`