### PR TITLE
Fix incorrect list numbering in `ecommerce.mdx`

### DIFF
--- a/src/content/docs/en/guides/ecommerce.mdx
+++ b/src/content/docs/en/guides/ecommerce.mdx
@@ -146,7 +146,7 @@ The following is an example of configuring a Snipcart checkout and adding button
     </script>
     ```
 
-4. Add `class="snipcart-add-item"` to any HTML element, such as a `<button>`, to add an item to the cart when clicked on. Also include any other data elements for [common Snipcart product attributes](https://docs.snipcart.com/v3/setup/products) such as price and description, and any optional fields.
+3. Add `class="snipcart-add-item"` to any HTML element, such as a `<button>`, to add an item to the cart when clicked on. Also include any other data elements for [common Snipcart product attributes](https://docs.snipcart.com/v3/setup/products) such as price and description, and any optional fields.
 
     ```html title="src/pages/my-product-page.astro"
     <button class="snipcart-add-item"
@@ -164,7 +164,7 @@ The following is an example of configuring a Snipcart checkout and adding button
     </button>
     ```
 
-6. Add a Snipcart checkout button with the `snipcart-checout` class to open the cart and allow guests to complete their purchase with a checkout modal.
+4. Add a Snipcart checkout button with the `snipcart-checout` class to open the cart and allow guests to complete their purchase with a checkout modal.
 
     ```html title="src/pages/my-product-page.astro"
     <button class="snipcart-checkout">Click here to checkout</button>


### PR DESCRIPTION
#### Description

I’ve noticed a small inconsistency in the Snipcart configuration section of the `ecommerce.mdx` page that could be slightly confusing to translators. The step numbering within the "Basic usage" subsection does not follow a sequential order. The current numbering sequence in the markdown is 1, 2, 4, 6. For clearer readability and future maintenance of the document, it may be beneficial to update the numbering to a sequential order: 1, 2, 3, 4.

I understand that when markdown is rendered, the list numbering is corrected automatically. However, for the ease of future documentation maintenance and clarity in the markdown source, adjusting the raw markdown numbers to be sequential could help reduce any potential confusion.