### PR TITLE
Add LightningCSS to preprocessors

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -491,17 +491,20 @@ Use `<style lang="less">` in `.astro` files.
 npm install lightningcss
 ```
 
-Update your `astro.config.ts`
+Update your `vite` configuration in `astro.config.mjs`:
 
-```diff
-+  vite: {
-+    css: {
-+      transformer: "lightningcss",
-+    },
-+  },
+```js title="astro.config.mjs" ins={4-8}
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+  vite: {
+    css: {
+      transformer: "lightningcss",
+    },
+  },
+})
+  
 ```
-
-Then LightningCSS will optimize and down-level your vanilla CSS.
 
 ### In framework components
 

--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -485,6 +485,24 @@ npm install less
 
 Use `<style lang="less">` in `.astro` files.
 
+### LightningCSS
+
+```shell
+npm install lightningcss
+```
+
+Update your `astro.config.ts`
+
+```diff
++  vite: {
++    css: {
++      transformer: "lightningcss",
++    },
++  },
+```
+
+Then LightningCSS will optimize and down-level your vanilla CSS.
+
 ### In framework components
 
 You can also use all of the above CSS preprocessors within JS frameworks as well! Be sure to follow the patterns each framework recommends:


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

"How to set up LightningCSS w/ Astro"

LightningCSS is supported by Astro, and allows using several features that something like Sass might support but via current CSS without leaving old browsers behind. We should document how to set it up

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

Feel free to workshop / move this / update my PR, I just wanted to make sure it's documented *somewhere*
