### PR TITLE
Fix a confusing React component example

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -309,7 +309,7 @@ The following example implements the same using `navigate()` in a React `<Form /
 import React from 'react';
 import { navigate } from 'astro:transitions/client';
 
-export default function ClickToNavigate({ to }) {
+export default function Form() {
   return <select onChange={(ev) => navigate(e.target.value)}>
     <option value="/play">Play</option>
     <option value="/blog">Blog</option>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I believe the navigation triggering React component has a just very slightly confusing name and an unused prop which somewhat misguide the reader's attention

#### Related issues & labels (optional)

- Suggested label: Fix a confusing React component example

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
