### PR TITLE
Update sharing-state.mdx

### DIFF
--- a/src/content/docs/en/core-concepts/sharing-state.mdx
+++ b/src/content/docs/en/core-concepts/sharing-state.mdx
@@ -739,7 +739,7 @@ export default function CartFlyout() {
       </li>
       {/each}
     </aside>
-  {#else}
+  {:else}
     <p>Your cart is empty!</p>
   {/if}
 {/if}


### PR DESCRIPTION
Svelte example should have colon instead of hash in `else`.
