### PR TITLE
Revert "Update mention about dynamically generated slot names (#6440)"

### DIFF
--- a/src/content/docs/en/basics/astro-components.mdx
+++ b/src/content/docs/en/basics/astro-components.mdx
@@ -291,7 +291,7 @@ Named slots can also be passed to [UI framework components](/en/guides/framework
 
 
 :::note
-Dynamically generating an Astro slot name, such as within a map function, was added in Astro v4.2.0. For earlier versions of Astro, it might be best to generate these dynamic slots within the framework itself.
+An astro slot name can not be dynamically generated, such as within a map function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
 :::
 
 

--- a/src/content/docs/en/basics/astro-components.mdx
+++ b/src/content/docs/en/basics/astro-components.mdx
@@ -291,7 +291,7 @@ Named slots can also be passed to [UI framework components](/en/guides/framework
 
 
 :::note
-An astro slot name can not be dynamically generated, such as within a map function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
+It is not possible to dynamically generate an Astro slot name, such as within a map function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
 :::
 
 


### PR DESCRIPTION
#### Description (required)

We're [temporarily rolling back a feature](https://github.com/withastro/compiler/pull/963#pullrequestreview-1865102712) (dynamically generated slots) which we added docs for in #6440, so I removed its mention in the docs