### PR TITLE
[i18nIgnore] Change event name

### DIFF
--- a/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
@@ -34,7 +34,7 @@ export default {
 	icon: '<svg>...</svg>',
 	init(canvas, eventTarget) {
     eventTarget.dispatchEvent(
-      new CustomEvent('app-notification', {
+      new CustomEvent('toggle-notification', {
         detail: {
           state: true,
         },

--- a/src/content/docs/es/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/es/reference/dev-toolbar-app-reference.mdx
@@ -34,7 +34,7 @@ export default {
 	icon: '<svg>...</svg>',
 	init(canvas, eventTarget) {
     eventTarget.dispatchEvent(
-      new CustomEvent('app-notification', {
+      new CustomEvent('toggle-notification', {
         detail: {
           state: true,
         },

--- a/src/content/docs/ko/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/ko/reference/dev-toolbar-app-reference.mdx
@@ -34,7 +34,7 @@ export default {
 	icon: '<svg>...</svg>',
 	init(canvas, eventTarget) {
     eventTarget.dispatchEvent(
-      new CustomEvent('app-notification', {
+      new CustomEvent('toggle-notification', {
         detail: {
           state: true,
         },

--- a/src/content/docs/zh-cn/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/zh-cn/reference/dev-toolbar-app-reference.mdx
@@ -34,7 +34,7 @@ export default {
 	icon: '<svg>...</svg>',
 	init(canvas, eventTarget) {
     eventTarget.dispatchEvent(
-      new CustomEvent('app-notification', {
+      new CustomEvent('toggle-notification', {
         detail: {
           state: true,
         },


### PR DESCRIPTION
#### Description (required)

The event name `app-notification` does not exist and can be misleading to users, so change it to an event name that does exist.

#### Related issues & labels (optional)

- Suggested label: code snippet update
