### PR TITLE
public files copied before build

### DIFF
--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -96,7 +96,7 @@ It is a common convention to store your CSS or Sass files in a `src/styles` dire
 
 ### `public/`
 
-The `public/` directory is for files and assets that do not need to be processed during Astro's build process. These files will be copied into the build folder untouched.
+The `public/` directory is for files and assets in your project that do not need to be processed during Astro's build process. These existing files will be copied into the build folder untouched, and then your site will be built.
 
 This behavior makes `public/` ideal for common assets like images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`.
 

--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -96,7 +96,7 @@ It is a common convention to store your CSS or Sass files in a `src/styles` dire
 
 ### `public/`
 
-The `public/` directory is for files and assets in your project that do not need to be processed during Astro's build process. These existing files will be copied into the build folder untouched, and then your site will be built.
+The `public/` directory is for files and assets in your project that do not need to be processed during Astro's build process. The files in this folder will be copied into the build folder untouched, and then your site will be built.
 
 This behavior makes `public/` ideal for common assets like images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a short clarification about the timing of when assets from public are copied into the build folder.

#### Related issues & labels (optional)

- Closes #5464 

