### PR TITLE
Fixes FailedtoLoadModuleSSR error

### DIFF
--- a/src/content/docs/en/tutorial/4-layouts/1.mdx
+++ b/src/content/docs/en/tutorial/4-layouts/1.mdx
@@ -30,7 +30,7 @@ You still have some Astro components repeatedly rendered on every page. It's tim
 
     ```astro title="src/layouts/BaseLayout.astro"
     ---
-    import Header from '../components/Header.astro';
+    import Header from '../components/Navigation.astro';
     import Footer from '../components/Footer.astro';
     import '../styles/global.css';
     const pageTitle = "Home Page";


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

While following the `Build a blog` tutorial, learners would encounter a `Could not import file` error due to wrong file importing in the `BaseLayout.astro` file. This PR fixes it.

#### Related issues & labels (optional)

- https://github.com/withastro/docs/issues/5952



