### PR TITLE
i18n(ru): Update `markdown-content.mdx` translation

### DIFF
--- a/src/content/docs/ru/guides/markdown-content.mdx
+++ b/src/content/docs/ru/guides/markdown-content.mdx
@@ -564,7 +564,7 @@ const { minutesRead } = Astro.props.frontmatter;
 
 ### Подсветка синтаксиса
 
-Astro идет со встроенной поддержкой для [Shiki](https://shiki.matsu.io/) и [Prism](https://prismjs.com/).
+Astro поставляется со встроенной поддержкой [Shiki](https://shiki.matsu.io/) (через [Shikiji](https://github.com/antfu/shikiji)) и [Prism](https://prismjs.com/).
 Это обеспечивает подсветку синтаксиса для:
 
 - все обрамления кода (\`\`\`) в Markdown (`.md`) и MDX (`.mdx`) файле.


### PR DESCRIPTION
#### Description

This PR updates the Russian translation of the `markdown-content.mdx` page, addressing outdated content identified by the Translation Tracker.

Related:
- #7204 