### PR TITLE
Fix typos in internationalization.mdx

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -157,7 +157,7 @@ Set this option when all routes will have their `/locale/` prefix in their URL a
           - index.astro
     </FileTree>
 
-- URLs without a local prefix, (e.g. `example.com/blog/`) will return a 404 (not found) status code.
+- URLs without a locale prefix, (e.g. `example.com/blog/`) will return a 404 (not found) status code.
 
 ### `defaultLocale` and `locales`
 
@@ -173,7 +173,7 @@ Depending on your deploy host, you may discover transformations in URL paths, so
 
 Astro's i18n routing combined with one of Astro's  [on-demand server rendering modes (`output:'server'` or `output:'hybrid'`)](/en/guides/server-side-rendering/) allow you to access two properties for browser language detection: `Astro.preferredLocale` and `Astro.preferredLocaleList`.
 
-These combine the browser's `Accept-Langauge` header, and your `locales` to automatically respect your visitor's preferred languages.
+These combine the browser's `Accept-Language` header, and your `locales` to automatically respect your visitor's preferred languages.
 
 - `Astro.preferredLocale`:  Astro can compute a **preferred locale** for your visitor if their browser's preferred locale is included in your `locales` array. This value is undefined if no such match exists.
 - `Astro.preferredLocaleList`: An array of all locales that are both requested by the browser and supported by your website. This produces a list of all compatible languages between your site and your visitor. The value is `[]` if none of the browser's requested languages are found in your `locales` array. If the browser does not specify any preferred languages, then this value will be [`i18n.locales`].


### PR DESCRIPTION
#### Description (required)

Fix two typos in the i18n page.
