### PR TITLE
[api-reference]: Refactoring Markdown Table to `ApiTable` component

### DIFF
--- a/src/components/ApiTable.astro
+++ b/src/components/ApiTable.astro
@@ -1,0 +1,23 @@
+---
+import { useTranslations } from '~/i18n/util';
+
+const t = useTranslations(Astro);
+---
+
+<table>
+	<colgroup>
+		<col width="15%">
+		<col width="35%">
+		<col width="50%">
+	</colgroup>
+	<thead>
+		<tr>
+			<th>{t('apiTable.name')}</th>
+			<th>{t('apiTable.type')}</th>
+			<th>{t('apiTable.description')}</th>
+		</tr>
+	</thead>
+	<tbody>
+		<slot/>
+	</tbody>
+</table>

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -3,6 +3,7 @@ title: API Reference
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
+import ApiTable from '~/components/ApiTable.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 
@@ -208,25 +209,78 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 
 `Astro.cookies` contains utilities for reading and manipulating cookies in [server-side rendering](/en/guides/server-side-rendering/) mode.
 
-| Name           | Type                                              | Description                                        |
-| :------------- | :------------------------------------------------ | :------------------------------------------------- |
-| `get`          | `(key: string, options?: CookieGetOptions) => AstroCookie`                       | Gets the cookie as an [`AstroCookie`](#astrocookie) object, which contains the `value` and utility functions for converting the cookie to non-string types.          |
-| `has`          | `(key: string) => boolean`                       | Whether this cookie exists. If the cookie has been set via `Astro.cookies.set()` this will return true, otherwise it will check cookies in the `Astro.request`.          |
-| `set`       | `(key: string, value: string \| number \| boolean \| object, options?: CookieSetOptions) => void` | Sets the cookie `key` to the given value. This will attempt to convert the cookie value to a string. Options provide ways to set [cookie features](https://www.npmjs.com/package/cookie#options-1), such as the `maxAge` or `httpOnly`.   |
-| `delete`       | `(key: string, options?: CookieDeleteOptions) => void` | Marks the cookie as deleted. Once a cookie is deleted `Astro.cookies.has()` will return `false` and `Astro.cookies.get()` will return an [`AstroCookie`](#astrocookie) with a `value` of `undefined`. Options allow setting the `domain` and `path` of the cookie to delete. |
-| `headers`       | `() => Iterator<string>` | Gets the header values for `Set-Cookie` that will be sent out with the response.   |
-
+<ApiTable>
+  <tr>
+    <td style="text-align: center">`get`</td>
+    <td>`(key: string, options?: CookieGetOptions) => AstroCookie`</td>
+    <td>
+    Gets the cookie as an [`AstroCookie`](#astrocookie) object, which contains the `value` and utility functions for converting the cookie to non-string types.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`has`</td>
+    <td>`(key: string) => boolean`</td>
+    <td>
+    Whether this cookie exists. If the cookie has been set via `Astro.cookies.set()` this will return true, otherwise it will check cookies in the `Astro.request`.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`set`</td>
+    <td>`(key: string, value: string \| number \| boolean \| object, options?: CookieSetOptions) => void`</td>
+    <td>
+    Sets the cookie `key` to the given value. This will attempt to convert the cookie value to a string. Options provide ways to set [cookie features](https://www.npmjs.com/package/cookie#options-1), such as the `maxAge` or `httpOnly`.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`delete`</td>
+    <td>`(key: string, options?: CookieDeleteOptions) => void`</td>
+    <td>
+    Marks the cookie as deleted. Once a cookie is deleted `Astro.cookies.has()` will return `false` and `Astro.cookies.get()` will return an [`AstroCookie`](#astrocookie) with a `value` of `undefined`. Options allow setting the `domain` and `path` of the cookie to delete.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`headers`</td>
+    <td>`() => Iterator<string>`</td>
+    <td>
+    Gets the header values for `Set-Cookie` that will be sent out with the response.
+    </td>
+  </tr>
+</ApiTable>
 
 #### `AstroCookie`
 
 Getting a cookie via `Astro.cookies.get()` returns a `AstroCookie` type. It has the following structure.
 
-| Name      | Type                        | Description                                                                                                    |
-| :-------- | :-------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| `value`   | `string \| undefined`       | The raw string value of the cookie.                                                                            |
-| `json`    | `() => Record<string, any>` | Parses the cookie value via `JSON.parse()`, returning an object. Throws if the cookie value is not valid JSON. |
-| `number`  | `() => number`              | Parses the cookie value as a Number. Returns NaN if not a valid number.                                        |
-| `boolean` | `() => boolean`             | Converts the cookie value to a boolean.                                                                        |
+<ApiTable>
+  <tr>
+    <td style="text-align: center">`value`</td>
+    <td>`string \| undefined`</td>
+    <td>
+    The raw string value of the cookie.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`json`</td>
+    <td>`() => Record<string, any>`</td>
+    <td>
+    Parses the cookie value via `JSON.parse()`, returning an object. Throws if the cookie value is not valid JSON.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`number`</td>
+    <td>`() => number`</td>
+    <td>
+    Parses the cookie value as a Number. Returns NaN if not a valid number.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`boolean`</td>
+    <td>`() => boolean`</td>
+    <td>
+    Converts the cookie value to a boolean.
+    </td>
+  </tr>
+</ApiTable>
 
 #### `CookieGetOptions`
 
@@ -234,9 +288,15 @@ Getting a cookie via `Astro.cookies.get()` returns a `AstroCookie` type. It has 
 
 Getting a cookie also allows specifying options via the `CookieGetOptions` interface:
 
-| Name      | Type                        | Description                                                                                                    |
-| :-------- | :-------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| `decode`   | `(value: string) => string`       | Allows customization of how a cookie is deserialized into a value. |
+<ApiTable>
+  <tr>
+    <td style="text-align: center">`decode`</td>
+    <td>`(value: string) => string`</td>
+    <td>
+    Allows customization of how a cookie is deserialized into a value.
+    </td>
+  </tr>
+</ApiTable>
 
 #### `CookieSetOptions`
 
@@ -244,16 +304,64 @@ Getting a cookie also allows specifying options via the `CookieGetOptions` inter
 
 Setting a cookie via `Astro.cookies.set()` allows passing in a `CookieSetOptions` to customize how the cookie is serialized.
 
-| Name      | Type                        | Description                                                                                                    |
-| :-------- | :-------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| `domain`   | `string`       | Specifies the domain. If no domain is set, most clients will interpret to apply to the current domain. |
-| `expires` | `Date` |                           Species the date on which the cookie will expire.                                             |
-| `httpOnly` | `boolean` | If true, the cookie will not be accessible client-side. |
-| `maxAge` | `number` | Specifies a number, in seconds, for which the cookie is valid. |
-| `path` | `string` | Specifies a subpath of the domain in which the cookie is applied. |
-| `sameSite` | `boolean \| 'lax' \| 'none' \| 'strict'` | Specifies the value of the [SameSite](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7) cookie header |
-| `secure` | `boolean` | If true, the cookie is only set on https sites. |
-| `encode` | `(value: string) => string` | Allows customizing how the cookie is serialized |
+<ApiTable>
+  <tr>
+    <td style="text-align: center">`domain`</td>
+    <td>`string`</td>
+    <td>
+    Specifies the domain. If no domain is set, most clients will interpret to apply to the current domain.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`expires`</td>
+    <td>`Date`</td>
+    <td>
+    Species the date on which the cookie will expire.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`httpOnly`</td>
+    <td>`boolean`</td>
+    <td>
+    If true, the cookie will not be accessible client-side.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`maxAge`</td>
+    <td>`number`</td>
+    <td>
+    Specifies a number, in seconds, for which the cookie is valid.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`path`</td>
+    <td>`string`</td>
+    <td>
+    Specifies a subpath of the domain in which the cookie is applied.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`sameSite`</td>
+    <td>`boolean \| 'lax' \| 'none' \| 'strict'`</td>
+    <td>
+    Specifies the value of the [SameSite](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7) cookie header
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`secure`</td>
+    <td>`boolean`</td>
+    <td>
+    If true, the cookie is only set on https sites.
+    </td>
+  </tr>
+  <tr>
+    <td style="text-align: center">`encode`</td>
+    <td>`(value: string) => string`</td>
+    <td>
+    Allows customizing how the cookie is serialized
+    </td>
+  </tr>
+</ApiTable>
 
 ### `Astro.redirect()`
 `Astro.redirect()` allows you to redirect to another page. 

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -130,4 +130,8 @@ export default {
 	// Starlight banner
 	'starlight.title': 'Want to build your own Docs?',
 	'starlight.description': 'Grab this template to get started.',
+	// Api Reference Table
+	'apiTable.name': 'Name',
+	'apiTable.type': 'Type',
+	'apiTable.description': 'Description',
 };


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)


Refactoring Markdown Table to `ApiTable` component

Since the original markdown table causes the text in the cell to collapse on newlines and is difficult to maintain.

And it is not possible to set the width, so I refactoring the Table component to use HTML table and specify the column width.



#### Before
![image](https://github.com/withastro/docs/assets/25167721/f6de4880-0c7d-4a96-a31a-43b2edbf2905)

#### After
![image](https://github.com/withastro/docs/assets/25167721/24cc1f99-dc46-46f0-8db1-866e12bf066c)

