### PR TITLE
[i18nIgnore]: add a comment for translators on the data structure in localized `nav.ts` files

### DIFF
--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -9,14 +9,10 @@
  *
  * For translators:
  *
- * To avoid accidental editing, please use the existing `{key: value}`
- * structure with `NavDictionary()` in non-English `nav.ts` files. 
- *
- * For example, the entry in `en/nav.ts`
- *   { text: 'Getting Started', slug: 'getting-started', key: 'getting-started' },
- * should be converted to
- *   'getting-started': 'Getting Started',
- * and only translate 'Getting Started' part into your language.
+ * Copy the English `key` value unchanged and translate only the `text` into your language:
+*
+ * `src/i18n/en/nav.ts`: `{ text: 'Getting Started', slug: 'getting-started', key: 'getting-started' },`
+ * `src/i18n/ja/nav.ts`: `'getting-started': 'はじめに',`
  */
 export default [
 	{ text: 'Start Here', header: true, type: 'learn', key: 'startHere' },

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -15,7 +15,7 @@
  * For example, the entry in `en/nav.ts`
  *   { text: 'Getting Started', slug: 'getting-started', key: 'getting-started' },
  * should be converted to
- *   'getting-started: 'Getting Started',
+ *   'getting-started': 'Getting Started',
  * and only translate 'Getting Started' part into your language.
  */
 export default [

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -6,6 +6,17 @@
  * - All entries MUST include `text` and `key`
  * - Heading entries MUST include `header: true` and `type`
  * - Link entries MUST include `slug` (which excludes the language code)
+ *
+ * For translators:
+ *
+ * To avoid accidental editing, please use the existing `{key: value}`
+ * structure with `NavDictionary()` in non-English `nav.ts` files. 
+ *
+ * For example, the entry in `en/nav.ts`
+ *   { text: 'Getting Started', slug: 'getting-started', key: 'getting-started' },
+ * should be converted to
+ *   'getting-started: 'Getting Started',
+ * and only translate 'Getting Started' part into your language.
  */
 export default [
 	{ text: 'Start Here', header: true, type: 'learn', key: 'startHere' },


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
I misunderstood how to update `nav.ts` for Japanese (ref. https://github.com/withastro/docs/pull/6985#issuecomment-1961828452). I also saw the same error in French translation.

To prevent incorrect data structure in `nav.ts` in the future, This adds a comment for translations in `en/nav.ts`.

/cc @Yan-Thomas 

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
