### PR TITLE
[i18nIgnore] i18n(fr): fix a typo in tailwind.mdx

### DIFF
--- a/src/content/docs/fr/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/tailwind.mdx
@@ -176,7 +176,7 @@ Lorsque vous utilisez la directive `@apply` dans une balise `<style>` d'Astro, V
 error   The `text-special` class does not exist. If `text-special` is a custom class, make sure it is defined within a `@layer` directive.
 ```
 
-[Au lieu d'utiliser les directives `@layer` dans une feuille de style globale](https://tailwindcss.com/docs/functions-and-directives#using-apply-with-per-component-css), éfinissez vos styles personnalisés en ajoutant un plugin à votre configuration Tailwind pour y remédier :
+[Au lieu d'utiliser les directives `@layer` dans une feuille de style globale](https://tailwindcss.com/docs/functions-and-directives#using-apply-with-per-component-css), définissez vos styles personnalisés en ajoutant un plugin à votre configuration Tailwind pour y remédier :
 
 ```js
 // tailwind.config.mjs


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
There is a typo in the `tailwind.mdx` translation in french:
"éfinissez" should be "définissez"
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
