### PR TITLE
Fix `tailwind.mdx` config extension

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -150,7 +150,7 @@ export default defineConfig({
   integrations: [
     tailwind({
       // Example: Provide a custom path to a Tailwind config file
-      configFile: './custom-config.cjs',
+      configFile: './custom-config.mjs',
     }),
   ],
 });

--- a/src/content/docs/en/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/en/guides/integrations-guide/tailwind.mdx
@@ -226,7 +226,7 @@ error   The `text-special` class does not exist. If `text-special` is a custom c
 
 [Instead of using `@layer` directives in a global stylesheet](https://tailwindcss.com/docs/functions-and-directives#using-apply-with-per-component-css), define your custom styles by adding a plugin to your Tailwind config to fix it:
 
-```js title="tailwind.config.cjs"
+```js title="tailwind.config.mjs"
 export default {
   // ...
   plugins: [


### PR DESCRIPTION
#### Description (required)

This fixes the Tailwind's config extension that was still `.cjs` to use the correct format according to its export statement: `.mjs`