### PR TITLE
Clearer instructions for using the Vercel adapter with additional services

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -10,9 +10,9 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Since from '~/components/Since.astro';
 import ReadMore from '~/components/ReadMore.astro'
 
-This adapter allows Astro to deploy your [`hybrid` or `server` rendered site](/en/basics/rendering-modes/#on-demand-rendered) to [Vercel](https://www.vercel.com/).
+This adapter allows Astro to deploy your [`static`, `hybrid` or `server` rendered site](/en/basics/rendering-modes/#on-demand-rendered) to [Vercel](https://www.vercel.com/) and configure additional services such as [Vercel Web Analytics](https://vercel.com/docs/analytics).
 
-If you're using Astro as a [static site builder](/en/basics/rendering-modes/#pre-rendered), you don't need an adapter.
+If you're using Astro as a [static site builder](/en/basics/rendering-modes/#pre-rendered) and do not need to set up services such as [Vercel Web Analytics](https://vercel.com/docs/analytics) and [Vercel Image Optimization](https://vercel.com/docs/image-optimization) or use a custom configuration, you don't need an adapter.
 
 Learn how to deploy your Astro site in our [Vercel deployment guide](/en/guides/deploy/vercel/).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

While updating the Vercel adapter, I read the Astro docs to make sure I'm using the latest APIs and mistakenly concluded that it is not needed in static builds, even if using other Vercel services which require a set up, such as Web Analytics.

<!-- Please describe the change you are proposing, and why -->

This PR mentions the need for installing and configuring the adapter even when using static builds, if other services need to be set up or customly configured.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: improve documentation <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs?  yes -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
