### PR TITLE
Update preact.mdx

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -34,8 +34,18 @@ To install `@astrojs/preact`, run the following from your project directory and 
   </Fragment>
   <Fragment slot="pnpm">
   ```sh
-  pnpm astro add preact
+  pnpm exec astro add preact
   ```
+  
+  > ⚠️ _**Important warning**_: When using `pnpm`, as package manager in an astro project, always use `pnpm exec astro` and *not* `pnpm dlx astro`. The reason is that `pnpm dlx` will invoke `npm` (`npx`) to install dependencies, which will change the folder structure created by pnpm to organize your dependencies. This will cause multiple issues, e.g., if you try after that, to install a package using `pnpm add <some package>`, you will get an error looking like :
+  
+  ```bash
+  $ pnpm add --save lucide-preact
+   WARN  Moving astro that was installed by a different package manager to "node_modules/.ignored"
+   WARN  Moving preact that was installed by a different package manager to "node_modules/.ignored"
+   EPERM  EPERM: operation not permitted, rename 'C:\Users\RichardMS\my project\node_modules\astro' -> 'C:\Users\Utilisateur\radio_jaune_2024\node_modules\.ignored\astro'
+  ```
+
   </Fragment>
   <Fragment slot="yarn">
   ```sh

--- a/src/content/docs/en/integrations/integrations.mdx
+++ b/src/content/docs/en/integrations/integrations.mdx
@@ -61,6 +61,16 @@ You can start a new astro project based on an existing github repostory by passi
   ```shell
   pnpm create astro@latest --template <github-username>/<github-repo>
   ```
+
+  > ⚠️ _**Important warning**_: When using `pnpm`, as package manager in an astro project, always use `pnpm exec astro` and *not* `pnpm dlx astro`. The reason is that `pnpm dlx` will invoke `npm` (`npx`) to install dependencies, which will change the folder structure created by pnpm to organize your dependencies. This will cause multiple issues, e.g., if you try after that, to install a package using `pnpm add <some package>`, you will get an error looking like :
+  
+  ```bash
+  $ pnpm add --save lucide-preact
+   WARN  Moving astro that was installed by a different package manager to "node_modules/.ignored"
+   WARN  Moving preact that was installed by a different package manager to "node_modules/.ignored"
+   EPERM  EPERM: operation not permitted, rename 'C:\Users\RichardMS\my project\node_modules\astro' -> 'C:\Users\Utilisateur\radio_jaune_2024\node_modules\.ignored\astro'
+  ```
+
   </Fragment>
   <Fragment slot="yarn">
   ```shell


### PR DESCRIPTION
fix doc typo: use `pnpm exec astro add preact` to run astro cli, instead of `pnpm astro add preact`

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Indeed, if you run `pnpm astro add preact`, you get the following error : 

```bash
$ pnpm astro add preact

> ossified-orbit@0.0.1 astro C:\Users\Utilisateur\radio_jaune_2024
> astro "add" "preact"

'astro' n’est pas reconnu en tant que commande interne
ou externe, un programme exécutable ou un fichier de commandes.
 ELIFECYCLE  Command failed with exit code 1.
```
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->


#### Environment

* `Git` bash for windows, 
* `astro` `4.2.4`
* `pnpm` `8.14.1`