### PR TITLE
Update external-links.mdx

### DIFF
--- a/src/content/docs/en/recipes/external-links.mdx
+++ b/src/content/docs/en/recipes/external-links.mdx
@@ -1,13 +1,16 @@
 ---
-title: Add icons to external links
-description: Learn how to install a rehype plugin to add icons to external links in your Markdown files.
+title: Customize external links
+description: Learn how to install a rehype plugin to add attributes and icons to external links in your Markdown files.
 i18nReady: true
 type: recipe
 ---
 
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-Using a rehype plugin, you can identify and modify links in your Markdown files that point to external sites. This example adds icons to the end of each external link, so that visitors will know they are leaving your site.
+Using a rehype plugin, you can identify and modify links in your Markdown files that point to external sites. This example adds three things:
+- `target="_blank"` attribute to open a new tab
+- `rel="nofollow, noopener, noreferrer"` attributes to follow the best security practices
+- the `🔗` emoji icon at the end of each external link, so that visitors will know they are leaving your site.
 
 ## Prerequisites
 - An Astro project using Markdown for content pages.
@@ -49,6 +52,8 @@ Using a rehype plugin, you can identify and modify links in your Markdown files 
           [
             rehypeExternalLinks,
             {
+              target: '_blank', 
+              rel: ['nofollow, noopener, noreferrer'],
               content: { type: 'text', value: ' 🔗' }
             }
           ],


### PR DESCRIPTION
Add common optional best practices for external links, like `rel="nofollow, noopener, noreferrer" target="_blank"` attributes

#### Description (required)
The generated output of external links should follow some common security practices.

Instead of having: `<a href="https://website.com">Link</a>`

We could prefer: `<a href="https://website.com" rel="nofollow, noopener, noreferrer" target="_blank">Link</a>`

Some resources:
- https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener
- https://stackoverflow.com/questions/50709625/link-with-target-blank-and-rel-noopener-noreferrer-still-vulnerable

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: improve documentation<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
