### PR TITLE
Add deprecated warning to Heroku deploy

### DIFF
--- a/src/content/docs/en/guides/deploy/heroku.mdx
+++ b/src/content/docs/en/guides/deploy/heroku.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 ---
 [Heroku](https://www.heroku.com/) is a platform-as-a-service for building, running, and managing modern apps in the cloud. You can deploy an Astro site to Heroku using this guide.
 
-:::caution 
+:::danger
 The following instructions use [the deprecated `heroku-static-buildpack`](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated). Please see [Heroku's documentation for using `heroku-buildpack-nginx`](https://github.com/dokku/heroku-buildpack-nginx) instead.
 :::
 

--- a/src/content/docs/en/guides/deploy/heroku.mdx
+++ b/src/content/docs/en/guides/deploy/heroku.mdx
@@ -4,8 +4,12 @@ description: How to deploy your Astro site to the web using Heroku.
 type: deploy
 i18nReady: true
 ---
-
 [Heroku](https://www.heroku.com/) is a platform-as-a-service for building, running, and managing modern apps in the cloud. You can deploy an Astro site to Heroku using this guide.
+
+:::caution 
+The following instructions use [the deprecated `heroku-static-buildpack`](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated). Please see [Heroku's documentation for using `heroku-buildpack-nginx`](https://github.com/dokku/heroku-buildpack-nginx) instead.
+:::
+
 ## How to deploy
 
 1. Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Until someone can contribute an updated guide, adds deprecation notice to the Deploy to Heroku page.

#### Related issues & labels (optional)

- Closes #5657 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
