### PR TITLE
[astro-components] add named slots example using Fragment

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -248,8 +248,40 @@ import Wrapper from '../components/Wrapper.astro';
 </Wrapper>
 ```
 
-
+:::tip
 Use a `slot="my-slot"` attribute on the child element that you want to pass through to a matching `<slot name="my-slot" />` placeholder in your component.
+:::
+
+To pass multiple HTML elements into a component's `<slot/>` placeholder without a wrapping `<div>`, use the `slot=""` attribute on [Astro's `<Fragment/>` component](/en/reference/api-reference/#fragment-):
+
+```astro title="src/components/CustomTable.astro" "<slot name="header"/>" "<slot name="body"/>"
+---
+// Create a custom table with named slot placeholders for head and body content
+---
+<table class="bg-white">
+  <thead class="sticky top-0 bg-white"><slot name="header"/></thead>
+  <tbody class="[&_td:nth-child(odd)]:bg-gray-100"><slot name="body"/></tbody>
+</table>
+```
+
+Inject multiple rows and columns of HTML content using a `slot=""` attribute to specify the `"header"` and `"body"` content. Individual HTML elements can also be styled:
+
+```astro title="src/components/my-table.astro" {5-7, 9-13} '<Fragment slot="header">' '<Fragment slot="body">'
+---
+import CustomTable from './CustomTable.astro';
+---
+<CustomTable>
+  <Fragment slot="header"> <!-- pass table header -->
+    <tr><th>Column 1</th><th>Column 2</th></tr>
+  </Fragment>
+
+  <Fragment slot="body"> <!-- pass table body -->
+    <tr><td>A1</td><td>A2</td></tr>
+    <tr><td>B1</td><td>B2</td></tr>
+    <tr><td>C1</td><td class="font-bold">C2</td></tr>
+  </Fragment>
+</CustomTable>
+```
 
 Note that named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
 

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -260,7 +260,7 @@ To pass multiple HTML elements into a component's `<slot/>` placeholder without 
 ---
 <table class="bg-white">
   <thead class="sticky top-0 bg-white"><slot name="header"/></thead>
-  <tbody class="[&_td:nth-child(odd)]:bg-gray-100"><slot name="body"/></tbody>
+  <tbody class="[&_tr:nth-child(odd)]:bg-gray-100"><slot name="body"/></tbody>
 </table>
 ```
 

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -281,6 +281,7 @@ import CustomTable from './CustomTable.astro';
     <tr><td>Sneakers</td><td class="text-red-500">0</td></tr>
   </Fragment>
 </CustomTable>
+```
 
 Note that named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
 

--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -266,22 +266,21 @@ To pass multiple HTML elements into a component's `<slot/>` placeholder without 
 
 Inject multiple rows and columns of HTML content using a `slot=""` attribute to specify the `"header"` and `"body"` content. Individual HTML elements can also be styled:
 
-```astro title="src/components/my-table.astro" {5-7, 9-13} '<Fragment slot="header">' '<Fragment slot="body">'
+```astro title="src/components/StockTable.astro" {5-7, 9-13} '<Fragment slot="header">' '<Fragment slot="body">'
 ---
 import CustomTable from './CustomTable.astro';
 ---
 <CustomTable>
   <Fragment slot="header"> <!-- pass table header -->
-    <tr><th>Column 1</th><th>Column 2</th></tr>
+    <tr><th>Product name</th><th>Stock units</th></tr>
   </Fragment>
 
   <Fragment slot="body"> <!-- pass table body -->
-    <tr><td>A1</td><td>A2</td></tr>
-    <tr><td>B1</td><td>B2</td></tr>
-    <tr><td>C1</td><td class="font-bold">C2</td></tr>
+    <tr><td>Flip-flops</td><td>64</td></tr>
+    <tr><td>Boots</td><td>32</td></tr>
+    <tr><td>Sneakers</td><td class="text-red-500">0</td></tr>
   </Fragment>
 </CustomTable>
-```
 
 Note that named slots must be an immediate child of the component. You cannot pass named slots through nested elements.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This adds another example to the section on named slots that shows using the named slot attribute on the Fragment component (`<Fragment slot="header">`) because the only existing examples showed adding the attribute to HTML elements.

In response to a request from an issue. Also note that this pattern is used and documented in the AstroWind template: https://astrowind.vercel.app/astrowind-template-in-depth , so it seemed reasonable to include an example here!

Am open to refining this example, or choosing a better one. Note that this one adds style classes (not style attributes) and therefore is maybe reflective of how it might be used, but not copy/pasteable. We could also choose to show inline styles if we cared instead.

Direct deploy preview: https://docs-git-named-fragment-slots-astrodotbuild.vercel.app/en/core-concepts/astro-components/#named-slots

#### Related issues & labels (optional)

- Closes #5959
