### PR TITLE
Update Markdoc integration description for obtaining Markdoc config in Astro component

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -426,6 +426,26 @@ export default defineMarkdocConfig({
 });
 ```
 
+### Markdoc variables within Astro components
+
+You can access Markdoc variables normally only from within Markdoc files, however the Markdoc config object is also provided to Astro components.
+
+You can use the following to access Markdoc variables, or any part of the config, within Astro components:
+
+```astro
+---
+import type { AstroMarkdocComponent } from '@astrojs/markdoc';
+
+interface Props extends AstroMarkdocComponent {
+  ...
+}
+
+const { ..., config } = Astro.props; // "config" here is the Markdoc config object
+---
+
+<p>{config.variables.hello}</p>
+```
+
 ### Access frontmatter from your Markdoc content
 
 To access frontmatter, you can pass the entry `data` property [as a variable](#pass-markdoc-variables) where you render your content:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Documentation regarding withastro/astro#9441

This is to explain to the user how to be able to access the Markdoc config from within Astro components, as created in the linked PR.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

N/A

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `4.x`. See astro PR [#9441](https://github.com/withastro/astro/pull/9441).
