### PR TITLE
Fix the logic error in docs [Build a blog 5:3]

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/3.mdx
@@ -278,7 +278,7 @@ Follow the steps below, then check your work by comparing it to the [final code 
     <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} /> 
 
     <div class="tags">
-      {tags.map((tag) => (
+      {frontmatter.tags.map((tag) => (
         <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
       ))}
     </div>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
There was logic error in **Build a blog** tutorial at **Unit 5: Astro api** 3rd section
![Screenshot 2024-01-21 114828](https://github.com/withastro/docs/assets/101964499/49788e8f-17b7-4eb7-986e-6ae41f93f1f6)
instead of `{tags.map ...}` it should be `{frontmatter.tags.map....}`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
