### PR TITLE
i18n(zh-CN): Fix incorrect translation text in `guides/integrations-guide/node.mdx` 

### DIFF
--- a/src/content/docs/zh-cn/guides/integrations-guide/node.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/node.mdx
@@ -13,7 +13,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 如果你将 Astro 用作[静态站点构建器](/zh-cn/basics/rendering-modes/#预渲染)，则不需要适配器。
 
-## 为什么是 Astro Node.js
+## 为什么选择 Astro Node.js
 
 [Node.js](https://nodejs.org/zh-cn) 是用于服务器端代码的 JavaScript 运行时。 @astrojs/node 可以在独立模式下使用，也可以作为其他 http 服务器（例如 [Express](https://expressjs.com/)）的中间件。
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Unify the style used in translation: 'Why Astro Node.js' should be translate to "为什么选择 Astro Node.js". 

This is a small correction. 

<!-- Please describe the change you are proposing, and why -->

<!--#### Related issues & labels (optional)-->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
