### PR TITLE
[i18nIgnore] New bun types package @types/bun

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -44,20 +44,12 @@ bun install
 
 ## Add Types
 
-Bun publishes the [`bun-types`](https://www.npmjs.com/package/bun-types) package, containing the runtime types for Bun.
+Bun publishes the [`@types/bun`](https://www.npmjs.com/package/@types/bun) package, containing the runtime types for Bun.
 
-Install `bun-types` using the following command:
+Install `@types/bun` using the following command:
 
 ```sh
-bun add -d bun-types
-```
-
-Add the package to your types in `tsconfig.json`
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## Using Astro integrations

--- a/src/content/docs/es/recipes/bun.mdx
+++ b/src/content/docs/es/recipes/bun.mdx
@@ -44,20 +44,12 @@ bun install
 
 ## Agrega Tipos
 
-Bun publica el paquete [`bun-types`](https://www.npmjs.com/package/bun-types), que contiene los tipos en runtime para Bun.
+Bun publica el paquete [`@types/bun`](https://www.npmjs.com/package/@types/bun), que contiene los tipos en runtime para Bun.
 
-Instala `bun-types` utilizando el siguiente comando:
+Instala `@types/bun` utilizando el siguiente comando:
 
 ```sh
-bun add -d bun-types
-```
-
-Agrega el paquete a tus tipos en `tsconfig.json`.
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## Utilizando las integraciones de Astro

--- a/src/content/docs/it/recipes/bun.mdx
+++ b/src/content/docs/it/recipes/bun.mdx
@@ -44,20 +44,12 @@ bun install
 
 ## Aggiungere i Types
 
-Bun pubblica i tipi di runtime per Bun nel pacchetto [`bun-types`](https://www.npmjs.com/package/bun-types).
+Bun pubblica i tipi di runtime per Bun nel pacchetto [`@types/bun`](https://www.npmjs.com/package/@types/bun).
 
-Installa `bun-types` usando il seguente comando:
+Installa `@types/bun` usando il seguente comando:
 
 ```sh
-bun add -d bun-types
-```
-
-Aggiungi il pacchetto ai tuoi types in `tsconfig.json`:
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## Usare le integrazioni di Astro

--- a/src/content/docs/ja/recipes/bun.mdx
+++ b/src/content/docs/ja/recipes/bun.mdx
@@ -44,20 +44,12 @@ bun install
 
 ## 型の追加
 
-Bunは[`bun-types`](https://www.npmjs.com/package/bun-types)パッケージを公開しており、Bunのランタイム型が含まれています。
+Bunは[`@types/bun`](https://www.npmjs.com/package/@types/bun)パッケージを公開しており、Bunのランタイム型が含まれています。
 
-以下のコマンドを使って`bun-types`をインストールしてください。
+以下のコマンドを使って`@types/bun`をインストールしてください。
 
 ```sh
-bun add -d bun-types
-```
-
-パッケージを`tsconfig.json`でtypesに追加します。
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## Astroインテグレーションを使う

--- a/src/content/docs/ko/recipes/bun.mdx
+++ b/src/content/docs/ko/recipes/bun.mdx
@@ -43,20 +43,12 @@ bun install
 
 ## 타입 추가
 
-Bun은 [`bun-types`](https://www.npmjs.com/package/bun-types) 패키지를 제공하며, 이 패키지에는 Bun의 런타임 타입이 포함되어 있습니다.
+Bun은 [`@types/bun`](https://www.npmjs.com/package/@types/bun) 패키지를 제공하며, 이 패키지에는 Bun의 런타임 타입이 포함되어 있습니다.
 
-다음 명령어로 `bun-types`를 설치합니다.
+다음 명령어로 `@types/bun`를 설치합니다.
 
 ```sh
-bun add -d bun-types
-```
-
-설치한 패키지를 `tsconfig.json` 파일의 types에 추가합니다.
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## Astro 통합 사용

--- a/src/content/docs/zh-cn/recipes/bun.mdx
+++ b/src/content/docs/zh-cn/recipes/bun.mdx
@@ -45,20 +45,12 @@ bun install
 
 ## 添加类型
 
-Bun 发布了含有 Bun 的运行时类型的 [`bun-types`](https://www.npmjs.com/package/bun-types) 包。
+Bun 发布了含有 Bun 的运行时类型的 [`@types/bun`](https://www.npmjs.com/package/@types/bun) 包。
 
-使用以下命令安装 `bun-types`：
+使用以下命令安装 `@types/bun`：
 
 ```sh
-bun add -d bun-types
-```
-
-在 `tsconfig.json` 文件中将该包添加到你的类型中：
-
-```ts title="tsconfig.json"
-  "compilerOptions": {
-    "types": ["bun-types"]
-  }
+bun add -d @types/bun
 ```
 
 ## 使用 Astro 集成


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update to use new @types/bun package instead of `bun-types` which will be deprecated in the future.

https://bun.sh/blog/bun-v1.0.19#re-introducing-types-bun-formerly-bun-types

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: documentation

#### Other information

I have updated the link and installation on all languages that bun recipe is available because only requires to update the link, delete `tsconfig` configuration and update shell command.
