### PR TITLE
Update mention about dynamically generated slot names

### DIFF
--- a/src/content/docs/en/core-concepts/astro-components.mdx
+++ b/src/content/docs/en/core-concepts/astro-components.mdx
@@ -291,7 +291,7 @@ Named slots can also be passed to [UI framework components](/en/core-concepts/fr
 
 
 :::note
-An astro slot name can not be dynamically generated, such as within a map function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
+To dynamically generate an astro slot name, such as within a map function, you need use Astro versions later than 4.2.0. If this feature is needed within UI framework components on older Astro versions, it might be best to generate these dynamic slots within the framework itself.
 :::
 
 


### PR DESCRIPTION
#### Description

In https://github.com/withastro/compiler/pull/933, we added support for dynamically generated slots. This PR updates a reference about that feature not being supported and underlines the minimum astro version required to use it

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->

#### For Astro version: `4.2.0`.

See astro PR https://github.com/withastro/astro/pull/9605
