### PR TITLE
Add Paraglide to i18n community libraries

### DIFF
--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -505,3 +505,4 @@ Translate the routes of your pages for each language.
 - [astro-i18next](https://github.com/yassinedoghri/astro-i18next) — An Astro integration for i18next including some utility components.
 - [astro-i18n](https://github.com/alexandre-fernandez/astro-i18n) — A TypeScript-first internationalization library for Astro.
 - [astro-i18n-aut](https://github.com/jlarmstrongiv/astro-i18n-aut) — An Astro integration for i18n that supports the `defaultLocale` without page generation. The integration is adapter agnostic and UI framework agnostic.
+- [paraglide](https://inlang.com/c/astro) - A fully typesafe i18n library that plays really well with islands.

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -505,4 +505,4 @@ Translate the routes of your pages for each language.
 - [astro-i18next](https://github.com/yassinedoghri/astro-i18next) — An Astro integration for i18next including some utility components.
 - [astro-i18n](https://github.com/alexandre-fernandez/astro-i18n) — A TypeScript-first internationalization library for Astro.
 - [astro-i18n-aut](https://github.com/jlarmstrongiv/astro-i18n-aut) — An Astro integration for i18n that supports the `defaultLocale` without page generation. The integration is adapter agnostic and UI framework agnostic.
-- [paraglide](https://inlang.com/c/astro) - A fully type-safe i18n library specifically designed for partial hydration patterns, like Astro islands.
+- [paraglide](https://inlang.com/c/astro) - A fully type-safe i18n library specifically designed for partial hydration patterns like Astro islands.

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -505,4 +505,4 @@ Translate the routes of your pages for each language.
 - [astro-i18next](https://github.com/yassinedoghri/astro-i18next) — An Astro integration for i18next including some utility components.
 - [astro-i18n](https://github.com/alexandre-fernandez/astro-i18n) — A TypeScript-first internationalization library for Astro.
 - [astro-i18n-aut](https://github.com/jlarmstrongiv/astro-i18n-aut) — An Astro integration for i18n that supports the `defaultLocale` without page generation. The integration is adapter agnostic and UI framework agnostic.
-- [paraglide](https://inlang.com/c/astro) - A fully typesafe i18n library that plays really well with islands.
+- [paraglide](https://inlang.com/c/astro) - A fully type-safe i18n library specifically designed for partial hydration patterns, like Astro islands.


### PR DESCRIPTION
#### Description (required)

This PR adds [Paraglide](https://inlang.com/c/astro) to the community libraries in the i18n recipie.

Paraglide plays really well with islands due to it's treeshakeable output. It only ships messages for an island if they are actually used, making it a great fit for translating interactive components and site shells. The resulting bundle can be as small as 120bytes, depending on the message and number of languages.

The Paraglide team is also committed to maintaining good Astro [guides](https://inlang.com/g/utqgkmzp/guide-lorissigrist-buildAGlobalAstroApp)  and [examples](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-astro/example).

#### Related issues & labels (optional)

- Suggested label: site improvement
