### PR TITLE
Add `glossary` label to labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,3 +8,5 @@
 i18n:
 - any: ['src/content/docs/**/*.mdx', '!src/content/docs/en/**/*']
 - any: ['src/i18n/**/*', '!src/i18n/en/*']
+glossary:
+- any: ['src/content/docs/**/glossary.mdx']


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This change adds the `glossary` label to any PR that modifies a glossary page in any language.
I can strictly limit this to the English translation on request from the i18n maintainers!

#### Related issues & labels (optional)

- Suggested label: `glossary` (however recursive), `ci`

