### PR TITLE
feat: clarification on dynamic file creation

### DIFF
--- a/src/content/docs/en/core-concepts/project-structure.mdx
+++ b/src/content/docs/en/core-concepts/project-structure.mdx
@@ -98,6 +98,10 @@ It is a common convention to store your CSS or Sass files in a `src/styles` dire
 
 The `public/` directory is for files and assets in your project that do not need to be processed during Astro's build process. The files in this folder will be copied into the build folder untouched, and then your site will be built.
 
+:::caution
+Since `public/` will be copied to the build folder **before** the build process runs, this means that any files that you add during your build process (e.g. images that you fetch from external sources) will not end up in your build folder. You'll have to copy them manually or via a script.
+:::
+
 This behavior makes `public/` ideal for common assets like images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`.
 
 You can place CSS and JavaScript in your `public/` directory, but be aware that those files will not be bundled or optimized in your final build.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adding another paragraph on top of #5880 to clarify that dynamically created files during build process will not be part of the output folder, but'll have to be copied manually.

#### Related issues & labels (optional)

- Closes #5464 