### PR TITLE
Fix typos in Internationalization guide

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -367,7 +367,7 @@ export default defineConfig({
 ```astro
 ---
 // src/pages/index.astro
-import { getLocaleByPath } from "astro:18n";
+import { getLocaleByPath } from "astro:i18n";
 console.log(getLocaleByPath("en")) // will log "en"
 console.log(getLocaleByPath("fr")) // will log "fr"
 console.log(getLocaleByPath("portugues")) // will log "pt-AO"

--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -300,11 +300,11 @@ getAbsoluteLocaleUrl("fr_CA", "getting-started", {
 Use this like [`getRelativeLocaleUrl`](#getrelativelocaleurl) to return a list of relative paths for all the locales.
 
 
-`getRelativeLocaleUrlList(locale: string, options?: GetLocaleOptions): string[]`
+`getRelativeLocaleUrlList(path?: string, options?: GetLocaleOptions): string[]`
 
 ### `getAbsoluteLocaleUrlList()`
 
-`getAbsoluteLocaleUrlList(locale: string, options?: GetLocaleOptions): string[]`
+`getAbsoluteLocaleUrlList(path?: string, options?: GetLocaleOptions): string[]`
 
 Use this like [`getAbsoluteLocaleUrl`](#getabsolutelocaleurl) to return a list of absolute paths for all the locales.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

This PR fixes two typos in the **Internationalization** guide:

- Fix wrong import for `getLocaleByPath` in example code:
  Imported from `astro:18n`, should be from `astro:i18n`.

- Fix wrong prototype for `getRelativeLocaleUrlList`:
  First argument is `locale: string`, should be `path?: string` (from [Astro's source code](https://github.com/withastro/astro/blob/4660aaa4051bd23fb77811968bbe56e2021161a2/packages/astro/client.d.ts#L221)).

- Fix wrong prototype for `getAbsoluteLocaleUrlList`:
  First argument is `locale: string`, should be `path?: string` (from [Astro's source code](https://github.com/withastro/astro/blob/4660aaa4051bd23fb77811968bbe56e2021161a2/packages/astro/client.d.ts#L229)).

#### Related issues & labels (optional)

<!-- - Closes #<!-- Add an issue number if this PR will close it. -->

- Suggested label: `improve documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
