### PR TITLE
Remove redundant English section after translation

### DIFF
--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -606,8 +606,6 @@ El componente `<ViewTransitions />` incluye un anunciador de ruta para la navega
 
 Las tecnologías de asistencia permiten que los visitantes sepan que la página ha cambiado anunciando el nuevo título de la página después de la navegación. Cuando se utiliza la navegación del lado del servidor con recargas tradicionales de la página completa en el navegador, esto ocurre automáticamente después de que la nueva página se carga. En la navegación del lado del cliente, el componente `<ViewTransitions />` realiza esta acción.
 
-To add route announcement to client-side routing, the component adds an element to the new page with the `aria-live` attribute set to `assertive`. This tells AT (assistive technology) to announce immediately. The component also checks for the following, in priority order, to determine the announcement text:
-
 Para agregar un anuncio de ruta a la navegación del lado del cliente, el componente agrega un elemento a la nueva página con el atributo `aria-live` configurado en `assertive`. Esto indica a las AT (tecnologías de asistencia) que deben anunciar inmediatamente. El componente también verifica lo siguiente, en orden de prioridad, para determinar el texto del anuncio:
 
 - El `<title>`, si existe.


### PR DESCRIPTION
This commit removes a section in English that has already been translated.

