### PR TITLE
i18n(ja): Update `/guides/deploy/gitlab.mdx`

### DIFF
--- a/src/content/docs/ja/guides/deploy/gitlab.mdx
+++ b/src/content/docs/ja/guides/deploy/gitlab.mdx
@@ -14,7 +14,8 @@ i18nReady: true
 ## デプロイ方法
 
 1. `astro.config.mjs`に正しい`site`を設定します。
-2. `astro.config.mjs`に`outDir:public`を設定します。この設定は、静的ビルドの出力をGitLab Pagesがファイルを公開するために必要なフォルダである`public`というフォルダに置くようにAstroに指示します。
+2. `public/`ディレクトリを`static`にリネームします.
+3. `astro.config.mjs`に`outDir:public`を設定します。この設定は、静的ビルドの出力をGitLab Pagesがファイルを公開するために必要なフォルダである`public`というフォルダに置くようにAstroに指示します。
 
    [`public/`ディレクトリ](/ja/core-concepts/project-structure/#public)をAstroプロジェクトで静的ファイルのソースとして使用していた場合は、名前を変更し、`astro.config.mjs`の`publicDir`の値に新しいフォルダ名を指定します。
 
@@ -25,34 +26,34 @@ i18nReady: true
 
    export default defineConfig({
      sitemap: true,
-     site: 'https://astro.build/',
+     site: 'https://<user>.gitlab.io',
+     base: '/<project-name>',
      outDir: 'public',
      publicDir: 'static',
    });
    ```
 
-3. プロジェクトのルートに`.gitlab-ci.yml`というファイルを以下の内容で作成します。これにより、コンテンツを変更するたびにサイトをビルドしてデプロイすることができます。
+4. プロジェクトのルートに`.gitlab-ci.yml`というファイルを以下の内容で作成します。これにより、コンテンツを変更するたびにサイトをビルドしてデプロイすることができます。
 
    ```yaml
-   # アプリのビルドに使用するDockerイメージ
-   image: node:lts
-
    pages:
-     cache:
-       paths:
-         - node_modules/
+     # アプリのビルドに使用するDockerイメージ
+     image: node:lts
+
+     before_script:
+       - npm ci
+
      script:
-       # アプリを構築するためのステップをここで指定します。
-       - npm install
+       # アプリのビルドに必要な手順をここで指定します
        - npm run build
 
      artifacts:
        paths:
-         # 公開されるビルドファイルを含むフォルダ。
-         # これは"public"である必要があります。
+         # 公開するビルド済みのファイルを含むフォルダ。
+         # "public"を指定する必要があります。
          - public
 
      only:
-       # 以下のブランチにプッシュがあった場合のみ、新規ビルドをトリガーし、デプロイします。
+       # 以下のブランチへのプッシュがある時のみに、新しいビルドとデプロイをトリガーします。
        - main
    ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I have reflected the following updates to the Japanese page of `/guides/deploy/gitlab.mdx`.

- https://github.com/withastro/docs/commits/main/src/content/docs/en/guides/deploy/gitlab.mdx?since=2023-10-17T11:20:32.000Z
    - https://github.com/withastro/docs/pull/5130
    - https://github.com/withastro/docs/pull/5294
    - https://github.com/withastro/docs/pull/5514

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
