### PR TITLE
Refactor card nav components

### DIFF
--- a/src/components/BackendGuidesNav.astro
+++ b/src/components/BackendGuidesNav.astro
@@ -33,25 +33,6 @@ const links = enPages
 	});
 ---
 
-<section class="backend-nav">
+<section>
 	<CardsNav minimal links={links} />
 </section>
-
-<style>
-	.backend-nav > :global(*) {
-		margin-top: -2rem;
-	}
-
-	.backend-nav > :global(* + *) {
-		margin-top: -3rem;
-	}
-
-	.backend-nav :global(.scope) {
-		font-weight: normal;
-		color: var(--theme-text-lighter);
-	}
-
-	h3 {
-		margin-bottom: 0;
-	}
-</style>

--- a/src/components/CMSGuidesNav.astro
+++ b/src/components/CMSGuidesNav.astro
@@ -33,12 +33,6 @@ const links = enPages
 	});
 ---
 
-<section class="cms-nav">
+<section>
 	<CardsNav minimal links={links} />
 </section>
-
-<style>
-	.cms-nav > :global(*) {
-		margin-top: -2rem;
-	}
-</style>

--- a/src/components/DeployGuidesNav.astro
+++ b/src/components/DeployGuidesNav.astro
@@ -46,7 +46,6 @@ const services: Service[] = [
 
 <CardsNav
 	minimal={minimal}
-	class="deploy-guides-nav"
 	links={services.map(({ title, slug, supports }) => ({
 		title,
 		href: `/${lang}/guides/deploy/${slug}/`,
@@ -54,20 +53,3 @@ const services: Service[] = [
 		tags: Object.fromEntries(supports.map((s) => [s, t(`deploy.${s}Tag`)!])),
 	}))}
 />
-
-<style>
-	@media (min-width: 37.75em) {
-		:global(.deploy-guides-nav) {
-			text-align: end;
-		}
-	}
-
-	h2 {
-		text-align: start;
-	}
-
-	.minimal h2 {
-		border-top: 4px solid var(--theme-divider);
-		padding-top: 3rem;
-	}
-</style>

--- a/src/components/DeployGuidesNav.astro
+++ b/src/components/DeployGuidesNav.astro
@@ -53,13 +53,7 @@ const services: Service[] = [
 		logo: slug,
 		tags: Object.fromEntries(supports.map((s) => [s, t(`deploy.${s}Tag`)!])),
 	}))}
->
-	<span class="filter-text">{t('deploy.filterLabel')}</span>
-	<input type="checkbox" id="ssr-checkbox" class="sr-only" />
-	<label for="ssr-checkbox" class="filter-text">{t('deploy.ssrTag')}</label>
-	<input type="checkbox" id="static-checkbox" class="sr-only" />
-	<label for="static-checkbox" class="filter-text">{t('deploy.staticTag')}</label>
-</CardsNav>
+/>
 
 <style>
 	@media (min-width: 37.75em) {
@@ -75,65 +69,5 @@ const services: Service[] = [
 	.minimal h2 {
 		border-top: 4px solid var(--theme-divider);
 		padding-top: 3rem;
-	}
-
-	label {
-		margin-inline-start: 0.5em;
-		border: 2px solid;
-		border-radius: 1.5em;
-		padding: 0.25em 0.75em;
-		color: var(--theme-text-lighter);
-		user-select: none;
-		font-weight: bold;
-		cursor: pointer;
-		unicode-bidi: plaintext;
-	}
-
-	.filter-text {
-		font-size: var(--theme-text-sm);
-		white-space: nowrap;
-	}
-
-	label::after {
-		content: ' +';
-	}
-
-	input[type='checkbox']:checked + label {
-		background-color: var(--theme-text);
-		border-color: var(--theme-text);
-		color: var(--theme-bg);
-	}
-
-	input[type='checkbox']:checked + label::after {
-		content: ' ✕';
-	}
-
-	label:hover,
-	input[type='checkbox']:focus-visible + label {
-		outline: 2px solid var(--theme-accent-secondary);
-		outline-offset: 2px;
-	}
-
-	#ssr-checkbox ~ :global(* .card) {
-		/* By default, hide cards and move them to the end of the flow order. */
-		visibility: hidden;
-		order: 1;
-	}
-
-	@media (max-width: 72em) {
-		/* On smaller screens, collapse space for hidden cards in maximal variant. */
-		#ssr-checkbox ~ :global(* .card--maximal) {
-			display: none;
-		}
-	}
-
-	#ssr-checkbox:checked ~ :global(* .ssr),
-	#static-checkbox:checked ~ :global(* .static),
-	#ssr-checkbox:not(:checked) ~ #static-checkbox:not(:checked) ~ :global(* .card) {
-		/* When a service supports a selected deploy type, show its card and restore its flow order position. */
-		visibility: visible;
-		order: unset;
-		/* Also restore display for maximal variant. */
-		display: grid;
 	}
 </style>

--- a/src/components/IntegrationsNav.astro
+++ b/src/components/IntegrationsNav.astro
@@ -51,31 +51,18 @@ const category = allCategories[Astro.props.category!];
 const categories = category ? [category] : allCategories;
 ---
 
-<section class="integrations-nav">
-	{
-		Object.values(categories).map((category) => (
-			<CardsNav minimal links={category.links}>
-				<h3>{category.title}</h3>
-			</CardsNav>
-		))
-	}
-</section>
+{
+	Object.values(categories).map((category) => (
+		<>
+			<h3>{category.title}</h3>
+			<CardsNav minimal links={category.links} class="integrations-nav" />
+		</>
+	))
+}
 
 <style>
-	.integrations-nav > :global(*) {
-		margin-top: -2rem;
-	}
-
-	.integrations-nav > :global(* + *) {
-		margin-top: -3rem;
-	}
-
 	.integrations-nav :global(.scope) {
-		font-weight: normal;
-		color: var(--theme-text-lighter);
-	}
-
-	h3 {
-		margin-bottom: 0;
+		font-weight: 400;
+		color: var(--sl-color-text);
 	}
 </style>

--- a/src/components/MigrationGuidesNav.astro
+++ b/src/components/MigrationGuidesNav.astro
@@ -33,25 +33,6 @@ const links = enPages
 	});
 ---
 
-<section class="cms-nav">
+<section>
 	<CardsNav minimal links={links} />
 </section>
-
-<style>
-	.cms-nav > :global(*) {
-		margin-top: -2rem;
-	}
-
-	.cms-nav > :global(* + *) {
-		margin-top: -3rem;
-	}
-
-	.cms-nav :global(.scope) {
-		font-weight: normal;
-		color: var(--theme-text-lighter);
-	}
-
-	h3 {
-		margin-bottom: 0;
-	}
-</style>

--- a/src/components/NavGrid/Card.astro
+++ b/src/components/NavGrid/Card.astro
@@ -13,9 +13,9 @@ export interface Props {
 const { href, logo, current, minimal, class: classes, ...attrs } = Astro.props as Props;
 ---
 
-<li class:list={['card', minimal ? 'card--minimal' : 'card--maximal', classes]} {...attrs}>
+<li class:list={['card', minimal && 'card--minimal', classes]} {...attrs}>
 	{logo && <BrandLogo brand={logo} />}
-	<div class="stack">
+	<div class="stack sl-flex">
 		<h3>
 			<a href={href} aria-current={current ? 'page' : 'false'}>
 				<slot name="title" />
@@ -28,15 +28,25 @@ const { href, logo, current, minimal, class: classes, ...attrs } = Astro.props a
 <style>
 	.card {
 		position: relative;
-		margin: -0.5rem !important;
-		padding: 0.75rem 0.75rem 0.75rem 0.75rem;
+		margin: -0.75rem;
+		padding: 0.75rem;
 		display: grid;
 		grid-template-columns: auto 1fr;
-		gap: 0.75rem;
+		gap: 0.5rem;
 		align-items: center;
-		border-radius: 1rem;
+		border-radius: 0.5rem;
+	}
+	.card--minimal {
+		grid-template-columns: 1fr;
+		justify-items: center;
+		text-align: center;
 	}
 
+	.card:hover,
+	.card:focus-within {
+		background-color: var(--sl-color-gray-6);
+		outline: 1px solid var(--sl-color-text-accent);
+	}
 	@media (forced-colors: active) {
 		.card:hover,
 		.card:focus-within {
@@ -44,35 +54,24 @@ const { href, logo, current, minimal, class: classes, ...attrs } = Astro.props a
 		}
 	}
 
-	.card--minimal {
-		grid-template-columns: 1fr;
-		justify-items: center;
-		text-align: center;
+	.stack {
+		flex-direction: column;
 		gap: 0.5rem;
 	}
 
-	.card:hover,
-	.card:focus-within {
-		background-color: var(--sl-color-gray-6);
-	}
-
-	.card:focus-within {
-		outline: 2px solid var(--sl-color-text-accent);
-	}
-
 	h3 {
-		margin: 0;
-		line-height: 1.25;
-		font-size: 1.15rem !important;
+		line-height: var(--sl-line-height-headings);
+		font-size: var(--sl-text-lg);
+		font-weight: 600;
 	}
 
 	.card--minimal h3 {
-		font-size: 0.875rem;
+		font-size: var(--sl-text-body);
 	}
 
 	a {
 		text-decoration: none;
-		color: var(--sl-color-white) !important;
+		color: var(--sl-color-white);
 	}
 
 	a:focus {
@@ -87,9 +86,5 @@ const { href, logo, current, minimal, class: classes, ...attrs } = Astro.props a
 		right: 0;
 		bottom: 0;
 		left: 0;
-	}
-
-	.stack > :global(* + *) {
-		margin-top: 0.5rem;
 	}
 </style>

--- a/src/components/NavGrid/CardsNav.astro
+++ b/src/components/NavGrid/CardsNav.astro
@@ -38,7 +38,7 @@ const currentPage = new URL(Astro.request.url).pathname;
 					<Fragment slot="details">
 						{description && <p class="description">{description}</p>}
 						{tags && (
-							<div class="tags">
+							<div class="tags sl-flex">
 								{Object.values(tags).map((tag) => (
 									<Badge>{tag}</Badge>
 								))}
@@ -52,20 +52,12 @@ const currentPage = new URL(Astro.request.url).pathname;
 </section>
 
 <style>
-	.cards-nav {
-		padding: 2rem 0;
-		accent-color: var(--theme-accent-secondary);
-	}
-
 	.description {
-		margin-top: 0.25rem;
-		color: var(--theme-text-lighter);
-		font-size: var(--theme-text-sm);
+		color: var(--sl-color-gray-2);
+		font-size: var(--sl-text-body-sm);
 	}
 
 	.tags {
-		margin-top: 0.5rem !important;
-		display: flex;
 		gap: 0.5rem;
 	}
 </style>

--- a/src/components/NavGrid/Grid.astro
+++ b/src/components/NavGrid/Grid.astro
@@ -14,18 +14,19 @@ const { minimal } = Astro.props as Props;
 	.fluid-grid {
 		--column-min-width: 13rem;
 		text-align: start;
-		padding: 2rem 0;
+		margin-block: 0.5rem;
+		padding-inline-start: 0;
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(var(--column-min-width), 1fr));
 		grid-template-columns: repeat(auto-fill, minmax(min(var(--column-min-width), 100%), 1fr));
-		gap: 2rem;
+		gap: 1.5rem 2rem;
 		list-style: none;
 		align-items: start;
 	}
 
 	@media (min-width: 37.75em) {
 		.fluid-grid {
-			gap: 2rem 2.5rem;
+			gap: 2rem;
 		}
 	}
 

--- a/src/components/RecipesNav.astro
+++ b/src/components/RecipesNav.astro
@@ -4,9 +4,7 @@ import { createIsLangEntry, isEnglishEntry, type DocsEntry } from '~/content/con
 import { getLanguageFromURL, stripLangFromSlug } from '~/util';
 import CardsNav from './NavGrid/CardsNav.astro';
 
-export interface Props {
-	minimal?: boolean;
-}
+export interface Props {}
 
 const lang = getLanguageFromURL(Astro.url.pathname);
 const langRecipes = recipePages.filter(createIsLangEntry(lang));
@@ -22,7 +20,6 @@ const recipes = englishRecipes.map((fallback) => {
 
 <div>
 	<CardsNav
-		minimal={Astro.props.minimal}
 		links={recipes.map(({ data, slug }) => {
 			const linkLang = slug.split('/').shift();
 			return {
@@ -38,9 +35,3 @@ const recipes = englishRecipes.map((fallback) => {
 		})}
 	/>
 </div>
-
-<style>
-	div > :global(*) {
-		margin-top: -2rem;
-	}
-</style>


### PR DESCRIPTION
#### Description (required)

This PR refactors our card nav components. Mostly this should be a subtle visual change but it also removes a fair bit of CSS which is fun. Because this is used in a lot of different contexts, it should still be double checked thoroughly in case I missed something somewhere.

A couple of higher profile details:

- The SSR/static tag filtering mechanism in the [deploy guides nav](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/deploy/) has been removed. This was starting to get inaccessible and was perhaps offering less than we initially thought.

- The [more recipes cards](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/recipes/) are now a slightly smaller font size to match the original docs redesign specs. Should help a bit with how noisy that grid is getting.

#### Impacted pages

- Integrations Guide: [before](https://docs.astro.build/en/guides/integrations-guide/#official-integrations) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/integrations-guide/#official-integrations)
- Individual integration pages: [before](https://docs.astro.build/en/guides/integrations-guide/preact/#examples) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/integrations-guide/preact/#examples)
- Framework Components: [before](https://docs.astro.build/en/core-concepts/framework-components/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/core-concepts/framework-components/)
- Adapters: [before](https://docs.astro.build/en/guides/server-side-rendering/#official-adapters) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/server-side-rendering/#official-adapters)
- Migrate to Astro: [before](https://docs.astro.build/en/guides/migrate-to-astro/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/migrate-to-astro/)
- Individual migration guides: [before](https://docs.astro.build/en/guides/migrate-to-astro/from-hugo/#community-resources) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/migrate-to-astro/from-hugo/#community-resources)
- Connect a CMS: [before](https://docs.astro.build/en/guides/cms/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/cms/)
- Individual CMS guides: [before](https://docs.astro.build/en/guides/cms/storyblok/#community-resources) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/cms/storyblok/#community-resources)
- Use a backend service: [before](https://docs.astro.build/en/guides/backend/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/backend/)
- Individual backend service guides: [before](https://docs.astro.build/en/guides/backend/google-firebase/#community-resources) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/backend/google-firebase/#community-resources)
- Deploy your Astro Site: [before](https://docs.astro.build/en/guides/deploy/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/deploy/)
- Individual deploy guides: [before](https://docs.astro.build/en/guides/deploy/netlify/#examples) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/guides/deploy/netlify/#examples)
- More recipes: [before](https://docs.astro.build/en/recipes/) / [after](https://docs-git-dx-918-recipe-grid-astrodotbuild.vercel.app/en/recipes/)