### PR TITLE
Update example to use webp instead of avif

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -634,7 +634,7 @@ The `getImage()` function is intended for generating images destined to be used 
 import { getImage } from "astro:assets";
 import myBackground from "../background.png"
 
-const optimizedBackground = await getImage({src: myBackground, format: 'avif'})
+const optimizedBackground = await getImage({src: myBackground, format: 'webp'})
 ---
 
 <div style={`background-image: url(${optimizedBackground.src});`}></div>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Following a discussion from Discord, it updates the background image format to use webp instead avif because:
- Avif is not the most standard format, with known issues on MS Edge
- A lot of beginners use this code snippet as is so it would be better to give them a "fully working" code
- This snippet must show we can pass a custom format. Even if webp is the default, it shows that it can be set

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes N/A
- Suggested label: code snippet update, low effort

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
