### PR TITLE
Update Documentation: tsconfig.json Aliases

### DIFF
--- a/src/content/docs/en/guides/configuring-astro.mdx
+++ b/src/content/docs/en/guides/configuring-astro.mdx
@@ -115,7 +115,7 @@ export default defineConfig({
 ```
 
 :::note
-Vite-specific `import.meta` properties, like `import.meta.env` or `import.meta.glob`, are _not_ accessible from your configuration file. We recommend alternatives like [dotenv](https://github.com/motdotla/dotenv) or [fast-glob](https://github.com/mrmlnc/fast-glob) for these respective use cases.
+Vite-specific `import.meta` properties, like `import.meta.env` or `import.meta.glob`, are _not_ accessible from your configuration file. We recommend alternatives like [dotenv](https://github.com/motdotla/dotenv) or [fast-glob](https://github.com/mrmlnc/fast-glob) for these respective use cases. Please note, that tsconfig aliases are not supported. For module imports in this file, we recommend using relative paths.
 :::
 
 ## Customising Output Filenames


### PR DESCRIPTION
#### Description 
Clarify in the documentation that tsconfig.json aliases are not supported in the astro.config.ts file. Suggest using relative paths for module imports in this file instead of tsconfig.json aliases.

#### Related issues 

- Closes #6003 

