### PR TITLE
feat: better sidebar UX

### DIFF
--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -53,3 +53,13 @@ sidebar = await Promise.all(sidebar.map(remap));
 		font-weight: 700;
 	}
 </style>
+
+<script>
+	const currentActiveMenu : Element = document.querySelector('a[aria-current="page"]');
+
+	currentActiveMenu.scrollIntoView(<ScrollIntoViewOptions>{
+		behavior: 'instant',
+		block: 'center',
+		inline: 'center',
+	});
+</script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Previously, the sidebar did not retain its scrolling position, which required readers to scroll down within the sidebar in order to continue reading. 

This PR will change the behavior of the sidebar, the highlighted item will instantly scroll to the view, this is somehow a better UX in my opnion.

Before: 

https://github.com/withastro/docs/assets/29943110/e00d30bb-52fb-4966-8158-81d2b4de5224

After: 

https://github.com/withastro/docs/assets/29943110/42132002-d75b-4307-b8d8-01e613c69954


