### PR TITLE
updates all aside text to sentence case

### DIFF
--- a/src/content/docs/en/core-concepts/astro-syntax.mdx
+++ b/src/content/docs/en/core-concepts/astro-syntax.mdx
@@ -13,7 +13,7 @@ Astro component syntax is a superset of HTML. The syntax was [designed to feel f
 
 You can define local JavaScript variables inside of the frontmatter component script between the two code fences (`---`) of an Astro component. You can then inject these variables into the component's HTML template using JSX-like expressions!
 
-:::note[dynamic vs reactive]
+:::note[Dynamic vs reactive]
 Using this approach, you can include **dynamic** values that are calculated in the frontmatter. But once included, these values are not **reactive** and will never change. Astro components are templates that only run once, during the rendering step.
 
 See below for more examples of [differences between Astro and JSX](#differences-between-astro-and-jsx).

--- a/src/content/docs/en/core-concepts/framework-components.mdx
+++ b/src/content/docs/en/core-concepts/framework-components.mdx
@@ -109,7 +109,7 @@ import Counter from '../components/Counter.svelte';
 </div>
 ```
 
-:::caution[passing functions as props]
+:::caution[Passing functions as props]
 You can pass a function as a prop to a framework component, but it only works during server rendering. If you try to use the function in a hydrated component (for example, as an event handler), an error will occur.
 
 This is because functions can't be _serialized_ (transferred from the server to the client) by Astro.

--- a/src/content/docs/en/core-concepts/sharing-state.mdx
+++ b/src/content/docs/en/core-concepts/sharing-state.mdx
@@ -118,7 +118,7 @@ Let's say we're building a simple ecommerce interface with three interactive ele
 
 <LoopingVideo sources={[{ src: '/videos/stores-example.mp4', type: 'video/mp4' }]} />
 
-_[**Try the completed example**](https://github.com/withastro/astro/tree/main/examples/with-nanostores) on your machine or online via Stackblitz._
+_[**Try the completed example**](https://github.com/withastro/astro/tree/main/examples/with-nanostores) on your machine or online via StackBlitz._
 
 Your base Astro file may look like this:
 
@@ -819,4 +819,4 @@ customElements.define('cart-flyout', CartFlyoutLit);
 
 Now, you should have a fully interactive ecommerce example with the smallest JS bundle in the galaxy 🚀
 
-[**Try the completed example**](https://github.com/withastro/astro/tree/main/examples/with-nanostores) on your machine or online via Stackblitz!
+[**Try the completed example**](https://github.com/withastro/astro/tree/main/examples/with-nanostores) on your machine or online via StackBlitz!

--- a/src/content/docs/en/guides/cms/builderio.mdx
+++ b/src/content/docs/en/guides/cms/builderio.mdx
@@ -89,7 +89,7 @@ In your new model use the **+ New Custom Field** button to create 2 new fields:
 
 Then click the **Save** button in the upper right. 
 
-:::caution[slugs]
+:::caution[Slugs]
 There are some pitfalls with the `slug` field:
 
 * Make sure your slug is not just a number. This seems to break the fetch request to Builder's API. 
@@ -224,7 +224,7 @@ Fetching via the content API returns an array of objects containing data for eac
 
 The `posts` array returned from the fetch displays a list of blog post titles on the home page. The individual page routes will be created in the next step.
 
-:::tip[framework integrations]
+:::tip[Framework integrations]
 If you are using a JavaScript framework (e.g. Svelte, Vue, or React) in your Astro project you can use [one of Builder's integrations](https://www.builder.io/m/integrations) as an alternative to making raw fetch calls through the REST API.
 :::
 

--- a/src/content/docs/en/guides/cms/caisy.mdx
+++ b/src/content/docs/en/guides/cms/caisy.mdx
@@ -56,7 +56,7 @@ const post = gqlResponse?.allBlogArticle?.edges?.[0]?.node;
 
 ## Official Resources
 
-- Check out the Caisy + Astro example on [GitHub](https://github.com/caisy-io/caisy-example-astro) or [Stackblitz](https://stackblitz.com/github/caisy-io/caisy-example-astro?file=src%2Fpages%2Fblog%2F%5B...slug%5D.astro)
+- Check out the Caisy + Astro example on [GitHub](https://github.com/caisy-io/caisy-example-astro) or [StackBlitz](https://stackblitz.com/github/caisy-io/caisy-example-astro?file=src%2Fpages%2Fblog%2F%5B...slug%5D.astro)
 - Query your documents in [draft mode](https://caisy.io/developer/docs/external-api/localization-and-preview#preview-mode-15) and multiple [locales](https://caisy.io/developer/docs/external-api/localization-and-preview#localization-in-a-graphql-query-8).
 - Use [pagination](https://caisy.io/developer/docs/external-api/queries-pagination) to query large numbers of documents.
 - Use [filter](https://caisy.io/developer/docs/external-api/external-filter-and-sorting) in your queries and [order](https://caisy.io/developer/docs/external-api/external-filter-and-sorting#sorting-8) the results

--- a/src/content/docs/en/guides/cms/keystatic.mdx
+++ b/src/content/docs/en/guides/cms/keystatic.mdx
@@ -140,7 +140,7 @@ export default config({
 });
 ```
 
-:::note[already using content collections?]
+:::note[Already using content collections?]
 If you are already using [content collections](/en/guides/content-collections/#defining-collections) in your Astro project, then update the schema above to exactly match the collection(s) defined in your existing schema.
 :::
 

--- a/src/content/docs/en/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/en/guides/cms/kontent-ai.mdx
@@ -85,7 +85,7 @@ export const deliveryClient = createDeliveryClient({
 });
 ```
 
-:::note[Note]
+:::note
 Read more on [getting environment variables in Astro](/en/guides/environment-variables/#getting-environment-variables).
 :::
 
@@ -192,7 +192,7 @@ When you're finished, publish the blog post using the **Publish** button at the 
 
 Next, you'll generate TypeScript types out of your content model.
 
-:::note[Note]
+:::note
 This step is optional but provides a much better developer experience and allows you to discover potential problems at build time rather than at runtime.
 :::
 

--- a/src/content/docs/en/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/en/guides/cms/kontent-ai.mdx
@@ -91,7 +91,7 @@ Read more on [getting environment variables in Astro](/en/guides/environment-var
 
 This implementation creates a new `DeliveryClient` object using credentials from the `.env` file.
 
-:::note[previews]
+:::note[Previews]
 The `previewApiKey` is optional. When used, you can [configure each query](https://github.com/kontent-ai/delivery-sdk-js#enable-preview-mode-per-query) to the Delivery API endpoint to return the latest versions of content items regardless of their state in the workflow. Otherwise, only published items are returned.
 :::
 

--- a/src/content/docs/en/guides/deploy.mdx
+++ b/src/content/docs/en/guides/deploy.mdx
@@ -27,7 +27,7 @@ These host platforms automatically detect pushes to your Astro project’s sourc
 
     Many common hosts will recognize your project as an Astro site, and should choose the appropriate configuration settings to build and deploy your site as shown below. (If not, these settings can be changed.)
 
-    :::note[Deploy Settings]
+    :::note[Deploy settings]
     - **Build Command:** `astro build` or `npm run build`
     - **Publish directory:** `dist`
     :::
@@ -67,7 +67,7 @@ Some hosts will have their own command line interface (CLI) you can install glob
 
     Many common hosts will build and deploy your site for you. They will usually recognize your project as an Astro site, and should choose the appropriate configuration settings to build and deploy as shown below. (If not, these settings can be changed.)
 
-    :::note[Deploy Settings]
+    :::note[Deploy settings]
     - **Build Command:** `astro build` or `npm run build`
     - **Publish directory:** `dist`
     :::

--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -103,7 +103,7 @@ Astro maintains the official `withastro/action` to deploy your project with very
   
 Your site should now be published! When you push changes to your Astro project’s repository, the GitHub Action will automatically deploy them for you.
 
-:::tip[set up a custom domain]
+:::tip[Set up a custom domain]
 You can optionally set up a custom domain by adding the following `./public/CNAME` file to your project: 
 
 ```js title="public/CNAME"

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -62,7 +62,7 @@ Images in the `public/` folder, as well as remote images not specifically config
 
 `<Image />` can transform a local or authorized remote image's dimensions, file type, and quality for control over your displayed image. The resulting `<img>` tag includes `alt`, `loading`, and `decoding` attributes and infers image dimensions to avoid **Cumulative Layout Shift (CLS)**.
 
-:::tip[What is Cumulative Layout Shift?]
+:::tip[What is cumulative layout shift?]
 [Cumulative Layout Shift (CLS)](https://web.dev/cls/) is a Core Web Vital metric for measuring how much content shifted on your page during loading. The `<Image />` component optimizes for CLS by automatically setting the correct `width` and `height` for your local images.
 :::
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -62,7 +62,7 @@ Images in the `public/` folder, as well as remote images not specifically config
 
 `<Image />` can transform a local or authorized remote image's dimensions, file type, and quality for control over your displayed image. The resulting `<img>` tag includes `alt`, `loading`, and `decoding` attributes and infers image dimensions to avoid **Cumulative Layout Shift (CLS)**.
 
-:::tip[What is cumulative layout shift?]
+:::tip[What is Cumulative Layout Shift?]
 [Cumulative Layout Shift (CLS)](https://web.dev/cls/) is a Core Web Vital metric for measuring how much content shifted on your page during loading. The `<Image />` component optimizes for CLS by automatically setting the correct `width` and `height` for your local images.
 :::
 

--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -51,7 +51,7 @@ Astro includes built-in support for [TypeScript](https://www.typescriptlang.org/
 
 **Astro doesn't perform any type checking itself.** Type checking should be taken care of outside of Astro, either by your IDE or through a separate script. For type checking Astro files, the [`astro check` command](/en/reference/cli-reference/#astro-check) is provided.
 
-:::note[Typescript and file extensions]
+:::note[TypeScript and file extensions]
 Per [TypeScript's module resolution rules](https://www.typescriptlang.org/docs/handbook/module-resolution.html), `.ts` and `.tsx` file extensions should not be used when importing TypeScript files. Instead, either use `.js`/`.jsx` file extensions or completely omit the file extension.
 
 ```ts

--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -51,7 +51,7 @@ Astro includes built-in support for [TypeScript](https://www.typescriptlang.org/
 
 **Astro doesn't perform any type checking itself.** Type checking should be taken care of outside of Astro, either by your IDE or through a separate script. For type checking Astro files, the [`astro check` command](/en/reference/cli-reference/#astro-check) is provided.
 
-:::note[TypeScript and file extensions]
+:::note[Typescript and file extensions]
 Per [TypeScript's module resolution rules](https://www.typescriptlang.org/docs/handbook/module-resolution.html), `.ts` and `.tsx` file extensions should not be used when importing TypeScript files. Instead, either use `.js`/`.jsx` file extensions or completely omit the file extension.
 
 ```ts
@@ -238,7 +238,7 @@ const data = JSON.parse(json);
 
 With **Vite** and compatible **Rollup** plugins, you can import file types which aren't natively supported by Astro. Learn where to find the plugins you need in the [Finding Plugins](https://vitejs.dev/guide/using-plugins.html#finding-plugins) section of the Vite Documentation.
 
-:::note[plugin configuration]
+:::note[Plugin configuration]
 Refer to your plugin's documentation for configuration options, and how to correctly install it.
 :::
 

--- a/src/content/docs/en/guides/integrations-guide.mdx
+++ b/src/content/docs/en/guides/integrations-guide.mdx
@@ -64,7 +64,7 @@ It's even possible to add multiple integrations at the same time!
   </Fragment>
 </PackageManagerTabs>
 
-:::note[Handling Integration Dependencies]
+:::note[Handling integration dependencies]
 If you see any warnings like `Cannot find package '[package-name]'` after adding an integration, your package manager may not have installed [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) for you. To install these missing packages, run `npm install [package-name]`.
 :::
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -136,7 +136,7 @@ import App from '../cra-project/App.jsx'
 <App client:load/>
 ```
 
-:::note[client directives]
+:::note[Client directives]
 Your app needs a [client directive](/en/reference/directives-reference/#client-directives) for interactivity. Astro will render your React app as static HTML until you opt-in to client-side JavaScript.
 
 Use `client:load` to ensure your app loads immediately from the server, or `client:only="react"` to skip server-side rendering and run your app entirely client-side.

--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -570,6 +570,6 @@ This page layout shows one header when visiting the home page, and a different h
 
 - Blog Post: [Migrating my website from Gatsby to Astro](https://dev.to/flashblaze/migrating-my-website-from-gatsby-to-astro-2ej5).
 
-:::note[have a resource to share?]
+:::note[Have a resource to share?]
 If you found (or made!) a helpful video or blog post about converting a Gatsby site to Astro, [edit this page](https://github.com/withastro/docs/blob/main/src/pages/en/guides/migrate-to-astro/from-gatsby.md) and add it here!
 :::

--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -100,7 +100,7 @@ export default defineConfig({
     });
     ```
 
-    :::tip[Set a baseurl]
+    :::tip[Set a `baseUrl`]
     You can set [`"baseUrl": "http://localhost:4321"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.js` configuration file to use `cy.visit("/")` instead of `cy.visit("http://localhost:4321/")` for a more convenient URL.
     :::
 
@@ -211,7 +211,7 @@ Alternatively, you can install Playwright within your Astro project using the pa
     });
     ```
 
-    :::tip[Set a baseurl]
+    :::tip[Set a `baseUrl`]
     You can set [`"baseURL": "http://localhost:4321"`](https://playwright.dev/docs/api/class-testoptions#test-options-base-url) in the `playwright.config.ts` configuration file to use `page.goto("/")` instead of `page.goto("http://localhost:4321/")` for a more convenient URL.
     :::
 

--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -100,7 +100,7 @@ export default defineConfig({
     });
     ```
 
-    :::tip[set a baseUrl]
+    :::tip[Set a baseurl]
     You can set [`"baseUrl": "http://localhost:4321"`](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app#Step-3-Configure-Cypress) in the `cypress.config.js` configuration file to use `cy.visit("/")` instead of `cy.visit("http://localhost:4321/")` for a more convenient URL.
     :::
 
@@ -135,7 +135,7 @@ Running:  index.cy.js                                                           
 1 passing (1s)
 ```
 
-:::note[fail the test]
+:::note[Fail the test]
 To check that your test really does work, you can change the following line in the `index.astro` file:
 
  ```astro title="src/pages/index.astro" del={2} ins={3}
@@ -211,7 +211,7 @@ Alternatively, you can install Playwright within your Astro project using the pa
     });
     ```
 
-    :::tip[set a baseurl]
+    :::tip[Set a baseurl]
     You can set [`"baseURL": "http://localhost:4321"`](https://playwright.dev/docs/api/class-testoptions#test-options-base-url) in the `playwright.config.ts` configuration file to use `page.goto("/")` instead of `page.goto("http://localhost:4321/")` for a more convenient URL.
     :::
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -415,7 +415,7 @@ import { ViewTransitions } from 'astro:transitions';
 <ViewTransitions fallback="swap">
 ```
 
-:::note[known limitations]
+:::note[Known limitations]
 The `initial` browser animation is not simulated by Astro. So any element using this animation will not currently be animated.
 :::
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -309,7 +309,7 @@ The `clear` command resets the telemetry data:
 astro telemetry clear
 ```
 
-:::tip[Want to disable telemetry in CI environments?]
+:::tip[Want to disable telemetry in ci environments?]
 Add the `astro telemetry disable` command to your CI scripts or set the `ASTRO_TELEMETRY_DISABLED` environment variable.
 :::
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -309,7 +309,7 @@ The `clear` command resets the telemetry data:
 astro telemetry clear
 ```
 
-:::tip[Want to disable telemetry in ci environments?]
+:::tip[Want to disable telemetry in CI environments?]
 Add the `astro telemetry disable` command to your CI scripts or set the `ASTRO_TELEMETRY_DISABLED` environment variable.
 :::
 

--- a/src/content/docs/en/tutorial/1-setup/1.mdx
+++ b/src/content/docs/en/tutorial/1-setup/1.mdx
@@ -48,7 +48,7 @@ If the command returns an error message like `Command 'node' not found`, or a ve
 
 Additionally, you will need to download and install a **code editor** to write your code. 
 
-:::tip[we'll use...]
+:::tip[We'll use...]
 This tutorial will use **VS Code**, but you can use any editor for your operating system.
 :::
 

--- a/src/content/docs/en/tutorial/1-setup/5.mdx
+++ b/src/content/docs/en/tutorial/1-setup/5.mdx
@@ -22,7 +22,7 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
 
 Here, you will connect your GitHub repository to Netlify. Netlify will use that project to build and deploy your site live on the web every time you commit a change to your code. 
 
-:::tip[we'll use...]
+:::tip[We'll use...]
 This tutorial will use **Netlify**, but you are welcome to use your preferred hosting service for deploying your site to the internet.
 :::
 

--- a/src/content/docs/en/tutorial/1-setup/index.mdx
+++ b/src/content/docs/en/tutorial/1-setup/index.mdx
@@ -19,7 +19,7 @@ Now that you know what you're going to build, it's time to set up all the tools 
 
 This unit shows you how to set up your development environment and deploy to Netlify. Skip ahead to [Unit 2](/en/tutorial/2-pages/) if you are already comfortable with your environment and workflow.
 
-:::tip[using stackblitz]
+:::tip[UsingStackBlitz]
 
 Want to complete this tutorial in an online code editor instead?
 <details>

--- a/src/content/docs/en/tutorial/1-setup/index.mdx
+++ b/src/content/docs/en/tutorial/1-setup/index.mdx
@@ -19,7 +19,7 @@ Now that you know what you're going to build, it's time to set up all the tools 
 
 This unit shows you how to set up your development environment and deploy to Netlify. Skip ahead to [Unit 2](/en/tutorial/2-pages/) if you are already comfortable with your environment and workflow.
 
-:::tip[UsingStackBlitz]
+:::tip[Using StackBlitz]
 
 Want to complete this tutorial in an online code editor instead?
 <details>

--- a/src/content/docs/en/tutorial/2-pages/1.mdx
+++ b/src/content/docs/en/tutorial/2-pages/1.mdx
@@ -136,7 +136,7 @@ When you are happy with the way your preview looks, **commit** your changes to y
 
 4. After waiting a few minutes, visit your Netlify URL to verify that your changes are published live.
 
-:::tip[commit and deploy regularly]
+:::tip[Commit and deploy regularly]
 Follow these steps every time you pause working! Your changes will be updated in your GitHub repository. If you've deployed to a Netlify website, it will be rebuilt and republished.
 :::
 

--- a/src/content/docs/en/tutorial/3-components/3.mdx
+++ b/src/content/docs/en/tutorial/3-components/3.mdx
@@ -109,7 +109,7 @@ Since your site will be viewed on different devices, it's time to create a page 
     - Include an `expanded` class that can be toggled to display or hide the links on mobile
     - Use a `@media` query to define different styles for larger screen sizes
 
-    :::tip[mobile-first design]
+    :::tip[Mobile-first design]
     Start by defining what should happen on small screen sizes first! Smaller screen sizes require simpler layouts. Then, adjust your styles to accommodate larger devices. If you design the complicated case first, then you have to work to try to make it simple again.
     :::
 

--- a/src/content/docs/en/tutorial/3-components/4.mdx
+++ b/src/content/docs/en/tutorial/3-components/4.mdx
@@ -188,7 +188,7 @@ Instead of writing your JavaScript directly on each page, you can move the conte
     </body>
     ```
 
-:::note[takeaway]
+:::note[Takeaway]
 You had previously used some JavaScript to build parts of your site:
 
 - Defining your page title and heading dynamically

--- a/src/content/docs/en/tutorial/4-layouts/2.mdx
+++ b/src/content/docs/en/tutorial/4-layouts/2.mdx
@@ -104,7 +104,7 @@ const { frontmatter } = Astro.props;
 ```
 </Box>
 
-:::note[avoid duplication]
+:::note[Avoid duplication]
  Anything rendered by your layout does **not** need to be typed into your blog post! If you notice any duplication when you check your browser preview, then be sure to remove content from your Markdown file.
  :::
 

--- a/src/content/docs/en/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/4.mdx
@@ -127,7 +127,7 @@ Individuals can subscribe to your feed in a feed reader, and receive a notificat
     
 5. Visit `http://localhost:4321/rss.xml` and verify that you can see (unformatted) text on the page with an `item` for each of your `.md` files. Each item should contain blog post information such as `title`, `url`, and `description`.
 
-    :::tip[view your rss feed in a reader]
+    :::tip[View your RSS feed in a reader]
     Download a feed reader, or sign up for an online feed reader service and subscribe to your site by adding your own Netlify URL. You can also share this link with others so they can subscribe to your posts, and be notified when a new one is published.
     :::
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This changes all of our aside (e.g. "tip", "note" etc.) custom titles to sentence case.

The Astro Docs site automatically converts all text written as a `:::note[custom title]` to uppercase, as a design choice.

Starlight, however, displays text exactly as written. Moreover, the design choice for Starlight is to NOT show this text as all upper case. So, existing asides had to be checked to make sure all custom title text was written in sentence case.

We used @vasfvitor 's find and replace algorithm to convert every custom title to sentence case, then manually inspected for proper nouns (e.g. Astro, StackBlitz, RSS) and manually added capitals.

![image](https://github.com/withastro/docs/assets/5098874/529c34e0-e5c1-4ccd-81ba-0a42c4fe6393)
