### PR TITLE
Update vercel.mdx - Vercel Speed Insights API is deprecated

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -130,29 +130,6 @@ export default defineConfig({
 });
 ```
 
-### Speed Insights
-
-You can enable [Vercel Speed Insights](https://vercel.com/docs/concepts/speed-insights) by setting `speedInsights: { enabled: true }`. This will collect and send Web Vital data to Vercel.
-
-**Type:** `VercelSpeedInsightsConfig`<br/>
-**Available for:** Serverless, Static<br/>
-<Since v="3.8.0" pkg="@astrojs/vercel" />
-
-```js title="astro.config.mjs" ins={8-10}
-import { defineConfig } from 'astro/config';
-import vercel from '@astrojs/vercel/serverless';
-
-export default defineConfig({
-  // ...
-  output: 'server',
-  adapter: vercel({
-    speedInsights: {
-      enabled: true,
-    },
-  }),
-});
-```
-
 ### imagesConfig
 
 **Type:** `VercelImageConfig`<br/>


### PR DESCRIPTION
#### Description (required)
Vercel has deprecated the framework-integrated API in favor of a framework-agnostic library that we don't need to document.

#### Related issues & labels (optional)
- https://github.com/withastro/astro/pull/9598