### PR TITLE
i18n(ru): Add translations for various pages in the `cms` dir

### DIFF
--- a/src/content/docs/ru/guides/cms/caisy.mdx
+++ b/src/content/docs/ru/guides/cms/caisy.mdx
@@ -1,0 +1,62 @@
+---
+title: Caisy и Astro
+description: Добавьте контент в проект Astro, используя Caisy в качестве CMS
+type: cms
+service: Caisy
+i18nReady: true
+stub: true
+---
+
+[Caisy](https://caisy.io/) — это безголовая CMS, предоставляющая GraphQL API для доступа к контенту.
+
+## Использование CMS Caisy с Astro
+
+Используйте `graphql-request` и рендерер Rich Text от Caisy для Astro, чтобы получать данные из вашей CMS и отображать контент на странице Astro:
+
+```astro title="src/pages/blog/[...slug].astro"
+---
+import RichTextRenderer from '@caisy/rich-text-astro-renderer';
+import { gql, GraphQLClient } from 'graphql-request';
+
+const params = Astro.params;
+
+const client = new GraphQLClient(
+	`https://cloud.caisy.io/api/v3/e/${import.meta.env.CAISY_PROJECT_ID}/graphql`,
+	{
+		headers: {
+			'x-caisy-apikey': import.meta.env.CAISY_API_KEY
+		}
+	}
+);
+const gqlResponse = await client.request(
+	gql`
+		query allBlogArticle($slug: String) {
+			allBlogArticle(where: { slug: { eq: $slug } }) {
+				edges {
+					node {
+						text {
+							json
+						}
+						title
+						slug
+						id
+					}
+				}
+			}
+		}
+	`,
+	{ slug: params.slug }
+);
+
+const post = gqlResponse?.allBlogArticle?.edges?.[0]?.node;
+---
+<h1>{post.title}</h1>
+<RichTextRenderer node={post.text.json} />
+```
+
+## Официальные ресурсы
+
+- Ознакомьтесь с примером Caisy + Astro на [GitHub](https://github.com/caisy-io/caisy-example-astro) или [StackBlitz](https://stackblitz.com/github/caisy-io/caisy-example-astro?file=src%2Fpages%2Fblog%2F%5B...slug%5D.astro).
+- Запрашивайте документы в [черновом режиме](https://caisy.io/developer/docs/external-api/localization-and-preview#preview-mode-15) и в нескольких [локалях](https://caisy.io/developer/docs/external-api/localization-and-preview#localization-in-a-graphql-query-8).
+- Используйте [пагинацию](https://caisy.io/developer/docs/external-api/queries-pagination) для запроса большого количества документов.
+- Используйте [фильтр](https://caisy.io/developer/docs/external-api/external-filter-and-sorting) в своих запросах и [упорядочивайте](https://caisy.io/developer/docs/external-api/external-filter-and-sorting#sorting-8) результаты.

--- a/src/content/docs/ru/guides/cms/crystallize.mdx
+++ b/src/content/docs/ru/guides/cms/crystallize.mdx
@@ -1,0 +1,48 @@
+---
+title: Crystallize и Astro
+description: Добавьте контент в проект Astro, используя Crystallize в качестве CMS
+type: cms
+stub: true
+service: Crystallize
+i18nReady: true
+---
+[Crystallize](https://crystallize.com/) — это безголовая система управления контентом для электронной коммерции, которая предоставляет GraphQL API.
+
+## Пример
+
+```astro title="src/pages/index.astro"
+---
+// Получите пути каталога из GraphQL API Crystallize
+
+
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { createClient } from '@crystallize/js-api-client';
+
+const apiClient = createClient({
+  tenantIdentifier: 'furniture'
+});
+
+const query = `
+  query getCataloguePaths{
+    catalogue(language: "en", path: "/shop") {
+      name
+      children {
+        name
+        path
+      }
+    }
+  }
+`
+const { data: { catalogue } } = await apiClient.catalogueApi(query)
+---
+<BaseLayout>
+  <h1>{catalogue.name}</h1>
+  <nav>
+    <ul>
+      {catalogue.children.map(child => (
+        <li><a href={child.path}>{child.name}</a></li>
+      ))}
+    </ul>
+  </nav>
+</BaseLayout>
+```

--- a/src/content/docs/ru/guides/cms/decap-cms.mdx
+++ b/src/content/docs/ru/guides/cms/decap-cms.mdx
@@ -1,0 +1,37 @@
+---
+title: Decap CMS и Astro
+description: Добавьте контент в проект Astro, используя Decap в качестве CMS
+type: cms
+stub: true
+service: Decap CMS
+i18nReady: true
+---
+import Grid from '~/components/FluidGrid.astro'
+import Card from '~/components/ShowcaseCard.astro'
+
+[Decap CMS](https://www.decapcms.org/) (ранее известная как Netlify CMS) — это система управления контентом с открытым исходным кодом, основанная на Git.
+
+## Ресурсы сообщества 
+
+- Используйте интеграцию [`astro-netlify-cms`](https://github.com/delucis/astro-netlify-cms) Astro для добавления Netlify CMS в ваш проект
+
+- Вы можете начать с [Astro Blog Starter with Netlify CMS](https://github.com/delucis/astro-netlify-cms-starter)
+
+- Запись в блоге: [Авторский контент вашего сайта Astro с помощью CMS на базе Git](https://aalam.vercel.app/blog/astro-and-git-cms-netlify) от Aftab Alam 
+
+- Учебное пособие на YouTube: [Создание пользовательского блога с Astro & NetlifyCMS за МИНУТЫ!](https://www.youtube.com/watch?v=3yip2wSRX_4) от Кумаил Пирзада
+
+## Сайты в производстве
+
+Следующие сайты используют Astro + Decap CMS в производстве:
+
+- [yunielacosta.com](https://www.yunielacosta.com/) от Yuniel Acosta — [исходный код на GitHub](https://github.com/yacosta738/yacosta738.github.io) (Netlify CMS)
+- [portfolioris.nl](https://www.portfolioris.nl/) от Joris Hulsbosch — [исходный код на GitHub](https://github.com/portfolioris/portfolioris.nl)
+
+## Темы
+
+<Grid >
+  <Card title="Astros" href="https://astro.build/themes/details/astros" thumbnail="astros.png"/>
+  <Card title="Enhanced Astro Starter" href="https://astro.build/themes/details/enhanced-astro-starter" thumbnail="enhanced-astro-starter.png"/>
+  <Card title="Astro Decap CMS Starter" href="https://astro.build/themes/details/astro-decap-cms-starter" thumbnail="astro-decap-starter.png"/>
+</Grid>

--- a/src/content/docs/ru/guides/cms/directus.mdx
+++ b/src/content/docs/ru/guides/cms/directus.mdx
@@ -1,0 +1,18 @@
+---
+title: Directus и Astro
+description: Добавьте контент в проект Astro, используя Directus в качестве CMS
+type: cms
+stub: true
+service: Directus
+i18nReady: true
+---
+
+[Directus](https://directus.io/) — это backend-as-a-service, который можно использовать для хранения данных и контента для вашего проекта Astro.
+
+## Официальные ресурсы
+
+- Directus предоставляет [пример шаблона блога Astro](https://github.com/directus/examples/tree/main/astro).
+
+## Ресурсы сообщества 
+
+- Добавьте свои!

--- a/src/content/docs/ru/guides/cms/keystonejs.mdx
+++ b/src/content/docs/ru/guides/cms/keystonejs.mdx
@@ -1,0 +1,10 @@
+---
+title: KeystoneJS и Astro
+description: Добавьте контент в проект Astro, используя KeystoneJS в качестве CMS
+type: cms
+stub: true
+service: KeystoneJS
+i18nReady: true
+---
+
+[KeystoneJS](https://keystonejs.com/) — это безголовая система управления контентом с открытым исходным кодом, которая позволяет описывать структуру вашей схемы.

--- a/src/content/docs/ru/guides/cms/microcms.mdx
+++ b/src/content/docs/ru/guides/cms/microcms.mdx
@@ -1,0 +1,15 @@
+---
+title: microCMS и Astro
+description: Добавьте контент в ваш проект Astro с помощью microCMS
+type: cms
+stub: true
+service: microCMS
+i18nReady: true
+---
+
+[microCMS](https://microcms.io/en) — это API-ориентированная безголовая CMS, которая позволяет определять контент с использованием схем и управлять им через панель управления.
+
+## Официальные ресурсы
+
+- Ознакомьтесь с [официальным документом по microCMS](https://document.microcms.io/tutorial/astro/astro-top)
+- Блог: [Создание блога с помощью microCMS](https://blog.microcms.io/astro-microcms-introduction/)

--- a/src/content/docs/ru/guides/cms/prismic.mdx
+++ b/src/content/docs/ru/guides/cms/prismic.mdx
@@ -1,0 +1,14 @@
+---
+title: Prismic и Astro
+description: Добавьте контент в проект Astro, используя Prismic в качестве CMS
+type: cms
+stub: true
+service: Prismic
+i18nReady: true
+---
+
+[Prismic](https://prismic.io/) — это безголовая система управления контентом (CMS).
+
+## Ресурсы сообщества
+
+- [Разработка с помощью Astro & Prismic — c Нейтом Муром](https://www.youtube.com/watch?v=qFUfuDSLdxM) (прямая трансляция) и [репозиторий из трансляции](https://github.com/natemoo-re/miles-of-code).

--- a/src/content/docs/ru/guides/cms/sanity.mdx
+++ b/src/content/docs/ru/guides/cms/sanity.mdx
@@ -1,0 +1,27 @@
+---
+title: Sanity и Astro
+description: Добавьте контент в проект Astro, используя Sanity в качестве CMS
+type: cms
+stub: true
+service: Sanity
+i18nReady: true
+---
+
+import Grid from '~/components/FluidGrid.astro'
+import Card from '~/components/ShowcaseCard.astro'
+
+[Sanity](http://sanity.io) — это безголовая система управления контентом, ориентированная на [структурированный контент](https://www.sanity.io/structured-content-platform).
+
+## Официальные ресурсы
+
+- [Официальная интеграция Sanity для Astro](https://www.sanity.io/plugins/sanity-astro)
+
+- [Создайте свой блог с помощью Astro и Sanity](https://www.sanity.io/guides/sanity-astro-blog)
+
+- [Минимальный сайт Astro с использованием Studio Sanity](https://www.sanity.io/templates/astro-sanity-clean)
+
+## Темы
+
+<Grid>
+  <Card title="The Balanced Chef" href="https://astro.build/themes/details/balanced-chef/" thumbnail="astro-chef-project.png"/>
+</Grid>

--- a/src/content/docs/ru/guides/cms/sitecore.mdx
+++ b/src/content/docs/ru/guides/cms/sitecore.mdx
@@ -1,0 +1,25 @@
+---
+title: Sitecore Experience Manager и Astro
+description: Добавьте контент в свой проект, используя Sitecore в качестве CMS.
+type: cms
+stub: true
+service: Sitecore XM
+i18nReady: true
+---
+
+[Sitecore Experience Manager (XM)](https://www.sitecore.com/products/experience-manager) — это система управления контентом корпоративного уровня, построенная на базе ASP.NET.
+
+## Начало работы
+
+1. [Создайте сайт Sitecore Headless](https://doc.sitecore.com/xp/en/developers/sxa/103/sitecore-experience-accelerator/create-a-headless-tenant-and-site.html), следуя официальной документации Sitcore.
+2. Выполните в терминале следующую команду инициализации проекта: 
+  ```hell
+  npx @astro-sitecore-jss/create-astro-sitecore-jss@latest
+  ```
+3. Следуйте инструкциям в терминале, чтобы создать ваш проект.
+
+## Ресурсы сообщества
+
+- [Комплект разработки программного обеспечения Sitecore JavaScript для Astro](https://github.com/exdst/jss-astro-public) на GitHub
+- [Введение в Sitecore с Astro](https://exdst.com/posts/20231002-sitecore-astro)
+- [Запуск вашего первого проекта Sitecore Astro](https://exdst.com/posts/20240103-first-sitecore-astro-project)

--- a/src/content/docs/ru/guides/cms/spinal.mdx
+++ b/src/content/docs/ru/guides/cms/spinal.mdx
@@ -1,0 +1,27 @@
+---
+title: Spinal и Astro
+description: Добавьте контент в ваш проект, используя Spinal в качестве CMS.
+type: cms
+stub: true
+service: Spinal
+i18nReady: true
+---
+
+[Spinal](https://spinalcms.com/cms-for-astro/) — это коммерческая CMS, ориентированная на SaaS, основанная на Git.
+
+## Начало работы
+
+1. [Создайте учетную запись Spinal](https://spinalcms.com/signup/).
+2. Подключите свой аккаунт GitHub к Spinal.
+3. Выберите репозиторий Astro, когда появится запрос.
+
+Все содержимое в формате Markdown из выбранной папки будет импортировано в вашу учетную запись Spinal и готово к редактированию.
+
+## Официальные ресурсы
+- [Тема документации, созданная для Astro с помощью Tailwind CSS](https://spinalcms.com/resources/astro-documentation-theme-with-tailwind-css/)
+
+## Сайты в производстве
+
+Следующие сайты используют Astro + Spinal в производстве:
+
+- [spinalcms.com](https://spinalcms.com/) (все статьи блога, документация, журнал изменений, функциональные страницы и т.д.)


### PR DESCRIPTION
#### Description

This PR adds Russian translations for various pages in the `cms` directory, resolving missing content flagged by the Translation Tracker.