### PR TITLE
[i18nIgnore] Fix aside casing in `integrations-guide.mdx`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide.mdx
+++ b/src/content/docs/en/guides/integrations-guide.mdx
@@ -17,7 +17,7 @@ Integrations can…
 - Add new features to your project, like automatic sitemap generation.
 - Write custom code that hooks into the build process, dev server, and more.
 
-:::tip[INTEGRATIONS DIRECTORY]
+:::tip[Integrations directory]
 Browse or search the complete set of hundreds of official and community integrations in our [integrations directory](https://astro.build/integrations/). Find packages to add to your Astro project for authentication, analytics, performance, SEO, accessibility, UI, developer tools, and more.
 :::
 


### PR DESCRIPTION
#### Description (required)

Changes aside from "INTEGRATIONS DIRECTORY" to "Integrations directory".
