### PR TITLE
Update view-transitions.mdx

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -374,8 +374,6 @@ This has the effect that if you go back from the `/main` page, the browser will 
 
 The `<ViewTransitions />` router will trigger in-page transitions from `<form>` elements, supporting both `GET` and `POST` requests.
 
-By default, your page will transition after a form is submitted, even if you are using `event.preventDefault()` to prevent this behavior.
-
 By default, Astro submits your form data as `multipart/form-data` when your `method` is set to `POST`. If you want to match the default behavior of web browsers, use the `enctype` attribute to submit your data encoded as `application/x-www-form-urlencoded`:
 
 ```astro title="src/components/Form.astro"


### PR DESCRIPTION
event.preventDefault() is now respected since #9486 😅

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

remove line about event.preventDefault() not being respected now that since `4.0.7` it is respected by default

#### Related issues & labels (optional)

[f6714f677](https://github.com/withastro/astro/commit/f6714f677cffa2484565f51d5eb55bd34309653b)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
