### PR TITLE
Unify recipe titles into sentence-case and add missing punctuation

### DIFF
--- a/src/content/docs/en/core-concepts/sharing-state.mdx
+++ b/src/content/docs/en/core-concepts/sharing-state.mdx
@@ -1,5 +1,5 @@
 ---
-title: Share State Between Islands
+title: Share state between Islands
 description: Learn how to share state across framework components with Nano Stores.
 i18nReady: true
 type: recipe

--- a/src/content/docs/en/recipes/build-custom-img-component.mdx
+++ b/src/content/docs/en/recipes/build-custom-img-component.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a custom image component 
-description: Learn how to build a custom image component that supports media queries using the getImage function
+description: Learn how to build a custom image component that supports media queries using the getImage function.
 i18nReady: true
 type: recipe
 ---

--- a/src/content/docs/en/recipes/build-forms-api.mdx
+++ b/src/content/docs/en/recipes/build-forms-api.mdx
@@ -1,6 +1,6 @@
 ---
-title: Build Forms With API Routes
-description: Learn how to use JavaScript to send form submissions to an API Route
+title: Build forms with API routes
+description: Learn how to use JavaScript to send form submissions to an API Route.
 i18nReady: true
 type: recipe
 ---

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -1,6 +1,6 @@
 ---
-title: Build HTML Forms in Astro Pages
-description: Learn how to build HTML forms and handle submissions in your frontmatter
+title: Build HTML forms in Astro pages
+description: Learn how to build HTML forms and handle submissions in your frontmatter.
 i18nReady: true
 type: recipe
 ---

--- a/src/content/docs/en/recipes/dynamically-importing-images.mdx
+++ b/src/content/docs/en/recipes/dynamically-importing-images.mdx
@@ -1,6 +1,6 @@
 ---
-title: Dynamically Import Images
-description: Learn how to dynamically import images using Vite's import.meta.glob function
+title: Dynamically import images
+description: Learn how to dynamically import images using Vite's import.meta.glob function.
 i18nReady: true
 type: recipe
 ---

--- a/src/content/docs/en/recipes/external-links.mdx
+++ b/src/content/docs/en/recipes/external-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add icons to external links
-description: Learn how to install a rehype plugin to add icons to external links in your Markdown files
+description: Learn how to install a rehype plugin to add icons to external links in your Markdown files.
 i18nReady: true
 type: recipe
 ---

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add Last Modified Time
+title: Add last modified time
 description: Build a remark plugin to add the last modified time to your Markdown and MDX.
 i18nReady: true
 type: recipe

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add Reading Time
+title: Add reading time
 description: Build a remark plugin to add reading time to your Markdown or MDX files.
 i18nReady: true
 type: recipe

--- a/src/content/docs/en/recipes/sharing-state.mdx
+++ b/src/content/docs/en/recipes/sharing-state.mdx
@@ -1,5 +1,5 @@
 ---
-title: Share State Between Astro Components
+title: Share state between Astro Components
 description: Learn how to share state across Astro components with Nano Stores.
 i18nReady: true
 type: recipe

--- a/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
+++ b/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
@@ -1,6 +1,6 @@
 ---
-title: Style Rendered Markdown with Tailwind Typography
-description: Learn how to use @tailwind/typography to style your rendered Markdown
+title: Style rendered Markdown with Tailwind Typography
+description: Learn how to use @tailwind/typography to style your rendered Markdown.
 i18nReady: true
 type: recipe
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR changes all Title-Case recipe titles to Sentence-case.
It also adds missing punctuation to unify all the recipe descriptions (terminal periods).

#### Related issues & labels (optional)

- Suggested label: typo/grammar fix
