### PR TITLE
i18n(zh-cn): translate `errors/could-not-transform-image.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/could-not-transform-image.mdx
+++ b/src/content/docs/zh-cn/reference/errors/could-not-transform-image.mdx
@@ -1,0 +1,19 @@
+---
+title: Could not transform image.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **CouldNotTransformImage**：不能转换图像 `IMAGE_PATH`。请参见堆栈跟踪以获取更多信息。
+
+## 哪里发生了错误？
+
+
+Astro 无法转换你的图片。通常这是由于图片损坏或格式不正确所导致的。将你的图片重新从编辑器中导出可能会解决这个问题。
+
+根据你所使用的图片服务，堆栈跟踪可能包含遇到的具体错误的更多信息。
+
+**请参阅**：
+-  [图像](/zh-cn/guides/images/)
+
+


### PR DESCRIPTION
#### Description (required)

translate `errors/could-not-transform-image.mdx` to Chinese version.

#### Related issues & labels (optional)

None
