### PR TITLE
chore(middleware): clarify usage

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -11,6 +11,11 @@ This also allows you to set and share request-specific information across endpoi
 
 Middleware is available in both SSG and SSR Astro projects.
 
+:::note
+In SSG, the middleware runs during the **build process**. Once the app is built, the middleware won't run in the deployed website. This is valid also for prerendered pages.
+In SSR, the middleware runs once the website is deployed.
+:::
+
 ## Basic Usage
 
 1. Create `src/middleware.js|ts` (Alternatively, you can create `src/middleware/index.js|ts`.)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In core, we have had some feedback where users expected to have the middleware run also in SSG when the website is deployed.

From one point of view, I can understand this. A middleware should run every time, at runtime, because that's what a middleware is meant for. Although, this isn't the case for our static and prerendered pages.

This PR is meant to add a small note to clarify how the middleware works in Astro.

<!-- Please describe the change you are proposing, and why -->

