### PR TITLE
<h1> to <h2> to Match Code Snippet

### DIFF
--- a/src/content/docs/en/recipes/streaming-improve-page-performance.mdx
+++ b/src/content/docs/en/recipes/streaming-improve-page-performance.mdx
@@ -52,7 +52,7 @@ const factData = await factResponse.json();
 ```
 
 
-The Astro page below using these components can render parts of the page sooner. The `<head>`, `<body>`, and `<h1>` tags are no longer blocked by data fetches. The server will then fetch data for `RandomName` and `RandomFact` in parallel and stream the resulting HTML to the browser.
+The Astro page below using these components can render parts of the page sooner. The `<head>`, `<body>`, and `<h2>` tags are no longer blocked by data fetches. The server will then fetch data for `RandomName` and `RandomFact` in parallel and stream the resulting HTML to the browser.
 
 ```astro title="src/pages/index.astro"
 ---


### PR DESCRIPTION
The code snippet has `<h2>` tags instead of `<h1>` so I updated the text to match.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
