### PR TITLE
Update captcha.mdx

### DIFF
--- a/src/content/docs/en/recipes/captcha.mdx
+++ b/src/content/docs/en/recipes/captcha.mdx
@@ -46,7 +46,7 @@ In this recipe, an API route is used to verify Google reCAPTCHA v3 without expos
     ```astro title="src/pages/index.astro"
     <html>
       <head>
-        <script src="https://www.google.com/recaptcha/api.js"></script>
+        <script is:inline src="https://www.google.com/recaptcha/api.js"></script>
       </head>
 
       <body>


### PR DESCRIPTION
#### Description (required)

Added is:inline directive to recaptcha external script.

Error below occurs without directive:

'https://www.google.com/recaptcha/api.js' from origin 'http://localhost:4321/' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

- Adam (apacher0se)
