### PR TITLE
typo: correct .mdoc extension to .astro

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -101,7 +101,7 @@ Markdoc files can only be used within content collections. Add entries to any co
 
 Then, query your collection using the [Content Collection APIs](/en/guides/content-collections/#querying-collections):
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 


### PR DESCRIPTION
It seems there is a typo suggesting that `.mdoc` files can be used inside the `pages` folder. After speaking with nate on Discord, it seems it should be `.astro`.

The makes the relevant change.