### PR TITLE
i18n(es): Update `sharing-state.mdx`, `from-nextjs.mdx`, `add-view-transitions.mdx` & `view-transitions.mdx`

### DIFF
--- a/src/content/docs/es/core-concepts/sharing-state.mdx
+++ b/src/content/docs/es/core-concepts/sharing-state.mdx
@@ -1,5 +1,5 @@
 ---
-title: Compartiendo Estado
+title: Comparte el estado entre Islas
 description: Aprende a compartir estado entre componentes de framework con Nano Stores.
 i18nReady: true
 type: recipe

--- a/src/content/docs/es/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/es/guides/migrate-to-astro/from-nextjs.mdx
@@ -128,12 +128,12 @@ Compara el siguiente componente de Next y su equivalente en Astro:
   <Fragment slot="jsx">
     ```jsx title="StarCount.jsx"
     import Header from "./header";
-    import Footer from './footer';
+    import Footer from "./footer";
     import "./layout.css";
 
     export async function getStaticProps() {
-        const res = await fetch('https://api.github.com/repos/withastro/astro')
-        const json = await res.json()
+        const res = await fetch("https://api.github.com/repos/withastro/astro")
+        const json = await res.json();
         return {
             props: { message: json.message, stars: json.stargazers_count || 0 },
         }
@@ -165,8 +165,8 @@ Compara el siguiente componente de Next y su equivalente en Astro:
     import Footer from "./footer";
     import "./layout.css";
 
-    const res = await fetch('https://api.github.com/repos/withastro/astro')
-    const json = await res.json()
+    const res = await fetch("https://api.github.com/repos/withastro/astro")
+    const json = await res.json();
     const message = json.message;
     const stars = json.stargazers_count || 0;
     ---
@@ -194,7 +194,7 @@ Next tiene dos métodos diferentes para crear archivos de diseño, cada uno de l
 
 - El directorio `pages`
 
-- [El directorio `/app` (en beta)](https://beta.nextjs.org/docs/routing/pages-and-layouts#layouts)
+- [El directorio `/app`](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#layouts)
 
 Cada página de Astro requiere explícitamente que se incluyan las etiquetas `<html>`, `<head>`, y `<body>`, por lo que es común reutilizar un archivo de diseño en varias páginas. Astro utiliza [`<slot />`](/es/core-concepts/astro-components/#slots) para el contenido de la página, sin necesidad de importar ninguna declaración. Observa la estructura estándar de templating de HTML y el acceso directo al elemento `<head>`:  
 
@@ -334,7 +334,7 @@ Astro no utiliza ningún componente especial para los enlaces, aunque puedes cre
 
 ```astro title="src/components/Link.astro"
 ---
-const { to } = Astro.props
+const { to } = Astro.props;
 ---
 <a href={to}><slot /></a>
 ```
@@ -347,7 +347,7 @@ Ten encuenta que `.astro` y varios otros tipos de archivos deben ser importados 
 
 ```astro title="src/pages/authors/Fred.astro"
 ---
-import Card from `../../components/Card.astro`
+import Card from "../../components/Card.astro";
 ---
 <Card />
 ```
@@ -356,7 +356,7 @@ import Card from `../../components/Card.astro`
 
 Convierte cualquier instancia de `{children}` a un elemento `<slot />` de Astro. Astro no necesita recibir `{children}` como una función prop y automáticamente renderizará `<slot />`.
 
-```astro title="src/components/MyComponent" del={3-9} ins={11-13}
+```astro title="src/components/MyComponent.astro" del={3-9} ins={11-13}
 ---
 ---
 export default function MyComponent(props) { 

--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -368,23 +368,11 @@ Esto tiene el efecto de que si retrocedes desde la página `/main`, el navegador
 
 <p><Since v="4.0.0" /></p>
 
-El enrutador `<ViewTransitions />` también admite la navegación desencadenada por envíos de formularios.
+El enrutador `<ViewTransitions />` activará transiciones en la página desde elementos `<form>`, admitiendo tanto peticiones `GET` como `POST`.
 
-```astro title="src/pages/index.astro"
----
-import { ViewTransitions } from "astro:transitions";
----
-<html>
-	<head>
-		<ViewTransitions />
-	</head>
-	<body>
-		<!-- cosas aquí -->
-	</body>
-</html>
-```
+Por defecto, tu página hará una transición depués de que se envíe un formulario, incluso si estás usando `event.preventDefault()` para prevenir este comportamiento.
 
-El enrutador activará transiciones dentro de la página desde elementos `<form>`, admitiendo tanto solicitudes `GET` como `POST`. Puedes optar por excluir las transiciones del enrutador en formularios individuales mediante el atributo `data-astro-reload`:
+Puedes optar por excluir las transiciones del enrutador en formularios individuales mediante el atributo `data-astro-reload`:
 
 ```astro title="src/components/Form.astro"
 <form action="/contact" data-astro-reload>
@@ -459,7 +447,9 @@ Si tienes código que configura el estado global, este estado deberá tener en c
 </script>
 ```
 
-Los scripts de módulo solo se ejecutan una vez porque el navegador realiza un seguimiento de qué módulos ya están cargados. Para estos scripts, no necesitas preocuparte por la reejecución.
+Los scripts de módulo, incluyendo aquellos que añaden listeners de eventos para `DOMContentLoaded`, solo se ejecutan una vez debido a que el navegador realiza un seguimiento de los módulos que ya están cargados. Debes añadir listeners para un [evento del ciclo de vida](#eventos-del-ciclo-de-vida) para volver a ejecutar scripts durante la navegación de la página en el lado del cliente.
+
+Consulta el [tutorial Ampliar con View Transitions](/es/tutorials/add-view-transitions/#actualiza-los-scripts) para ver un ejemplo actualizando los scripts existentes en un proyecto.
 
 ## Eventos del ciclo de vida
 

--- a/src/content/docs/es/recipes/sharing-state.mdx
+++ b/src/content/docs/es/recipes/sharing-state.mdx
@@ -1,5 +1,5 @@
 ---
-title: Comparte el estado entre Islas
+title: Comparte el estado entre componentes de Astro
 description: Aprende como compartir el estado entre componentes de Astro con Nano Stores.
 i18nReady: true
 type: recipe

--- a/src/content/docs/es/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/es/tutorials/add-view-transitions.mdx
@@ -46,7 +46,7 @@ Debido a que cada nueva página no requiere una actualización completa del nave
  
 Hay momentos en los que querrás o necesitarás una actualización completa del navegador. Por ejemplo, cuando un enlace lleva a un visitante a un documento `.pdf`, necesitarás que el navegador cargue esa nueva página desde el servidor. Incluso con las view transitions habilitadas en tu proyecto de Astro, podrás especificar cómo debería navegar el navegador tanto de forma predeterminada como de forma específica para cada enlace, incluso eligiendo no utilizar enrutamiento del lado del cliente en absoluto.
 
-Lee más sobre las [view transitions de Astro](/es/guides/view-transitions/) en nuestra guía, o comienza con las instrucciones a continuación para convertir un blog básico de `src/pages/posts/` a `src/content/posts/`.
+Lee más sobre las [view transitions de Astro](/es/guides/view-transitions/) en nuestra guía, o sumérgete en las instrucciones a continuación para ampliar el blog con view transitions.
 
 <Box icon="question-mark">
 ### Pon a prueba tus conocimientos
@@ -105,7 +105,7 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      # Actualizar a Astro v3.x
+      # Actualizar a Astro v4.x
       npm install astro@latest
 
       # Ejemplo: actualizar la integración de Preact en el tutorial del blog
@@ -114,7 +114,7 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      # Actualizar a Astro v3.x
+      # Actualizar a Astro v4.x
       pnpm install astro@latest
 
      # Ejemplo: actualizar la integración de Preact en el tutorial del blog
@@ -123,7 +123,7 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      # Actualizar a Astro v3.x
+      # Actualizar a Astro v4.x
       yarn add astro@latest
 
       # Ejemplo: actualizar la integración de Preact en el tutorial del blog
@@ -144,7 +144,7 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
 
     ```astro title="src/layouts/BaseLayout.astro" ins={2,15}
     ---
-    import { ViewTransitions } from 'astro:transitions';
+    import { ViewTransitions } from "astro:transitions";
     import Header from "../components/Header.astro";
     import Footer from "../components/Footer.astro";
     import "../styles/global.css";
@@ -181,7 +181,7 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
 
 ### Actualiza los scripts
 
-Con las view transitions, algunos scripts pueden dejar de ejecutarse después de la navegación de página, a diferencia de lo que ocurre con las actualizaciones completas del navegador. Hay dos eventos durante la navegación del lado del cliente a los que puedes escuchar y disparar eventos cuando ocurren: [`astro:page-load`](/es/guides/view-transitions/#astropage-load) y [`astro:after-swap`](/es/guides/view-transitions/#astroafter-swap).
+Con las view transitions, algunos scripts pueden dejar de ejecutarse después de la navegación de página, a diferencia de lo que ocurre con las actualizaciones completas del navegador. Hay varios [eventos durante la navegación del lado del cliente a los que puedes escuchar](/es/guides/view-transitions/#eventos-del-ciclo-de-vida) y disparar eventos cuando ocurren. Los scripts en tu proyecto necesitarán ahora engancharse a dos eventos para ejecutarse en el momento adecuado durante la navegación de la página: [`astro:page-load`](/es/guides/view-transitions/#astropage-load) y [`astro:after-swap`](/es/guides/view-transitions/#astroafter-swap).
 
 4. Haz que el script que controla el componente del menú móvil `<Hamburger />` esté disponible después de navegar a una nueva página.
 
@@ -296,7 +296,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
 
 7. Cambia la animación predeterminada de `fade` a `slide` para el título de la página.
 
-    Con las view transitions habilitadas, actualmente tienes una pequeña transición de desvanecimiento configurada para todas las animaciones de transición de página. Astro también proporciona una animación incorporada llamada `slide`. Para cambiar el tipo de animación para un solo elemento, agrega la directiva `transition:animation=""`.
+    Con las view transitions habilitadas, actualmente tienes una pequeña transición de desvanecimiento configurada para todas las animaciones de transición de página. Astro también proporciona una animación incorporada llamada `slide`. Para cambiar el tipo de animación para un solo elemento, agrega la directiva `transition:animate=""`.
 
     Por ejemplo, para hacer que los títulos de las páginas se deslicen en lugar de desvanecerse, agrega `transition:animate="slide"` al elemento `<h1>` en el BaseLayout:
 
@@ -305,7 +305,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
     import Header from "../components/Header.astro";
     import Footer from "../components/Footer.astro";
     import "../styles/global.css";
-    import { ViewTransitions } from 'astro:transitions';
+    import { ViewTransitions } from "astro:transitions";
     const { pageTitle } = Astro.props;
     ---
 
@@ -363,7 +363,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
     ```astro title="src/layouts/MarkdownPostLayout.astro" ins={3} ins="transition:animate={fade({ duration: '2s' })}"
     ---
     import BaseLayout from "./BaseLayout.astro";
-    import { fade } from 'astro:transitions';
+    import { fade } from "astro:transitions";
     const { frontmatter } = Astro.props;
     ---
 
@@ -385,7 +385,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
 
     En ocasiones, querrás que se realice una recarga completa del navegador cuando los visitantes hagan clic en ciertos enlaces. Por ejemplo, puede que estés vinculando a una página que no utiliza el enrutador `<ViewTransitions />`, o a un archivo directamente, como un archivo `.pdf`.
 
-    Para lograr que tu navegador se actualice cada vez que hagas clic en el enlace de navegación para ir a tu página Acerca de, agrega el atributo `data-astro-reload` a la etiqueta `<a>` en tu componente `<Navigation/>`. Esto anulará completamente el enrutador `<ViewTransitions />` y cualquier animación de las view transitions para este enlace en particular.
+    Para lograr que tu navegador se actualice cada vez que hagas clic en el enlace de navegación para ir a tu página Acerca de, agrega el atributo `data-astro-reload` a la etiqueta `<a>` en tu componente `<Navigation />`. Esto anulará completamente el enrutador `<ViewTransitions />` y cualquier animación de las view transitions para este enlace en particular.
 
      ```astro title="src/components/Navigation.astro" ins='data-astro-reload'
       ---
@@ -409,7 +409,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
     ```astro title="src/layouts/MarkdownPostLayout.astro" ins='<a href="/about/">' ins="</a>"
     ---
     import BaseLayout from "./BaseLayout.astro";
-    import { fade } from 'astro:transitions';
+    import { fade } from "astro:transitions";
     const { frontmatter } = Astro.props;
     ---
 
@@ -425,7 +425,7 @@ Con las view transitions, algunos scripts pueden dejar de ejecutarse después de
     Si visitas cualquier entrada de blog en la vista previa del navegador y luego haces clic en el nombre del autor vinculado para ir a la página Acerca de, ¿cómo se ve la navegación de la página?
 
     <p>
-      Cuando un visitante hace clic en un enlace a la página Acerca de desde una entrada de blog individual, el título de la página y los enlaces de navegación en la cabecera <Spoiler>se deslizan en la pantalla</Spoiler> porque <Spoiler>el atributo `data-astro-reload` no está configurado en estos enlaces</Spoiler>
+      Cuando un visitante hace clic en un enlace a la página Acerca de desde una entrada de blog individual, el título de la página y los enlaces de navegación en la cabecera <Spoiler>se deslizan en la pantalla</Spoiler> porque <Spoiler>el atributo `data-astro-reload` no está configurado en estos enlaces.</Spoiler>
     </p>
 
 ¡Todavía hay mucho más por explorar! Consulta nuestra [Guía completa de View Transitions](/es/guides/view-transitions/) para descubrir más cosas que puedes hacer con las view transitions.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`sharing-state.mdx` [`3795132`](https://github.com/withastro/docs/commit/3795132d12d83e847be04bf2eae7fc632d337538#diff-83382bff225a8224ef90326f3c9569a018757ba23a7bdb689845540b35fcee4b)
`from-nextjs.mdx` [`a59604e`](https://github.com/withastro/docs/commit/a59604e1233057c182261a89e5ba9cbf80332625)
`add-view-transitions.mdx` [`479cffa`](https://github.com/withastro/docs/commit/479cffaa1338496971e0deaa5731b5c2a3d6604c) & [`13a0db8`](https://github.com/withastro/docs/commit/13a0db86f1bb949b073948810b2e5392a1021c2c)
`view-transitions.mdx` [`acfc72b`](https://github.com/withastro/docs/commit/acfc72b467a1260b727f1c5603a4ddefd7d49f7b)

> [!NOTE]
> In this [PR](https://github.com/withastro/docs/pull/5798) I changed the title `Comparte el estado entre componentes de Astro` to `Comparte el estado entre Islas` this was because I got confused with the `core-concepts/sharing-state.mdx` page which has that title.