### PR TITLE
Introduces transition:reload instead of data-astro-reload

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v4.mdx
@@ -44,7 +44,7 @@ After upgrading Astro to the latest version, you may not need to make any change
 But, if you notice errors or unexpected behavior, please check below for what has changed that might need updating in your project.
 :::
 
-Astro v4.0 includes [potentially breaking changes](#breaking-changes), as well as the [removal of some previously deprecated features](#previously-deprecated-features-now-removed). 
+Astro v4.0 includes [potentially breaking changes](#breaking-changes), as well as the [removal of some previously deprecated features](#previously-deprecated-features-now-removed).
 
 If your project doesn't work as expected after upgrading to v4.0, check this guide for an overview of all breaking changes and instructions on how to update your codebase.
 
@@ -129,7 +129,7 @@ injectRoute({
 
 ### Changed: `app.render` signature in Integrations API
 
-In Astro v3.0, the `app.render()` method accepted `routeData` and `locals` as separate, optional arguments. 
+In Astro v3.0, the `app.render()` method accepted `routeData` and `locals` as separate, optional arguments.
 
 Astro v4.0 changes the `app.render()` signature. These two properties are now available in a single object. Both the object and these two properties are still optional.
 
@@ -226,10 +226,10 @@ import { ViewTransitions } from "astro:transitions";
 </html>
 ```
 
-To opt out of `submit` event handling, add the `data-astro-reload` attribute to relevant `form` elements.
+To opt out of `submit` event handling, add the `transition:reload` directive to relevant `form` elements. This directive is supported starting with Astro v4.x. When migrating to an earlier v4 version use the `data-astro-reload` attribute instead of the `transition:reload` directive.
 
-```astro title="src/components/Form.astro" ins="data-astro-reload"
-<form action="/contact" data-astro-reload>
+```astro title="src/components/Form.astro" ins="transition:reload"
+<form action="/contact" transition:reload>
   <!-- -->
 </form>
 ```
@@ -349,7 +349,7 @@ Please see the v3 migration guide [for guidance using uppercase HTTP request met
 In Astro v3.x, the Astro preview server returned a 301 redirect when accessing public directory assets without a base path.
 
 Astro v4.0 returns a 404 status without a base path prefix for public directory assets when the preview server is running, matching the behavior of the dev server.
- 
+
 #### What should I do?
 
 When using the Astro preview server, all of your static asset imports and URLs from the public directory must have [the base value](/en/reference/configuration-reference/#base) prefixed to the path.

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -7,7 +7,7 @@ i18nReady: true
 
 import Since from '~/components/Since.astro'
 
-Astro supports **opt-in, per-page, view transitions** with just a few lines of code. View transitions update your page content without the browser's normal, full-page navigation refresh and provide seamless animations between pages. 
+Astro supports **opt-in, per-page, view transitions** with just a few lines of code. View transitions update your page content without the browser's normal, full-page navigation refresh and provide seamless animations between pages.
 
 Astro provides a `<ViewTransitions />` routing component that can be added to a single page's `<head>` to control page transitions as you navigate away to another page. It provides a lightweight client-side router that [intercepts navigation](#client-side-navigation-process) and allows you to customize the transition between pages.
 
@@ -69,7 +69,7 @@ import { ViewTransitions } from 'astro:transitions';
 
 No other configuration is necessary to enable Astro's default client-side navigation!
 
-Use [transition directives](#transition-directives) or [override default client-side navigation](#preventing-client-side-navigation) on individual elements for finer control. 
+Use [transition directives](#transition-directives) or [override default client-side navigation](#preventing-client-side-navigation) on individual elements for finer control.
 
 ## Transition Directives
 
@@ -100,7 +100,7 @@ Note that the provided `transition:name` value can only be used once on each pag
 
 <p><Since v="2.10.0" /></p>
 
-You can persist components and HTML elements (instead of replacing them) across page navigations using the `transition:persist` directive. 
+You can persist components and HTML elements (instead of replacing them) across page navigations using the `transition:persist` directive.
 
 For example, the following `<video>` will continue to play as you navigate to another page that contains the same video element. This works for both forwards and backwards navigation.
 
@@ -172,7 +172,7 @@ import { CommonHead } from '../components/CommonHead.astro';
 
 You can customize all aspects of a transition with any CSS animation properties.
 
-To customize a built-in animation, first import the animation from `astro:transitions`, and then pass in customization options. 
+To customize a built-in animation, first import the animation from `astro:transitions`, and then pass in customization options.
 
 The example below customizes the duration of the built-in `fade` animation:
 
@@ -244,7 +244,7 @@ The `<ViewTransitions />` router handles navigation by listening to:
 
 The following options allow you to further control when navigation occurs within the router:
 
-- `data-astro-reload`: an `<a>` tag attribute to [force a full-page navigation](#preventing-client-side-navigation)
+- `transition:reload`: a directive for `<a>`, `<area>` and `<form>` tags to [force a full-page navigation](#preventing-client-side-navigation)
 - `data-astro-history="auto | push | replace"`: an `<a>` tag attribute to [control the browser's history](#replace-entries-in-the-browser-history)
 - `navigate(href, options)`: a method available to any client script or client component to [trigger navigation](#trigger-navigation)
 
@@ -252,19 +252,24 @@ The following options allow you to further control when navigation occurs within
 
 There are some cases where you cannot navigate via client-side routing since both pages involved must use the `<ViewTransitions />` router to prevent a full-page reload. You may also not want client-side routing on every navigation change and would prefer a traditional page navigation on select routes instead.
 
-You can opt out of client-side routing on a per-link basis by adding the `data-astro-reload` attribute to any `<a>` or `<form>` tag. This attribute will override any existing `<ViewTransitions />` component and instead trigger a browser refresh during navigation.
+You can opt out of client-side routing on a per-link basis by adding the `transition:reload` directive to any `<a>`, `<area>` or `<form>` tag. This attribute will override any existing `<ViewTransitions />` component and instead trigger a browser refresh during navigation.
+
+:::note
+The `transition:reload` directive was introduced in Astro v4.x. In earlier v4.x versions and in Astro v3.x you can use the `data-astro-reload` attribute to achieve the same effect.
+:::
+
 
 The following example shows preventing client-side routing when navigating to an article from the home page only. This still allows you to have animation on shared elements, such as a hero image, when navigating to the same page from an article listing page:
 
 ```astro title="src/pages/index.astro"
-<a href="/articles/emperor-penguins" data-astro-reload>
+<a href="/articles/emperor-penguins" transition:reload>
 ```
 
 ```astro title="src/pages/articles.astro"
 <a href="/articles/emperor-penguins">
 ```
 
-Links with the `data-astro-reload` attribute will be ignored by the router and a full-page navigation will occur.
+Links with the `transition:reload` directive will be ignored by the router and a full-page navigation will occur.
 
 ### Trigger navigation
 
@@ -340,7 +345,7 @@ The `navigate` method takes these arguments:
 - `href` (required) - The new page to navigate to.
 - `options` - An optional object with the following properties:
 	- `history`: `'push'` | `'replace'` | `'auto'`
-		- `'push'`: the router will use `history.pushState` to create a new entry in the browser history. 
+		- `'push'`: the router will use `history.pushState` to create a new entry in the browser history.
 		- `'replace'`: the router will use `history.replaceState` to update the URL without adding a new entry into navigation.
 		- `'auto'` (default): the router will attempt `history.pushState`, but if the URL is not one that can be transitioned to, the current URL will remain with no changes to the browser history.
   - `formData`: A FormData object for `POST` requests.
@@ -349,14 +354,14 @@ For backward and forward navigation through the browser history, you can combine
 
 ### Replace entries in the browser history
 
-Normally, each time you navigate, a new entry is written to the browser's history. This allows navigation between pages using the browser's `back` and `forward` buttons. 
+Normally, each time you navigate, a new entry is written to the browser's history. This allows navigation between pages using the browser's `back` and `forward` buttons.
 
 The `<ViewTransitions />` router allows you to overwrite history entries by adding the `data-astro-history` attribute to any individual `<a>` tag.
 
-The `data-astro-history` attribute can be set to the same three values as the [`history` option of the `navigate()` function](#trigger-navigation): 
+The `data-astro-history` attribute can be set to the same three values as the [`history` option of the `navigate()` function](#trigger-navigation):
 
 `data-astro-history`: `'push'` | `'replace'` | `'auto'`
-- `'push'`: the router will use `history.pushState` to create a new entry in the browser history. 
+- `'push'`: the router will use `history.pushState` to create a new entry in the browser history.
 - `'replace'`: the router will use `history.replaceState` to update the URL without adding a new entry into navigation.
 - `'auto'` (default): the router will attempt `history.pushState`, but if the URL is not one that can be transitioned to, the current URL will remain with no changes to the browser history.
 
@@ -382,10 +387,10 @@ By default, Astro submits your form data as `multipart/form-data` when your `met
 </form>
 ```
 
-You can opt out of router transitions on any individual form using the `data-astro-reload` attribute:
+You can opt out of router transitions on any individual form using the `transition:reload` directive:
 
 ```astro title="src/components/Form.astro"
-<form action="/contact" data-astro-reload>
+<form action="/contact" transition:reload>
   <!-- -->
 </form>
 ```
@@ -425,18 +430,18 @@ When using the `<ViewTransitions />` router, the following steps occur to produc
 3. The router adds the `data-astro-transition` attribute to the HTML element with a value of `'forward'` or `'back'` as appropriate.
 4. The router calls `document.startViewTransition`. This triggers the browser's own [view transition process](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#the_view_transition_process). Importantly, the browser screenshots the current state of the page.
 5. Inside the `startViewTransition` callback, the router performs a __swap__, which consists of the following sequence of events:
-    
+
     - The contents of the `<head>` are swapped out, with some elements kept:
         - Stylesheet DOM nodes are left in if they exist on the new page, to prevent FOUC.
         - Scripts are left in if they exist on the new page.
         - Any other head elements with `transition:persist` are left in if there is a corresponding element in the new page.
-    
+
     - The `<body>` is completely replaced with the new page's body.
-    
+
     - Elements marked `transition:persist` are moved over to the new DOM if they exist on the new page.
-    
+
     - Scroll position is restored if necessary.
-    
+
     - The `astro:after-swap` event is triggered on the `document`. This is the end of the __swap__ process.
 
 6. The router waits for any new stylesheets to load before resolving the transition.
@@ -445,7 +450,7 @@ When using the `<ViewTransitions />` router, the following steps occur to produc
 
 ## Script behavior during page navigation
 
-When navigating between pages with the `<ViewTransitions />` component, scripts are run in sequential order to match browser behavior. 
+When navigating between pages with the `<ViewTransitions />` component, scripts are run in sequential order to match browser behavior.
 
 If you have code that sets up global state, this state will need to take into account that the script might execute more than once. Check for the global state in your `<script>` tag, and conditionally execute your code where possible:
 
@@ -465,7 +470,7 @@ See the [Add View Transitions Tutorial](/en/tutorials/add-view-transitions/#upda
 
 The `<ViewTransition />` router fires a number events on the `document` during navigation. These events provide hooks into the lifecycle of navigation, allowing you to do things like show indicators that a new page is loading, override default behavior, and restore state as navigation is completing.
 
-The navigation process involves a **preparation** phase, when new content is loaded; a **DOM swap** phase, where the old page's content is replaced by the new page's content; and a **completion** phase where scripts are executed, loading is reported as completed and clean-up work is carried out. 
+The navigation process involves a **preparation** phase, when new content is loaded; a **DOM swap** phase, where the old page's content is replaced by the new page's content; and a **completion** phase where scripts are executed, loading is reported as completed and clean-up work is carried out.
 
 Astro's View Transition API lifecycle events in order are:
 - [`astro:before-preparation`](#astrobefore-preparation)
@@ -492,7 +497,7 @@ This event is used:
 - To alter loading, such as loading content you've defined in a template rather than from the external URL.
 - To change the `direction` of the navigation (which is usually either `forward` or `backward`) for custom animation.
 
-Here is an example of using the `astro:before-preparation` event to load a spinner before the content is loaded and stop it immediately after loading. Note that using the loader callback in this way allows asynchronous execution of code. 
+Here is an example of using the `astro:before-preparation` event to load a spinner before the content is loaded and stop it immediately after loading. Note that using the loader callback in this way allows asynchronous execution of code.
 
 ```js
 <script is:inline>
@@ -526,7 +531,7 @@ This example uses the `astro:before-preparation` event to start a loading indica
   });
 </script>
 ```
-This is a simpler version of loading a spinner than the example shown above: if all of the listener's code can be executed synchronously, there is no need to hook into the loader's callback. 
+This is a simpler version of loading a spinner than the example shown above: if all of the listener's code can be executed synchronously, there is no need to hook into the loader's callback.
 
 ### `astro:before-swap`
 
@@ -568,17 +573,17 @@ At this point of the lifecycle, you could choose to define your own swap impleme
 
 ### `astro:after-swap`
 
-An event that fires immediately after the new page replaces the old page. You can listen to this event on the `document` and trigger actions that will occur before the new page's DOM elements render and scripts run. 
+An event that fires immediately after the new page replaces the old page. You can listen to this event on the `document` and trigger actions that will occur before the new page's DOM elements render and scripts run.
 
 This event, when listened to on the **outgoing page**, is useful to pass along and restore any state on the DOM that needs to transfer over to the new page.
 
 This is the latest point in the lifecycle where it is still safe to, for example, add a dark mode class name (`<html class="dark-mode">`), though you may wish to do so in an earlier event.
 
-The `astro:after-swap` event occurs immediately after the browser history has been updated and the scroll position has been set. 
-Therefore, one use of targeting this event is to override the default scroll restore for history navigation. The following example resets the horizontal and vertical scroll position to the top left corner of the page for each navigation. 
+The `astro:after-swap` event occurs immediately after the browser history has been updated and the scroll position has been set.
+Therefore, one use of targeting this event is to override the default scroll restore for history navigation. The following example resets the horizontal and vertical scroll position to the top left corner of the page for each navigation.
 
 ```js
-document.addEventListener('astro:after-swap', 
+document.addEventListener('astro:after-swap',
   () => window.scrollTo({ left: 0, top: 0, behavior: 'instant' }))
 ```
 
@@ -691,7 +696,7 @@ import { ViewTransitions } from "astro:components astro:transitions"
 
 **Added:** Astro also supports a new `transition:animate` value, `none`. This value can be used on a page's `<html>` element to disable animated full-page transitions on an entire page. This will only override **default animation behavior** on page elements without an animation directive. You can still set animations on individual elements, and these specific animations will occur.
 
-4. You may now disable all default transitions on an individual page, animating only elements that explicitly use a `transition:animate` directive: 
+4. You may now disable all default transitions on an individual page, animating only elements that explicitly use a `transition:animate` directive:
 
     ```astro ins="transition:animate=\"none\""
     <html transition:animate="none">

--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -45,7 +45,7 @@ When a browser refreshes and loads a new page, there is no continuity between th
 Client-side routing is a feature of single-page application (SPA) sites, where your entire site or app is "one page" of JavaScript whose content is updated based on visitor interaction.
 
 Because each new page does not require a full browser refresh, client-side routing allows you to control page transitions in several ways. **Persistent elements**, such as a common page header, do not have to be entirely rerendered on the screen. The transition from one page to another can appear much smoother. And, state can be preserved, allowing you to transfer values from one page to the next, or even keep a video playing as your visitors navigate pages!
- 
+
 There are times when you will want or need a full-page browser refresh. For example, when a link takes a visitor to a `.pdf` document, you will need the browser to load that new page from the server. Even with view transitions enabled in your Astro project, you will be able to specify how the browser should navigate both by default and on a per-link basis, even opting out of client-side routing entirely.
 
 Read more about [Astro's view transitions](/en/guides/view-transitions/) in our guide, or dive into the instructions below to extend the blog with view transitions.
@@ -81,7 +81,7 @@ Read more about [Astro's view transitions](/en/guides/view-transitions/) in our 
       </Option>
     </MultipleChoice>
 
-3. The view transitions router... 
+3. The view transitions router...
     <MultipleChoice>
       <Option>
         Requires me to use a UI framework such as React
@@ -140,7 +140,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
 
 ### Add the `<ViewTransitions />` router
 
-2. Import and add the `<ViewTransitions />` component to the `<head>` of your page layout. 
+2. Import and add the `<ViewTransitions />` component to the `<head>` of your page layout.
 
     In the Blog tutorial example, the `<head>` element is found in `src/layouts/BaseLayout.astro`. The `ViewTransitions` router must be first imported into the component's frontmatter. Then, add the routing component inside the `<head>` element.
 
@@ -178,7 +178,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
 3. Navigate between pages in your site preview.
 
     View your site preview **at a large screen size, such as desktop mode**. As you move between pages on your site, notice that the old page content appears to fade out as the new page content fades in. Use the [view transitions guide](/en/guides/view-transitions/) to add custom behavior if you are not satisfied with the defaults.
-    
+
     View your site preview **at a smaller screen size**, and try to use the hamburger menu to navigate between pages. Notice that your menu will no longer work after the first page load.
 
 ### Update scripts
@@ -200,7 +200,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
 5. Make the script controlling the theme toggle available after page navigation.
 
     The `<script>` that controls the light/dark theme toggle is located in the `<ThemeIcon />` component. For the theme toggle to continue to function on every page, remove the `is:inline` attribute from the script and add the same event listener as in the previous example so that `astro:page-load` event can trigger your existing function.
-    
+
     Update the existing script tag so that your function runs in response to the `astro:page-load` event, making your theme toggle interactive after the new page is fully loaded and visible to the user:
 
     ```astro title="src/components/ThemeIcon.astro" ins={8,38} del="is:inline"
@@ -259,10 +259,10 @@ With view transitions, some scripts may no longer re-run after page navigation l
 
     <script>
       document.addEventListener('astro:after-swap', () => {
-        localStorage.theme === 'dark' 
+        localStorage.theme === 'dark'
         ? document.documentElement.classList.add("dark")
         : document.documentElement.classList.add("light");
-      }); 
+      });
     </script>
     ```
 
@@ -332,7 +332,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
     </html>
     ```
 
-    In your browser preview, you will now see the page titles slide on to the screen, while other elements such as the body text continues to fade in and out. 
+    In your browser preview, you will now see the page titles slide on to the screen, while other elements such as the body text continues to fade in and out.
 
     <Box icon="puzzle-piece">
       ### Try it yourself - Make the navigation links slide in
@@ -385,26 +385,26 @@ With view transitions, some scripts may no longer re-run after page navigation l
 
 9. Prevent client-side routing and instead require the browser to reload when navigating to your About page.
 
-    Sometimes you will want a full browser reload when visitors click a certain link. For example, you may be linking to a page that does not also use the `<ViewTransitions />` router, or to a file directly such as a `.pdf`. 
+    Sometimes you will want a full browser reload when visitors click a certain link. For example, you may be linking to a page that does not also use the `<ViewTransitions />` router, or to a file directly such as a `.pdf`.
 
-    To make it so that your browser refreshes every time you click the navigation link to go to your About page, add the `data-astro-reload` attribute to the `<a>` tag in your `<Navigation />` component. This will override the `<ViewTransitions />` router entirely, and any of the view transition animations, for this one link.
+    To make it so that your browser refreshes every time you click the navigation link to go to your About page, add the `transition:reload` directive to the `<a>` tag in your `<Navigation />` component. This will override the `<ViewTransitions />` router entirely, and any of the view transition animations, for this one link.
 
-     ```astro title="src/components/Navigation.astro" ins='data-astro-reload'
+     ```astro title="src/components/Navigation.astro" ins='transition:reload'
       ---
       ---
       <div transition:animate="slide" class="nav-links">
         <a href="/">Home</a>
-        <a href="/about/" data-astro-reload>About</a>
+        <a href="/about/" transition:reload>About</a>
         <a href="/blog/">Blog</a>
         <a href="/tags/">Tags</a>
       </div>
       ```
-    
+
     Now, when you click the navigation link to your About page, no animations will occur. The page links and title will not slide in, and the page content will not fade in when you navigate to your About page **using this link**.
 
 10. Add a link to your About page from your author name in your Markdown layout for blog posts.
 
-    `data-astro-reload` only triggers a full browser refresh when going to a new page **from the link it is added to**. It does not control all instances of navigating to your About page.
+    `transition:reload` only triggers a full browser refresh when going to a new page **from the link it is added to**. It does not control all instances of navigating to your About page.
 
     In your `<MarkdownPostLayout />` component, add a link to your About page on your author name:
 
@@ -427,7 +427,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
     If you visit any blog post in your browser preview, and then click on the linked author name to be taken to the About page, what does the page navigation look like?
 
     <p>
-      When a visitor clicks a link to the About page from an individual blog post, the page title and header navigation links <Spoiler>slide in across the screen</Spoiler> because <Spoiler>the `data-astro-reload` attribute is not set on these links.</Spoiler>
+      When a visitor clicks a link to the About page from an individual blog post, the page title and header navigation links <Spoiler>slide in across the screen</Spoiler> because <Spoiler>the `transition:reload` directive is not set on these links.</Spoiler>
     </p>
 
 There is still so much more to explore! See our [full View Transitions Guide](/en/guides/view-transitions/) for more things you can do with view transitions.


### PR DESCRIPTION
#### Description (required)

## Background:
Since version 3.0.0 you can use `data-astro-reload` to disable view transitions for certain links.
At first this was for `<a>` tags, but then it was extended to `<form>`, `<area>` and `<svg>` anchors.
https://github.com/withastro/astro/pull/9977 now also introduces `data-astro-reload` for `<script>` tags to allow users to mark scripts for re-execution during view transitions.

Astro only has a few places where it relies on `data-astro-*` attributes. These are typically for low-level techniques or implementation details. Most of the time Astro uses `xyz:*` directives to control things. These look more official and, more importantly, they have better compiler and language tool support.

## This PR ...
documents the  `transition:reload` directive introduced by  https://github.com/withastro/compiler/pulls that will replace `data-astro-reload` for the sake of better warning messages when misused and better language tool support. 
`data-astro-reload` will still continue to work.


#### Related issues & labels (optional)
Documents [compiler PR #965](https://github.com/withastro/compiler/pull/965)
Not sure yet what implication a compiler minor(?) has on Astro releases and docs.
This PR should be merged only after [#6798](https://github.com/withastro/docs/pull/6798) and  [compiler PR #965](https://github.com/withastro/compiler/pull/965).

