### PR TITLE
i18n(zh-cn): Update translate from #6623

### DIFF
--- a/src/content/docs/zh-cn/reference/error-reference.mdx
+++ b/src/content/docs/zh-cn/reference/error-reference.mdx
@@ -60,8 +60,10 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 - [**InvalidGlob**](/zh-cn/reference/errors/invalid-glob/)<br/>Invalid glob pattern.
 - [**FailedToFindPageMapSSR**](/zh-cn/reference/errors/failed-to-find-page-map-ssr/)<br/>Astro couldn't find the correct page to render
 - [**MissingLocale**](/zh-cn/reference/errors/missing-locale/)<br/>The provided locale does not exist.
+- [**MissingIndexForInternationalization**](/zh-cn/reference/errors/missing-index-for-internationalization/)<br/>Index page not found.
 - [**CantRenderPage**](/zh-cn/reference/errors/cant-render-page/)<br/>Astro can't render the route.
 - [**UnhandledRejection**](/zh-cn/reference/errors/unhandled-rejection/)<br/>Unhandled rejection
+- [**i18nNotEnabled**](/zh-cn/reference/errors/i18n-not-enabled/)<br/>i18n Not Enabled
 ## CSS 错误
 
 - [**UnknownCSSError**](/zh-cn/reference/errors/unknown-csserror/)<br/>Unknown CSS Error.

--- a/src/content/docs/zh-cn/reference/errors/astro-glob-no-match.mdx
+++ b/src/content/docs/zh-cn/reference/errors/astro-glob-no-match.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **AstroGlobNoMatch**: `Astro.glob(GLOB_STR)` 没有返回任何匹配的文件。检查模式是否有拼写错误。
+> **AstroGlobNoMatch**: `Astro.glob(GLOB_STR)` 没有返回任何匹配的文件。
 
 ## 哪里出了问题？
 

--- a/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
@@ -18,6 +18,6 @@ export default defineConfig({
 
 有关 Astro 中的国际化支持的更多信息，请参阅我们的[国际化指南](/zh-cn/guides/internationalization/)。
 
-**另请参阅：**
+**请参阅：**
 -  [国际化](/zh-cn/guides/internationalization/)
 -  [`i18n` 配置参考](/zh-cn/reference/configuration-reference/#i18n)

--- a/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
@@ -1,5 +1,5 @@
 ---
-title: 未启用国际化
+title: Index page not found.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---

--- a/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
@@ -1,5 +1,5 @@
 ---
-title: Index page not found.
+title: i18n Not Enabled
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---

--- a/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
@@ -19,5 +19,5 @@ export default defineConfig({
 有关 Astro 中的国际化支持的更多信息，请参阅我们的[国际化指南](/zh-cn/guides/internationalization/)。
 
 **另请参阅：**
--  [国际化](/en/guides/internationalization/)
+-  [国际化](/zh-cn/guides/internationalization/)
 -  [`i18n` 配置参考](/zh-cn/reference/configuration-reference/#i18n)

--- a/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx
@@ -1,0 +1,23 @@
+---
+title: 未启用国际化
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+> **i18nNotEnabled**: 在你的 Astro 配置中未启用 `astro:i18n` 模块。
+## 出了什么问题？
+在你的 Astro 配置中未启用 `astro:i18n` 模块。要启用国际化，请在你的 Astro 配置中添加默认语言环境和支持的语言环境列表：
+```js
+import { defineConfig } from 'astro'
+export default defineConfig({
+ i18n: {
+	 defaultLocale: 'en',
+	 locales: ['en', 'fr'],
+	},
+})
+```
+
+有关 Astro 中的国际化支持的更多信息，请参阅我们的[国际化指南](/zh-cn/guides/internationalization/)。
+
+**另请参阅：**
+-  [国际化](/en/guides/internationalization/)
+-  [`i18n` 配置参考](/zh-cn/reference/configuration-reference/#i18n)

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -7,7 +7,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 ## 出了什么问题？
 Astro 无法找到你网站的索引 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个索引页面，以便 Astro 可以从主索引页面创建一个重定向到默认语言环境的本地化索引页面。
 
-**参见：**
+**请参阅：**
 -  [国际化](/zh-cn/guides/internationalization/#routing)
 -  [`i18n.routing` 配置参考](/zh-cn/reference/configuration-reference/#i18nrouting)
 

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -3,7 +3,7 @@ title: Index page not found.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-> **MissingIndexForInternationalization**: 无法找到首页。需要一个根首页来创建一个重定向到默认语言环境的首页 URL。（`/DEFAULT_LOCALE`）
+> **MissingIndexForInternationalization**: 无法找到首页。需要一个根目录的首页来创建一个重定向到默认语言环境的首页 URL。（`/DEFAULT_LOCALE`）
 
 ## 出了什么问题？
 Astro 无法找到你网站的首页 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个首页来 Astro 可以创建一个重定向到默认语言环境的本地化首页。

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -1,5 +1,5 @@
 ---
-title: 未找到索引页面。
+title: Index page not found.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -8,6 +8,6 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 Astro 无法找到你网站的索引 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个索引页面，以便 Astro 可以从主索引页面创建一个重定向到默认语言环境的本地化索引页面。
 
 **参见：**
--  [国际化](/en/guides/internationalization/#routing)
+-  [国际化](/zh-cn/guides/internationalization/#routing)
 -  [`i18n.routing` 配置参考](/zh-cn/reference/configuration-reference/#i18nrouting)
 

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -1,0 +1,13 @@
+---
+title: 未找到索引页面。
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+> **MissingIndexForInternationalization**: 无法找到索引页面。需要一个根索引页面，以便创建一个重定向到默认语言环境的索引 URL。(`/DEFAULT_LOCALE`)
+## 出了什么问题？
+Astro 无法找到你网站的索引 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个索引页面，以便 Astro 可以从主索引页面创建一个重定向到默认语言环境的本地化索引页面。
+
+**参见：**
+-  [国际化](/en/guides/internationalization/#routing)
+-  [`i18n.routing` 配置参考](/zh-cn/reference/configuration-reference/#i18nrouting)
+

--- a/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx
@@ -3,9 +3,10 @@ title: Index page not found.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
-> **MissingIndexForInternationalization**: 无法找到索引页面。需要一个根索引页面，以便创建一个重定向到默认语言环境的索引 URL。(`/DEFAULT_LOCALE`)
+> **MissingIndexForInternationalization**: 无法找到首页。需要一个根首页来创建一个重定向到默认语言环境的首页 URL。（`/DEFAULT_LOCALE`）
+
 ## 出了什么问题？
-Astro 无法找到你网站的索引 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个索引页面，以便 Astro 可以从主索引页面创建一个重定向到默认语言环境的本地化索引页面。
+Astro 无法找到你网站的首页 URL。当使用 [`i18n.routing.prefixDefaultLocale`](/zh-cn/reference/configuration-reference/#i18nroutingprefixdefaultlocale) 时，需要一个首页来 Astro 可以创建一个重定向到默认语言环境的本地化首页。
 
 **请参阅：**
 -  [国际化](/zh-cn/guides/internationalization/#routing)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update translate from #6623

Update files:
- [reference/error-reference.mdx](https://github.com/withastro/docs/blob/main/src/content/docs/zh-cn/reference/error-reference.mdx)
- [reference/errors/astro-glob-no-match.mdx](https://github.com/withastro/docs/blob/main/src/content/docs/zh-cn/reference/errors/astro-glob-no-match.mdx)

Create files:
- [reference/errors/i18n-not-enabled.mdx](https://github.com/withastro/docs/blob/main/src/content/docs/zh-cn/reference/errors/i18n-not-enabled.mdx)
- [reference/errors/missing-index-for-internationalization.mdx](https://github.com/withastro/docs/blob/main/src/content/docs/zh-cn/reference/errors/missing-index-for-internationalization.mdx)

#### Related issues & labels (optional)

- #6623 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->
