### PR TITLE
Document --host and --port flags for preview

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -197,25 +197,6 @@ If you started your project using [the `create astro` wizard](/en/install/auto/#
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
-<h3>Flags</h3>
-
-Use these flags to customize the behavior of the Astro dev server. For flags shared with other Astro commands, see [common flags](#common-flags) below.
-
-#### `--port <number>`
-
-Specifies which port to run on. Defaults to `4321`.
-
-#### `--host [optional host address]`
-
-Sets which network IP addresses the dev server should listen on (i.e. non-localhost IPs). This can be useful for testing your project on local devices like a mobile phone during development.
-
-- `--host` — listen on all addresses, including LAN and public addresses
-- `--host <custom-address>` — expose on a network IP address at `<custom-address>`
-
-:::caution
-Do not use the `--host` flag to expose the dev server in a production environment. The dev server is designed for local use while developing your site only.
-:::
-
 ## `astro build`
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If [SSR is enabled](/en/guides/server-side-rendering/), this will generate the necessary server files to serve your site.
@@ -385,6 +366,21 @@ Configures the [`site`](/en/reference/configuration-reference/#site) for your pr
 <p><Since v="1.4.1" /></p>
 
 Configures the [`base`](/en/reference/configuration-reference/#base) for your project. Passing this flag will override the `base` value in your `astro.config.mjs` file, if one exists.
+
+### `--port <number>`
+
+Specifies which port to run the dev server and preview server on. Defaults to `4321`.
+
+### `--host [optional host address]`
+
+Sets which network IP addresses the dev server and preview server should listen on (i.e. non-localhost IPs). This can be useful for testing your project on local devices like a mobile phone during development.
+
+- `--host` — listen on all addresses, including LAN and public addresses
+- `--host <custom-address>` — expose on a network IP address at `<custom-address>`
+
+:::caution
+Do not use the `--host` flag to expose the dev server and preview server in a production environment. The servers are designed for local use while developing your site only.
+:::
 
 ### `--verbose`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`--host` and `--port` works for `astro preview` for a very long time (since the command existed?). I moved the two flags under `dev` flags to common flags. And roughly updated the "dev server" phrase to "dev server and preview server".

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

The Astro core PR that updated the flags is https://github.com/withastro/astro/pull/9572. We don't have to align the merge release with it though. I think it's more of missing docs.
