### PR TITLE
Try removing imports from `'virtual:starlight/components'`

### DIFF
--- a/src/components/starlight/PageSidebar.astro
+++ b/src/components/starlight/PageSidebar.astro
@@ -1,7 +1,8 @@
 ---
 import type { Props } from '@astrojs/starlight/props';
+import MobileTableOfContents from './MobileTableOfContents.astro';
+import TableOfContents from './TableOfContents.astro';
 
-import { TableOfContents, MobileTableOfContents } from 'virtual:starlight/components';
 import StarlightBanner from '~/components/StarlightBanner.astro';
 ---
 
@@ -44,10 +45,12 @@ import StarlightBanner from '~/components/StarlightBanner.astro';
 		display: block;
 		font-size: var(--sl-text-xs);
 		text-decoration: none;
-		color: var(--sl-color-gray-3);
 		overflow-wrap: anywhere;
 	}
-	.right-sidebar-panel :global(a:hover) {
+	.right-sidebar-panel :global(a:not([aria-current='true'])) {
+		color: var(--sl-color-gray-3);
+	}
+	.right-sidebar-panel :global(a[aria-current='true']:hover) {
 		color: var(--sl-color-white);
 	}
 	@media (min-width: 72rem) {

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -1,7 +1,7 @@
 ---
 import type { Props } from '@astrojs/starlight/props';
 import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
-import { MobileMenuFooter } from 'virtual:starlight/components';
+import MobileMenuFooter from '@astrojs/starlight/components/MobileMenuFooter.astro';
 import type { SidebarEntry } from 'node_modules/@astrojs/starlight/utils/navigation';
 
 import Sponsors from '../LeftSidebar/Sponsors.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Test PR that removes imports from Starlight’s virtual components module. Trying this to see if it is related to some errors @sarah11918 in particular has been experiencing.

Doing this has shifted CSS order, so I made a couple of hotfixes to CSS. We can revisit those to do them more correctly if this seems to work.

