### PR TITLE
Refactor `cachedFetch()` to always retry failed fetches

### DIFF
--- a/src/components/Version.astro
+++ b/src/components/Version.astro
@@ -10,12 +10,13 @@ const { pkgName } = Astro.props as Props;
 const url = `https://registry.npmjs.org/${pkgName}/latest`;
 
 const response = await cachedFetch(url);
+const json = await response.json();
+
 if (!response.ok) {
 	throw new Error(
 		`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`
 	);
 }
-const { version } = await response.json();
 ---
 
-<span>v{version}</span>
+<span>v{json.version}</span>

--- a/src/components/Version.astro
+++ b/src/components/Version.astro
@@ -1,5 +1,4 @@
 ---
-import pRetry from 'p-retry';
 import { cachedFetch } from '../util-server';
 
 export interface Props {
@@ -10,25 +9,13 @@ const { pkgName } = Astro.props as Props;
 
 const url = `https://registry.npmjs.org/${pkgName}/latest`;
 
-const packageInfo = await pRetry(
-	async () => {
-		const response = await cachedFetch(url);
-		const json = await response.json();
-
-		if (!response.ok) {
-			throw new Error(
-				`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(
-					json
-				)}`
-			);
-		}
-
-		return json;
-	},
-	{ retries: 10 }
-);
-
-const { version } = packageInfo;
+const response = await cachedFetch(url);
+if (!response.ok) {
+	throw new Error(
+		`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(json)}`
+	);
+}
+const { version } = await response.json();
 ---
 
 <span>v{version}</span>

--- a/src/components/starlight/Hero/FacePile.astro
+++ b/src/components/starlight/Hero/FacePile.astro
@@ -1,5 +1,6 @@
 ---
 import { Image } from 'astro:assets';
+import { cachedFetch } from '~/util-server';
 
 export interface Props {
 	tagline: string;
@@ -13,7 +14,7 @@ type Contributor = {
 	avatar_url: string;
 };
 
-const res = await fetch('https://astro.badg.es/api/v1/top-contributors.json');
+const res = await cachedFetch('https://astro.badg.es/api/v1/top-contributors.json');
 const allContributors: Contributor[] = (await res.json()).data;
 
 const arrangement = [3, 4, 3, 3, 6, 4, 6, 3, 3, 3];

--- a/src/util-server.ts
+++ b/src/util-server.ts
@@ -5,6 +5,7 @@
 
 // @ts-expect-error Package without types we can’t do anything about.
 import EleventyFetch from '@11ty/eleventy-fetch';
+import retry from 'p-retry';
 
 export type CachedFetchOptions = {
 	duration?: string;
@@ -21,12 +22,14 @@ export async function cachedFetch(
 	let buffer: Buffer | undefined;
 
 	try {
-		buffer = await EleventyFetch(url, {
-			duration,
-			verbose,
-			type: 'buffer',
-			fetchOptions,
-		});
+		buffer = await retry(() =>
+			EleventyFetch(url, {
+				duration,
+				verbose,
+				type: 'buffer',
+				fetchOptions,
+			})
+		);
 	} catch (e: unknown) {
 		const error = e as Error;
 		const msg: string = error?.message || error.toString();


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates our `cachedFetch()` utility to use `p-retry` to automatically retry up to 10 times if a fetch fails. We were already using this strategy in the `<Version>` component — wrapping `cachedFetch()` in a retry — and this is now our default behaviour, so I refactored that component to remove the now redundant retry logic.

Should help with some flaky GitHub API calls we’ve been encountering (with so many contributors, we now need 8 calls just to get them all, so the chance of one flaking out has increased).

I’ve also switched the face pile component used in the new landing page hero to use `cachedFetch()` instead of a plain `fetch()`.