### PR TITLE
[from-docusaurus.mdx]: refresh with more Starlight-specific text

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -35,7 +35,7 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 - Docusaurus is a React-based single-page application (SPA). Astro sites are multi-page apps built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 
-- Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that you would have to build yourself in Astro. Instead, Astro offers some of these features through [Starlight: an official docs theme](https://starlight.astro.build). This website was the inspiration for that template, and runs on Starlight! You can also find more [community docs themes](https://astro.build/themes?search=&categories%5B%5D=docs) with built-in features in our Themes Showcase.
+- Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that you would have to build yourself in Astro. Instead, Astro offers some of these features through [Starlight: an official docs theme](https://starlight.astro.build). This website was the inspiration for Starlight, and now runs on it! You can also find more [community docs themes](https://astro.build/themes?search=&categories%5B%5D=docs) with built-in features in our Themes Showcase.
 
 - Docusaurus sites use MDX pages for content. Astro's docs theme uses Markdown (`.md`) files by default and does not require you to use MDX. You can optionally [install Astro's MDX integration](/en/guides/integrations-guide/mdx/) and use `.mdx` files in addition to standard Markdown files.
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -37,7 +37,7 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 - Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that you would have to build yourself in Astro. Instead, Astro offers some of these features through [Starlight: an official docs theme](https://starlight.astro.build). This website was the inspiration for Starlight, and now runs on it! You can also find more [community docs themes](https://astro.build/themes?search=&categories%5B%5D=docs) with built-in features in our Themes Showcase.
 
-- Docusaurus sites use MDX pages for content. Astro's docs theme uses Markdown (`.md`) files by default and does not require you to use MDX. You can optionally [install Astro's MDX integration](/en/guides/integrations-guide/mdx/) and use `.mdx` files in addition to standard Markdown files.
+- Docusaurus sites use MDX pages for content. Astro's docs theme uses Markdown (`.md`) files by default and does not require you to use MDX. You can optionally [install Astro's MDX integration](/en/guides/integrations-guide/mdx/) (included in our Starlight theme by default) and use `.mdx` files in addition to standard Markdown files.
 
 
 ## Switch from Docusaurus to Astro
@@ -64,7 +64,7 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     </Fragment>
   </PackageManagerTabs>
 
-Add our MDX integration and [bring your existing content files to Starlight](https://starlight.astro.build/getting-started/#add-content).
+Astro's MDX integration is included by default, so you can [bring your existing content files to Starlight](https://starlight.astro.build/getting-started/#add-content) right away.
 
 You can find Astro's docs starter, and other official templates, on [astro.new](https://astro.new). You'll find a link to each project's GitHub repository, as well as one-click links to open a working project in StackBlitz, CodeSandbox and Gitpod online development environments.
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-docusaurus.mdx
@@ -35,7 +35,7 @@ When you rebuild your Docusaurus site in Astro, you will notice some important d
 
 - Docusaurus is a React-based single-page application (SPA). Astro sites are multi-page apps built using [`.astro` components](/en/core-concepts/astro-components/), but can also support [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/en/core-concepts/framework-components/) and raw HTML templating.
 
-- Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that you would have to build yourself in Astro. Instead, Astro offers some of these features through an [official docs theme](https://starlight.astro.build). This website was the inspiration for that template! You can also find more [community docs themes](https://astro.build/themes?search=&categories%5B%5D=docs) with built-in features in our Themes Showcase.
+- Docusaurus was designed to build documentation websites and has some built-in, documentation-specific website features that you would have to build yourself in Astro. Instead, Astro offers some of these features through [Starlight: an official docs theme](https://starlight.astro.build). This website was the inspiration for that template, and runs on Starlight! You can also find more [community docs themes](https://astro.build/themes?search=&categories%5B%5D=docs) with built-in features in our Themes Showcase.
 
 - Docusaurus sites use MDX pages for content. Astro's docs theme uses Markdown (`.md`) files by default and does not require you to use MDX. You can optionally [install Astro's MDX integration](/en/guides/integrations-guide/mdx/) and use `.mdx` files in addition to standard Markdown files.
 
@@ -64,10 +64,7 @@ You can pass a `--template` argument to the `create astro` command to start a ne
     </Fragment>
   </PackageManagerTabs>
 
-
-Add our MDX integration and bring your existing content files to [create MDX pages](/en/guides/markdown-content/). You can still take advantage of [file-based routing](/en/core-concepts/routing/) by copying these documents directly into `src/pages/` in Astro, the same folder you currently use. Create folders with names that correspond to your existing Docusaurus project, and you should be able to keep your existing URLs. 
-
-Docusaurus probably handled much of your site layout and metadata for you. You may wish to read about [building Astro Layouts as page wrappers for Markdown and MDX](/en/core-concepts/layouts/#markdownmdx-layouts) to see how to manage templating yourself in Astro, including your page `<head>`.
+Add our MDX integration and [bring your existing content files to Starlight](https://starlight.astro.build/getting-started/#add-content).
 
 You can find Astro's docs starter, and other official templates, on [astro.new](https://astro.new). You'll find a link to each project's GitHub repository, as well as one-click links to open a working project in StackBlitz, CodeSandbox and Gitpod online development environments.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This page updates our guidance migrating from Docusarus to:
- mention Starlight in an appropriate spot
- remove outdated info re: using `src/pages` for content 
- add that Astro Docs runs on Starlight

cc @delucis for any other specific changes while we're on this page.
