### PR TITLE
[i18nIgnore] Updates deprecated Node.js 16 github actions

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: pnpm/action-setup@v3
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       FORCE_COLOR: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install

--- a/.github/workflows/discord-i18n-ping.yml
+++ b/.github/workflows/discord-i18n-ping.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
       - id: message
         name: Format Discord message
         run: pnpm tsm --require=./scripts/lib/filter-warnings.cjs ./scripts/tuesday-bot.ts
-      
+
       - name: Send a Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_I18N }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Format code
         run: pnpm run format:ci
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: '[ci] format'
           branch: ${{ github.head_ref }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       - name: Check out code using Git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           # Needs access to push to main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code using Git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code using Git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,7 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-  

--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Welcome First Time Contributors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: zephyrproject-rtos/action-first-interaction@7e6446f8439d8b4399169880c36a3a12b5747699
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
@@ -25,8 +25,8 @@ jobs:
             1. Our GitHub bots will run to check your changes.
                If they spot any broken links you will see some error messages on this PR.
                Don’t hesitate to ask any questions if you’re not sure what these mean!
-            
+
             2. In a few minutes, you’ll be able to see a preview of your changes on Vercel 🥳
-            
+
             3. One or more of our maintainers will take a look and may ask you to make changes.
                We try to be responsive, but don’t worry if this takes a few days.

--- a/src/content/docs/de/guides/deploy/aws.mdx
+++ b/src/content/docs/de/guides/deploy/aws.mdx
@@ -211,7 +211,7 @@ Es gibt viele Möglichkeiten, die kontinuierliche Bereitstellung für AWS einzur
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/de/guides/deploy/deno.mdx
+++ b/src/content/docs/de/guides/deploy/deno.mdx
@@ -100,7 +100,7 @@ Wenn dein Projekt auf GitHub gespeichert ist, führt dich die [Deno Deploy-Webse
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # Du benutzt kein npm? Ändere `npm ci` in `yarn install` oder `pnpm i`
           - name: Install dependencies

--- a/src/content/docs/de/guides/deploy/github.mdx
+++ b/src/content/docs/de/guides/deploy/github.mdx
@@ -45,7 +45,7 @@ Astro pflegt die offizielle `withastro/action`, welche dein Projekt mit minimale
         runs-on: ubuntu-latest
         steps:
           - name: Checke dein Repository mit Git aus
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
           - name: Installiere Abhängigkeiten, erzeuge deine Website und lade sie hoch
             uses: withastro/action@v0
 

--- a/src/content/docs/en/guides/deploy/aws.mdx
+++ b/src/content/docs/en/guides/deploy/aws.mdx
@@ -194,7 +194,7 @@ There are many ways to set up continuous deployment for AWS. One possibility for
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/en/guides/deploy/deno.mdx
+++ b/src/content/docs/en/guides/deploy/deno.mdx
@@ -103,7 +103,7 @@ If your project is stored on GitHub, the [Deno Deploy website](https://dash.deno
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # Not using npm? Change `npm ci` to `yarn install` or `pnpm i`
           - name: Install dependencies

--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -15,10 +15,10 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 ## Configure Astro for GitHub Pages
 
-### Deploying to a `github.io` URL
+### Deploying to a `github.io` URL 
 
 Set the [`site`](/en/reference/configuration-reference/#site) and [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
-
+    
 ```js title="astro.config.mjs" ins={4-5}
 import { defineConfig } from 'astro/config'
 
@@ -62,13 +62,13 @@ See more about [configuring a `base` value](/en/reference/configuration-referenc
 ### Using GitHub pages with a custom domain
 
 :::tip[Set up a custom domain]
-You can set up a custom domain by adding the following `./public/CNAME` file to your project:
+You can set up a custom domain by adding the following `./public/CNAME` file to your project: 
 
 ```js title="public/CNAME"
 sub.mydomain.com
 ```
 
-This will deploy your site at your custom domain instead of `user.github.io`. Don't forget to also [configure DNS for your domain provider](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).
+This will deploy your site at your custom domain instead of `user.github.io`. Don't forget to also [configure DNS for your domain provider](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
 :::
 
 To configure Astro for using GitHub pages with a custom domain, set your domain as the value for `site`. Do not set a value for `base`:
@@ -95,7 +95,7 @@ export default defineConfig({
         branches: [ main ]
       # Allows you to run this workflow manually from the Actions tab on GitHub.
       workflow_dispatch:
-
+      
     # Allow this job to clone the repo and create a page deployment
     permissions:
       contents: read
@@ -107,12 +107,12 @@ export default defineConfig({
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Install, build, and upload your site
-            uses: withastro/action@v1
+            uses: withastro/action@v2
             # with:
               # path: . # The root location of your Astro project inside the repository. (optional)
-              # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
+              # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
               # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
       deploy:
@@ -124,22 +124,22 @@ export default defineConfig({
         steps:
           - name: Deploy to GitHub Pages
             id: deployment
-            uses: actions/deploy-pages@v1
+            uses: actions/deploy-pages@v4
     ```
 
     :::note
     The astro action takes a few optional inputs. These can be provided by uncommenting the `with:` line and the input you want to use.
     :::
-
+    
     :::caution
     The official Astro [action](https://github.com/withastro/action) scans for a lockfile to detect your preferred package manager (`npm`, `yarn`, `pnpm`, or `bun`). You should commit your package manager's automatically generated `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file to your repository.
     :::
 
 2. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.
 
-3. Choose **GitHub Actions** as the **Source** of your site.
+3. Choose **GitHub Actions** as the **Source** of your site.  
 
-4. Commit the new workflow file and push it to GitHub.
+4. Commit the new workflow file and push it to GitHub.  
 
-
+  
 Your site should now be published! When you push changes to your Astro project’s repository, the GitHub Action will automatically deploy them for you.

--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -15,10 +15,10 @@ Astro maintains the official `withastro/action` to deploy your project with very
 
 ## Configure Astro for GitHub Pages
 
-### Deploying to a `github.io` URL 
+### Deploying to a `github.io` URL
 
 Set the [`site`](/en/reference/configuration-reference/#site) and [`base`](/en/reference/configuration-reference/#base) options in `astro.config.mjs`.
-    
+
 ```js title="astro.config.mjs" ins={4-5}
 import { defineConfig } from 'astro/config'
 
@@ -62,13 +62,13 @@ See more about [configuring a `base` value](/en/reference/configuration-referenc
 ### Using GitHub pages with a custom domain
 
 :::tip[Set up a custom domain]
-You can set up a custom domain by adding the following `./public/CNAME` file to your project: 
+You can set up a custom domain by adding the following `./public/CNAME` file to your project:
 
 ```js title="public/CNAME"
 sub.mydomain.com
 ```
 
-This will deploy your site at your custom domain instead of `user.github.io`. Don't forget to also [configure DNS for your domain provider](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
+This will deploy your site at your custom domain instead of `user.github.io`. Don't forget to also [configure DNS for your domain provider](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).
 :::
 
 To configure Astro for using GitHub pages with a custom domain, set your domain as the value for `site`. Do not set a value for `base`:
@@ -95,7 +95,7 @@ export default defineConfig({
         branches: [ main ]
       # Allows you to run this workflow manually from the Actions tab on GitHub.
       workflow_dispatch:
-      
+
     # Allow this job to clone the repo and create a page deployment
     permissions:
       contents: read
@@ -107,12 +107,12 @@ export default defineConfig({
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v4
+            uses: actions/checkout@v3
           - name: Install, build, and upload your site
-            uses: withastro/action@v2
+            uses: withastro/action@v1
             # with:
               # path: . # The root location of your Astro project inside the repository. (optional)
-              # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+              # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
               # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
       deploy:
@@ -124,22 +124,22 @@ export default defineConfig({
         steps:
           - name: Deploy to GitHub Pages
             id: deployment
-            uses: actions/deploy-pages@v4
+            uses: actions/deploy-pages@v1
     ```
 
     :::note
     The astro action takes a few optional inputs. These can be provided by uncommenting the `with:` line and the input you want to use.
     :::
-    
+
     :::caution
     The official Astro [action](https://github.com/withastro/action) scans for a lockfile to detect your preferred package manager (`npm`, `yarn`, `pnpm`, or `bun`). You should commit your package manager's automatically generated `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb` file to your repository.
     :::
 
 2. On GitHub, go to your repository’s **Settings** tab and find the **Pages** section of the settings.
 
-3. Choose **GitHub Actions** as the **Source** of your site.  
+3. Choose **GitHub Actions** as the **Source** of your site.
 
-4. Commit the new workflow file and push it to GitHub.  
+4. Commit the new workflow file and push it to GitHub.
 
-  
+
 Your site should now be published! When you push changes to your Astro project’s repository, the GitHub Action will automatically deploy them for you.

--- a/src/content/docs/es/guides/deploy/aws.mdx
+++ b/src/content/docs/es/guides/deploy/aws.mdx
@@ -195,7 +195,7 @@ Hay muchas formas de configurar despliegue continuo en AWS. Una posibilidad si e
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/es/guides/deploy/deno.mdx
+++ b/src/content/docs/es/guides/deploy/deno.mdx
@@ -104,7 +104,7 @@ Si tu proyecto está almacenado en GitHub, la [página web de Deno Deploy](https
 
         steps:
           - name: Clonar el repositorio
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # ¿No usas npm? Cambia `npm ci` por `yarn install` o `pnpm i`.
           - name: Instalar las dependencias

--- a/src/content/docs/fr/guides/deploy/aws.mdx
+++ b/src/content/docs/fr/guides/deploy/aws.mdx
@@ -186,7 +186,7 @@ Il existe de nombreuses façons de mettre en place un déploiement continu pour 
          runs-on: ubuntu-latest
          steps:
            - name: Checkout
-             uses: actions/checkout@v3
+             uses: actions/checkout@v4
            - name: Configure AWS Credentials
              uses: aws-actions/configure-aws-credentials@v1
              with:

--- a/src/content/docs/fr/guides/deploy/deno.mdx
+++ b/src/content/docs/fr/guides/deploy/deno.mdx
@@ -103,7 +103,7 @@ Si votre projet est stocké sur GitHub, le [site Deno Deploy](https://dash.deno.
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # Vous n'utilisez pas npm ? Remplacez `npm ci` par `yarn install` ou `pnpm i`
           - name: Install dependencies

--- a/src/content/docs/it/guides/deploy/deno.mdx
+++ b/src/content/docs/it/guides/deploy/deno.mdx
@@ -102,7 +102,7 @@ Se il tuo progetto si trova su GitHub, il sito di [Deno Deploy](https://dash.den
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # No usi npm? Cambia `npm ci` con `yarn install` o `pnpm i`
           - name: Install dependencies

--- a/src/content/docs/ja/guides/deploy/aws.mdx
+++ b/src/content/docs/ja/guides/deploy/aws.mdx
@@ -258,7 +258,7 @@ AWSで継続的デプロイを設定する方法はたくさんあります。Gi
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/ja/guides/deploy/deno.mdx
+++ b/src/content/docs/ja/guides/deploy/deno.mdx
@@ -100,7 +100,7 @@ GitHub Actions、またはDeno DeployのCLI（コマンドラインインター�
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # npmを使用していない場合は、`npm ci`を`yarn install`または`pnpm i`に変更してください。
           - name: Install dependencies

--- a/src/content/docs/ja/guides/deploy/github.mdx
+++ b/src/content/docs/ja/guides/deploy/github.mdx
@@ -66,7 +66,7 @@ Astroは公式の`withastro/action`を保守しており、ほとんど設定す
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Install, build, and upload your site
             uses: withastro/action@v1
             # with:

--- a/src/content/docs/ko/guides/deploy/aws.mdx
+++ b/src/content/docs/ko/guides/deploy/aws.mdx
@@ -257,7 +257,7 @@ AWS에 대한 지속적 배포를 설정하는 방법에는 여러 가지가 있
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/ko/guides/deploy/deno.mdx
+++ b/src/content/docs/ko/guides/deploy/deno.mdx
@@ -104,7 +104,7 @@ GitHub Actions 또는 Deno Deploy의 CLI (명령줄 인터페이스)를 사용�
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # npm을 사용하지 않나요? `npm ci`를 `yarn install` 또는 `pnpm i`로 변경하세요.
           - name: Install dependencies

--- a/src/content/docs/pt-br/guides/deploy/aws.mdx
+++ b/src/content/docs/pt-br/guides/deploy/aws.mdx
@@ -235,7 +235,7 @@ Há muitas maneiras de configurar continuous deployment com a AWS. Uma possibili
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/pt-br/guides/deploy/deno.mdx
+++ b/src/content/docs/pt-br/guides/deploy/deno.mdx
@@ -100,7 +100,7 @@ Se o seu projeto está armazenado no GitHub, o [website do Deno Deploy](https://
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # Não está utilizando npm? Mude `npm ci` para `yarn install` ou `pnpm i`
           - name: Install dependencies

--- a/src/content/docs/pt-br/guides/deploy/github.mdx
+++ b/src/content/docs/pt-br/guides/deploy/github.mdx
@@ -67,7 +67,7 @@ O Astro mantém oficialmente o `withastro/action` para fazer o deploy do seu pro
        runs-on: ubuntu-latest
        steps:
          - name: Checkout your repository using git
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
          - name: Install, build, and upload your site
            uses: withastro/action@v1
             # with:

--- a/src/content/docs/zh-cn/guides/deploy/aws.mdx
+++ b/src/content/docs/zh-cn/guides/deploy/aws.mdx
@@ -194,7 +194,7 @@ CloudFront 是一个提供内容分发网络 (CDN) 功能的 Web 服务。它用
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:

--- a/src/content/docs/zh-cn/guides/deploy/deno.mdx
+++ b/src/content/docs/zh-cn/guides/deploy/deno.mdx
@@ -101,7 +101,7 @@ npx astro add deno
 
         steps:
           - name: Clone repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           # 没有使用 npm？请将 `npm ci` 修改为 `yarn install` 或 `pnpm i`
           - name: Install dependencies


### PR DESCRIPTION
#### Description (required)

Get rid of those warnings:
![image](https://github.com/withastro/docs/assets/94928215/02dc1e91-b879-416b-bc7e-64c4419f7b5d)

In addition, I updated the action versions in the examples so that no warnings are issued when copying and pasting.