### PR TITLE
Explain that props are updated on navigation

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -134,6 +134,8 @@ As a convenient shorthand, `transition:persist` can alternatively take a transit
 <video controls="" autoplay="" transition:persist="media-player">
 ```
 
+When you add `transition:persist` to an island, the state is retained upon navigation, but any props that change will be carried over to the new page, causing your component to re-render with new props, but the existing state.
+
 ### Built-in Animation Directives
 
 Astro comes with a few built-in animations to override the default `fade` transition. Add the `transition:animate` directive to individual elements to customize the behavior of specific transitions.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

With https://github.com/withastro/astro/pull/10136 `transition:persist` is changing to update props upon navigation when used on an island. This explains that props will trigger a re-render.

#### Related issues & labels (optional)

#### For Astro version: `4.5`. See astro PR [#10136](https://github.com/withastro/astro/pull/10136).

