### PR TITLE
fix: Fix a link in getting-started.mdx

### DIFF
--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -38,7 +38,7 @@ import Discord from '~/components/Landing/Discord.astro'
   </Card>
 
   <Card title="Take a guided tour" icon="star">
-    Complete our introductory [Build a Blog Tutorial](https://astro.build/themes/) to learn the basics and create your first Astro site.
+    Complete our introductory [Build a Blog Tutorial](https://docs.astro.build/en/tutorial/0-introduction/) to learn the basics and create your first Astro site.
   </Card>
 
   <SplitCard title="Start a new project" icon="rocket">

--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -38,7 +38,7 @@ import Discord from '~/components/Landing/Discord.astro'
   </Card>
 
   <Card title="Take a guided tour" icon="star">
-    Complete our introductory [Build a Blog Tutorial](https://docs.astro.build/en/tutorial/0-introduction/) to learn the basics and create your first Astro site.
+    Complete our introductory [Build a Blog Tutorial](/en/tutorial/0-introduction/) to learn the basics and create your first Astro site.
   </Card>
 
   <SplitCard title="Start a new project" icon="rocket">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Update `getting-started.mdx` file in `src/content/docs/en/` to correct the link to be consistent with the content.
- The original content is linked to the Astro theme page, but suggest it would be better to be linked to the actual tutorial page in Astro docs.
```md
[Build a Blog Tutorial]
(https://astro.build/themes/) --> (https://docs.astro.build/en/tutorial/0-introduction/)
```

<!-- #### Related issues & labels (optional) -->

<!-- - Closes #<!-- Add an issue number if this PR will close it. -->
<!-- - Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
