### PR TITLE
renamed dev overlay to dev toolbar in migration guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v4.mdx
@@ -75,7 +75,7 @@ export default defineConfig({
 })
 ```
 
-These features are now available in Astro v4.0.
+These configureations, `i18n` and the renamed `devToolbar`, are now available in Astro v4.0.
 
 Read more about these two exciting features and more in [the v4.0 Blog post](https://astro.build/blog/astro-4/)!
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

mentions in the experimental unflagged section that `devOverlay` is now named `devToolbar`

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
