### PR TITLE
Fix headings spacing

### DIFF
--- a/src/components/starlight/MarkdownContent.astro
+++ b/src/components/starlight/MarkdownContent.astro
@@ -128,6 +128,12 @@ const { entry } = Astro.props;
 		line-height: var(--sl-line-height-headings);
 	}
 
+	/* Headings after non-headings have more spacing. */
+	.sl-markdown-content
+		:global(:not(.heading-wrapper) + :is(.heading-wrapper):not(:where(.not-content *))) {
+		margin-top: 1.5em;
+	}
+
 	/* Set font-size on wrapper element, so line-height, margins etc. match heading size. */
 	.sl-markdown-content :global(.level-h2) {
 		font-size: var(--sl-text-h2);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Because we wrap our heading elements in a `<div>` to support the layout of the anchor link icons, Starlight’s built-in `:not(heading) + heading` styles weren’t applying.

This PR adds back those spacing styles for less ugly pages 💅 

Click around several pages to see the difference, but here is one before/after comparison:

| Before | After |
|--------|--------|
| ![Page with minimal spacing before headings](https://github.com/withastro/docs/assets/357379/ed2b07c3-4a85-4596-9f82-cdb789f1c0bb) | ![Page with more generous spacing before headings](https://github.com/withastro/docs/assets/357379/92bff1dd-f0d8-4475-9166-a37cfde1a9d7) |
