### PR TITLE
Fix stylying and formatting on API reference

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1141,14 +1141,14 @@ Middleware allows you to intercept requests and responses and inject behaviors d
 
 A required exported function from `src/middleware.js` that will be called before rendering every page or API route. It accepts two optional arguments: [context](#contextlocals) and [next()](#next). `onRequest()` must return a `Response`: either directly, or by calling `next()`.
 
-    ```js title="src/middleware.js"
-    export function onRequest (context, next) {
-        // intercept response data from a request
-        // optionally, transform the response
-        // return a Response directly, or the result of calling `next()`
-        return next();
-    };
-    ```
+```js title="src/middleware.js"
+export function onRequest (context, next) {
+    // intercept response data from a request
+    // optionally, transform the response
+    // return a Response directly, or the result of calling `next()`
+    return next();
+};
+```
 
 ### `next()`
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2,8 +2,8 @@
 title: API Reference
 i18nReady: true
 ---
-import Since from '~/components/Since.astro'
-import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import Since from '~/components/Since.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Badge from '~/components/Badge.astro';
 
 
@@ -222,12 +222,12 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 
 Getting a cookie via `Astro.cookies.get()` returns a `AstroCookie` type. It has the following structure.
 
-| Name           | Type                                              | Description                                        |
-| :------------- | :------------------------------------------------ | :------------------------------------------------- |
-| `value`          | `string \| undefined`                       | The raw string value of the cookie.          |
-| `json`          | `() => Record<string, any>`                       | Parses the cookie value via `JSON.parse()`, returning an object. Throws if the cookie value is not valid JSON.         |
-| `number`       | `() => number` | Parses the cookie value as a Number. Returns NaN if not a valid number.   |
-| `boolean`       | `() => boolean` | Converts the cookie value to a boolean.   |
+| Name      | Type                        | Description                                                                                                    |
+| :-------- | :-------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| `value`   | `string \| undefined`       | The raw string value of the cookie.                                                                            |
+| `json`    | `() => Record<string, any>` | Parses the cookie value via `JSON.parse()`, returning an object. Throws if the cookie value is not valid JSON. |
+| `number`  | `() => number`              | Parses the cookie value as a Number. Returns NaN if not a valid number.                                        |
+| `boolean` | `() => boolean`             | Converts the cookie value to a boolean.                                                                        |
 
 ### `Astro.redirect()`
 `Astro.redirect()` allows you to redirect to another page. 
@@ -779,10 +779,6 @@ Pagination will pass a `page` prop to every rendered page that represents a sing
 | `page.url.prev`    | `string \| undefined` | Get the URL of the previous page (will be `undefined` if on page 1).                                                              |
 | `page.url.next`    | `string \| undefined` | Get the URL of the next page (will be `undefined` if no more pages).                                                              |
 
-
-
-
-
 ## `import.meta`
 
 All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://vitejs.dev/guide/env-and-mode.html).
@@ -795,9 +791,9 @@ export default function () {
 }
 ```
 
-##  Images (`astro:assets`)
+## Images (`astro:assets`)
 
-### getImage()
+### `getImage()`
 
 :::caution
 `getImage()` relies on server-only APIs and breaks the build when used on the client.


### PR DESCRIPTION
Update the title for one of the methods that was missing the `` ` ` ``.

Since I was already fixing a markdown formatting I also:
- Removed a chunk of newlines that were unnecessary
- Aligned a table
- Added `;` to the imports that were missing
- Removed unnecessary indentation from one of the examples