### PR TITLE
Replace non-break space with regular space [en-only]

### DIFF
--- a/src/content/docs/en/guides/integrations-guide.mdx
+++ b/src/content/docs/en/guides/integrations-guide.mdx
@@ -74,7 +74,7 @@ Astro integrations are always added through the `integrations` property in your 
 
 There are three common ways to import an integration into your Astro project:
 1. Installing an npm package integration.
-2. Import your own integration from a local file inside your project.
+2. Import your own integration from a local file inside your project.
 3. Write your integration inline, directly in your config file.
 
     ```js


### PR DESCRIPTION
#### Description (required)

Replaced the non-break space (`U+00A0`) between "file" and "inside" with regular space.