### PR TITLE
Clarify route precedence in routing.mdx

### DIFF
--- a/src/content/docs/en/core-concepts/routing.mdx
+++ b/src/content/docs/en/core-concepts/routing.mdx
@@ -305,9 +305,9 @@ It's possible for multiple defined routes to attempt to build the same URL path.
     - [...slug].astro
 </FileTree>
 
-Astro needs to know which route should be used to build the page. To do so, it sorts them according to the following rules in order:
+Astro needs to know which route should be used to build the page. To do so, it sorts the routes according to the following rules (if two rules apply, the one that comes first in the following list takes precedence):
 
-- Routes with more path segments will take precedence over less specific routes. In the example above, all routes under `/posts/` take precedence over `/[...slug].astro` at the root.
+- Routes with more path segments will take precedence over routes with fewer path segments. In the example above, all routes under `/posts/` take precedence over `/[...slug].astro` at the root.
 - Static routes without path parameters will take precedence over dynamic routes. E.g. `/posts/create.astro` takes precedence over all the other routes in the example.
 - Dynamic routes using named parameters take precedence over rest parameters. E.g. `/posts/[page].astro` takes precedence over `/posts/[...slug].astro`.
 - Pre-rendered dynamic routes take precedence over server dynamic routes.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Clarify what "them" and "in order" exactly refer to.
- "Routes with ... will take precedence over less specific routes" -> seems like a circular definition, since "precedence" and "specificity" seem to refer to the same thing here...