### PR TITLE
Fix issue with rendering VT events

### DIFF
--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -182,7 +182,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
 
 ### Update scripts
 
-With view transitions, some scripts may no longer re-run after page navigation like they do with full-page browser refreshes. There are several [events during client-side routing that you can listen for](/en/guides/view-transitions/#lifecycle-events), and fire events when they occur. The scripts in your project will now need to hook into two events to run at the right time during page navigation: [astro:page-load](/en/guides/view-transitions/#astropage-load) and [astro:after-swap](/en/guides/view-transitions/#astroafter-swap).
+With view transitions, some scripts may no longer re-run after page navigation like they do with full-page browser refreshes. There are several [events during client-side routing that you can listen for](/en/guides/view-transitions/#lifecycle-events), and fire events when they occur. The scripts in your project will now need to hook into two events to run at the right time during page navigation: [`astro:page-load`](/en/guides/view-transitions/#astropage-load) and [`astro:after-swap`](/en/guides/view-transitions/#astroafter-swap).
 
 4. Make the script controlling the `<Hamburger />` mobile menu component available after navigating to a new page.
 


### PR DESCRIPTION
#### Description (required)

It seems there's currently an issue with displaying View Transition events inside Markdown, causing this reported issue:
![image](https://github.com/withastro/docs/assets/61414485/db28253a-afaf-44e5-8ffb-bf80d07b5af7)

This PR fixes this in docs by wrapping it around with backticks. I'll make an repro and report as bug later.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
