### PR TITLE
Update astro version to v4.0 in the docs

### DIFF
--- a/src/content/docs/ar/getting-started.mdx
+++ b/src/content/docs/ar/getting-started.mdx
@@ -8,11 +8,11 @@ import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-:::tip[نسخة أسترو 3.0 هنا!]
-**ما الجديد في نسخة أسترو 3.0?** [
+:::tip[نسخة أسترو 4.0 هنا!]
+**ما الجديد في نسخة أسترو 4.0?** [
 اقرأ المدونة الخاصة بالإعلان
-](https://astro.build/blog/astro-3/).  
-**مستعد للترقية؟** [تابع دليلنا للترقية](/ar/guides/upgrade-to/v3/).
+](https://astro.build/blog/astro-4/).
+**مستعد للترقية؟** [تابع دليلنا للترقية](/ar/guides/upgrade-to/v4/).
 :::
 
 <h2>ما هو أسترو؟</h2>

--- a/src/content/docs/de/getting-started.mdx
+++ b/src/content/docs/de/getting-started.mdx
@@ -7,9 +7,9 @@ import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 
-:::tip[Astro Version 3 ist da!]
-**Was gibt es Neues in Astro v3?** [Erfahre es im Ankündigungs-Blogpost](https://astro.build/blog/astro-3/).  
-**Bereit fürs Upgrade?** [Folge unserer Upgrade-Anleitung](/de/guides/upgrade-to/v3/).
+:::tip[Astro Version 4 ist da!]
+**Was gibt es Neues in Astro v4?** [Erfahre es im Ankündigungs-Blogpost](https://astro.build/blog/astro-4/).
+**Bereit fürs Upgrade?** [Folge unserer Upgrade-Anleitung](/de/guides/upgrade-to/v4/).
 :::
 
 #### Was ist Astro?

--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -100,7 +100,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro 4.x
       npm install astro@latest
 
       # Example: upgrade the blog tutorial Preact integration
@@ -109,7 +109,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro v4.x
       pnpm add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration
@@ -118,7 +118,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro v4.x
       yarn add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration

--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -106,7 +106,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro v4.x
       npm install astro@latest
 
       # Example: upgrade the blog tutorial Preact integration
@@ -115,7 +115,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro v4.x
       pnpm add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration
@@ -124,7 +124,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      # Upgrade to Astro v3.x
+      # Upgrade to Astro v4.x
       yarn add astro@latest
 
     # Example: upgrade the blog tutorial Preact integration

--- a/src/content/docs/es/getting-started.mdx
+++ b/src/content/docs/es/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[¡La versión 3 de Astro ha llegado!]
-**¿Qué hay de nuevo en Astro v3?** [Descúbrelo en la publicación del blog de anuncio](https://astro.build/blog/astro-3/).
-**¿Listo para actualizar?** [Sigue nuestra guía de actualización](/es/guides/upgrade-to/v3/).
+:::tip[¡La versión 4 de Astro ha llegado!]
+**¿Qué hay de nuevo en Astro v4?** [Descúbrelo en la publicación del blog de anuncio](https://astro.build/blog/astro-4/).
+**¿Listo para actualizar?** [Sigue nuestra guía de actualización](/es/guides/upgrade-to/v4/).
 :::
 
 <h2>¿Qué es Astro?</h2>

--- a/src/content/docs/fr/getting-started.mdx
+++ b/src/content/docs/fr/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[La version 3 d'Astro est ici!]
-**Quoi de nouveau dans Astro v3?** [Découvrez-le dans l'article d'annonce du blog](https://astro.build/blog/astro-3/).  
-**Prêt à mettre à niveau?** [Suivez notre guide de mise à niveau](/fr/guides/upgrade-to/v3/).
+:::tip[La version 4 d'Astro est ici!]
+**Quoi de nouveau dans Astro v4?** [Découvrez-le dans l'article d'annonce du blog](https://astro.build/blog/astro-4/).
+**Prêt à mettre à niveau?** [Suivez notre guide de mise à niveau](/fr/guides/upgrade-to/v4/).
 :::
 
 <h2>Astro, qu'est-ce que c'est ?</h2>

--- a/src/content/docs/fr/tutorials/add-content-collections.mdx
+++ b/src/content/docs/fr/tutorials/add-content-collections.mdx
@@ -100,7 +100,7 @@ Les étapes ci-dessous vous montrent comment étendre le produit final du tutori
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      # Mettre à jour Astro v3.x
+      # Mettre à jour Astro v4.x
       npm install astro@latest
 
       # Exemple : mise à jour du tutoriel du blog Intégration de Preact
@@ -109,7 +109,7 @@ Les étapes ci-dessous vous montrent comment étendre le produit final du tutori
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      # Mettre à jour Astro v3.x
+      # Mettre à jour Astro v4.x
       pnpm add astro@latest
 
     # Exemple : mise à jour du tutoriel du blog Intégration de Preact
@@ -118,7 +118,7 @@ Les étapes ci-dessous vous montrent comment étendre le produit final du tutori
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      # Mettre à jour Astro v3.x
+      # Mettre à jour Astro v4.x
       yarn add astro@latest
 
     # Exemple : mise à jour du tutoriel du blog Intégration de Preact

--- a/src/content/docs/hi/getting-started.mdx
+++ b/src/content/docs/hi/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[Astro संस्करण 3 यहाँ है!]
-**Astro में नया क्या है?** [जानिए घोषणा ब्लॉग पोस्ट में।](https://astro.build/blog/astro-3/)
-**अपग्रेड करने के लिए तैयार हैं?** [हमारे अपग्रेड मार्गदर्शक का पालन करें।](/hi/guides/upgrade-to/v3/)
+:::tip[Astro संस्करण 4 यहाँ है!]
+**Astro में नया क्या है?** [जानिए घोषणा ब्लॉग पोस्ट में।](https://astro.build/blog/astro-4/)
+**अपग्रेड करने के लिए तैयार हैं?** [हमारे अपग्रेड मार्गदर्शक का पालन करें।](/hi/guides/upgrade-to/v4/)
 :::
 
 <h2>Astro क्या है?</h2>

--- a/src/content/docs/it/getting-started.mdx
+++ b/src/content/docs/it/getting-started.mdx
@@ -7,9 +7,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[La versione 3 di Astro è arrivata!]
-**Quali sono le novità di Astro v3?** [Scoprilo nel post sul blog dell'annuncio](https://astro.build/blog/astro-3/).  
-**Pronto per l'aggiornamento?** [Segui la nostra guida all'aggiornamento](/it/guides/upgrade-to/v3/).
+:::tip[La versione 4 di Astro è arrivata!]
+**Quali sono le novità di Astro v4?** [Scoprilo nel post sul blog dell'annuncio](https://astro.build/blog/astro-4/).
+**Pronto per l'aggiornamento?** [Segui la nostra guida all'aggiornamento](/it/guides/upgrade-to/v4/).
 :::
 
 <h2>Cos’è Astro?</h2>

--- a/src/content/docs/ja/getting-started.mdx
+++ b/src/content/docs/ja/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[Astroバージョン3が登場！]
-**Astro v3の新機能は？**[アナウンスメントのブログ記事を確認してください](https://astro.build/blog/astro-3/)。  
-**アップグレードの準備はできましたか？**[アップグレードガイドを参照してください](/ja/guides/upgrade-to/v3/)。
+:::tip[Astroバージョン4が登場！]
+**Astro v4の新機能は？**[アナウンスメントのブログ記事を確認してください](https://astro.build/blog/astro-4/)。
+**アップグレードの準備はできましたか？**[アップグレードガイドを参照してください](/ja/guides/upgrade-to/v4/)。
 :::
 
 <h2>Astroとは？</h2>

--- a/src/content/docs/ko/getting-started.mdx
+++ b/src/content/docs/ko/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro';
 import ContributorList from '~/components/ContributorList.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-:::tip[Astro 버전 3이 출시되었습니다!]
-**Astro v3의 새로운 기능은 무엇인가요?** [블로그 게시물에서 알아보세요](https://astro.build/blog/astro-3/).  
-**업그레이드할 준비가 되셨나요?** [업그레이드 가이드를 따르세요](/ko/guides/upgrade-to/v3/).
+:::tip[Astro 버전 4이 출시되었습니다!]
+**Astro v4의 새로운 기능은 무엇인가요?** [블로그 게시물에서 알아보세요](https://astro.build/blog/astro-4/).
+**업그레이드할 준비가 되셨나요?** [업그레이드 가이드를 따르세요](/ko/guides/upgrade-to/v4/).
 :::
 
 <h2>Astro란 무엇인가요?</h2>

--- a/src/content/docs/pt-br/getting-started.mdx
+++ b/src/content/docs/pt-br/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[A versão 3 do Astro chegou!]
-**O que há de novo no Astro v3?** [Descubra na postagem do blog de anúncio](https://astro.build/blog/astro-3/).  
-**Pronto para atualizar?** [Siga nosso guia de atualização](/pt-br/guides/upgrade-to/v3/).
+:::tip[A versão 4 do Astro chegou!]
+**O que há de novo no Astro v4?** [Descubra na postagem do blog de anúncio](https://astro.build/blog/astro-4/).
+**Pronto para atualizar?** [Siga nosso guia de atualização](/pt-br/guides/upgrade-to/v4/).
 :::
 
 <h2>O que é Astro?</h2>

--- a/src/content/docs/zh-cn/getting-started.mdx
+++ b/src/content/docs/zh-cn/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[Astro 3.0 版本重磅来袭！]
-**Astro v3 有什么新功能？** [在我们的公告博客文章中找到它们](https://astro.build/blog/astro-3/)。  
-**准备好升级了？** [请遵循我们的升级指南](/zh-cn/guides/upgrade-to/v3/)。
+:::tip[Astro 4.0 版本重磅来袭！]
+**Astro v4 有什么新功能？** [在我们的公告博客文章中找到它们](https://astro.build/blog/astro-4/)。
+**准备好升级了？** [请遵循我们的升级指南](/zh-cn/guides/upgrade-to/v4/)。
 :::
 
 <h2>什么是 Astro</h2>

--- a/src/content/docs/zh-cn/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/zh-cn/tutorials/add-view-transitions.mdx
@@ -106,7 +106,7 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      # 升级到 Astro v3.x
+      # 升级到 Astro v4.x
       npm install astro@latest
 
       # 例：升级博客教程中的 Preact 集成
@@ -115,7 +115,7 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      # 升级到 Astro v3.x
+      # 升级到 Astro v4.x
       pnpm add astro@latest
 
       # 例：升级博客教程中的 Preact 集成
@@ -124,7 +124,7 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      # 升级到 Astro v3.x
+      # 升级到 Astro v4.x
       yarn add astro@latest
 
       # 例：升级博客教程中的 Preact 集成

--- a/src/content/docs/zh-tw/getting-started.mdx
+++ b/src/content/docs/zh-tw/getting-started.mdx
@@ -8,9 +8,9 @@ import TranslatorList from '~/components/TranslatorList.astro'
 import ContributorList from '~/components/ContributorList.astro'
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-:::tip[Astro 3.0 現已發布！]
-**Astro v3 有甚麼新功能？** [在公告文章中了解詳情](https://astro.build/blog/astro-3/)。  
-**準備好升級了？** [請按照我們的升級指南](/zh-tw/guides/upgrade-to/v3/)。
+:::tip[Astro 4.0 現已發布！]
+**Astro v4 有甚麼新功能？** [在公告文章中了解詳情](https://astro.build/blog/astro-4/)。
+**準備好升級了？** [請按照我們的升級指南](/zh-tw/guides/upgrade-to/v4/)。
 :::
 
 <h2>甚麼是 Astro？</h2>

--- a/src/i18n/ar/nav.ts
+++ b/src/i18n/ar/nav.ts
@@ -6,7 +6,7 @@ export default NavDictionary({
 	'getting-started': 'دليل البداية',
 	install: 'التثبيت',
 	'editor-setup': 'إعداد المحرر',
-	'guides/upgrade-to/v3': 'الترقية إلى الإصدار 3',
+	'guides/upgrade-to/v4': 'الترقية إلى الإصدار 4',
 
 	// Core Concepts
 	coreConcepts: 'المفاهيم الأساسية',

--- a/src/i18n/de/nav.ts
+++ b/src/i18n/de/nav.ts
@@ -6,7 +6,7 @@ export default NavDictionary({
 	'getting-started': 'Erste Schritte',
 	install: 'Installation',
 	'editor-setup': 'Editor-Einrichtung',
-	'guides/upgrade-to/v3': 'Upgrade auf Astro v3',
+	'guides/upgrade-to/v4': 'Upgrade auf Astro v4',
 
 	// Core Concepts
 	coreConcepts: 'Kernkonzepte',

--- a/src/i18n/es/nav.ts
+++ b/src/i18n/es/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': 'Cómo Empezar',
 	install: 'Instalación',
 	'editor-setup': 'Configuración del Editor',
-	'guides/upgrade-to/v3': 'Actualizar a v3',
+	'guides/upgrade-to/v4': 'Actualizar a v4',
 
 	coreConcepts: 'Conceptos Principales',
 	'concepts/why-astro': 'Por qué Astro',

--- a/src/i18n/fr/nav.ts
+++ b/src/i18n/fr/nav.ts
@@ -12,7 +12,7 @@ export default [
 	{ text: 'Bien démarrer', slug: 'getting-started', key: 'getting-started' },
 	{ text: 'Installation', slug: 'install/auto', key: 'install' },
 	{ text: "Configuration de l'éditeur de code", slug: 'editor-setup', key: 'editor-setup' },
-	{ text: 'Mise à jour vers la v3', slug: 'guides/upgrade-to/v3', key: 'guides/upgrade-to/v3' },
+	{ text: 'Mise à jour vers la v4', slug: 'guides/upgrade-to/v4', key: 'guides/upgrade-to/v4' },
 
 	{ text: 'Concepts Fondamentaux', header: true, type: 'learn', key: 'coreConcepts' },
 	{ text: 'Pourquoi Astro ?', slug: 'concepts/why-astro', key: 'concepts/why-astro' },

--- a/src/i18n/hi/nav.ts
+++ b/src/i18n/hi/nav.ts
@@ -6,7 +6,7 @@ export default NavDictionary({
 
 	install: 'स्थापित करें',
 	'editor-setup': 'एडिटर सेटअप',
-	'guides/upgrade-to/v3': 'v3 में अपग्रेड करें',
+	'guides/upgrade-to/v4': 'v4 में अपग्रेड करें',
 
 	coreConcepts: 'मूल अवधारणाएँ',
 	'concepts/why-astro': 'क्यों Astro',

--- a/src/i18n/it/nav.ts
+++ b/src/i18n/it/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': 'Per Iniziare',
 	install: 'Installazione',
 	'editor-setup': 'Setup dell’Editor',
-	'guides/upgrade-to/v3': 'Aggiorna a v3',
+	'guides/upgrade-to/v4': 'Aggiorna a v4',
 
 	coreConcepts: 'Concetti Chiave',
 	'concepts/why-astro': 'Perché Astro',

--- a/src/i18n/ja/nav.ts
+++ b/src/i18n/ja/nav.ts
@@ -6,7 +6,7 @@ export default NavDictionary({
 	'getting-started': 'はじめに',
 	install: 'インストール',
 	'editor-setup': 'エディタのセットアップ',
-	'guides/upgrade-to/v3': 'v3へのアップグレード',
+	'guides/upgrade-to/v4': 'v4へのアップグレード',
 
 	// Core Concepts
 	coreConcepts: 'コアコンセプト',

--- a/src/i18n/ko/nav.ts
+++ b/src/i18n/ko/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': '개요',
 	install: '설치',
 	'editor-setup': '편집기 설정',
-	'guides/upgrade-to/v3': 'v3로 업그레이드',
+	'guides/upgrade-to/v4': 'v4로 업그레이드',
 
 	coreConcepts: '핵심 개념',
 	'concepts/why-astro': '왜 Astro인가?',

--- a/src/i18n/pl/nav.ts
+++ b/src/i18n/pl/nav.ts
@@ -6,7 +6,7 @@ export default NavDictionary({
 	install: 'Instalacja',
 	'editor-setup': 'Konfiguracja edytora',
 	'guides/migrate-to-astro': 'Migracja do Astro',
-	'guides/upgrade-to/v3': 'Aktualizacja do Astro 3.0',
+	'guides/upgrade-to/v4': 'Aktualizacja do Astro 4',
 	//migrate: 'Przewodnik migracji',
 	tutorials: 'Samouczki',
 	'blog-tutorial': 'Zbuduj bloga',

--- a/src/i18n/pt-br/nav.ts
+++ b/src/i18n/pt-br/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': 'Introdução',
 	install: 'Instalação',
 	'editor-setup': 'Configuração do Editor',
-	'guides/upgrade-to/v3': 'Atualize para a v3',
+	'guides/upgrade-to/v4': 'Atualize para a v4',
 	coreConcepts: 'Principais Conceitos',
 	'concepts/why-astro': 'Por que Astro?',
 	'concepts/islands': 'Ilhas Astro',

--- a/src/i18n/ru/nav.ts
+++ b/src/i18n/ru/nav.ts
@@ -50,7 +50,7 @@ export default NavDictionary({
 	'guides/content-collections': 'Коллекции контента',
 	'guides/migrate-to-astro': 'Перейти на Astro',
 	'guides/testing': 'Тестирование',
-	'guides/upgrade-to/v3': 'Обновление до v3',
+	'guides/upgrade-to/v4': 'Обновление до v4',
 	'reference/error-reference': 'Справочник по ошибкам',
 	tutorials: 'Обучение',
 	examples: 'Рецепты',

--- a/src/i18n/zh-cn/nav.ts
+++ b/src/i18n/zh-cn/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': '入门指南',
 	install: '安装',
 	'editor-setup': '编辑器设置',
-	'guides/upgrade-to/v3': '升级到 v3',
+	'guides/upgrade-to/v4': '升级到 v4',
 
 	coreConcepts: '核心理念',
 	'concepts/why-astro': '为什么选择 Astro',

--- a/src/i18n/zh-tw/nav.ts
+++ b/src/i18n/zh-tw/nav.ts
@@ -5,7 +5,7 @@ export default NavDictionary({
 	'getting-started': '新手上路',
 	install: '安裝',
 	'editor-setup': '編輯器設定',
-	'guides/upgrade-to/v3': '升级到 v3',
+	'guides/upgrade-to/v4': '升级到 4',
 
 	coreConcepts: '核心理念',
 	'concepts/why-astro': '為何選擇 Astro',


### PR DESCRIPTION
This PR addresses the recent update of Astro from v3 to v4 The changes include updating the version number in the sidebar, the version announcement panel, add-content-collections.mdx and add-view-transitions.mdx to reflect the latest release.