### PR TITLE
explain images in cc are same as md/mdx images

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -518,7 +518,7 @@ import rocket from '../assets/rocket.png';
 
 ## Images in Content Collections
 
-Images in Content Collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which file type you are using.
+Images in content collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which file type you are using.
 
 Additionally, you can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -518,7 +518,7 @@ import rocket from '../assets/rocket.png';
 
 ## Images in Content Collections
 
-Images in Content Collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which filetype you are using.
+Images in Content Collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which file type you are using.
 
 Additionally you can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
 

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -520,7 +520,7 @@ import rocket from '../assets/rocket.png';
 
 Images in Content Collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which file type you are using.
 
-Additionally you can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
+Additionally, you can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
 
 ```md title="src/content/blog/my-post.md" {3}
 ---

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -518,7 +518,9 @@ import rocket from '../assets/rocket.png';
 
 ## Images in Content Collections
 
-You can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
+Images in Content Collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which filetype you are using.
+
+Additionally you can declare an associated image for a content collections entry, such as a blog post's cover image, in your frontmatter using its path relative to the current folder:
 
 ```md title="src/content/blog/my-post.md" {3}
 ---

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -516,7 +516,7 @@ import rocket from '../assets/rocket.png';
 
 ```
 
-## Images in Content Collections
+## Images in content collections
 
 Images in content collections will be processed the same way they are in [Markdown](#images-in-markdown-files) and [MDX](#images-in-mdx-files) depending on which file type you are using.
 


### PR DESCRIPTION
#### Description (required)

Adds explanation that md/mdx images are treated the same in CC as normal md/mdx
