### PR TITLE
refactor(i18n): remove `routingStrategy` in favour of `routing` object

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -35,7 +35,7 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
    })
    ```
   
-2. Choose and configure a [`routingStrategy`](#routingstrategy) based on the desired URL path for your `defaultLocale`:
+2. Choose and configure a [`routing`](#routingstrategy) based on the desired URL path for your `defaultLocale`:
 
   - `"prefix-other-locales"` (default): URLs in your default language will **not** have a `/[locale]/` prefix. All other locales will.
 
@@ -48,15 +48,17 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
         i18n: {
           defaultLocale: "en",
           locales: ["es", "en", "fr"],
-          routingStrategy: "prefix-always"
+          routing: {
+              prefixDefaultLocale: false
+          }
         }
       }
     })
     ```
 
-3. Organize your content folders with localized content by language. Your folder names must match the items in `locales` exactly, and your folder organization must match the URL paths chosen for your [`routingStrategy`](#routingstrategy).
+3. Organize your content folders with localized content by language. Your folder names must match the items in `locales` exactly, and your folder organization must match the URL paths chosen for your [`routing`](#routing).
 
-    Include a localized folder for your `defaultLocale` only if you configure `prefix-always` to show a localized URL path.
+    Include a localized folder for your `defaultLocale` only if you configure `prefixDefaultLocale: false` to show a localized URL path.
 
     <FileTree>
     - src
@@ -92,11 +94,11 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
     <a href={aboutURL}>Acerca</a> 
     ```
 
-### `routingStrategy`
+### `routing`
 
-Astro's built-in file-based routing automatically creates URL routes for you based on your file structure within `src/pages/`. When you configure i18n routing, the `routingStrategy` value now allows you to specify your file structure (and corresponding URL paths generated) in order to use helper functions to generate, use, and verify the routes in your project.
+Astro's built-in file-based routing automatically creates URL routes for you based on your file structure within `src/pages/`. When you configure i18n routing, the `routing` value now allows you to specify your file structure (and corresponding URL paths generated) in order to use helper functions to generate, use, and verify the routes in your project.
 
-#### `'prefix-other-locales'`
+#### ``
 
 ```js title="astro.config.mjs" ins={7}
 import { defineConfig } from "astro/config"
@@ -105,7 +107,9 @@ export default defineConfig({
     i18n: {
       defaultLocale: "en",
       locales: ["es", "en", "fr"],
-      routingStrategy: "prefix-other-locales"
+      routing: {
+          prefixDefaultLocale: false
+      }
     }
   }
 })
@@ -127,7 +131,9 @@ export default defineConfig({
     i18n: {
       defaultLocale: "en",
       locales: ["es", "en", "fr"],
-      routingStrategy: "prefix-always"
+      routing: {
+          prefixDefaultLocale: true
+      }
     }
   }
 })
@@ -158,7 +164,7 @@ Both a default language ([`defaultLocale`](/en/reference/configuration-reference
 
 Each language must be a string (e.g. `"fr"`, `"pt-br"`), but no particular language format or syntax is enforced while this feature is still experimental and under development. This may be subject to change in future versions.
 
-Your `/[locale]/` folder names must match exactly the `locales` in the list, and your [routing strategy](#routingstrategy) must correspond to whether or not you have a localized folder for your default language. Every other supported language must have its own localized folder.
+Your `/[locale]/` folder names must match exactly the `locales` in the list, and your [routing](#routing) must correspond to whether or not you have a localized folder for your default language. Every other supported language must have its own localized folder.
 
 Depending on your deploy host, you may discover transformations in URL paths, so check your deployed site to determine the best syntax for your project.
 
@@ -208,9 +214,9 @@ Creating routes for your project with the i18n router will depend on certain con
 - [`site`](/en/reference/configuration-reference/#site)
 
 
-Also, note that the returned URLs created by these functions for your `defaultLocale` will reflect your `i18n.routingStrategy` configuration.
+Also, note that the returned URLs created by these functions for your `defaultLocale` will reflect your `i18n.routing` configuration.
 
-URLs created when `prefix-always` is configured will include a `/lang/` path in the URL. URLs created with `prefix-other-locales` will not include a language prefix.
+URLs created when `prefixDefaultLocale: true` is configured will include a `/lang/` path in the URL. URLs created with `prefixDefaultLocale: false` will not include a language prefix.
 
 ### `getRelativeLocaleUrl()`
 

--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -35,7 +35,7 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
    })
    ```
   
-2. Choose and configure a [`routing`](#routingstrategy) based on the desired URL path for your `defaultLocale`:
+2. Choose and configure a [`routing`](#routing) based on the desired URL path for your `defaultLocale`:
 
   - `"prefix-other-locales"` (default): URLs in your default language will **not** have a `/[locale]/` prefix. All other locales will.
 

--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -37,11 +37,11 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
   
 2. Choose and configure a [`routing`](#routing) based on the desired URL path for your `defaultLocale`:
 
-  - `"prefix-other-locales"` (default): URLs in your default language will **not** have a `/[locale]/` prefix. All other locales will.
+  - `"prefixDefaultLocale: false"` (default): URLs in your default language will **not** have a `/[locale]/` prefix. All other locales will.
 
-  - `"prefix-always"`: All URLs, including your default language, will have a `/[locale]/` prefix.
+  - `"prefixDefaultLocale: true"`: All URLs, including your default language, will have a `/[locale]/` prefix.
 
-    ```js title="astro.config.mjs" ins={7}
+    ```js title="astro.config.mjs" ins={8}
     import { defineConfig } from "astro/config"
     export default defineConfig({
       experimental: {
@@ -98,9 +98,10 @@ This routing API helps you generate, use, and verify the URLs that your multi-la
 
 Astro's built-in file-based routing automatically creates URL routes for you based on your file structure within `src/pages/`. When you configure i18n routing, the `routing` value now allows you to specify your file structure (and corresponding URL paths generated) in order to use helper functions to generate, use, and verify the routes in your project.
 
-#### ``
 
-```js title="astro.config.mjs" ins={7}
+#### `prefixDefaultLocale: false`
+
+```js title="astro.config.mjs" ins={8}
 import { defineConfig } from "astro/config"
 export default defineConfig({
   experimental: {
@@ -122,9 +123,9 @@ This is the **default** value. Set this option when URLs in your default languag
 - If there is no file at `src/pages/es/blog.astro`, then the route `example.com/es/blog/` will 404 unless you specify a [fallback strategy](#fallback).
 
 
-#### `'prefix-always'`
+#### `prefixDefaultLocale: true`
 
-```js title="astro.config.mjs" ins={7}
+```js title="astro.config.mjs" ins={8}
 import { defineConfig } from "astro/config"
 export default defineConfig({
   experimental: {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

RFC change: https://github.com/withastro/roadmap/pull/734/commits/089253d317e4327ee4e3b93eb303ddc28859952b

This PR updates the page to use the new `routing` object. The old `routingStrategy` has been removed.

Here's how the old configuration is mapped to the new one

```diff
export default defineConfig({
  experimental: {
      i18n: {
-          routingStrategy: "prefix-always",
+          routing: {
+              prefixDefaultLocale: true,
+          }  
      }
  }
})
```

```diff
export default defineConfig({
  experimental: {
      i18n: {
-          routingStrategy: "prefix-other-locales",
+          routing: {
+              prefixDefaultLocale: false,
+          }  
      }
  }
})
```

Also, it's worth noting that `routing` contains a key called [`strategy`](https://github.com/withastro/astro/blob/8deeb313ca98f74a90ffd5a1f6d109298440b540/packages/astro/src/core/config/schema.ts#L354), but since its value is only one, ** for now**, I decided not to mention it at all. 

<!-- Please describe the change you are proposing, and why -->
#### For Astro version: `next release`. See astro PR [#9236](https://github.com/withastro/astro/pull/9236).
