### PR TITLE
Remove legacy hash transformation

### DIFF
--- a/src/components/starlight/Search.astro
+++ b/src/components/starlight/Search.astro
@@ -46,7 +46,6 @@ const docSearchStrings = getDocSearchStrings(Astro);
 				// We transform the absolute URL into a relative URL to
 				// work better on localhost, preview URLS.
 				const url = new URL(item.url);
-				if (url.hash === '#overview') url.hash = '';
 				if (url.hash === '#_top') url.hash = '';
 				return {
 					...item,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Remove legacy hash transformation (`#overview`) from `Search.astro`

#### Related issues & labels (optional)

- Related PR comment: https://github.com/withastro/docs/pull/6917#discussion_r1493470494
