### PR TITLE
Fix typo in animation directive

### DIFF
--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -14,7 +14,7 @@ Agrega este componente a un componente `.astro` reutilizable, como un encabezado
 
 El soporte de las view transitions en Astro está impulsado por la nueva API del navegador [View Transitions](https://developer.chrome.com/docs/web-platform/view-transitions/) y también incluye:
 
-- Algunas [opciones de animación integradas](#directivas-de-animación-integradas), como `fade`, `slice` y `none`.
+- Algunas [opciones de animación integradas](#directivas-de-animación-integradas), como `fade`, `slide` y `none`.
 - Soporte para animaciones de navegación hacia adelante y hacia atrás.
 - La capacidad de [personalizar completamente todos los aspectos de la animación de transición](#personalizando-animaciones) y crear tus propias animaciones.
 - La opción de [impedir la navegación del lado del cliente para enlaces que no sean de página](#previniendo-la-navegación-del-lado-del-cliente).


### PR DESCRIPTION
Fix typo in animation directive: change 'slice' to 'slide
