### PR TITLE
Fix: missing interface assign in code example

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -147,7 +147,7 @@ interface Props {
   name: string;
   greeting?: string;
 }
-const { greeting = 'Hello', name } = Astro.props;
+const { greeting = 'Hello', name } = Astro.props as Props;
 ---
 <h2>{greeting}, {name}!</h2>
 ```


### PR DESCRIPTION
#### Description (required)

Code doesn't work without assigning props variables to interface
