### PR TITLE
Add prefix option to change output sitemap filenames

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -392,6 +392,24 @@ The resulting sitemap looks like this:
 ...
 ```
 
+### prefix
+
+By default `sitemap-index.xml` and `sitemap-*.xml` are created in the output directory. By setting `prefix`, You can change the filename.
+
+```js title="astro.config.mjs" ins={8}
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://stargazers.club',
+  integrations: [
+    sitemap({
+      prefix: 'astrosite-', // output files will be `astrosite-index.xml` and `astrosite-*.xml`.
+    }),
+  ],
+});
+```
+
 ## Examples
 
 * The official Astro website uses Astro Sitemap to generate [its sitemap](https://astro.build/sitemap-index.xml).

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -394,7 +394,7 @@ The resulting sitemap looks like this:
 
 ### prefix
 
-By default `sitemap-index.xml` and `sitemap-*.xml` are created in the output directory. By setting `prefix`, You can change the filename.
+By default, files named `sitemap-index.xml` and `sitemap-*.xml` are created in the output directory when you run `astro build`. You can change these filenames by adding a value for `prefix` in your `sitemap()` configuration.
 
 ```js title="astro.config.mjs" ins={8}
 import { defineConfig } from 'astro/config';


### PR DESCRIPTION
#### Description (required)

Add prefix to sitemap options so that the filename can be changed optionally.

#### For `@astrojs/sitemap` version: `3.1`. See astro PR https://github.com/withastro/astro/pull/9846
