### PR TITLE
[i18nignore] Update formatting for Turso backend guide

### DIFF
--- a/src/content/docs/en/guides/backend/turso.mdx
+++ b/src/content/docs/en/guides/backend/turso.mdx
@@ -87,9 +87,9 @@ The following example fetches all `posts` from your table, then displays a list 
 
 ```astro title="src/components/BlogIndex.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {rows} = await turso.execute('SELECT * FROM posts')
+const { rows } = await turso.execute('SELECT * FROM posts')
 ---
 
 <ul>
@@ -107,11 +107,11 @@ The following example fetches a single entry from the `posts` table `WHERE` the 
 
 ```astro title="src/pages/index.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {slug} = Astro.params
+const { slug } = Astro.params
 
-const {rows} = await turso.execute({
+const { rows } = await turso.execute({
   sql: 'SELECT * FROM posts WHERE slug = ?',
   args: [slug!]
 })

--- a/src/content/docs/es/guides/backend/turso.mdx
+++ b/src/content/docs/es/guides/backend/turso.mdx
@@ -87,9 +87,9 @@ El siguiente ejemplo obtiene todos los `posts` de tu tabla y muestra una lista d
 
 ```astro title="src/components/BlogIndex.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {rows} = await turso.execute('SELECT * FROM posts')
+const { rows } = await turso.execute('SELECT * FROM posts')
 ---
 
 <ul>
@@ -107,11 +107,11 @@ El siguiente ejemplo obtiene una única entrada de la tabla `posts` `WHERE` el `
 
 ```astro title="src/pages/index.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {slug} = Astro.params
+const { slug } = Astro.params
 
-const {rows} = await turso.execute({
+const { rows } = await turso.execute({
   sql: 'SELECT * FROM posts WHERE slug = ?',
   args: [slug!]
 })

--- a/src/content/docs/fr/guides/backend/turso.mdx
+++ b/src/content/docs/fr/guides/backend/turso.mdx
@@ -87,9 +87,9 @@ L'exemple suivant récupère tous les `articles` de votre table, puis affiche un
 
 ```astro title="src/components/BlogIndex.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {rows} = await turso.execute('SELECT * FROM posts')
+const { rows } = await turso.execute('SELECT * FROM posts')
 ---
 
 <ul>
@@ -107,11 +107,11 @@ L'exemple suivant récupère une seule entrée de la table `posts` `WHERE` le `s
 
 ```astro title="src/pages/index.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {slug} = Astro.params
+const { slug } = Astro.params
 
-const {rows} = await turso.execute({
+const { rows } = await turso.execute({
   sql: 'SELECT * FROM posts WHERE slug = ?',
   args: [slug!]
 })

--- a/src/content/docs/it/guides/backend/turso.mdx
+++ b/src/content/docs/it/guides/backend/turso.mdx
@@ -87,9 +87,9 @@ L'esempio seguente ottiene tutti i `posts` dalla tua tabella, mostrando a scherm
 
 ```astro title="src/components/BlogIndex.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {rows} = await turso.execute('SELECT * FROM posts')
+const { rows } = await turso.execute('SELECT * FROM posts')
 ---
 
 <ul>
@@ -107,11 +107,11 @@ L'esempio seguente ottiene un valore singolo dalla tabella `posts` `WHERE` lo `s
 
 ```astro title="src/pages/index.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {slug} = Astro.params
+const { slug } = Astro.params
 
-const {rows} = await turso.execute({
+const { rows } = await turso.execute({
   sql: 'SELECT * FROM posts WHERE slug = ?',
   args: [slug!]
 })

--- a/src/content/docs/zh-cn/guides/backend/turso.mdx
+++ b/src/content/docs/zh-cn/guides/backend/turso.mdx
@@ -87,9 +87,9 @@ export const turso = createClient({
 
 ```astro title="src/components/BlogIndex.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {rows} = await turso.execute('SELECT * FROM posts')
+const { rows } = await turso.execute('SELECT * FROM posts')
 ---
 
 <ul>
@@ -107,11 +107,11 @@ const {rows} = await turso.execute('SELECT * FROM posts')
 
 ```astro title="src/pages/index.astro"
 ---
-import {turso} from '../../turso'
+import { turso } from '../../turso'
 
-const {slug} = Astro.params
+const { slug } = Astro.params
 
-const {rows} = await turso.execute({
+const { rows } = await turso.execute({
   sql: 'SELECT * FROM posts WHERE slug = ?',
   args: [slug!]
 })


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the Turso backend guide for consistent formatting. 

These files were also recently translated into `es`, `fr`, `it`, and `zh-cn`, so I changed those as well. They are currently marked as updated [on the tracker](https://i18n.docs.astro.build/)

#### Related issues & labels (optional)

- Suggested label:

