### PR TITLE
fix: fix dark mode code example

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -44,7 +44,6 @@ Let's build a clickable icon to let your users toggle between light or dark mode
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }

--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -42,12 +42,12 @@ Let's build a clickable icon to let your users toggle between light or dark mode
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
       
 
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/es/tutorial/6-islands/2.mdx
+++ b/src/content/docs/es/tutorial/6-islands/2.mdx
@@ -44,7 +44,6 @@ Vamos a crear un icono en el que se pueda hacer clic para que los usuarios pueda
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }

--- a/src/content/docs/es/tutorial/6-islands/2.mdx
+++ b/src/content/docs/es/tutorial/6-islands/2.mdx
@@ -42,12 +42,12 @@ Vamos a crear un icono en el que se pueda hacer clic para que los usuarios pueda
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
       
 
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/fr/tutorial/6-islands/2.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/2.mdx
@@ -42,7 +42,6 @@ Construisons une icône cliquable pour permettre à vos utilisateurs de basculer
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }

--- a/src/content/docs/fr/tutorial/6-islands/2.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/2.mdx
@@ -40,12 +40,12 @@ Construisons une icône cliquable pour permettre à vos utilisateurs de basculer
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
       
 
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/ja/tutorial/6-islands/2.mdx
+++ b/src/content/docs/ja/tutorial/6-islands/2.mdx
@@ -42,12 +42,12 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
       
 
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/ja/tutorial/6-islands/2.mdx
+++ b/src/content/docs/ja/tutorial/6-islands/2.mdx
@@ -44,7 +44,6 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }

--- a/src/content/docs/pt-br/tutorial/6-islands/2.mdx
+++ b/src/content/docs/pt-br/tutorial/6-islands/2.mdx
@@ -41,12 +41,11 @@ Vamos construir um ícone clicável para permitir usuários alternarem entre um 
         border: 0;
         background: none;
       }
-      .sol { fill: black; }
-      .lua { fill: transparent; }
-      
+      .sol { fill: transparent; }
+      .lua { fill: black; }
 
-      :global(.escuro) .sol { fill: transparent; }
-      :global(.escuro) .lua { fill: white; }
+      :global(.escuro) .sol { fill: white; }
+      :global(.escuro) .lua { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/ru/tutorial/6-islands/2.mdx
+++ b/src/content/docs/ru/tutorial/6-islands/2.mdx
@@ -42,12 +42,12 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
+      
 
-
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/ru/tutorial/6-islands/2.mdx
+++ b/src/content/docs/ru/tutorial/6-islands/2.mdx
@@ -44,7 +44,6 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }

--- a/src/content/docs/zh-cn/tutorial/6-islands/2.mdx
+++ b/src/content/docs/zh-cn/tutorial/6-islands/2.mdx
@@ -39,12 +39,12 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
         border: 0;
         background: none;
       }
-      .sun { fill: black; }
-      .moon { fill: transparent; }
+      .sun { fill: transparent; }
+      .moon { fill: black; }
       
 
-      :global(.dark) .sun { fill: transparent; }
-      :global(.dark) .moon { fill: white; }
+      :global(.dark) .sun { fill: white; }
+      :global(.dark) .moon { fill: transparent; }
     </style>
     ```
 

--- a/src/content/docs/zh-cn/tutorial/6-islands/2.mdx
+++ b/src/content/docs/zh-cn/tutorial/6-islands/2.mdx
@@ -41,7 +41,6 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
       }
       .sun { fill: transparent; }
       .moon { fill: black; }
-      
 
       :global(.dark) .sun { fill: white; }
       :global(.dark) .moon { fill: transparent; }


### PR DESCRIPTION
#### Description (required)

When you have the light theme on, the theme toggle button should display the moon, and when you have the dark theme, it should display the sun.

This is done on all sites, including the Astro documentation site.

#### Related issues & labels (optional)

N/A
