### PR TITLE
[i18nIgnore]: Fix pnpm command

### DIFF
--- a/src/content/docs/ar/editor-setup.mdx
+++ b/src/content/docs/ar/editor-setup.mdx
@@ -74,7 +74,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/de/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/de/guides/deploy/cloudflare.mdx
@@ -61,7 +61,7 @@ Nachdem du deine Assets hochgeladen hast, gibt dir Wrangler eine Vorschau-URL, m
 Damit die Vorschau funktioniert, musst du `wrangler` installieren
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 Es ist dann möglich, das Vorschauskript zu aktualisieren, um `wrangler` anstelle des in Astro eingebauten Vorschau-Befehls auszuführen:

--- a/src/content/docs/de/guides/fonts.mdx
+++ b/src/content/docs/de/guides/fonts.mdx
@@ -73,7 +73,7 @@ Das [Fontsource](https://fontsource.org/)-Projekt ermöglicht die Verwendung von
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/de/guides/rss.mdx
+++ b/src/content/docs/de/guides/rss.mdx
@@ -23,7 +23,7 @@ Das `@astrojs/rss`-Paket bietet Hilfsfunktionen zur Erzeugung von RSS-Feeds mith
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/rss
+  pnpm add @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/de/guides/typescript.mdx
+++ b/src/content/docs/de/guides/typescript.mdx
@@ -46,7 +46,7 @@ Wenn du nicht VSCode verwendest, kannst du das [Astro TypeScript Plugin](https:/
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/ts-plugin
+  pnpm add @astrojs/ts-plugin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/de/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/de/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ Aktualisiere die Astro-Version deines Projekts mit deinem Paketmanager auf die n
   <Fragment slot="pnpm">
   ```shell
   # Upgrade auf Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Beispiel: React- und Tailwind-Integrationen aktualisieren
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/de/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/de/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ Aktualisiere die Astro-Version deines Projekts mit deinem Paketmanager auf die n
   <Fragment slot="pnpm">
   ```shell
   # Upgrade auf Astro v3.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Beispiel: React- und Tailwind-Integrationen aktualisieren 
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -522,7 +522,7 @@ Astro v3.0 enthält jetzt standardmäßig Sharp als Bildverarbeitungsdienst und 
 Bei Verwendung eines [strikten Paketmanagers](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) wie `pnpm` musst du möglicherweise Sharp manuell in dein Projekt installieren, obwohl es eine Abhängigkeit von Astro ist:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/de/reference/api-reference.mdx
+++ b/src/content/docs/de/reference/api-reference.mdx
@@ -900,7 +900,7 @@ Um die Textmarker-Komponente `Prism` zu verwenden, musst du zuerst das Paket `@a
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/prism
+  pnpm add @astrojs/prism
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/en/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/en/guides/deploy/google-firebase.mdx
@@ -38,7 +38,7 @@ Deploying an SSR Astro site to Firebase requires the [Blaze plan](https://fireba
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install firebase-tools
+      pnpm add firebase-tools
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -691,7 +691,7 @@ If the image is merely decorative (i.e. doesn’t contribute to the understandin
 When using a [strict package manager](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) like `pnpm`, you may need to manually install Sharp into your project even though it is an Astro dependency:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -86,7 +86,7 @@ For example, to install the Vercel adapter manually:
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/vercel
+     pnpm add @astrojs/vercel
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/en/install/manual.mdx
+++ b/src/content/docs/en/install/manual.mdx
@@ -71,7 +71,7 @@ Astro must be installed locally, not globally. Make sure you are *not* running `
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/editor-setup.mdx
+++ b/src/content/docs/es/editor-setup.mdx
@@ -78,7 +78,7 @@ Para comenzar, primero instala Prettier y el plugin:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/backend/google-firebase.mdx
+++ b/src/content/docs/es/guides/backend/google-firebase.mdx
@@ -92,7 +92,7 @@ Para conectar Astro con Firebase, instala los siguientes paquetes utilizando el 
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install firebase firebase-admin
+  pnpm add firebase firebase-admin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/cms/buttercms.mdx
+++ b/src/content/docs/es/guides/cms/buttercms.mdx
@@ -47,7 +47,7 @@ Para empezar, necesitarás lo siguiente:
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install buttercms
+      pnpm add buttercms
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/es/guides/cms/contentful.mdx
+++ b/src/content/docs/es/guides/cms/contentful.mdx
@@ -79,7 +79,7 @@ Para conectar tu proyecto Astro con tu espacio de Contentful, instala los siguie
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install contentful @contentful/rich-text-html-renderer
+  pnpm add contentful @contentful/rich-text-html-renderer
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/cms/ghost.mdx
+++ b/src/content/docs/es/guides/cms/ghost.mdx
@@ -69,7 +69,7 @@ Para conectar con Ghost, instala el paquete oficial [`@tryghost/content-api`](ht
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @tryghost/content-api
+  pnpm add @tryghost/content-api
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/es/guides/cms/kontent-ai.mdx
@@ -64,7 +64,7 @@ Para conectar Astro con tu proyecto de Kontent.ai, instala el [Kit de desarrollo
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/delivery-sdk
+    pnpm add @kontent-ai/delivery-sdk
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -206,7 +206,7 @@ Primero, instala el [generador de modelos de Kontent.ai JS](https://github.com/k
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/model-generator ts-node dotenv
+    pnpm add @kontent-ai/model-generator ts-node dotenv
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/cms/storyblok.mdx
+++ b/src/content/docs/es/guides/cms/storyblok.mdx
@@ -60,7 +60,7 @@ Para conectar Astro con tu espacio de Storyblok, instala la [integración oficia
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @storyblok/astro vite
+  pnpm add @storyblok/astro vite
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/es/guides/deploy/cloudflare.mdx
@@ -61,7 +61,7 @@ Una vez que tus archivos sean subidos, Wrangler te dará una preview URL para in
 Para que preview funcione, debes instalar `wrangler`
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 Entonces será posible actualizar el script preview para ejecutar `wrangler` en lugar del comando preview ya integrado en Astro:

--- a/src/content/docs/es/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/es/guides/deploy/google-firebase.mdx
@@ -38,7 +38,7 @@ Desplegar un sitio SSR de Astro en Firebase requiere el [plan Blaze](https://fir
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install firebase-tools
+      pnpm add firebase-tools
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/es/guides/fonts.mdx
+++ b/src/content/docs/es/guides/fonts.mdx
@@ -60,7 +60,7 @@ El proyecto [Fontsource](https://fontsource.org/) simplifica el uso de Google Fo
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/es/guides/images.mdx
+++ b/src/content/docs/es/guides/images.mdx
@@ -689,7 +689,7 @@ Si la imagen es meramente decorativa (es decir, no contribuye a la comprensión 
 Cuando se utiliza un [administrador de paquetes estricto](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como `pnpm`, es posible que debas instalar manualmente Sharp en tu proyecto, aunque sea una dependencia de Astro:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/es/guides/rss.mdx
+++ b/src/content/docs/es/guides/rss.mdx
@@ -24,7 +24,7 @@ El paquete [`@astrojs/rss`](https://github.com/withastro/astro/tree/main/package
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/es/guides/server-side-rendering.mdx
+++ b/src/content/docs/es/guides/server-side-rendering.mdx
@@ -86,7 +86,7 @@ Por ejemplo, para instalar manualmente el adaptador de Vercel:
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/vercel
+     pnpm add @astrojs/vercel
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/es/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/es/guides/upgrade-to/v2.mdx
@@ -27,10 +27,10 @@ Actualiza la versión de tu proyecto Astro a la última versión usando el gesto
   <Fragment slot="pnpm">
   ```shell
   # Actualiza a la versión Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Ejemplo: actualiza las integraciones de React y Tailwind
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/es/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ Actualiza la versión de Astro en tu proyecto a la última versión utilizando t
   <Fragment slot="pnpm">
   ```shell
   # Actualizar a Astro v3.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Ejemplo: actualizar las integraciones de React y Tailwind
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -522,7 +522,7 @@ Ahora Astro v3.0 incluye Sharp como el servicio de procesamiento de imágenes pr
 Cuando uses un [administrador de paquetes estricto](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como `pnpm`, es posible que necesites instalar manualmente Sharp en tu proyecto, aunque sea una dependencia de Astro:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/es/install/manual.mdx
+++ b/src/content/docs/es/install/manual.mdx
@@ -69,7 +69,7 @@ Astro debe ser instalado localmente, no globalmente. Asegúrate de *no* ejecutar
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/recipes/modified-time.mdx
+++ b/src/content/docs/es/recipes/modified-time.mdx
@@ -23,7 +23,7 @@ Aprende cómo construir un [plugin de remark](https://github.com/remarkjs/remark
      </Fragment>
      <Fragment slot="pnpm">
        ```shell
-       pnpm install dayjs
+       pnpm add dayjs
        ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/es/recipes/reading-time.mdx
+++ b/src/content/docs/es/recipes/reading-time.mdx
@@ -25,7 +25,7 @@ Crea un plugin de [remark](https://github.com/remarkjs/remark) que añada una pr
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-  pnpm install reading-time mdast-util-to-string
+  pnpm add reading-time mdast-util-to-string
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/es/recipes/sharing-state.mdx
+++ b/src/content/docs/es/recipes/sharing-state.mdx
@@ -25,7 +25,7 @@ Cuando construyes un sitio web con Astro, es posible que necesites compartir el 
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm install nanostores
+    pnpm add nanostores
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/es/reference/api-reference.mdx
+++ b/src/content/docs/es/reference/api-reference.mdx
@@ -1406,7 +1406,7 @@ Para usar el componente resaltador `Prism`, primero **instala** el paquete `@ast
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/prism
+  pnpm add @astrojs/prism
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/es/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/es/tutorial/5-astro-api/4.mdx
@@ -37,7 +37,7 @@ Las personas pueden suscribirse a tu feed en un lector de feeds y recibir una no
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/es/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/es/tutorials/add-view-transitions.mdx
@@ -116,10 +116,10 @@ Los pasos a continuación te muestran cómo ampliar el producto final del tutori
       <Fragment slot="pnpm">
       ```shell
       # Actualizar a Astro v4.x
-      pnpm install astro@latest
+      pnpm add astro@latest
 
      # Ejemplo: actualizar la integración de Preact en el tutorial del blog
-      pnpm install @astrojs/preact@latest
+      pnpm add @astrojs/preact@latest
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/fr/guides/cms/buttercms.mdx
+++ b/src/content/docs/fr/guides/cms/buttercms.mdx
@@ -46,7 +46,7 @@ Pour démarrer, vous aurez besoin de ce qui suit :
       </Fragment>
       <Fragment slot="pnpm">
         ```shell
-        pnpm install buttercms
+        pnpm add buttercms
         ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/fr/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/fr/guides/deploy/google-firebase.mdx
@@ -38,7 +38,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install firebase-tools
+      pnpm add firebase-tools
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/fr/guides/fonts.mdx
+++ b/src/content/docs/fr/guides/fonts.mdx
@@ -58,7 +58,7 @@ Le projet [Fontsource](https://fontsource.org/) simplifie l'utilisation de Googl
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/fr/guides/images.mdx
+++ b/src/content/docs/fr/guides/images.mdx
@@ -671,7 +671,7 @@ Si l'image est simplement décorative (c'est-à-dire qu'elle ne contribue pas à
 Lorsque vous utilisez un [gestionnaire de paquet strict](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) comme `pnpm`, vous pouvez avoir besoin d'installer manuellement Sharp dans votre projet même si c'est une dépendance d'Astro :
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/fr/guides/server-side-rendering.mdx
+++ b/src/content/docs/fr/guides/server-side-rendering.mdx
@@ -86,7 +86,7 @@ Par exemple, pour installer manuellement l'adaptateur Vercel :
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/vercel
+     pnpm add @astrojs/vercel
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/fr/install/manual.mdx
+++ b/src/content/docs/fr/install/manual.mdx
@@ -71,7 +71,7 @@ Astro doit être installé localement, pas globalement. Assurez-vous que vous n'
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/fr/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/fr/tutorial/5-astro-api/4.mdx
@@ -38,7 +38,7 @@ Les personnes peuvent s'abonner à votre flux dans un lecteur de flux et recevoi
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/hi/install/manual.mdx
+++ b/src/content/docs/hi/install/manual.mdx
@@ -71,7 +71,7 @@ Astro को स्थानीय स्तर पर इंस्टॉल क
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/it/editor-setup.mdx
+++ b/src/content/docs/it/editor-setup.mdx
@@ -77,7 +77,7 @@ Per iniziare, prima installa Prettier ed il plugin:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/it/guides/backend/google-firebase.mdx
+++ b/src/content/docs/it/guides/backend/google-firebase.mdx
@@ -91,7 +91,7 @@ Per collegare Astro a Firebase, installa i seguenti pacchetti utilizzando il com
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install firebase firebase-admin
+  pnpm add firebase firebase-admin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/it/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/it/guides/deploy/cloudflare.mdx
@@ -60,7 +60,7 @@ Dopo aver caricato i file del tuo progetto, Wrangler ti fornirà un URL per visu
 Per far funzionare l'anteprima, è necessario installare `wrangler`
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 A questo punto è possibile aggiornare lo script di preview in modo da utilizzare wrangler, invece del comando di anteprima della CLI di Astro.

--- a/src/content/docs/it/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/it/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ Aggiorna Astro all'ultima versione usando il tuo package manager. Se stai usando
   <Fragment slot="pnpm">
   ```shell
   # Upgrade to Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Example: upgrade React and Tailwind integrations
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/it/install/manual.mdx
+++ b/src/content/docs/it/install/manual.mdx
@@ -70,7 +70,7 @@ Astro deve essere installato localmente, non globalmente. Assicurati di *non* st
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro 
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/it/recipes/sharing-state.mdx
+++ b/src/content/docs/it/recipes/sharing-state.mdx
@@ -26,7 +26,7 @@ Astro raccomanda l'utilizzo di [Nano Stores](https://github.com/nanostores/nanos
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm install nanostores
+    pnpm add nanostores
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/cms/storyblok.mdx
+++ b/src/content/docs/ja/guides/cms/storyblok.mdx
@@ -59,7 +59,7 @@ AstroとStoryblokスペースを接続するために、次の中から好みの
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @storyblok/astro
+  pnpm add @storyblok/astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/configuring-astro.mdx
+++ b/src/content/docs/ja/guides/configuring-astro.mdx
@@ -155,7 +155,7 @@ Astroは他のファイルをロードする前に設定ファイルを評価し
 `pnpm`では、プロジェクトに直接インストールされていないモジュールをインポートできません。`pnpm`を使用している場合は、`loadEnv`ヘルパーを使用するために`vite`をインストールする必要があります。
 
 ```sh
-pnpm install vite --save-dev
+pnpm add vite --save-dev
 ```
 :::
 

--- a/src/content/docs/ja/guides/fonts.mdx
+++ b/src/content/docs/ja/guides/fonts.mdx
@@ -61,7 +61,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/images.mdx
+++ b/src/content/docs/ja/guides/images.mdx
@@ -669,7 +669,7 @@ const optimizedBackground = await getImage({src: myBackground, format: 'webp'})
 `pnpm`のような[厳格なパッケージマネージャー](https://pnpm.io/pnpm-vs-npm#npms-flat-tree)を使用している場合は、Astroの依存関係であるにもかかわらず、プロジェクトにSharpを手動でインストールする必要があるかもしれません。
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/ja/guides/rss.mdx
+++ b/src/content/docs/ja/guides/rss.mdx
@@ -24,7 +24,7 @@ Astroはブログやその他のコンテンツウェブサイト向けに、RSS
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/rss
+  pnpm add @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/server-side-rendering.mdx
+++ b/src/content/docs/ja/guides/server-side-rendering.mdx
@@ -109,7 +109,7 @@ SSRを有効にしたプロジェクトをデプロイするには、アダプ�
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/my-adapter
+     pnpm add @astrojs/my-adapter
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/ja/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ import FileTree from '~/components/FileTree.astro'
   <Fragment slot="pnpm">
   ```shell
   # Astro v2.xのアップグレード
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # 例: ReactとTailwindのインテグレーションをアップグレードする
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ja/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/ja/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ import FileTree from '~/components/FileTree.astro'
   <Fragment slot="pnpm">
   ```shell
   # Astro v3.xにアップグレード
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # ReactとTailwindのインテグレーションをアップグレードする例
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -537,7 +537,7 @@ Astro v3.0では、デフォルトの画像処理サービスとしてSharpが�
 `pnpm`のような[厳格なパッケージマネージャー](https://pnpm.io/pnpm-vs-npm#npms-flat-tree)を使用している場合は、Astroの依存関係であるにもかかわらず、プロジェクトにSharpを手動でインストールする必要があるかもしれません。
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/ja/install/manual.mdx
+++ b/src/content/docs/ja/install/manual.mdx
@@ -68,7 +68,7 @@ Astroはグローバルではなく、ローカルにインストールする必
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ja/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/ja/tutorial/5-astro-api/4.mdx
@@ -36,7 +36,7 @@ Astroは、ウェブサイトにRSSフィードを素早く追加するための
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/ko/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/ko/guides/deploy/google-firebase.mdx
@@ -39,7 +39,7 @@ SSR Astro 사이트를 Firebase에 배포하려면 [Blaze 요금제](https://fir
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install firebase-tools
+      pnpm add firebase-tools
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/ko/guides/fonts.mdx
+++ b/src/content/docs/ko/guides/fonts.mdx
@@ -58,7 +58,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/ko/guides/images.mdx
+++ b/src/content/docs/ko/guides/images.mdx
@@ -668,7 +668,7 @@ const optimizedBackground = await getImage({src: myBackground, format: 'webp'})
 `pnpm`과 같은 [엄격한 패키지 관리자](https://pnpm.io/pnpm-vs-npm#npms-flat-tree)를 사용하는 경우 Astro 종속성임에도 불구하고 Sharp를 프로젝트에 수동으로 설치해야 할 수 있습니다.
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/ko/guides/rss.mdx
+++ b/src/content/docs/ko/guides/rss.mdx
@@ -24,7 +24,7 @@ Astro는 블로그 및 기타 콘텐츠 웹사이트를 위한 빠른 자동 RSS
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/rss
+  pnpm add @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ko/guides/server-side-rendering.mdx
+++ b/src/content/docs/ko/guides/server-side-rendering.mdx
@@ -86,7 +86,7 @@ Astro의 두 주문형 렌더링 출력 모드 (`server` 및 `hybrid`)를 사용
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/vercel
+     pnpm add @astrojs/vercel
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/ko/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/ko/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ import FileTree from '~/components/FileTree.astro'
   <Fragment slot="pnpm">
   ```shell
   # Astro v2.x 설치하기
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # 예시: 최신 React, tailwind 설치하기.
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ko/install/manual.mdx
+++ b/src/content/docs/ko/install/manual.mdx
@@ -70,7 +70,7 @@ Astro는 전역이 아닌 로컬에 설치되어야 합니다. 실수로 `npm in
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pl/editor-setup.mdx
+++ b/src/content/docs/pl/editor-setup.mdx
@@ -74,7 +74,7 @@ Aby zacząć, najpierw zainstaluj Prettier i naszą wtyczkę:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pl/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/pl/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ Zaktualizuj Astro w swoim projekcie do najnowszej wersji przy użyciu swojego me
   <Fragment slot="pnpm">
   ```shell
   # Zaktualizuj do Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Przykład: aktualizacja integracji React i Tailwind
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pl/install/manual.mdx
+++ b/src/content/docs/pl/install/manual.mdx
@@ -72,7 +72,7 @@ Astro musi być zainstalowany lokalnie, nie globalnie. Upewnij się, że *nie* u
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/editor-setup.mdx
+++ b/src/content/docs/pt-br/editor-setup.mdx
@@ -76,7 +76,7 @@ Para começar, primeiro instale Prettier e o plugin:
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/pt-br/guides/deploy/cloudflare.mdx
@@ -60,7 +60,7 @@ Depois dos seus assets serem enviados, Wrangler irá te dar uma URL de pré-visu
 Para a pré-visualização funcionar, você precisa instalar `wrangler`
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 Após, é possível atualizar o script "preview" para executar `wrangler` ao invés do comando "preview" integrado do Astro:

--- a/src/content/docs/pt-br/guides/fonts.mdx
+++ b/src/content/docs/pt-br/guides/fonts.mdx
@@ -60,7 +60,7 @@ O projeto [Fontsource](https://fontsource.org/) simplifica utilizar Google Fonts
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/pt-br/guides/images.mdx
+++ b/src/content/docs/pt-br/guides/images.mdx
@@ -668,7 +668,7 @@ export default defineConfig({
 Ao usar um [gerenciador de pacotes rigoroso](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como o `pnpm`, talvez seja necessário instalar o Sharp manualmente o seu projeto, mesmo que seja uma dependência do Astro:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/pt-br/guides/rss.mdx
+++ b/src/content/docs/pt-br/guides/rss.mdx
@@ -24,7 +24,7 @@ O pacote [`@astrojs/rss`](https://github.com/withastro/astro/tree/main/packages/
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/rss
+  pnpm add @astrojs/rss
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/guides/typescript.mdx
+++ b/src/content/docs/pt-br/guides/typescript.mdx
@@ -43,7 +43,7 @@ Se você não está usando VSCode, você pode instalar o [plugin Astro TypeScrip
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/ts-plugin
+  pnpm add @astrojs/ts-plugin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/pt-br/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ Atualize a versão do Astro do seu projeto para a mais recente utilizando seu ge
   <Fragment slot="pnpm">
   ```shell
   # Atualize para o Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Exemplo: atualize as integrações para React e Tailwind
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/pt-br/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ Atualize a versão do Astro de seu projeto para a versão mais recente utilizand
   <Fragment slot="pnpm">
   ```shell
   # Atualize para v3.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # Exemplo: atualize as integrações React e Tailwind
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -529,7 +529,7 @@ Astro v3.0 agora inclui Sharp como o novo serviço de processamento de imagem pa
 Ao usar um [gerenciador de pacotes rigoroso](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como o `pnpm`, talvez seja necessário instalar o Sharp manualmente o seu projeto, mesmo que seja uma dependência do Astro:
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/pt-br/install/manual.mdx
+++ b/src/content/docs/pt-br/install/manual.mdx
@@ -71,7 +71,7 @@ O Astro precisa ser instalado localmente, não globalmente. Tenha certeza que vo
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/pt-br/recipes/reading-time.mdx
+++ b/src/content/docs/pt-br/recipes/reading-time.mdx
@@ -25,7 +25,7 @@ Instale esses dois pacotes utilitários:
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-  pnpm install reading-time mdast-util-to-string
+  pnpm add reading-time mdast-util-to-string
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/pt-br/recipes/sharing-state.mdx
+++ b/src/content/docs/pt-br/recipes/sharing-state.mdx
@@ -25,7 +25,7 @@ Enquanto constrói um website Astro, você pode precisar compartilhar estado ent
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm install nanostores
+    pnpm add nanostores
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/ru/editor-setup.mdx
+++ b/src/content/docs/ru/editor-setup.mdx
@@ -67,7 +67,7 @@ Astro работает с любым редактором кода. Однако
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install -D prettier prettier-plugin-astro
+  pnpm add -D prettier prettier-plugin-astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ru/guides/fonts.mdx
+++ b/src/content/docs/ru/guides/fonts.mdx
@@ -72,7 +72,7 @@ Astro поддерживает все распространенные мето�
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/ru/guides/typescript.mdx
+++ b/src/content/docs/ru/guides/typescript.mdx
@@ -39,9 +39,21 @@ Astro поддерживает три расширяемых `tsconfig.json` ш�
 Если вы не используете VS Code, вы можете установить [Astro TypeScript плагин](https://www.npmjs.com/package/@astrojs/ts-plugin) для поддержки импортов `.astro` файлов из `.ts` файлов (что может быть полезно при переиспользовании).
 
 <PackageManagerTabs>
-  <Fragment slot="npm">```shell npm install @astrojs/ts-plugin ```</Fragment>
-  <Fragment slot="pnpm">```shell pnpm install @astrojs/ts-plugin ```</Fragment>
-  <Fragment slot="yarn">```shell yarn add @astrojs/ts-plugin ```</Fragment>
+  <Fragment slot="npm">
+  ```shell
+  npm install @astrojs/ts-plugin
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm add @astrojs/ts-plugin
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn add @astrojs/ts-plugin
+  ```
+  </Fragment>
 </PackageManagerTabs>
 
 Затем, добавьте код ниже в `tsconfig.json`:

--- a/src/content/docs/ru/install/manual.mdx
+++ b/src/content/docs/ru/install/manual.mdx
@@ -70,7 +70,7 @@ Astro необходимо устанавливать локально, а не 
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/ru/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/ru/tutorial/5-astro-api/4.mdx
@@ -38,7 +38,7 @@ Astro предоставляет специальный пакет для быс
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/backend/google-firebase.mdx
+++ b/src/content/docs/zh-cn/guides/backend/google-firebase.mdx
@@ -90,7 +90,7 @@ interface ImportMeta {
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install firebase firebase-admin
+  pnpm add firebase firebase-admin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/cms/buttercms.mdx
+++ b/src/content/docs/zh-cn/guides/cms/buttercms.mdx
@@ -46,7 +46,7 @@ ButterCMS 是一种允许你在项目中发布结构化内容的 headless CMS和
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install buttercms
+      pnpm add buttercms
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/cms/contentful.mdx
+++ b/src/content/docs/zh-cn/guides/cms/contentful.mdx
@@ -77,7 +77,7 @@ interface ImportMetaEnv {
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install contentful @contentful/rich-text-html-renderer
+  pnpm add contentful @contentful/rich-text-html-renderer
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/cms/ghost.mdx
+++ b/src/content/docs/zh-cn/guides/cms/ghost.mdx
@@ -68,7 +68,7 @@ interface ImportMetaEnv {
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @tryghost/content-api
+  pnpm add @tryghost/content-api
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/zh-cn/guides/cms/kontent-ai.mdx
@@ -64,7 +64,7 @@ interface ImportMetaEnv {
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/delivery-sdk
+    pnpm add @kontent-ai/delivery-sdk
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -206,7 +206,7 @@ const blogPosts = await deliveryClient
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-    pnpm install @kontent-ai/model-generator ts-node dotenv
+    pnpm add @kontent-ai/model-generator ts-node dotenv
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/zh-cn/guides/deploy/cloudflare.mdx
@@ -61,7 +61,7 @@ npx wrangler pages deploy dist
 要使预览版正常工作，你必须安装 `wrangler`
 
 ```bash
-pnpm install wrangler --save-dev
+pnpm add wrangler --save-dev
 ```
 
 然后就可以将预览脚本从 Astro 的内置预览命令更新为 `wrangler` 了：

--- a/src/content/docs/zh-cn/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/zh-cn/guides/deploy/google-firebase.mdx
@@ -38,7 +38,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install firebase-tools
+      pnpm add firebase-tools
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/fonts.mdx
+++ b/src/content/docs/zh-cn/guides/fonts.mdx
@@ -60,7 +60,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @fontsource/twinkle-star
+      pnpm add @fontsource/twinkle-star
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/images.mdx
+++ b/src/content/docs/zh-cn/guides/images.mdx
@@ -686,7 +686,7 @@ const optimizedBackground = await getImage({src: myBackground, format: 'webp'})
 当使用像 `pnpm` 这样的[严格包管理器](https://pnpm.io/pnpm-vs-npm#npms-flat-tree)时，即使 Sharp 已经是 Astro 的依赖项，你也可能需要手动安装 Sharp 到你的项目中：
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/zh-cn/guides/rss.mdx
+++ b/src/content/docs/zh-cn/guides/rss.mdx
@@ -23,7 +23,7 @@ Astro 支持为博客和其他内容网站快速，自动的 RSS 提要生成。
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/server-side-rendering.mdx
+++ b/src/content/docs/zh-cn/guides/server-side-rendering.mdx
@@ -84,7 +84,7 @@ Astro 的两种按需渲染输出模式（`server` 和 `hybrid`）都允许你�
      </Fragment>
      <Fragment slot="pnpm">
      ```shell
-     pnpm install @astrojs/vercel
+     pnpm add @astrojs/vercel
      ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/typescript.mdx
+++ b/src/content/docs/zh-cn/guides/typescript.mdx
@@ -43,7 +43,7 @@ Astro 中包含三个可扩展的 `tsconfig.json` 模板：`base`、`strict` 和
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install @astrojs/ts-plugin
+  pnpm add @astrojs/ts-plugin
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/zh-cn/guides/upgrade-to/v2.mdx
@@ -28,10 +28,10 @@ import FileTree from '~/components/FileTree.astro'
   <Fragment slot="pnpm">
   ```shell
   # 升级到 Astro v2.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # 示例：升级 React 和 Tailwind 集成
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/zh-cn/guides/upgrade-to/v3.mdx
@@ -28,10 +28,10 @@ import FileTree from '~/components/FileTree.astro'
   <Fragment slot="pnpm">
   ```shell
   # 升级到 Astro v3.x
-  pnpm install astro@latest
+  pnpm add astro@latest
 
   # 示例：升级 React 和 Tailwind 集成
-  pnpm install @astrojs/react@latest @astrojs/tailwind@latest
+  pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -520,7 +520,7 @@ Astro v3.0 将 Sharp 作为默认的图像处理服务，并提供了一个配�
 当使用像 `pnpm` 这样的 [严格包管理器](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) 时，即使 Sharp 已经是 Astro 的依赖项，你也可能需要手动安装 Sharp 到你的项目中：
 
 ```bash
-pnpm install sharp
+pnpm add sharp
 ```
 :::
 

--- a/src/content/docs/zh-cn/install/manual.mdx
+++ b/src/content/docs/zh-cn/install/manual.mdx
@@ -68,7 +68,7 @@ Astro 必须本地安装，不能全局安装。请确保**不要**运行 `npm i
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/recipes/modified-time.mdx
+++ b/src/content/docs/zh-cn/recipes/modified-time.mdx
@@ -23,7 +23,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
      </Fragment>
      <Fragment slot="pnpm">
        ```shell
-       pnpm install dayjs
+       pnpm add dayjs
        ```
      </Fragment>
      <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/recipes/reading-time.mdx
+++ b/src/content/docs/zh-cn/recipes/reading-time.mdx
@@ -25,7 +25,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-  pnpm install reading-time mdast-util-to-string
+  pnpm add reading-time mdast-util-to-string
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/recipes/sharing-state.mdx
+++ b/src/content/docs/zh-cn/recipes/sharing-state.mdx
@@ -25,7 +25,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
     </Fragment>
     <Fragment slot="pnpm">
     ```shell
-    pnpm install nanostores
+    pnpm add nanostores
     ```
     </Fragment>
     <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/zh-cn/tutorial/5-astro-api/4.mdx
@@ -33,7 +33,7 @@ Astro 提供了一个可自定义包，用于快速为你的网站添加一个 R
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm install @astrojs/rss
+      pnpm add @astrojs/rss
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-cn/tutorials/add-content-collections.mdx
+++ b/src/content/docs/zh-cn/tutorials/add-content-collections.mdx
@@ -110,10 +110,10 @@ import Option from '~/components/tutorial/Option.astro';
       <Fragment slot="pnpm">
       ```shell
       # 更新至 Astro v4.x
-      pnpm install astro@latest
+      pnpm add astro@latest
 
     # 示例：更新博客教程的 Preact 集成
-      pnpm install @astrojs/preact@latest
+      pnpm add @astrojs/preact@latest
       ```
       </Fragment>
       <Fragment slot="yarn">

--- a/src/content/docs/zh-tw/install/manual.mdx
+++ b/src/content/docs/zh-tw/install/manual.mdx
@@ -61,7 +61,7 @@ cd my-astro-project
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro 
+  pnpm add astro
   ```
   </Fragment>
   <Fragment slot="yarn">


### PR DESCRIPTION
#### Description

Continues the work of #5284 in all other languages.

There is one remaining case of `pnpm install` on the outdated Portuguese translation of the Netlify guide. In that case, the correct command is indeed `pnpm install`, but it will be removed once that page is updated.

Also fixes the code blocks for one Russian case that was missing newlines

#### Related issues & labels (optional)

- English fix made in #5284