### PR TITLE
fix(sidebar): Preserve sidebar scroll across page navigations

### DIFF
--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -53,3 +53,18 @@ sidebar = await Promise.all(sidebar.map(remap));
 		font-weight: 700;
 	}
 </style>
+
+<!-- Preserve sidebar scroll across page navigations -->
+<script is:inline>
+	const selector = '#starlight__sidebar';
+	const STORAGE_KEY = `position:${selector}`;
+
+	const sidebarElement = document.querySelector(selector);
+	const scrollPosition = sessionStorage.getItem(STORAGE_KEY);
+	if (scrollPosition !== null) {
+		sidebarElement.scrollTop = parseInt(scrollPosition, 10);
+	}
+	window.addEventListener('beforeunload', () => {
+		sessionStorage.setItem(STORAGE_KEY, sidebarElement.scrollTop);
+	});
+</script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Resolve the issue of the left sidebar scroll position jumping to the top during page navigations by implementing a feature to preserve the scroll position in the session storage

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #5771 <!-- Add an issue number if this PR will close it. -->
- Suggested label: bug <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `3.x`. See astro PR [#](url). -->
