### PR TITLE
[i18nIgnore] i18n(pt-br): fix information about `scopedStyleStrategy` config

### DIFF
--- a/src/content/docs/pt-br/reference/configuration-reference.mdx
+++ b/src/content/docs/pt-br/reference/configuration-reference.mdx
@@ -274,9 +274,9 @@ Você também pode definir isto se você preferir ser mais estrito consigo mesmo
 </p>
 
 Especifica a estratégia usada para definir o escopo de estilos dentro de componentes do Astro. Escolha entre:
-  - `'where'`     - Usa seletores `:where`, causando nenhum aumento de especificidade.
+  - `'where'`     - Usa seletores `:where`, não causando aumento de especificidade.
   - `'class'`     - Usa seletores baseados em classe, causando um aumento de +1 de especificidade.
-  - `'attribute'` - Usa atributos `data-`, causando nenhum aumento de especificidade.
+  - `'attribute'` - Usa atributos `data-`, causando um aumento de +1 de especificidade.
 
 Usar `'class'` é útil quando você quer garantir que os seletores de elementos em componentes Astro sobrescrevam os padrões de estilo globais (e.x. de uma folha de estilo global).
 Usar `'where'` dá a você mais controle sobre a especificidade, mas requer que você use seletores de especificidade mais alta, camadas e outras ferramentas para controlar quais seletores são aplicados.


### PR DESCRIPTION
fix pt-br translation about options of `scopedStyleStrategy`

#### Description (required)

The information about the `scopedStyleStrategy` option for `attribute` was wrong. And I improved the description of the `where` option

---
Discord user: jeff_drumgod
