### PR TITLE
Update getting-started.mdx

### DIFF
--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -31,6 +31,7 @@ import Card from '~/components/Landing/Card.astro'
 import ListCard from '~/components/Landing/ListCard.astro'
 import SplitCard from '~/components/Landing/SplitCard.astro'
 import Discord from '~/components/Landing/Discord.astro'
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 <CardGrid>
   <Card title="What will you build with Astro?" icon="laptop">
@@ -42,10 +43,26 @@ import Discord from '~/components/Landing/Discord.astro'
   </Card>
 
   <SplitCard title="Start a new project" icon="rocket">
-    ```sh
-    # create a new project with npm
-    npm create astro@latest
-    ```
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+        ```shell
+        # create a new project with npm
+        npm create astro@latest
+        ```
+      </Fragment>
+      <Fragment slot="pnpm">
+        ```shell
+        # create a new project with pnpm
+        pnpm create astro@latest
+        ```
+      </Fragment>
+      <Fragment slot="yarn">
+        ```shell
+        # create a new project with yarn
+        yarn create astro
+        ```
+      </Fragment>
+    </PackageManagerTabs>
     
     Our [installation guide](/en/install/auto/) has step-by-step instructions for installing Astro using our CLI wizard, creating a new project from an existing Astro GitHub repository, and for installing Astro manually.
   </SplitCard>
@@ -58,7 +75,7 @@ import Discord from '~/components/Landing/Discord.astro'
   </ListCard>
 
   <ListCard title="Extend" icon="puzzle">
-    - [Add integrations like React, and Tailwind](/en/guides/integrations-guide/)
+    - [Add integrations like React and Tailwind](/en/guides/integrations-guide/)
     - [Create type safe content collections](/en/guides/content-collections/)
     - [Enhance navigation with view transitions](/en/guides/view-transitions/)
     - [Connect a headless CMS to your project](/en/guides/cms/)


### PR DESCRIPTION
#### Description (required)

- add package manager tabs like on other setup pages so same access to npm/pnpm/Yarn commands
  - https://docs.astro.build/en/install/auto/#1-run-the-setup-wizard
  - https://docs.astro.build/en/tutorial/1-setup/2/#launch-the-astro-setup-wizard
- grammar/nitpicky - remove comma

![Untitled](https://github.com/withastro/docs/assets/54233296/0735bc70-12aa-46ff-bf5e-d104fbcc400b)
