### PR TITLE
warn about extra sanitization on RSS page

### DIFF
--- a/src/content/docs/en/guides/rss.mdx
+++ b/src/content/docs/en/guides/rss.mdx
@@ -154,7 +154,7 @@ items: import.meta.glob('./blog/*.{md,mdx}'),
 The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
 
 :::tip
-A package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) will make sure that your content is properly sanitized, escaped, and encoded.
+A package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) will make sure that your content is properly sanitized, escaped, and encoded. In the process, such a package might also remove some harmless elements and attributes, so make sure to verify the output and configure the package according to your needs.
 :::
 
 When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:


### PR DESCRIPTION
#### Description (required)

Discussed beforehand with Sarah, this PR expands the tip about `sanitize-html` to warn about potentially too much sanitization.

When I first added RSS to my blog, I simply followed the tutorial and it took me quite a bit of time to understand that many parts of the post content were broken because `sanitize-html` was stripping out elements and attributes beyond just `<script>` and `<style>`.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: add new content

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
