### PR TITLE
i18n(es): Translate `cant-render-page`, `missing-locale` & `unhandled-rejection`

### DIFF
--- a/src/content/docs/es/reference/errors/cant-render-page.mdx
+++ b/src/content/docs/es/reference/errors/cant-render-page.mdx
@@ -1,0 +1,14 @@
+---
+title: Astro can't render the route.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+
+> **CantRenderPage**: Astro no pudo encontrar ningún contenido para renderizar para esta ruta. No hay ningún archivo o redirección asociado con esta ruta.
+
+## ¿Qué salió mal?
+Astro no pudo encontrar un archivo asociado con contenido mientras intentaba renderizar la ruta. Este es un error de Astro y no un error del usuario. Si al reiniciar el servidor de desarrollo no se soluciona el problema, por favor, envia un issue.
+
+
+

--- a/src/content/docs/es/reference/errors/missing-locale.mdx
+++ b/src/content/docs/es/reference/errors/missing-locale.mdx
@@ -1,0 +1,14 @@
+---
+title: The provided locale does not exist.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+
+> **MissingLocale**: La configuración regional/ruta `LOCALE` no existe en la configuración `i18n.locales`.
+
+## ¿Qué salió mal?
+Astro no puede encontrar la configuración regional solicitada. Todas las configuraciones regionales admitidas deben configurarse en [i18n.locales](/es/reference/configuration-reference/#i18nlocales) y tener directorios correspondientes dentro de `src/pages/`.
+
+
+

--- a/src/content/docs/es/reference/errors/unhandled-rejection.mdx
+++ b/src/content/docs/es/reference/errors/unhandled-rejection.mdx
@@ -1,0 +1,14 @@
+---
+title: Unhandled rejection
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+
+> **UnhandledRejection**: Astro detectó un rechazo no controlado. Aquí está la traza de la pila:<br/>STACK
+
+## ¿Qué salió mal?
+Astro no pudo encontrar ningún código para manejar una `Promise` rechazada. Asegúrete de que todas sus promesas tengan un controlador `await` o `.catch()`.
+
+
+

--- a/src/content/docs/es/reference/errors/unhandled-rejection.mdx
+++ b/src/content/docs/es/reference/errors/unhandled-rejection.mdx
@@ -8,7 +8,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 > **UnhandledRejection**: Astro detectó un rechazo no controlado. Aquí está la traza de la pila:<br/>STACK
 
 ## ¿Qué salió mal?
-Astro no pudo encontrar ningún código para manejar una `Promise` rechazada. Asegúrete de que todas sus promesas tengan un controlador `await` o `.catch()`.
+Astro no pudo encontrar ningún código para manejar una `Promise` rechazada. Asegúrate de que todas tus promesas tengan un controlador `await` o `.catch()`.
 
 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translate `cant-render-page`, `missing-locale` & `unhandled-rejection`

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
