### PR TITLE
Remove useless code line in state section

### DIFF
--- a/src/content/docs/en/recipes/sharing-state.mdx
+++ b/src/content/docs/en/recipes/sharing-state.mdx
@@ -78,7 +78,6 @@ The following `Button` and `Dialog` components each use the shared `isOpen` stat
       }
     })
 
-    document.getElementById('openDialog').addEventListener('click', openDialog);
   </script>
   ```
 

--- a/src/content/docs/es/recipes/sharing-state.mdx
+++ b/src/content/docs/es/recipes/sharing-state.mdx
@@ -78,7 +78,6 @@ Los siguientes componentes `Button` y `Dialog`  utilizan el estado compartido `i
       }
     })
 
-    document.getElementById('openDialog').addEventListener('click', openDialog);
   </script>
   ```
 

--- a/src/content/docs/fr/recipes/sharing-state.mdx
+++ b/src/content/docs/fr/recipes/sharing-state.mdx
@@ -78,7 +78,6 @@ Les composants `Button` et `Dialog` suivants utilisent chacun l'état partagé `
       }
     })
 
-    document.getElementById('openDialog').addEventListener('click', openDialog);
   </script>
   ```
 

--- a/src/content/docs/it/recipes/sharing-state.mdx
+++ b/src/content/docs/it/recipes/sharing-state.mdx
@@ -79,7 +79,6 @@ I componenti `Button` e `Dialog` qui di seguito condividono entrambi lo stato `i
       }
     })
 
-    document.getElementById('openDialog').addEventListener('click', openDialog);
   </script>
   ```
 

--- a/src/content/docs/zh-cn/recipes/sharing-state.mdx
+++ b/src/content/docs/zh-cn/recipes/sharing-state.mdx
@@ -78,7 +78,6 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
       }
     })
 
-    document.getElementById('openDialog').addEventListener('click', openDialog);
   </script>
   ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

In the **store** section, we don't need to have a selector with a listener on the `Dialog.astro` component. This is needed only on the Button component who will toggle the Dialog.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
