### PR TITLE
typo: fix a small typo in the welcome bot message

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -26,7 +26,7 @@ jobs:
                If they spot any broken links you will see some error messages on this PR.
                Don’t hesitate to ask any questions if you’re not sure what these mean!
             
-            2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
+            2. In a few minutes, you’ll be able to see a preview of your changes on Vercel 🥳
             
             3. One or more of our maintainers will take a look and may ask you to make changes.
                We try to be responsive, but don’t worry if this takes a few days.


### PR DESCRIPTION
The welcome bot states that a preview will be available on Netlify, but it seems deploys are now done to Vercel.