### PR TITLE
Update astro-components.mdx to add boolean attribute prop feature.

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -163,6 +163,29 @@ const { greeting = "Hello", name = "Astronaut" } = Astro.props;
 <h2>{greeting}, {name}!</h2>
 ```
 
+### Boolean Attribute Props
+
+In addition to regular props, Astro supports boolean attribute props, which allows you to use shorthand syntax for boolean attributes. For example, instead of writing danger={true} explicitly, you can simply include danger in the component tag.
+
+Here's an example with a Button component that accepts boolean attribute props:
+
+```astro
+---
+// src/components/Button.astro
+const { size, danger, fluid } = Astro.props;
+---
+<button class={`btn-${size} ${danger ? 'danger' : ''} ${fluid ? 'fluid' : ''}`}>
+  <slot />
+</button>
+```
+
+Now, you can use the **Button** component with boolean attribute props:
+
+<Button size="sm" danger fluid>Simple button</Button>
+
+This syntax provides a concise and readable way to handle boolean attributes in your Astro components.
+
+
 ## Slots
 
 The `<slot />` element is a placeholder for external HTML content, allowing you to inject (or "slot") child elements from other files into your component template.

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -181,7 +181,7 @@ const { size, danger, fluid } = Astro.props;
 
 Now, you can use the **Button** component with boolean attribute props:
 
-```
+```astro
 <Button size="sm" danger fluid>Simple button</Button>
 ```
 

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -181,7 +181,9 @@ const { size, danger, fluid } = Astro.props;
 
 Now, you can use the **Button** component with boolean attribute props:
 
+```
 <Button size="sm" danger fluid>Simple button</Button>
+```
 
 This syntax provides a concise and readable way to handle boolean attributes in your Astro components.
 


### PR DESCRIPTION
Added notes on how Astro props supports boolean attributes without explicitly writing prop={true}

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
