### PR TITLE
i18n(zh-cn): Fix indentation of directory structure

### DIFF
--- a/src/content/docs/zh-cn/recipes/dynamically-importing-images.mdx
+++ b/src/content/docs/zh-cn/recipes/dynamically-importing-images.mdx
@@ -16,7 +16,7 @@ import FileTree from '~/components/FileTree.astro'
 
     <FileTree>
     - src/
-    - assets/
+      - assets/
         - avatar-1.jpg
         - avatar-2.png
         - avatar-3.jpeg


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Compare to the English version, the indentation of directory structure is not correct, `assets` should be under the `src`.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
