### PR TITLE
Add missing semicolons in code examples

### DIFF
--- a/src/content/docs/en/guides/prefetch.mdx
+++ b/src/content/docs/en/guides/prefetch.mdx
@@ -15,7 +15,7 @@ import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   prefetch: true
-})
+});
 ```
 
 A prefetch script will be added to all pages of your site. You can then add the `data-astro-prefetch` attribute to any `<a />` links on your site to opt-in to prefetching. When you hover over the link, the script will fetch the page in the background.
@@ -62,7 +62,7 @@ export default defineConfig({
   prefetch: {
     defaultStrategy: 'viewport'
   }
-})
+});
 ```
 
 ### Prefetch all links by default
@@ -76,7 +76,7 @@ export default defineConfig({
   prefetch: {
     prefetchAll: true
   }
-})
+});
 ```
 
 You can then opt-out of prefetching for individual links by setting `data-astro-prefetch="false"`:
@@ -138,7 +138,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   // Disable prefetch completely
   prefetch: false
-})
+});
 ```
 
 ```js title="astro.config.mjs"
@@ -149,7 +149,7 @@ export default defineConfig({
   prefetch: {
     prefetchAll: false
   }
-})
+});
 ```
 
 ## Migrating from `@astrojs/prefetch`
@@ -165,7 +165,7 @@ The `@astrojs/prefetch` integration was deprecated in v3.5.0 and will eventually
     export default defineConfig({
       integrations: [prefetch()],
       prefetch: true
-    })
+    });
     ```
 
 2. Convert from `@astrojs/prefetch`'s configuration options:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- Please describe the change you are proposing, and why -->

This pull request adds missing semicolons in code examples within the section about prefetching. This follows the standard set in other sections, like [SSR Adapters](https://docs.astro.build/en/guides/server-side-rendering/#manual-install).

