### PR TITLE
[i18nIgnore] Fix typo in Markdoc code sample title

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -509,7 +509,7 @@ You may need to pass [variables][markdoc-variables] to your content. This is use
 
 Variables can be passed as props via the `Content` component:
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 

--- a/src/content/docs/es/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/es/guides/integrations-guide/markdoc.mdx
@@ -101,7 +101,7 @@ Los archivos Markdoc solo se pueden usar dentro de las colecciones de contenido.
 
 Luego, consulta tu colección usando las [APIs de colecciones de contenido](/es/guides/content-collections/#consultando-colecciones):
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 
@@ -531,7 +531,7 @@ Es posible que necesites pasar [variables][markdoc-variables] a tu contenido. Es
 
 Las variables pueden pasarse como props a través del componente `Content`:
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 

--- a/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
@@ -101,7 +101,7 @@ Les fichiers Markdoc ne peuvent être utilisés que dans les collections de cont
 
 Interrogez ensuite votre collection à l'aide des [API de Collections de contenus](/fr/guides/content-collections/#interroger-les-collections) :
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 
@@ -394,7 +394,7 @@ Vous pouvez avoir besoin de passer des [variables][markdoc-variables] à votre c
 
 Les variables peuvent être passées en tant que props via le composant `Content` :
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 

--- a/src/content/docs/ko/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/ko/guides/integrations-guide/markdoc.mdx
@@ -394,7 +394,7 @@ VS Code를 사용하는 경우 구성된 태그에 대한 구문 강조 및 자�
 
 변수는 `Content` 컴포넌트를 통해 Props로 전달될 수 있습니다.
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/markdoc.mdx
@@ -503,7 +503,7 @@ export default defineMarkdocConfig({
 
 变量可以通过 `Content` 组件作为 props 传递：
 
-```astro title="src/pages/why-markdoc.mdoc"
+```astro title="src/pages/why-markdoc.astro"
 ---
 import { getEntryBySlug } from 'astro:content';
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes the title of some example code in the Markdoc integration page that used the wrong extension.

