### PR TITLE
i18n(ko-KR): add `invalid-content-entry-slug-error.mdx`

### DIFF
--- a/src/content/docs/ko/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/content/docs/ko/reference/errors/invalid-content-entry-slug-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Invalid content entry slug.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` → `ENTRY_ID` has an invalid slug. `slug` must be a string.
+
+## 무엇이 잘못되었나요?
+
+`src/content/` 항목에 잘못된 `slug`가 있습니다. 이 필드는 항목 슬러그를 생성하기 위해 예약되어 있으며, 존재할 경우 문자열이어야 합니다.
+
+**더 보기:**
+
+-  [예약된 항목인 `slug` 필드](/ko/guides/content-collections/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- add `invalid-content-entry-slug-error.mdx`

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
