### PR TITLE
i18n(fr): Update supabase.mdx

### DIFF
--- a/src/content/docs/fr/guides/backend/supabase.mdx
+++ b/src/content/docs/fr/guides/backend/supabase.mdx
@@ -262,6 +262,7 @@ import Layout from "../layouts/Layout.astro";
     <button type="submit">Se connecter</button>
   </form>
 </Layout>
+```
 
 `signin.astro` contient un formulaire permettant d'identifier un utilisateur. Il accepte un email et un mot de passe et envoie une requête `POST` à `/api/auth/signin`. Il vérifie également la présence des jetons d'accès et de rafraîchissement. S'ils sont présents, il redirige vers le tableau de bord.
 
@@ -290,6 +291,7 @@ if (accessToken && refreshToken) {
     <button type="submit">Se connecter</button>
   </form>
 </Layout>
+```
 
 `dashboard.astro` contient une page qui n'est accessible qu'aux utilisateurs authentifiés. Elle vérifie la présence des jetons d'accès et de rafraîchissement. S'ils ne sont pas présents, elle redirige vers la page de connexion.
 


### PR DESCRIPTION
Fix missing backticks after code block

#### Description (required)

In supabase documentation the code blocks for signin.astro, register.astro and dashboard.astro are not appearing properly. Fix missing backticks after code block

#### Related issues & labels (optional)

- Suggested label: Documentation