### PR TITLE
Update middleware.mdx

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -115,7 +115,7 @@ You can import and use the utility function `defineMiddleware()` to take advanta
 
 ```ts
 // src/middleware.ts
-import { defineMiddleware } from "astro:middleware";
+import { defineMiddleware } from "astro/middleware";
 
 // `context` and `next` are automatically typed
 export const onRequest = defineMiddleware((context, next) => {
@@ -158,7 +158,7 @@ Then, inside the middleware file, you can take advantage of autocompletion and t
 Multiple middlewares can be joined in a specified order using [`sequence()`](/en/reference/api-reference/#sequence):
 
 ```js title="src/middleware.js"
-import { sequence } from "astro:middleware";
+import { sequence } from "astro/middleware";
 
 async function validation(_, next) {
     console.log("validation request");


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The import path for `defineMiddleware` and `sequence` seem to be outdated.
Using `astro/middleware` instead of `astro:middleware` solves it

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Suggested label: typo

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
