### PR TITLE
Remove #_top anchor from search result URLs

### DIFF
--- a/src/components/starlight/Search.astro
+++ b/src/components/starlight/Search.astro
@@ -47,6 +47,7 @@ const docSearchStrings = getDocSearchStrings(Astro);
 				// work better on localhost, preview URLS.
 				const url = new URL(item.url);
 				if (url.hash === '#overview') url.hash = '';
+				if (url.hash === '#_top') url.hash = '';
 				return {
 					...item,
 					url: url.href.replace(url.origin, ''),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Removes the `#_top` anchor from URLs in search results.

#### Related issues & labels (optional)

- Closes #6897 
