### PR TITLE
update: added Response.json tip

### DIFF
--- a/src/content/docs/en/core-concepts/endpoints.mdx
+++ b/src/content/docs/en/core-concepts/endpoints.mdx
@@ -131,6 +131,18 @@ export async function GET({ params }) {
 
 This will respond to any request that matches the dynamic route. For example, if we navigate to `/helmet.json`, `params.id` will be set to `helmet`. If `helmet` exists in the mock product database, the endpoint will use create a `Response` object to respond with JSON and return a successful [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/API/Response/status). If not, it will use a `Response` object to respond with a `404`.
 
+:::tip
+You can use the [Response.json](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) method to create a response without having to inform the content-type in the header with the value application/json.
+```js title="tip Response.json"
+export function GET() {
+  return Response.json({
+    hello: "world"
+  });
+}
+Notice that we do not use the `new` operator before Response.json.
+```
+:::
+
 In SSR mode, certain providers require the `Content-Type` header to return an image. In this case, use a `Response` object to specify a `headers` property. For example, to produce a binary `.png` image:
 
 ```ts title="src/pages/astro-logo.png.ts"

--- a/src/content/docs/en/core-concepts/endpoints.mdx
+++ b/src/content/docs/en/core-concepts/endpoints.mdx
@@ -133,14 +133,13 @@ This will respond to any request that matches the dynamic route. For example, if
 
 :::tip
 You can use the [Response.json](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) method to create a response without having to inform the content-type in the header with the value application/json.
-```js title="tip Response.json"
+```js title="src/pages/hello.js"
 export function GET() {
-  return Response.json({
-    hello: "world"
-  });
+  const data = { hello: "world" };
+  return Response.json(data);
 }
-Notice that we do not use the `new` operator before Response.json.
 ```
+Notice that we do not use the `new` operator before Response.json.
 :::
 
 In SSR mode, certain providers require the `Content-Type` header to return an image. In this case, use a `Response` object to specify a `headers` property. For example, to produce a binary `.png` image:

--- a/src/content/docs/en/core-concepts/endpoints.mdx
+++ b/src/content/docs/en/core-concepts/endpoints.mdx
@@ -132,14 +132,14 @@ export async function GET({ params }) {
 This will respond to any request that matches the dynamic route. For example, if we navigate to `/helmet.json`, `params.id` will be set to `helmet`. If `helmet` exists in the mock product database, the endpoint will use create a `Response` object to respond with JSON and return a successful [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/API/Response/status). If not, it will use a `Response` object to respond with a `404`.
 
 :::tip
-You can use the [Response.json](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) method to create a response without having to inform the content-type in the header with the value application/json.
+You can use the [`Response.json`](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) method to create a response without having to inform the `content-type` in the `header` with the value `application/json`.
 ```js title="src/pages/hello.js"
 export function GET() {
   const data = { hello: "world" };
   return Response.json(data);
 }
 ```
-Notice that we do not use the `new` operator before Response.json.
+Notice that we do not use the `new` operator before `Response.json`.
 :::
 
 In SSR mode, certain providers require the `Content-Type` header to return an image. In this case, use a `Response` object to specify a `headers` property. For example, to produce a binary `.png` image:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Added tip showing how to use `Response.json`  
so you don't need to enter `application/json` in the `content-type` `header`, every time you need to return JSON

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: api-routes

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `4.x`.

[doc preview link - Guides > Enpoints](https://docs-2o3iug2h0-astrodotbuild.vercel.app/en/core-concepts/endpoints/#server-endpoints-api-routes)
