### PR TITLE
i18n(pt-br): Update `guides/middleware`

### DIFF
--- a/src/content/docs/pt-br/guides/middleware.mdx
+++ b/src/content/docs/pt-br/guides/middleware.mdx
@@ -15,12 +15,12 @@ Middleware está disponível tanto para projetos Astro SSG quanto SSR.
 
 1. Crie um arquivo `src/middleware.js|ts` (Como alternativa, você pode criar `src/middleware/index.js|ts`.)
 
-2. Dentro deste arquivo, exporte uma função [`onRequest()`](#onrequest). Esta exportação não pode ser um default export.
+2. Dentro deste arquivo, exporte uma função [`onRequest()`](/pt-br/reference/api-reference/#onrequest) que pode receber um [object `context`](#o-object-context) e uma função `next()`. Esse não pode ser a exportação padrão (`export default`).
 
     ```js title="src/middleware.js"
     export function onRequest ({ locals, request }, next) {
         // intercepta dados de uma requisição
-        // opcionalmente, transforma a requisição modificando `locals`
+        // opcionalmente, modifica as propriedades em `locals`
         locals.titulo = "Novo Título";
 
         // retorna uma `Response` ou o resultado de chamar `next()`
@@ -30,15 +30,86 @@ Middleware está disponível tanto para projetos Astro SSG quanto SSR.
 
 3. Dentro de qualquer arquivo `.astro`, acesse os dados da resposta utilizando `Astro.locals`.
 
-```astro title="src/components/Componente.astro"
----
-const dados = Astro.locals;
----
-<h1>{dados.titulo}</h1>
-<p>Essa {dados.propriedade} veio do middleware.</p>
+    ```astro title="src/components/Componente.astro"
+    ---
+    const dados = Astro.locals;
+    ---
+    <h1>{dados.titulo}</h1>
+    <p>Essa {dados.propriedade} veio do middleware.</p>
+    ```
+
+### O object `context`
+
+O object [`context`](/pt-br/reference/api-reference/#contexto-de-endpoint) inclui informações que serão disponibilizadas para outros middlewares, rotas de API e rotas `.astro` durante o processo de renderização.
+
+Esse é um argumento opcional passado para `onRequest()` que pode contar o objecto `locals` assim como propriedades adicionais a serem compartilhadas durante a renderização. Por exemplo, o objecto `context` pode incluir cookies utilizados para autenticação.
+
+### Armazenando informações em `context.locals`
+
+`context.locals` é um objeto que pode ser manipulado dentro do middleware.
+
+Esse objeto `locals` é encaminhado através do processamento da chamada e é disponibilizado como um propriedade em [`APIContext`](/pt-br/reference/api-reference/#context.locals) e [`AstroGlobal`](/pt-br/reference/api-reference/#astrolocals). Isso permite que dados sejam compartilhados entre middlewares, rotas de API, e páginas `.astro`. Isso é útil para armazenar dados específicos de uma chamada, como dados do usuário, entre processos de renderização.
+
+:::tip[Propriedades de integrações]
+[Integrações](/pt-br/guides/integrations-guide/) pode definir propriedades e prover funcionalidades através do objeto `locals`. Se você estiver utilizando uma integração, confira a documentação para garantir que você não está sobrescrevendo uma de suas propriedades or fazendo algum trabalho desnecessário.
+:::
+
+Você pode armazenar dados de qualquer tipo dentro de `locals`: strings, numbers, e até mesmo tipos complexos como funções e maps.
+
+```js title="src/middleware.js"
+export function onRequest ({ locals, request }, next) {
+    // intercepta dados de uma requisição
+    // opcionalmente, modifica as propriedades em `locals`
+    locals.usuario.nome = "John Wick";
+    locals.tituloBoasVindas = () => {
+        return "Bem-vindo de volta, " + locals.usuario.nome;
+    };
+
+    // retorna uma `Response` ou o resultado de chamar `next()`
+    return next();
+};
 ```
 
-### Tipos do Middleware
+Desta forma você pode utilizar essas informações dentro de qualquer arquivo `.astro` com `Astro.locals`.
+
+```astro title="src/pages/compras.astro"
+---
+const titulo = Astro.locals.tituloBoasVindas();
+const compras = Array.from(Astro.locals.compras.entries());
+---
+<h1>{titulo}</h1>
+<p>Essa {data.propriedade} veio do middleware.</p>
+<ul>
+    {compras.map(compra => {
+        return <li>{/* faça algo com cada compra */}</li>;
+    })}
+</ul>
+```
+
+`locals` é um objeto que vive e morre dentro de uma única rota AStro; quando a página de sua rota for renderizada, `locals` não existirá mais e um novo será criado. Informação que precise persistir entre chamadas para múltiplas páginas devem ser armazenas em outro lugar.
+
+:::note
+O valor de `locals` não pode ser sobrescrito em tempo de execução. Fazer isso arriscaria apagar todas as informações armazenadas pelo usuário. Em modo `dev`, Astro valida e emite um erro se `locals` for sobrescrito.
+:::
+
+## Exemplo: editando informações sensíveis
+
+O exemplo abaixo utiliza middleware para substituir "INFORMAÇÃO PESSOAL" pela palavra "REMOVIDO" para lhe permitir renderizar HTML modificado na sua página:
+
+```js title="src/middleware.js"
+export const onRequest = async (context, next) => {
+    const resposta = await next();
+    const html = await response.text();
+    const htmlDaResposta = html.replaceAll("INFORMAÇÃO PESSOAL", "REMOVIDO");
+    
+    return new Response(redactedHtml, {
+        status: 200,
+        headers: response.headers
+    });
+};
+```
+
+## Tipos do Middleware
 
 Você pode importar e utilizar a função utilitária `defineMiddleware()` para se aproveitar da segurança de tipo:
 
@@ -84,58 +155,9 @@ declare namespace App {
 
 Então, dentro do arquivo do middleware, podemos nos aproveitar de preenchimento automático e segurança de tipos.
 
-Você pode armazenar dados de qualquer tipo dentro de `Astro.locals`: strings, numbers, e até mesmo tipos complexos como funções e maps.
+## Encadeando middleware
 
-```js title="src/middleware.js"
-export function onRequest ({ locals, request }, next) {
-    // intercepta dados de resposta de uma requisição
-    // opcionalmente, transforma a resposta modificando `locals`
-    locals.usuario.nome = "John Wick";
-    locals.tituloBoasVindas = () => {
-        return "Bem-vindo de volta, " + locals.usuario.nome;
-    };
-
-    // retorna uma `Response` ou o resultado de chamar `next()`
-    return next();
-};
-```
-
-Desta forma você pode utilizar essas informações dentro de qualquer arquivo `.astro`.
-
-```astro title="src/pages/compras.astro"
----
-const titulo = Astro.locals.tituloBoasVindas();
-const compras = Array.from(Astro.locals.compras.entries());
----
-<h1>{titulo}</h1>
-<p>Essa {data.propriedade} veio do middleware.</p>
-<ul>
-    {compras.map(compra => {
-        return <li>{/* faça algo com cada compra */}</li>;
-    })}
-</ul>
-```
-
-### Exemplo: editando informações sensíveis
-
-O exemplo abaixo utiliza middleware para substituir "INFORMAÇÃO PESSOAL" pela palavra "REMOVIDO" para lhe permitir renderizar HTML modificado na sua página:
-
-```js title="src/middleware.js"
-export const onRequest = async (context, next) => {
-    const resposta = await next();
-    const html = await response.text();
-    const htmlDaResposta = html.replaceAll("INFORMAÇÃO PESSOAL", "REMOVIDO");
-    
-    return new Response(redactedHtml, {
-        status: 200,
-        headers: response.headers
-    });
-};
-```
-
-### Encadeando middleware
-
-Múltiplos middlewares podem ser conectados em uma sequência ordenada utilizando [`sequence()`](#sequence):
+Múltiplos middlewares podem ser conectados em uma sequência ordenada utilizando [`sequence()`](/pt-br/reference/api-reference/#sequence):
 
 ```js title="src/middleware.js"
 import { sequence } from "astro:middleware";
@@ -174,56 +196,4 @@ cumprimentos da resposta
 autenticação da resposta
 validação da resposta
 ```
-
-## Referência da API
-
-### `onRequest()`
-
-Uma função exportada obrigatória do arquivo `src/middleware.js` que será chamada antes da renderização de cada página ou rota da API.
-Ela aceita dois argumentos opcionais: [context](#context) e [next()](#next).
-`onRequest()` deve retornar uma `Response`: ou diretamente, ou chamando `next()`.
-
-### `context`
-
-Um objeto que inclui informações a serem disponibilizadas para outro middleware, rotas de API e rotas `.astro` durante o processo de renderização.
-
-Esse é um argumento opcional passado para `onRequest()` que pode conter o objeto [`locals`](#locals) junto com qualquer propriedade adicional a ser compartilhada durante a renderização.
-Por exemplo, o objeto `context` pode incluir cookies utilizados para autenticação.
-
-Esse é o mesmo objeto [`context`](/pt-br/reference/api-reference/#contexto-de-endpoint) que é passada para as rotas de API.
-
-### `next()`
-
-Uma função que intercepta (lê e modifica) a resposta (`Response`) de uma requisição (`Request`) ou invoca o próximo middleware na sequência e retorna uma `Response`.
-Por exemplo, essa função pode modificar o corpo HTML de uma resposta.
-
-Esse é um argumento opcional de `onRequest()`, e pode prover a `Response` que o middleware deve retornar.
-
-### `locals`
-
-Um objeto contendo dados de uma `Response` que podem ser manipulados dentro do middleware.
-
-Esse objeto `locals` é repassado através do processo de manipulação da requisição e é diponibilizado como uma propriedade em [`APIContext`](/pt-br/reference/api-reference/#contexto-de-endpoint) e [`AstroGlobal`](/pt-br/reference/api-reference/#global-astro).
-Isso permite que dados sejam compartilados entre middlewares, rotas da API, e páginas `.astro`. Isso é útil para armazenar dados específicos de uma chamada, como dados do usuário, através das etapas de renderização.
-
-`locals` é um objeto que vive e morre dentro de uma única rota Astro; quando a página da sua rota for renderizada, `locals` deixará de existir e um novo objeto será criado.
-Informações que precisarem ser persistidas através de múltiplas páginas devem ser armazenadas em outro lugar.
-
-:::note
-O valor de `locals` não pode ser sobrescrito tem tempo de execução. Fazer isso causaria um risco descartar toda a informação armazenada pelo usuário. Em modo de desenvolvimento (`dev`), Astro executa validações e emitirá um erro se `locals` for sobrescrito.
-:::
-
-### `sequence()`
-
-Uma função que aceita funções de middleware como argumentos, e os executará na ordem que foram passados.
-
-### `createContext`
-
-Uma API de baixo nível para criar um [`APIContext`](/pt-br/reference/api-reference/#contexto-de-endpoint) que pode ser utilizado pelo middleware Astro.
-
-Essa função pode ser usada por integrações/adaptadores para executar programaticamente os middlewares Astro.
-
-### `trySerializeLocals`
-
-Uma API de baixo nível que recebe qualquer valor e tenta retornar uma versão serializada (uma string) desse valor. Se o valor não puder ser serializado, essa função irá lançar um erro de runtime.
 


### PR DESCRIPTION
#### Description (required)

Update the Brazilian Portuguese translation of the middleware guide.

Some content from this page was extracted into the API reference and that translation is not up-to-date yet, so those links are broken. I noticed it after finishing this translation.

I'll open a separate PR to update the API reference translation and link it here. This PR should not be merged until that page is updated or people will get confused.