### PR TITLE
Standardize the Integration Installation Steps 

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinej
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/alpinejs`, run the following from your project directory and follow the prompts:
 
@@ -41,7 +34,7 @@ To install `@astrojs/alpinejs`, run the following from your project directory an
   </Fragment>
 </PackageManagerTabs>
 
-Try the manual installation steps below, and if you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues).
+If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
 ### Manual Install
 

--- a/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
@@ -12,9 +12,16 @@ This **[Astro integration][astro-integration]** adds [Alpine.js](https://alpinej
 
 ## Installation
 
+There are two ways to add integrations to your project. Let's try the most convenient option first!
+
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
+
+1. (Optionally) Install all necessary dependencies and peer dependencies
+2. (Also optionally) Update your `astro.config.*` file to apply this integration
+
+To install `@astrojs/alpinejs`, run the following from your project directory and follow the prompts:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -38,7 +45,7 @@ Try the manual installation steps below, and if you run into any issues, [feel f
 
 ### Manual Install
 
-First, install the `@astrojs/alpinejs` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+First, install the `@astrojs/alpinejs` package.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -62,32 +69,32 @@ Most package managers will install associated peer dependencies as well. However
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install alpinejs @types/alpinejs
-    ```
+  ```sh
+  npm install alpinejs @types/alpinejs
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add alpinejs @types/alpinejs
-    ```
+  ```sh
+  pnpm add alpinejs @types/alpinejs
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add alpinejs @types/alpinejs
-    ```
+  ```sh
+  yarn add alpinejs @types/alpinejs
+  ```
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins="alpine()" title="astro.config.mjs" ins={2}
-  import { defineConfig } from 'astro/config';
-  import alpine from '@astrojs/alpinejs';
+import { defineConfig } from 'astro/config';
+import alpine from '@astrojs/alpinejs';
 
-  export default defineConfig({
-    // ...
-    integrations: [alpine()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [alpine()],
+});
 ```
 
 ## Usage

--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -11,9 +11,12 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 An SSR adapter for use with Cloudflare Pages Functions targets. Write your code in Astro/Javascript and deploy to Cloudflare Pages.
 
-## Install
+## Installation
 
-Add the Cloudflare adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
+### Quick Install
+
+Add the Cloudflare adapter to enable SSR in your Astro project with the `astro add` command. 
+This will install `@astrojs/cloudflare` and make the appropriate changes to your `astro.config.*` file in one step.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -33,9 +36,9 @@ Add the Cloudflare adapter to enable SSR in your Astro project with the followin
   </Fragment>
 </PackageManagerTabs>
 
-If you prefer to install the adapter manually instead, complete the following two steps:
+### Manual Install
 
-1. Add the Cloudflare adapter to your project's dependencies using your preferred package manager.
+First, add the `@astrojs/cloudflare` adapter to your project's dependencies using your preferred package manager.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -55,7 +58,7 @@ If you prefer to install the adapter manually instead, complete the following tw
   </Fragment>
 </PackageManagerTabs>
 
-2. Add the following to your `astro.config.mjs` file:
+Then, add the following to your `astro.config.*` file:
 
 ```js title="astro.config.mjs" ins={2,5-6}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/lit`, run the following from your project directory and follow the prompts:
 
@@ -65,7 +58,7 @@ First, install the `@astrojs/lit` package:
   </Fragment>
 </PackageManagerTabs>
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'lit'" (or similar) warning when you start up Astro, you'll need to install `lit` and `@webcomponents/template-shadowroot`:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'lit'" (or similar) warning when you start up Astro, you'll need to install `lit` and `@webcomponents/template-shadowroot`:
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -14,9 +14,9 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### `astro add` command
+### Quick Install
 
-Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
 
 1. (Optionally) Install all necessary dependencies and peer dependencies
 2. (Also optionally) Update your `astro.config.*` file to apply this integration
@@ -43,25 +43,25 @@ To install `@astrojs/lit`, run the following from your project directory and fol
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
-### Install dependencies manually
+### Manual Install
 
-First, install the `@astrojs/lit` integration like so:
+First, install the `@astrojs/lit` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/lit
-    ```
+  ```sh
+  npm install @astrojs/lit
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/lit
-    ```
+  ```sh
+  pnpm add @astrojs/lit
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/lit
-    ```
+  ```sh
+  yarn add @astrojs/lit
+  ```
   </Fragment>
 </PackageManagerTabs>
 
@@ -69,32 +69,32 @@ Most package managers will install associated peer dependencies as well. Still, 
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install lit @webcomponents/template-shadowroot
-    ```
+  ```sh
+  npm install lit @webcomponents/template-shadowroot
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add lit @webcomponents/template-shadowroot
-    ```
+  ```sh
+  pnpm add lit @webcomponents/template-shadowroot
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add lit @webcomponents/template-shadowroot
-    ```
+  ```sh
+  yarn add lit @webcomponents/template-shadowroot
+  ```
   </Fragment>
 </PackageManagerTabs>
 
-Now, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins={2} ins="lit()" title="astro.config.mjs"
-  import { defineConfig } from 'astro/config';
-  import lit from '@astrojs/lit';
+import { defineConfig } from 'astro/config';
+import lit from '@astrojs/lit';
 
-  export default defineConfig({
-    // ...
-    integrations: [lit()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [lit()],
+});
 ```
 
 ## Getting started

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -43,43 +43,42 @@ If you run into any issues, [feel free to report them to us on GitHub](https://g
 
 ### Manual Install
 
-First, install the `@astrojs/markdoc` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+First, install the `@astrojs/markdoc` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/markdoc
-    ```
+  ```sh
+  npm install @astrojs/markdoc
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/markdoc
-    ```
+  ```sh
+  pnpm add @astrojs/markdoc
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/markdoc
-    ```
+  ```sh
+  yarn add @astrojs/markdoc
+  ```
   </Fragment>
 </PackageManagerTabs>
-
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins="markdoc()" title="astro.config.mjs" ins={2}
-  import { defineConfig } from 'astro/config';
-  import markdoc from '@astrojs/markdoc';
-  export default defineConfig({
-    // ...
-    integrations: [markdoc()],
-  });
+import { defineConfig } from 'astro/config';
+import markdoc from '@astrojs/markdoc';
+export default defineConfig({
+  // ...
+  integrations: [markdoc()],
+});
 ```
 
 ### Editor Integration
 
 [VS Code](https://code.visualstudio.com/) supports Markdown by default. However, for Markdoc editor support, you may wish to add the following setting in your VSCode config. This ensures authoring Markdoc files provides a Markdown-like editor experience.
 
-```json title=".vscode/settings.json"
+```json title=".vscode/settings.json" ins={3}
 {
   "files.associations": {
     "*.mdoc": "markdown"

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -63,7 +63,7 @@ First, install the `@astrojs/markdoc` package:
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins="markdoc()" title="astro.config.mjs" ins={2}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -17,9 +17,9 @@ Markdoc allows you to enhance your Markdown with [Astro components][astro-compon
 
 ## Installation
 
-### Quick Install
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
+Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -16,9 +16,9 @@ MDX allows you to [use variables, JSX expressions and components within Markdown
 
 ## Installation
 
-### Quick Install
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
+Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -18,26 +18,23 @@ MDX allows you to [use variables, JSX expressions and components within Markdown
 
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    # Using NPM
-    npx astro add mdx
+  ```sh
+  npx astro add mdx
     ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    # Using PNPM
-    pnpm astro add mdx
-    ```
+  ```sh
+  pnpm astro add mdx
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    # Using Yarn
-    yarn astro add mdx
-    ```
+  ```sh
+  yarn astro add mdx
+  ```
   </Fragment>
  </PackageManagerTabs>
 
@@ -45,36 +42,36 @@ If you run into any issues, [feel free to report them to us on GitHub](https://g
 
 ### Manual Install
 
-First, install the `@astrojs/mdx` package using your preferred package manager:
+First, install the `@astrojs/mdx` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/mdx
-    ```
+  ```sh
+  npm install @astrojs/mdx
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/mdx
-    ```
+  ```sh
+  pnpm add @astrojs/mdx
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/mdx
-    ```
+  ```sh
+  yarn add @astrojs/mdx
+  ```
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js title="astro.config.mjs" ins={2} ins="mdx()"
-  import { defineConfig } from 'astro/config';
-  import mdx from '@astrojs/mdx';
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
 
-  export default defineConfig({
-    // ...
-    integrations: [mdx()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [mdx()],
+});
 ```
 
 ### Editor Integration

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -22,7 +22,10 @@ If you wish to [use on-demand rendering, also known as server-side rendering (SS
 
 ## Installation
 
-Add the Netlify adapter with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
+### Quick Install
+
+Add the Netlify adapter to enable SSR in your Astro project with the `astro add` command. 
+This will install `@astrojs/netlify` and make the appropriate changes to your `astro.config.mjs` file in one step.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -42,31 +45,29 @@ Add the Netlify adapter with the following `astro add` command. This will instal
   </Fragment>
 </PackageManagerTabs>
 
-### Add dependencies manually
+### Manual Install
 
-If you prefer to install the adapter manually instead, complete the following two steps:
+First, install the Netlify adapter to your project’s dependencies using your preferred package manager:
 
-1. Install the Netlify adapter to your project’s dependencies using your preferred package manager:
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install @astrojs/netlify
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add @astrojs/netlify
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add @astrojs/netlify
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-  <PackageManagerTabs>
-    <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/netlify
-    ```
-    </Fragment>
-    <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/netlify
-    ```
-    </Fragment>
-    <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/netlify
-    ```
-    </Fragment>
-  </PackageManagerTabs>
-
-2. Add two new lines to your `astro.config.mjs` project configuration file.
+Then, add two new lines to your `astro.config.mjs` project configuration file.
 
    ```js title="astro.config.mjs" ins={2, 6-7}
     import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -21,7 +21,10 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 ## Installation
 
-Add the Node adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
+### Quick Install
+
+Add the Node adapter to enable SSR in your Astro project with the `astro add` command. 
+This will install `@astrojs/node` and make the appropriate changes to your `astro.config.*` file in one step.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -41,43 +44,41 @@ Add the Node adapter to enable SSR in your Astro project with the following `ast
   </Fragment>
 </PackageManagerTabs>
 
-### Add dependencies manually
+### Manual Install
 
-If you prefer to install the adapter manually instead, complete the following two steps:
+First, add the Node adapter to your project’s dependencies using your preferred package manager.
 
-1. Install the Node adapter to your project’s dependencies using your preferred package manager.
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install @astrojs/node
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add @astrojs/node
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add @astrojs/node
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-   <PackageManagerTabs>
-     <Fragment slot="npm">
-     ```sh
-     npm install @astrojs/node
-     ```
-     </Fragment>
-     <Fragment slot="pnpm">
-     ```sh
-     pnpm add @astrojs/node
-     ```
-     </Fragment>
-     <Fragment slot="yarn">
-     ```sh
-     yarn add @astrojs/node
-     ```
-     </Fragment>
-   </PackageManagerTabs>
+Then, add two new lines to your `astro.config.*` project configuration file.
 
-2. Add two new lines to your `astro.config.mjs` project configuration file.
+```js title="astro.config.mjs" ins={2,5-8}
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
 
-   ```js title="astro.config.mjs" ins={2,6-8}
-   import { defineConfig } from 'astro/config';
-   import node from '@astrojs/node';
-
-   export default defineConfig({
-     output: 'server',
-     adapter: node({
-       mode: 'standalone',
-     }),
-   });
-   ```
+export default defineConfig({
+  output: 'server',
+  adapter: node({
+    mode: 'standalone',
+  }),
+});
+```
 
 ## Configuration
 

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -22,7 +22,7 @@ The Astro Partytown integration installs Partytown for you and makes sure it's e
 
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -46,7 +46,7 @@ If you run into any issues, [feel free to report them to us on GitHub](https://g
 
 ### Manual Install
 
-First, install the `@astrojs/partytown` package using your package manager.
+First, install the `@astrojs/partytown` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -20,9 +20,9 @@ The Astro Partytown integration installs Partytown for you and makes sure it's e
 
 ## Installation
 
-### Quick Install
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
+Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -66,7 +66,7 @@ First, install the `@astrojs/partytown` package:
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js title="astro.config.mjs" ins={2} ins="partytown()"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -22,14 +22,7 @@ Check out [“Learn Preact in 10 minutes”](https://preactjs.com/tutorial), an 
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/preact`, run the following from your project directory and follow the prompts:
 
@@ -75,7 +68,7 @@ First, install the `@astrojs/preact` package:
   </Fragment>
 </PackageManagerTabs>
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'preact'" (or similar) warning when you start up Astro, you'll need to install Preact:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'preact'" (or similar) warning when you start up Astro, you'll need to install Preact:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -97,7 +90,7 @@ Most package managers will install associated peer dependencies as well. Still, 
 
 Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
-```js title="astro.config.mjs" ins={2} "preact()"
+```js title="astro.config.mjs" ins={2} ins="preact()"
 import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 

--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -22,9 +22,16 @@ Check out [“Learn Preact in 10 minutes”](https://preactjs.com/tutorial), an 
 
 ## Installation
 
+There are two ways to add integrations to your project. Let's try the most convenient option first!
+
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
+
+1. (Optionally) Install all necessary dependencies and peer dependencies
+2. (Also optionally) Update your `astro.config.*` file to apply this integration
+
+To install `@astrojs/preact`, run the following from your project directory and follow the prompts:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -48,7 +55,7 @@ If you run into any issues, [feel free to report them to us on GitHub](https://g
 
 ### Manual Install
 
-First, install the `@astrojs/preact` package using your package manager.
+First, install the `@astrojs/preact` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -88,13 +95,14 @@ Most package managers will install associated peer dependencies as well. Still, 
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js title="astro.config.mjs" ins={2} "preact()"
 import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
 
 export default defineConfig({
+  // ...
   integrations: [preact()],
 });
 ```

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -14,9 +14,9 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### `astro add` command
+### Quick Install
 
-Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
 
 1. (Optionally) Install all necessary dependencies and peer dependencies
 2. (Also optionally) Update your `astro.config.*` file to apply this integration
@@ -43,25 +43,25 @@ To install `@astrojs/react`, run the following from your project directory and f
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
-### Install dependencies manually
+### Manual Install
 
-First, install the `@astrojs/react` integration like so:
+First, install the `@astrojs/react` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/react
-    ```
+  ```sh
+  npm install @astrojs/react
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/react
-    ```
+  ```sh
+  pnpm add @astrojs/react
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/react
-    ```
+  ```sh
+  yarn add @astrojs/react
+  ```
   </Fragment>
 </PackageManagerTabs>
 
@@ -69,32 +69,32 @@ Most package managers will install associated peer dependencies as well. Still, 
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install react react-dom
-    ```
+  ```sh
+  npm install react react-dom
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add react react-dom
-    ```
+  ```sh
+  pnpm add react react-dom
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add react react-dom
-    ```
+  ```sh
+  yarn add react react-dom
+  ```
   </Fragment>
 </PackageManagerTabs>
 
-Now, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins="react()" ins={2} title="astro.config.mjs"
-  import { defineConfig } from 'astro/config';
-  import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
 
-  export default defineConfig({
-    // ...
-    integrations: [react()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [react()],
+});
 ```
 
 ## Getting started

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/react`, run the following from your project directory and follow the prompts:
 
@@ -65,7 +58,7 @@ First, install the `@astrojs/react` package:
   </Fragment>
 </PackageManagerTabs>
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'react'" (or similar) warning when you start up Astro, you'll need to install `react` and `react-dom`:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'react'" (or similar) warning when you start up Astro, you'll need to install `react` and `react-dom`:
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -24,23 +24,23 @@ This integration cannot generate sitemap entries for dynamic routes in [SSR mode
 
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npx astro add sitemap
-    ```
+  ```sh
+  npx astro add sitemap
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm astro add sitemap
-    ```
+  ```sh
+  pnpm astro add sitemap
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn astro add sitemap
-    ```
+  ```sh
+  yarn astro add sitemap
+  ```
   </Fragment>
 </PackageManagerTabs>
 
@@ -52,32 +52,32 @@ First, install the `@astrojs/sitemap` package using your package manager.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/sitemap
-    ```
+  ```sh
+  npm install @astrojs/sitemap
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/sitemap
-    ```
+  ```sh
+  pnpm add @astrojs/sitemap
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/sitemap
-    ```
+  ```sh
+  yarn add @astrojs/sitemap
+  ```
   </Fragment>
 </PackageManagerTabs>
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins={2} ins="sitemap()"
-  import { defineConfig } from 'astro/config';
-  import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
-  export default defineConfig({
-    // ...
-    integrations: [sitemap()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [sitemap()],
+});
 ```
 
 ## Usage

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -68,7 +68,7 @@ First, install the `@astrojs/sitemap` package using your package manager.
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins={2} ins="sitemap()"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -22,9 +22,9 @@ This integration cannot generate sitemap entries for dynamic routes in [SSR mode
 
 ## Installation
 
-### Quick Install
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.
+Run one of the following commands in a new terminal window.
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/solid-js`, run the following from your project directory and follow the prompts:
 
@@ -65,7 +58,7 @@ First, install the `@astrojs/solid-js` package:
   </Fragment>
 </PackageManagerTabs>
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'solid-js'" (or similar) warning when you start up Astro, you'll need to install SolidJS:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'solid-js'" (or similar) warning when you start up Astro, you'll need to install SolidJS:
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -14,9 +14,9 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### `astro add` command
+### Quick Install
 
-Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
 
 1. (Optionally) Install all necessary dependencies and peer dependencies
 2. (Also optionally) Update your `astro.config.*` file to apply this integration
@@ -43,9 +43,9 @@ To install `@astrojs/solid-js`, run the following from your project directory an
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
-### Install dependencies manually
+### Manual Install
 
-First, install the `@astrojs/solid-js` integration like so:
+First, install the `@astrojs/solid-js` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -85,7 +85,7 @@ Most package managers will install associated peer dependencies as well. Still, 
   </Fragment>
 </PackageManagerTabs>
 
-Now, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js title="astro.config.mjs" ins={2} ins="solid()"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/en/guides/integrations-guide/svelte.mdx
@@ -6,7 +6,6 @@ githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/int
 category: renderer
 i18nReady: true
 ---
-
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [Svelte](https://svelte.dev/) components. It supports Svelte 3, 4, and 5 (experimental).
@@ -15,9 +14,9 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### `astro add` command
+### Quick Install
 
-Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
 
 1. (Optionally) Install all necessary dependencies and peer dependencies
 2. (Also optionally) Update your `astro.config.*` file to apply this integration
@@ -44,9 +43,9 @@ To install `@astrojs/svelte`, run the following from your project directory and 
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
-### Install dependencies manually
+### Manual Install
 
-First, install the `@astrojs/svelte` integration like so:
+First, install the `@astrojs/svelte` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -86,7 +85,7 @@ Most package managers will install associated peer dependencies as well. Still, 
   </Fragment>
 </PackageManagerTabs>
 
-Now, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js title="astro.config.mjs" ins={2} "svelte()"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/en/guides/integrations-guide/svelte.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/svelte`, run the following from your project directory and follow the prompts:
 
@@ -65,7 +58,7 @@ First, install the `@astrojs/svelte` package:
   </Fragment>
 </PackageManagerTabs>
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'svelte'" (or similar) warning when you start up Astro, you'll need to install Svelte:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'svelte'" (or similar) warning when you start up Astro, you'll need to install Svelte:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -87,7 +80,7 @@ Most package managers will install associated peer dependencies as well. Still, 
 
 Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
-```js title="astro.config.mjs" ins={2} "svelte()"
+```js title="astro.config.mjs" ins={2} ins="svelte()"
 import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
 

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -71,7 +71,7 @@ First, install the `@astrojs/tailwind` and `tailwindcss` packages using your pac
   </Fragment>
 </PackageManagerTabs>
 
-Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins={2} ins="tailwind()" title="astro.config.mjs"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -27,23 +27,23 @@ Note: it's generally discouraged to use both Tailwind and another styling method
 
 ### Quick Install
 
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. (If you aren't sure which package manager you're using, run the first command.) Then, follow the prompts, and type "y" in the terminal (meaning "yes") for each one.
+The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. 
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npx astro add tailwind
-    ```
+  ```sh
+  npx astro add tailwind
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm astro add tailwind
-    ```
+  ```sh
+  pnpm astro add tailwind
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn astro add tailwind
-    ```
+  ```sh
+  yarn astro add tailwind
+  ```
   </Fragment>
 </PackageManagerTabs>
 
@@ -55,65 +55,65 @@ First, install the `@astrojs/tailwind` and `tailwindcss` packages using your pac
 
 <PackageManagerTabs>
   <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/tailwind tailwindcss
-    ```
+  ```sh
+  npm install @astrojs/tailwind tailwindcss
+  ```
   </Fragment>
   <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/tailwind tailwindcss
-    ```
+  ```sh
+  pnpm add @astrojs/tailwind tailwindcss
+  ```
   </Fragment>
   <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/tailwind tailwindcss
-    ```
+  ```sh
+  yarn add @astrojs/tailwind tailwindcss
+  ```
   </Fragment>
 </PackageManagerTabs>
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-```js ins={3} ins="tailwind()" title="astro.config.mjs"
-  import { defineConfig } from 'astro/config';
-  import tailwind from '@astrojs/tailwind';
+```js ins={2} ins="tailwind()" title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
 
-  export default defineConfig({
-    // ...
-    integrations: [tailwind()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [tailwind()],
+});
 ```
 
 Then, create a `tailwind.config.cjs` file in your project's root directory. You can use the following command to generate a basic configuration file for you:
   
-  <PackageManagerTabs>
-    <Fragment slot="npm">
-    ```sh
-    npx tailwindcss init
-    ```
-    </Fragment>
-    <Fragment slot="pnpm">
-    ```sh
-    pnpm dlx tailwindcss init
-    ```
-    </Fragment>
-    <Fragment slot="yarn">
-    ```sh
-    yarn dlx tailwindcss init
-    ```
-    </Fragment>
-  </PackageManagerTabs>
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npx tailwindcss init
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm dlx tailwindcss init
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn dlx tailwindcss init
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
 Finally, add this basic configuration to your `tailwind.config.cjs` file:
 
 ```js ins={3} title="tailwind.config.cjs" "content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}']"
-  /** @type {import('tailwindcss').Config} */
-  module.exports = {
-    content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-    theme: {
-      extend: {},
-    },
-    plugins: [],
-  };
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
 ```
 
 ## Usage

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -7,7 +7,6 @@ category: other
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
-import Video from '~/components/Video.astro';
 
 This **[Astro integration][astro-integration]** brings [Tailwind's](https://tailwindcss.com/) utility CSS classes to every `.astro` file and [framework component](/en/core-concepts/framework-components/) in your project, along with support for the Tailwind configuration file.
 
@@ -23,11 +22,9 @@ Note: it's generally discouraged to use both Tailwind and another styling method
 
 ## Installation
 
-<Video src="https://user-images.githubusercontent.com/4033662/197398760-8fd30eff-4d13-449d-a598-00a6a1ac4644.mp4" type="video/mp4" />
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
-### Quick Install
-
-The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window. 
+Run one of the following commands in a new terminal window. 
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -22,7 +22,10 @@ If you wish to [use server-side rendering (SSR)](/en/guides/server-side-renderin
 
 ## Installation
 
-Add the Vercel adapter to enable SSR in your Astro project with the following `astro add` command. This will install the adapter and make the appropriate changes to your `astro.config.mjs` file in one step.
+### Quick Install
+
+Add the Vercel adapter to enable SSR in your Astro project with the following `astro add` command. 
+This will install `@astrojs/vercel` and make the appropriate changes to your `astro.config.mjs` file in one step.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -37,48 +40,47 @@ Add the Vercel adapter to enable SSR in your Astro project with the following `a
   </Fragment>
   <Fragment slot="yarn">
   ```sh
-  yarn astro add react
+  yarn astro add vercel
   ```
   </Fragment>
 </PackageManagerTabs>
 
-### Add dependencies manually
+### Manual Install
 
-If you prefer to install the adapter manually instead, complete the following two steps:
+First, add the `@astrojs/vercel` adapter to your project’s dependencies using your preferred package manager:
 
-1. Install the Vercel adapter to your project’s dependencies using your preferred package manager:
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install @astrojs/vercel
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add @astrojs/vercel
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add @astrojs/vercel
+  ```
+  </Fragment>
+</PackageManagerTabs>
 
-  <PackageManagerTabs>
-    <Fragment slot="npm">
-    ```sh
-    npm install @astrojs/vercel
-    ```
-    </Fragment>
-    <Fragment slot="pnpm">
-    ```sh
-    pnpm add @astrojs/vercel
-    ```
-    </Fragment>
-    <Fragment slot="yarn">
-    ```sh
-    yarn add @astrojs/vercel
-    ```
-    </Fragment>
-  </PackageManagerTabs>
+Then, add three new lines to your `astro.config.mjs` project configuration file.
 
-2. Add three new lines to your `astro.config.mjs` project configuration file.
+```js title="astro.config.mjs" ins={2, 6-7}
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/serverless';
 
-  ```js title="astro.config.mjs" ins={2, 6-7}
-     import { defineConfig } from 'astro/config';
-     import vercel from '@astrojs/vercel/serverless';
+export default defineConfig({
+// ...
+  output: 'server',
+  adapter: vercel(),
+});
+````
 
-     export default defineConfig({
-      // ...
-       output: 'server',
-       adapter: vercel(),
-     });
-
-### Targets
+### Choosing a Target
 
 You can deploy to different targets:
 
@@ -87,7 +89,7 @@ You can deploy to different targets:
 
 You can change where to target by changing the import:
 
-```js
+```js "serverless" "static"
 import vercel from '@astrojs/vercel/serverless';
 import vercel from '@astrojs/vercel/static';
 ```

--- a/src/content/docs/en/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vue.mdx
@@ -12,14 +12,7 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 ## Installation
 
-There are two ways to add integrations to your project. Let's try the most convenient option first!
-
-### Quick Install
-
-Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
-
-1. (Optionally) Install all necessary dependencies and peer dependencies
-2. (Also optionally) Update your `astro.config.*` file to apply this integration
+Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
 
 To install `@astrojs/vue`, run the following from your project directory and follow the prompts:
 
@@ -66,7 +59,7 @@ First, install the `@astrojs/vue` package:
 </PackageManagerTabs>
 
 
-Most package managers will install associated peer dependencies as well. Still, if you see a "Cannot find package 'vue'" (or similar) warning when you start up Astro, you'll need to install Vue:
+Most package managers will install associated peer dependencies as well. If you see a "Cannot find package 'vue'" (or similar) warning when you start up Astro, you'll need to install Vue:
 
 <PackageManagerTabs>
   <Fragment slot="npm">

--- a/src/content/docs/en/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vue.mdx
@@ -14,9 +14,9 @@ This **[Astro integration][astro-integration]** enables server-side rendering an
 
 There are two ways to add integrations to your project. Let's try the most convenient option first!
 
-### `astro add` command
+### Quick Install
 
-Astro includes a CLI tool for adding first party integrations: `astro add`. This command will:
+Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
 
 1. (Optionally) Install all necessary dependencies and peer dependencies
 2. (Also optionally) Update your `astro.config.*` file to apply this integration
@@ -43,9 +43,9 @@ To install `@astrojs/vue`, run the following from your project directory and fol
 
 If you run into any issues, [feel free to report them to us on GitHub](https://github.com/withastro/astro/issues) and try the manual installation steps below.
 
-### Install dependencies manually
+### Manual Install
 
-First, install the `@astrojs/vue` integration like so:
+First, install the `@astrojs/vue` package:
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -86,16 +86,16 @@ Most package managers will install associated peer dependencies as well. Still, 
   </Fragment>
 </PackageManagerTabs>
 
-Now, apply this integration to your `astro.config.*` file using the `integrations` property:
+Then, apply the integration to your `astro.config.*` file using the `integrations` property:
 
 ```js ins={2} ins="vue()" title="astro.config.mjs"
-  import { defineConfig } from 'astro/config';
-  import vue from '@astrojs/vue';
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
 
-  export default defineConfig({
-    // ...
-    integrations: [vue()],
-  });
+export default defineConfig({
+  // ...
+  integrations: [vue()],
+});
 ```
 
 ## Getting started


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I have updated every integration guide with a standardized version of the installation steps outlined below.
I also updated the formatting to be consistent with the rest of the `docs` (at least in the installation sections, I did not go past that)

This is meant for #5978

---

## Installation

### Quick Install

#### **For UI Integrations:**
>Astro includes a CLI tool for adding first-party integrations: `astro add`. This command will:
>
>1. (Optionally) Install all necessary dependencies and peer dependencies
>2. (Also optionally) Update your `astro.config.*` file to apply this integration
>
>To install `@astrojs/_`, run the following from your project directory and follow the prompts:

#### **For Adapter Integrations:**
>Add the _ adapter to enable SSR in your Astro project with the `astro add` command.
>This will install `@astrojs/_` and make the appropriate changes to your `astro.config.*` file in one step.

#### **For Other Integrations:**
>The `astro add` command-line tool automates the installation for you. Run one of the following commands in a new terminal window.

### Manual Install

Instead of lists: 
#### **For UI and Other Integrations:**
>First, install the `@astrojs/_` package:
>Then, apply the integration to your `astro.config.*` file using the `integrations` property:

#### **For Adapter Integrations:**
>First, add the _ adapter to your projects’s dependencies using your preferred package manager.
>Then, add _ new lines to your `astro.config.*` project configuration file.

---

Please let me know if I should add or remove anything to this! Sorry that it's such a big PR... I figured that if I am going to do this, I should do it right the first time!!!