### PR TITLE
Update keystatic Guide

### DIFF
--- a/src/content/docs/en/guides/cms/keystatic.mdx
+++ b/src/content/docs/en/guides/cms/keystatic.mdx
@@ -36,7 +36,7 @@ Select the Astro template, and you'll be ready to [deploy](#deploying-keystatic-
 
 ## Prerequisites
 
-- An existing Astro project [with server-side rendering (SSR) and `output: 'hybrid'` configured](/en/guides/server-side-rendering/).
+- An existing Astro project [with server-side rendering (SSR) and `output: 'hybrid'` or `output: 'server'` configured](/en/guides/server-side-rendering/).
 
 :::note
 If you intend to sync Keystatic's data with GitHub, you will also need **a GitHub account with `write` permissions** on the repository for this project.


### PR DESCRIPTION
The Keystatic integration was updated to support both `hybrid` and `server` output modes, so this PR updates the guide accordingly.