### PR TITLE
Prevent scrolling when feedback modal is open

### DIFF
--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -150,6 +150,7 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 			const openModal = (event: MouseEvent) => {
 				showSuccess(false);
 				dialog.showModal();
+				document.body.classList.add('overflow-hidden');
 				form.querySelector<HTMLInputElement>('input:checked')?.focus();
 				// Prevent click bubbling up and immediately closing the modal again.
 				event.stopPropagation();
@@ -158,6 +159,7 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 
 			const closeModal = () => {
 				dialog.close();
+				document.body.classList.remove('overflow-hidden');
 				window.removeEventListener('click', onWindowClick);
 			};
 
@@ -430,5 +432,9 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 
 	[hidden] {
 		display: none;
+	}
+
+	:global(.overflow-hidden) {
+		overflow: hidden;
 	}
 </style>


### PR DESCRIPTION
#### Description

- This PR prevents scrolling when the feedback modal is open. It should lead to:
  - Better user experience
  - Consistent behavior with the search modal, which also prevents scrolling
- Demonstration:

  | Before | After |
  | ------ | ----- |
  | <video src="https://github.com/withastro/docs/assets/40516784/dcb95588-bd2a-4ecc-9ee6-b639438ed89a" /> | <video src="https://github.com/withastro/docs/assets/40516784/3cde158b-3977-4219-92c7-ebc1e14335a1" />  |

#### Related issues & labels

- Closes #5334
- Suggested label: site improvement
