### PR TITLE
Module resolution issue StoryblokComponent

### DIFF
--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -194,6 +194,10 @@ export default defineConfig({
 To test the setup, in Storyblok create a new story with the `blogPost` content type named `test-post`.
 In Astro, create a new page in the `src/pages/` directory named `test-post.astro` with the following content:
 
+:::caution
+  If you are using Typescript. Make sure that your module resolution settings are set to "NodeNext" otherwise you might face issues with importing the "StoryblokComponent"
+  :::
+
 ```astro title="src/pages/test-post.astro"
 ---
 import { useStoryblokApi } from '@storyblok/astro'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

If using typescript. you get this intermittent eslint issue where you can't resolve StoryblokComponent.
From what I am aware if you set your module resolution in tsconfig to "NodeNext"

To save people frustration I have created a Caution Box to alert people of this issue.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

I am a first-time contributor to Astro Docs

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
