### PR TITLE
Fix Formatting and Update Dynamic Image Import Recipe for Vite 5

### DIFF
--- a/src/content/docs/en/recipes/dynamically-importing-images.mdx
+++ b/src/content/docs/en/recipes/dynamically-importing-images.mdx
@@ -36,7 +36,7 @@ In this recipe, you will learn how to dynamically import your images using Vite'
 
 3. Specify the `props` that your component will receive in order to display the necessary information on each card. You can optionally define their types, if you are using TypeScript in your project.
 
-    ```astro title="src/components/MyCustomCardComponent.astro" ins={4-9, 10-11}
+    ```astro title="src/components/MyCustomCardComponent.astro" ins={4-11}
     ---
     import { Image } from 'astro:assets';
 

--- a/src/content/docs/en/recipes/dynamically-importing-images.mdx
+++ b/src/content/docs/en/recipes/dynamically-importing-images.mdx
@@ -14,77 +14,80 @@ In this recipe, you will learn how to dynamically import your images using Vite'
 
 1. Create a new `assets` folder under the `src` directory and add your images inside that new folder. 
 
-<FileTree>
-- src/
-  - assets/
-    - avatar-1.jpg
-    - avatar-2.png
-    - avatar-3.jpeg
-</FileTree>
+    <FileTree>
+    - src/
+      - assets/
+        - avatar-1.jpg
+        - avatar-2.png
+        - avatar-3.jpeg
+    </FileTree>
 
-:::note
-`assets` is a popular folder name convention for placing images but you are free to name the folder whatever you like.
-::: 
+    :::note
+    `assets` is a popular folder name convention for placing images but you are free to name the folder whatever you like.
+    ::: 
 
 2. Create a new Astro component for your card and import the `<Image />` component.
 
     ```astro title="src/components/MyCustomCardComponent.astro" 
     ---
-     import { Image } from 'astro:assets';
+    import { Image } from 'astro:assets';
     ---
     ```
 
 3. Specify the `props` that your component will receive in order to display the necessary information on each card. You can optionally define their types, if you are using TypeScript in your project.
 
-    ```astro title="src/components/MyCustomCardComponent.astro" ins={4-11}
+    ```astro title="src/components/MyCustomCardComponent.astro" ins={4-9, 10-11}
     ---
-     import { Image } from 'astro:assets';
+    import { Image } from 'astro:assets';
 
-     interface Props {
-        imagePath: string;
-        altText: string;
-        name: string;
-        age: number;
-     }
+    interface Props {
+       imagePath: string;
+       altText: string;
+       name: string;
+       age: number;
+    }
 
-     const { imagePath, altText, name, age } = Astro.props;
+    const { imagePath, altText, name, age } = Astro.props;
     ---
     ``` 
 
-4. Create a new `images` variable and use the `import.meta.glob` function which returns an object of all of the image paths inside the `assets` folder. 
+4. Create a new `images` variable and use the `import.meta.glob` function which returns an object of all of the image paths inside the `assets` folder. You will also need to import `ImageMetadata` type to help define the type of the `images` variable. 
 
-    ```astro title="src/components/MyCustomCardComponent.astro" ins={12}
+    ```astro title="src/components/MyCustomCardComponent.astro" ins={2, 13} "ImageMetadata"
     ---
-     import { Image } from 'astro:assets';
+    import type { ImageMetadata } from 'astro';
+    import { Image } from 'astro:assets';
 
-     interface Props {
-        imagePath: string;
-        altText: string;
-        name: string;
-        age: number;
-     }
-     
-     const { imagePath, altText, name, age } = Astro.props;
-     const images = import.meta.glob('/src/assets/*.{jpeg,jpg,png,gif}')
+    interface Props {
+       imagePath: string;
+       altText: string;
+       name: string;
+       age: number;
+    }
+    
+    const { imagePath, altText, name, age } = Astro.props;
+    const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/*.{jpeg,jpg,png,gif}')
     ---
     ```
+    
 
 5. Use the props to create the markup for your card component. 
 
-    ```astro title="src/components/MyCustomCardComponent.astro" ins={14-18}
+    ```astro title="src/components/MyCustomCardComponent.astro" ins={16-20}
     ---
-     import { Image } from 'astro:assets';
+    import type { ImageMetadata } from 'astro';
+    import { Image } from 'astro:assets';
 
-     interface Props {
-        imagePath: string;
-        altText: string;
-        name: string;
-        age: number;
-     }
-     
-     const { imagePath, altText, name, age } = Astro.props;
-     // Type: Record<string, () => Promise<{default: ImageMetadata}>>
-     const images = import.meta.glob('/src/assets/*.{jpeg,jpg,png,gif}')
+    interface Props {
+       imagePath: string;
+       altText: string;
+       name: string;
+       age: number;
+    }
+    
+    const { imagePath, altText, name, age } = Astro.props;
+    // Type: Record<string, () => Promise<{default: ImageMetadata}>>
+    const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/*.{jpeg,jpg,png,gif}')
     ---
     <div class="card">
         <h2>{name}</h2>
@@ -95,19 +98,21 @@ In this recipe, you will learn how to dynamically import your images using Vite'
 
 6. Inside the `src` attribute, pass in the `images` object and use bracket notation for the image path. Then make sure to invoke the glob function. 
    
-    ```astro title="src/components/MyCustomCardComponent.astro" ins={17}
-    ---
-     import { Image } from 'astro:assets';
+    ```astro title="src/components/MyCustomCardComponent.astro" ins="images[imagePath]()"
 
-     interface Props {
-        imagePath: string;
-        altText: string;
-        name: string;
-        age: number;
-     }
-     
-     const { imagePath, altText, name, age } = Astro.props;
-     const images = import.meta.glob('/src/assets/*.{jpeg,jpg,png,gif}')
+    ---
+    import type { ImageMetadata } from 'astro';
+    import { Image } from 'astro:assets';
+
+    interface Props {
+       imagePath: string;
+       altText: string;
+       name: string;
+       age: number;
+    }
+    
+    const { imagePath, altText, name, age } = Astro.props;
+    const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/*.{jpeg,jpg,png,gif}')
     ---
     <div class="card">
         <h2>{name}</h2>
@@ -116,19 +121,19 @@ In this recipe, you will learn how to dynamically import your images using Vite'
     </div>
     ```
 
-:::note
-`images` is an object that contains all of the image paths inside the `assets` folder. 
+    :::note
+    `images` is an object that contains all of the image paths inside the `assets` folder. 
 
-```js
-const images = {
-  './assets/avatar-1.jpg': () => import('./assets/avatar-1.jpg'),
-  './assets/avatar-2.png': () => import('./assets/avatar-2.png'),
-  './assets/avatar-3.jpeg': () => import('./assets/avatar-3.jpeg')
-}
-```
+    ```js
+    const images = {
+      './assets/avatar-1.jpg': () => import('./assets/avatar-1.jpg'),
+      './assets/avatar-2.png': () => import('./assets/avatar-2.png'),
+      './assets/avatar-3.jpeg': () => import('./assets/avatar-3.jpeg')
+    }
+    ```
 
-The `imagePath` prop is a string that contains the path to the image that you want to display. The `import.meta.glob()` is doing the work of finding the image path that matches the `imagePath` prop and handling the import for you.
-::: 
+    The `imagePath` prop is a string that contains the path to the image that you want to display. The `import.meta.glob()` is doing the work of finding the image path that matches the `imagePath` prop and handling the import for you.
+    ::: 
 
 7. Import and use the card component inside an Astro page, passing in the values for the `props`. 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As of Astro v4.0, which now uses Vite 5, the `import.meta.glob<>()` API no longer returns `any` and now returns `unknown` unless a generic is specified. This PR updates the dynamic image import recipe to reflect these changes. It also fixes indentation and unnecessary whitespace in the recipe.

Affected page: [Modified](https://docs-git-fork-voxelmc-fix-image-import-recipe-astrodotbuild.vercel.app/en/recipes/dynamically-importing-images/#_top)

#### Related issues & labels (optional)

- Closes #5695 
- Suggested label: improve documentation
