### PR TITLE
i18n(zh-cn): fix link from-gatsby.mdx

### DIFF
--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-gatsby.mdx
@@ -573,5 +573,5 @@ export const pageQuery = graphql`
 - 博客帖子：[再次迁移：从 Gatsby 到 Astro](https://logarithmicspirals.com/blog/migrating-from-gatsby-to-astro/)。
 
 :::note[你有资源分享吗？]
-如果你找到（或制作）了一个关于将 Gatsby 网站转换为 Astro 的有用的视频或博客文章，[编辑此页面](https://github.com/withastro/docs/edit/main/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx)并将其添加到这里！
+如果你找到（或制作）了一个关于将 Gatsby 网站转换为 Astro 的有用的视频或博客文章，[编辑此页面](https://github.com/withastro/docs/edit/main/src/content/docs/zh-cn/guides/migrate-to-astro/from-gatsby.mdx)并将其添加到这里！
 :::


### PR DESCRIPTION
#### Description (required)

The link has been fixed, it was pointing to the English version edition. #6926

