### PR TITLE
i18n(zh-cn): Update `middleware-cant-be-loaded.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/middleware-cant-be-loaded.mdx
+++ b/src/content/docs/zh-cn/reference/errors/middleware-cant-be-loaded.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **MiddlewareCantBeLoaded**: 当 Astro 尝试加载这个中间件时，它抛出了一个错误。
+> **MiddlewareCantBeLoaded**: 加载你的中间件时发生了未知错误。
 
 ## 哪里出了问题？
 在开发模式下，当 Astro 尝试加载这个中间件时，它抛出了一个错误。


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I've updated the latest Simplified Chinese translation from `middleware-cant-be-loaded.mdx`.
The latest changes in English docs is in: https://github.com/withastro/docs/commit/7db5cf519459d3ec3f730e385efa42f3c6f08267

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
