### PR TITLE
document new behavior(vercel, netlify): edge middleware verification

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -146,7 +146,7 @@ export default defineConfig({
 
 When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
-For on-demand rendered pages, `context.locals` are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+For on-demand rendered pages, the `context.locals` obect is serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 ### Netlify Image CDN support
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -146,7 +146,7 @@ export default defineConfig({
 
 When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
-For on-demand rendered pages, the `context.locals` obect is serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+For on-demand rendered pages, the `context.locals` object is serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 ### Netlify Image CDN support
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -144,7 +144,9 @@ export default defineConfig({
 });
 ```
 
-When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages. For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
+
+For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 ### Netlify Image CDN support
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -125,7 +125,7 @@ declare namespace App {
 
 This is not available on prerendered pages.
 
-### Running Astro middleware in Edge Functions
+### Running Astro middleware on Netlify Edge Functions
 
 Any Astro middleware is applied to pre-rendered pages at build-time, and to on-demand-rendered pages at runtime.
 
@@ -144,7 +144,7 @@ export default defineConfig({
 });
 ```
 
-Configuring `edgeMiddleware: true` will deploy your middleware as an Edge Function, and run it on all routes - including pre-rendered pages. However, locals specified in the middleware won't be available to any pre-rendered pages, because they've already been fully-rendered at build-time.
+When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages. For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 ### Netlify Image CDN support
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -146,7 +146,7 @@ export default defineConfig({
 
 When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
-For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+For on-demand rendered pages, `context.locals` are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 ### Netlify Image CDN support
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -339,7 +339,7 @@ You may not need to install this package for your middleware. `@vercel/edge` is 
 
 The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
-For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+For on-demand rendered pages, `context.locals` are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 This is an opt-in feature. To enable it, set `edgeMiddleware` to `true`:
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -305,7 +305,7 @@ export default defineConfig({
 
 ### Vercel Edge Middleware
 
-You can use Vercel Edge middleware to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You may not need to install this package for your middleware. `@vercel/edge` is only required to use some middleware features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
+You can use [Vercel Edge middleware](https://vercel.com/docs/functions/edge-middleware) to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You may not need to install this package for your middleware. `@vercel/edge` is only required to use some middleware features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
 
 1. Add a `middleware.js` file to the root of your project:
 
@@ -333,11 +333,11 @@ You can use Vercel Edge middleware to intercept a request and redirect before se
 **Trying to rewrite?** Currently rewriting a request with middleware only works for static files.
 :::
 
-### Vercel Edge Middleware with Astro middleware
+### Running Astro middleware on Vercel Edge Functions
 
-The `@astrojs/vercel/serverless` adapter can automatically create the Vercel Edge middleware from an Astro middleware in your code base.
+The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages. For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
-This is an opt-in feature, and the `edgeMiddleware` option needs to be set to `true`:
+This is an opt-in feature. To enable it, set `edgeMiddleware` to `true`:
 
 ```js title="astro.config.mjs" "edgeMiddleware: true"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -337,7 +337,7 @@ You may not need to install this package for your middleware. `@vercel/edge` is 
 
 ### Running Astro middleware on Vercel Edge Functions
 
-The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages.
+The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
 For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -339,7 +339,7 @@ You may not need to install this package for your middleware. `@vercel/edge` is 
 
 The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
 
-For on-demand rendered pages, `context.locals` are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+For on-demand rendered pages, the `context.locals` object is serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 This is an opt-in feature. To enable it, set `edgeMiddleware` to `true`:
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -305,7 +305,9 @@ export default defineConfig({
 
 ### Vercel Edge Middleware
 
-You can use [Vercel Edge middleware](https://vercel.com/docs/functions/edge-middleware) to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments. You may not need to install this package for your middleware. `@vercel/edge` is only required to use some middleware features such as geolocation. For more information see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
+You can use [Vercel Edge middleware](https://vercel.com/docs/functions/edge-middleware) to intercept a request and redirect before sending a response. Vercel middleware can run for Edge, SSR, and Static deployments.
+
+You may not need to install this package for your middleware. `@vercel/edge` is only required to use some middleware features such as geolocation. For more information, see [Vercel’s middleware documentation](https://vercel.com/docs/concepts/functions/edge-middleware).
 
 1. Add a `middleware.js` file to the root of your project:
 
@@ -335,7 +337,9 @@ You can use [Vercel Edge middleware](https://vercel.com/docs/functions/edge-midd
 
 ### Running Astro middleware on Vercel Edge Functions
 
-The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages. For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
+The `@astrojs/vercel/serverless` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests for static assets, prerendered pages, and on-demand rendered pages.
+
+For on-demand rendered pages, the locals are serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 
 This is an opt-in feature. To enable it, set `edgeMiddleware` to `true`:
 


### PR DESCRIPTION
#### Description (required)
Enabling `edgeMiddleware` will now involve a check to prevent anyone but the generated middleware from providing locals.

#### Related issues & labels (optional)
- https://github.com/withastro/astro/pull/9987
- https://github.com/withastro/astro/pull/10018
- https://github.com/withastro/adapters/pull/152
- https://github.com/withastro/adapters/pull/156