### PR TITLE
i18n(es): update kontent-ai.mdx

### DIFF
--- a/src/content/docs/es/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/es/guides/cms/kontent-ai.mdx
@@ -322,8 +322,6 @@ const blogPosts = await deliveryClient
 La llamada de recuperación devolverá un objeto `response` que contiene una lista de todas las entradas de blog en `data.items`. En la sección HTML de la página de Astro, puedes usar la función `map()` para enumerar las entradas de blog:
 
 ```astro title="src/pages/index.astro" ins={11-29}
-
-```astro title="src/pages/index.astro" ins={11-29}
 ---
 import { deliveryClient } from '../lib/kontent';
 import type { BlogPost } from '../models';


### PR DESCRIPTION
#### Description (required)

Fixed a problem with the highlighted block. This part was duplicated `astro title="src/pages/index.astro" ins={11-29}`