### PR TITLE
i18n(da): add translations for docsearch, nav and ui

### DIFF
--- a/src/i18n/da/docsearch.ts
+++ b/src/i18n/da/docsearch.ts
@@ -1,0 +1,12 @@
+import { DocSearchDictionary } from '../translation-checkers';
+
+export default DocSearchDictionary({
+	button: 'Søg',
+	placeholder: 'Søg documentationen',
+	shortcutLabel: 'Tryk / for at søge',
+	resultsFooterLede: 'Leder du efter en Astro integration eller tema? Brug for mere hjælp?',
+	resultsFooterIntegrations: 'Astro integrations vejviser',
+	resultsFooterThemes: 'Astro tema fremvisning',
+	resultsFooterDiscord: 'Kom med på Discord',
+	modal: {},
+});

--- a/src/i18n/da/nav.ts
+++ b/src/i18n/da/nav.ts
@@ -1,0 +1,73 @@
+import { NavDictionary } from '../translation-checkers';
+
+export default NavDictionary({
+	// Start Here
+	startHere: 'Begynd her',
+	'getting-started': 'Kom i gang',
+	install: 'Installation',
+	'editor-setup': 'Editor-opsætning',
+	'guides/upgrade-to/v3': 'Opgrader til Astro v3',
+
+	// Core Concepts
+	coreConcepts: 'Kernekoncepter',
+	'concepts/islands': 'Astro-øer',
+	'concepts/why-astro': 'Hvorfor Astro',
+
+	// Tutorial
+	tutorials: 'Tutorials',
+	'blog-tutorial': 'Byg en blog',
+
+	// Basics
+	basics: 'Grundlæggende',
+	'core-concepts/project-structure': 'Projektstruktur',
+	'core-concepts/astro-components': 'Komponenter',
+	'core-concepts/astro-pages': 'Sider',
+	'core-concepts/layouts': 'Layouts',
+
+	// Recipes
+	examples: 'Instruktioner',
+	'guides/migrate-to-astro': 'Migrær til Astro',
+	'guides/cms': 'Forbind med CMS',
+	'guides/backend': 'Tilføj backend-tjenester',
+	'guides/integrations-guide': 'Guide til integrationer',
+	'guides/deploy': 'Offentligør websiden',
+	'guides/recipes': 'Flere instruktioner',
+
+	// Features
+	features: 'Funktioner',
+	'core-concepts/astro-syntax': 'Astro-Syntax',
+	'core-concepts/framework-components': 'UI-Frameworks',
+	'core-concepts/routing': 'Routing',
+	'guides/markdown-content': 'Markdown & MDX',
+	'guides/content-collections': 'Content-samlinger',
+	'guides/client-side-scripts': 'Scripts og eventhåndtering',
+	'guides/styling': 'CSS & Styling',
+	'guides/images': 'Billeder',
+	'guides/fonts': 'Skriftstyper',
+	'guides/imports': 'Importeringer',
+	'guides/server-side-rendering': 'Serverside-rendering (SSR)',
+	'core-concepts/endpoints': 'Endepunkter',
+	'guides/data-fetching': 'Data indlæsning',
+	'guides/middleware': 'Middleware',
+	'guides/testing': 'Testning',
+	'guides/view-transitions': 'View Transitions',
+	'guides/troubleshooting': 'Problemsøgning',
+	// 'guides/rss': 'RSS',
+
+	configuration: 'Konfiguration',
+	'guides/configuring-astro': 'Astro konfigurationsfilen',
+	'guides/typescript': 'TypeScript',
+	'guides/aliases': 'Import-Aliasnavne',
+	'guides/environment-variables': 'Miljøvariabler',
+
+	// Reference
+	reference: 'Refference',
+	'reference/configuration-reference': 'Konfiguration',
+	'reference/api-reference': 'Runtime-API',
+	'reference/integrations-reference': 'Integrations-API',
+	'reference/adapter-reference': 'Adapter-API',
+	'reference/image-service-reference': 'Billedetjeneste-API',
+	'reference/directives-reference': 'Skabelonsdirektiver',
+	'reference/cli-reference': 'Kommandolinjegrænseflade (CLI)',
+	'reference/error-reference': 'Fejlrefference',
+	'guides/publish-to-npm': 'NPM-Pakkeformat',});

--- a/src/i18n/da/ui.ts
+++ b/src/i18n/da/ui.ts
@@ -1,0 +1,128 @@
+import { UIDictionary } from '../translation-checkers';
+
+export default UIDictionary({
+	'a11y.skipLink': 'Spring videre til indhold',
+	'a11y.sectionLink': 'Afsnit med titlen',
+	'navbar.a11yTitle': 'Top',
+	// Site settings
+	'site.title': 'Astro Dokumentation',
+	'site.description': 'Byg hurtigere hjemmesider med mindre klientside JavaScript.',
+	'site.og.imageSrc': '/default-og-image.png?v=1',
+	'site.og.imageAlt':
+		'astro logo i et stjernefyldt rum med en lilla saturn-agtig planet, der svæver i forgrunden',
+	// Left Sidebar
+	'leftSidebar.a11yTitle': 'Primær',
+	'leftSidebar.learnTab': 'Lær',
+	'leftSidebar.referenceTab': 'Refference',
+	'leftSidebar.viewInEnglish': 'Vis på engelsk',
+	'leftSidebar.sponsoredBy': 'Sponsoreret af',
+	// Right Sidebar
+	'rightSidebar.a11yTitle': 'Sekundær',
+	'rightSidebar.onThisPage': 'På denne side',
+	'rightSidebar.overview': 'Oversigt',
+	'rightSidebar.community': 'Fælleskab',
+	'rightSidebar.joinDiscord': 'Kom med os på Discord',
+	'rightSidebar.readBlog': 'Læs vores blogindslag',
+	'rightSidebar.openCollective': 'Åben vores samling',
+	'rightSidebar.contribute': 'Hjælp til',
+	'rightSidebar.contributorGuides': 'Guides til at hjælpe',
+	'rightSidebar.editPage': 'Rediger denne side',
+	'rightSidebar.translatePage': 'Oversæt denne side',
+	'rightSidebar.github': 'Astro Docs på GitHub',
+	// Footer
+	'footer.privacyPolicy': 'Fortrolighedspolitik',
+	// `<ThemeToggleButton>` acessibility labels
+	'themeToggle.useLight': 'Brug lyst tema',
+	'themeToggle.useDark': 'Brug mørkt tema',
+	// Used in previous/next page links at the bottom of pages
+	'articleNav.nextPage': 'Næste side',
+	'articleNav.prevPage': 'Tilbage',
+	// Used in `<Since>`: Added in: v0.24.0 [NEW]
+	'since.addedIn': 'Tilføjet i:',
+	'since.new': 'Ny',
+	'since.beta': 'Beta',
+	// Installation Guide
+	'install.autoTab': 'Automatisk CLI',
+	'install.manualTab': 'Manuelt Setup',
+	// `<DeployGuidesNav>` vocabulary
+	'deploy.sectionTitle': 'Offentliggørelses Guides',
+	'deploy.altSectionTitle': 'Flere offentliggøreslses Guides',
+	'deploy.filterLabel': 'Filtrer med offentliggørelses-type',
+	'deploy.ssrTag': 'SSR',
+	'deploy.staticTag': 'Statisk',
+	// CMS Guides vocabulary
+	'cms.navTitle': 'Flere CMS guides',
+	// Migration Guides vocabulary
+	'migration.navTitle': 'Flere migrations guides',
+	// Recipes vocabulary
+	'recipes.navTitle': 'More instruktioner',
+	// `<RecipeLinks>` vocabulary
+	'recipesLink.singular': 'Relaterede instruktioner:',
+	'recipesLink.plural': 'Relaterede instruktioner',
+	// `<ContributorList>` fallback text
+	'contributors.seeAll': 'Se alle medvirkende',
+	// Fallback content notice shown when a page is not yet translated
+	'fallbackContent.notice':
+		'Denne side er endnu ikke tilgængeligt på dit sprog, så vi viser dig den engelske version. Du kan hjælpe os med at oversætte den!',
+	'fallbackContent.linkText': 'Lær mere om hvordan du kan hjælpe til',
+	// 404 Page
+	'404.title': 'Ikke fundet',
+	'404.content': 'Denne side er ikke i vores solsystem.',
+	'404.linkText': 'Tag mig hjem.',
+	// Aside component default labels
+	'aside.note': 'Note',
+	'aside.tip': 'Tip',
+	'aside.caution': 'Pas på',
+	'aside.danger': 'Fare',
+	// `<LanguageSelect>` vocabulary
+	'languageSelect.label': 'Vælg sprog',
+	// Integrations vocabulary
+	'integrations.changelog': 'Changelog',
+	'integrations.footerTitle': 'Flere integrationer',
+	'integrations.renderers': 'UI Frameworks',
+	'integrations.adapters': 'SSR Adaptere',
+	'integrations.others': 'Andre',
+	// Checklist component
+	'checklist.or': 'eller',
+	// Multiple Choice component
+	'multipleChoice.defaultCorrect': 'Korrekt!',
+	'multipleChoice.defaultIncorrect': 'Prøv igen!',
+	'multipleChoice.submitLabel': 'Indsend',
+	// Tutorial Progress
+	'progress.todo': 'To-do',
+	'progress.done': 'Færdig',
+	// Tutorial Navigation
+	'tutorial.trackerLabel': 'Tutorial Tracker',
+	'tutorial.unit': 'Enhed',
+	// Tutorial
+	'tutorial.getReady': 'Vær klar på…',
+	// Feedback Fish widget
+	'feedback.button': 'Giv os feedback',
+	'feedback.a11yLabel': 'Feedback formular',
+	'feedback.formTitle': 'Hvad har du på hjerte?',
+	'feedback.categoryGroupLabel': 'Vælg feedback kategori',
+	'feedback.issue': 'Problem',
+	'feedback.createIssue': 'Lav et GitHub Issue',
+	'feedback.idea': 'Idé',
+	'feedback.other': 'Andre',
+	'feedback.messageA11yLabel': 'Beskeder',
+	'feedback.placeholder': 'Hvad skal vi vide?',
+	'feedback.submit': 'Send feedback',
+	'feedback.close': 'Luk feedback formular',
+	'feedback.success': 'Tak! Vi har modtaget din feedback.',
+	// `<FileTree>` component
+	'fileTree.directoryLabel': 'Vejviser',
+	// Code snippet vocabulary
+	'expressiveCode.terminalWindowFallbackTitle': 'Terminal vindue',
+	'expressiveCode.copyButtonTooltip': 'Kopier til udkipsholder',
+	'expressiveCode.copyButtonCopied': 'Kopieret!',
+	// Backend Guides vocabulary
+	'backend.navTitle': 'Flere backend-service guider',
+	// Stubs vocabulary
+	'stub.title': 'Udvid denne stub!',
+	'stub.subtitle': 'Denne guide er en stub.',
+	'stub.description.migration':
+		'Vil du hjælpe os med denne guide? Har du et blog indlæg, video eller andre resourcer at dele om migration fra denne teknologi til Astro?',
+	'stub.description.cms': 'Ved du mere om hvordan man bruger denne CMS med Astro?',
+	'stub.description.backend': 'Ved du mere om hvordan man bruger denne backend-service med Astro?',
+});


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I added a Danish translation for the docsearch dictionary, the nav dictionary and the UI dictionary

#### Related issues & labels (optional)

- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
