### PR TITLE
i18n(es): update publish-to-npm.mdx

### DIFF
--- a/src/content/docs/es/reference/publish-to-npm.mdx
+++ b/src/content/docs/es/reference/publish-to-npm.mdx
@@ -44,13 +44,13 @@ Para crear un nuevo paquete, configura tu entorno de desarrollo para utilizar **
 <FileTree>
 - my-new-component-directory/
   - demo/
-    - ... for testing and demonstration
+    - ... para pruebas y demostraciones
   - package.json
   - packages/
     - my-component/
       - index.js
       - package.json
-      - ... additional files used by the package
+      - ... archivos adicionales utilizados por el paquete
 </FileTree>
 
 Este ejemplo, llamado `mi-proyecto`, crea un proyecto con un solo paquete, llamado `mi-componente`, y un directorio `demo/` para probar y demostrar el componente.
@@ -239,12 +239,12 @@ Mientras tanto, nuestra recomendación actual para las pruebas es:
 3. Cada página debe incluir un uso distinto de los componentes que te gustaría probar.
 4. Ejecuta `astro build` para construir tus fixtures, luego compara los resultados en el directorio `dist/__fixtures__/` con los resultados esperados.
 
-```bash
-my-project/demo/src/pages/__fixtures__/
-  ├─ test-name-01.astro
-  ├─ test-name-02.astro
-  └─ test-name-03.astro
-```
+<FileTree>
+- my-project/demo/src/pages/\_\_fixtures\_\_/
+  - test-name-01.astro
+  - test-name-02.astro
+  - test-name-03.astro
+</FileTree>
 
 ## Publicando tu componente
 
@@ -271,7 +271,7 @@ La biblioteca de integraciones lee los datos `name`, `description`, `repository`
 ¡Los avatares son una excelente manera de resaltar tu marca en la biblioteca! Una vez que se publique tu paquete, puedes [crear una issue en GitHub](https://github.com/withastro/astro.build/issues/new/choose) con tu avatar adjunto y lo agregaremos al listado.
 
 :::tip
-¿Necesitas anular la información que nuestra biblioteca lee de NPM? ¡No hay problema! [Crea una issue](https://github.com/withastro/astro.build/issues/new/choose) con la información actualizada y nos aseguraremos de que el "nombre", la "descripción" o la "página de inicio" personalizados sean utilizados en su lugar.
+¿Necesitas anular la información que nuestra biblioteca lee de NPM? ¡No hay problema! [Crea una issue](https://github.com/withastro/astro.build/issues/new/choose) con la información actualizada y nos aseguraremos de que el `nombre`, la `descripción` o la `página de inicio` personalizados sean utilizados en su lugar.
 :::
 
 ### Colecciones


### PR DESCRIPTION
#### Description (required)

- Comments have been translated
- The bash section has been changed to the FileTree component.
- In the tip it has been changed so that the names are highlighted

#### Related issues & labels (optional)

- Closes #N/A
- Suggested label: i18n
