### PR TITLE
i18n(en): update talks.mdx to make explicit that links to livestreams are recor…

### DIFF
--- a/src/content/docs/en/community-resources/talks.mdx
+++ b/src/content/docs/en/community-resources/talks.mdx
@@ -40,7 +40,7 @@ Subscribe to [the Astro Community Events Google Calendar](https://calendar.googl
 - [Astro and MDX for digital gardening](https://podrocket.logrocket.com/astro-mdx-kathleen-mcmahon) with Kathleen McMahon on PodRocket
 - [Decoding the Astro Web Framework](https://www.youtube.com/watch?v=4PKT8x78yOQ) with Chris Pennington on Code Ryan
 
-## Livestream coding sessions
+## Recorded livestream coding sessions
 
 - [Building faster websites with Astro](https://www.youtube.com/watch?v=0eka27P4Pr4) with Cassidy Williams
 - [Astro SSR and building a Hackernews demo](https://www.youtube.com/watch?v=2ZEMb_H-LYE) with Fred K. Schott and Ryan Carnito


### PR DESCRIPTION
…dings



<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
The section `Livestream coding sessions` only has links to recorded streams on YouTube, so changing the title makes it more explicit about the content.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label:  i18n
