### PR TITLE
[install-auto] add note about dev toolbar

### DIFF
--- a/src/content/docs/en/install/auto.mdx
+++ b/src/content/docs/en/install/auto.mdx
@@ -85,6 +85,8 @@ If all goes well, Astro should now be serving your project on [http://localhost:
 
 Astro will listen for live file changes in your `src/` directory, so you will not need to restart the server as you make changes during development.
 
+When viewing your site in the browser, you'll have access to the [Astro dev toolbar](/en/reference/configuration-reference/#dev-toolbar-options). As you build, it will help you inspect your [islands](/en/concepts/islands/), spot accessiblity issues, and more.
+
 If you aren't able to open your project in the browser, go back to the terminal where you ran the `dev` command and look to see if an error occurred, or if your project is being served at a different URL than the one linked to above.
 
 ## Starter Templates


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This adds a line after "start the dev server" to the getting started instructions mentioning that you have access to the dev toolbar.

> When viewing your site in the browser, you'll have access to the [Astro dev toolbar](/en/reference/configuration-reference/#dev-toolbar-options). As you build, it will help you inspect your [islands](/en/concepts/islands/), spot accessibility issues, and more.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
