### PR TITLE
i18n(es): Fix typo in `why-astro.mdx`

### DIFF
--- a/src/content/docs/es/concepts/why-astro.mdx
+++ b/src/content/docs/es/concepts/why-astro.mdx
@@ -82,7 +82,7 @@ Una de nuestras frases favoritas es: **optar por la complejidad.** Diseñamos As
 
 ### Centrado en el desarrollador
 
-Creemos firmemento que Astro es un proyecto exitoso si a las personas les encantan usarlo. Astro tiene todo lo que necesitas para apoyarte mientras construyes con Astro.
+Creemos firmemente que Astro es un proyecto exitoso si a las personas les encantan usarlo. Astro tiene todo lo que necesitas para apoyarte mientras construyes con Astro.
 
 Astro invierte en herramientas de desarrollo como una gran experiencia en el CLI desde el momento que abres la terminal, una extension oficial de VS Code para el resaltado de sintaxis, TypeScript y Intellisense, y una documentación mantenida activamente por cientos de contribuidores de la comunidad, disponible en 14 idiomas.
 


### PR DESCRIPTION
I corrected the text "Creemos firmemento" to "Creemos firmemente"