### PR TITLE
Fix duplicate links in `ecommerce.mdx`

### DIFF
--- a/src/content/docs/en/guides/ecommerce.mdx
+++ b/src/content/docs/en/guides/ecommerce.mdx
@@ -37,7 +37,7 @@ The following is an example of adding a Lemon Squeezy "Buy now" element to an As
 
 #### Lemon.js
 
-Lemon.js also provides additional behavior such as [programmatically opening overlays](https://docs.lemonsqueezy.com/help/lemonjs/opening-overlays) and [handling overlay events](https://docs.lemonsqueezy.com/help/lemonjs/opening-overlays).
+Lemon.js also provides additional behavior such as [programmatically opening overlays](https://docs.lemonsqueezy.com/help/lemonjs/opening-overlays) and [handling overlay events](https://docs.lemonsqueezy.com/help/lemonjs/handling-events).
 
 <ReadMore> Read the [Lemon Squeezy developer getting started guide](https://docs.lemonsqueezy.com/guides/developer-guide) for more information.</ReadMore>
 


### PR DESCRIPTION
#### Description

This PR corrects an issue where the "handling overlay events" link in the `ecommerce.mdx` page was pointing to the same URL as "programmatically opening overlays". The incorrect link has been updated to point to the appropriate section in the Lemon.js documentation.