### PR TITLE
i18n(pt-br): Added missing i18n error pages

### DIFF
--- a/src/content/docs/pt-br/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/pt-br/guides/upgrade-to/v3.mdx
@@ -311,7 +311,7 @@ Astro v3.0 remove a planificação automática do resultado de `getStaticPaths()
 
 Se você está retornando um array de arrays no lugar de um array de _objetos_ (como é esperado), `.flatMap` e `.flat` agora devem ser usados para garantir que você está retornando um array plano.
 
-Uma [mensagem de erro indicando que o valor de retorno de `getStaticPath()` deve ser um array de objetos](/pt-br/reference/errors/invalid-get-static-paths-entry/#what-went-wrong) será providenciado se você precisa atualizar seu código.
+Uma [mensagem de erro indicando que o valor de retorno de `getStaticPath()` deve ser um array de objetos](/pt-br/reference/errors/invalid-get-static-paths-entry/#o-que-deu-errado) será providenciado se você precisa atualizar seu código.
 
 ### Movido: `astro check` agora requer um pacote externo
 

--- a/src/content/docs/pt-br/reference/errors/astro-glob-no-match.mdx
+++ b/src/content/docs/pt-br/reference/errors/astro-glob-no-match.mdx
@@ -1,0 +1,13 @@
+---
+title: Astro.glob() não encontrou nenhum arquivo.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **AstroGlobNoMatch**: `Astro.glob(GLOB_STR)` não retornou arquivo correspondente.
+
+## O que deu errado?
+`Astro.glob()` não retornou um arquivo correspondente. Pode haver um erro de digitação no padrão glob.
+
+**Veja também:**
+-  [Astro.glob](/pt-br/reference/api-reference/#astroglob)

--- a/src/content/docs/pt-br/reference/errors/astro-glob-used-outside.mdx
+++ b/src/content/docs/pt-br/reference/errors/astro-glob-used-outside.mdx
@@ -1,0 +1,13 @@
+---
+title: Astro.glob() utilizado fora de um arquivo Astro.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **AstroGlobUsedOutside**: `Astro.glob(GLOB_STR)` só pode ser utilizado em arquivos `.astro`. `import.meta.glob(GLOB_STR)` pode ser usado em seu lugar para alcançar um resultado similar.
+
+## O que deu errado?
+`Astro.glob()` só pode ser utilizado em arquivos `.astro`. Você pode usar [`import.meta.glob()`](https://vitejs.dev/guide/features.html#glob-import) em seu lugar para alcançar o mesmo resultado.
+
+**Veja também:**
+-  [Astro.glob](/pt-br/reference/api-reference/#astroglob)

--- a/src/content/docs/pt-br/reference/errors/astro-response-headers-reassigned.mdx
+++ b/src/content/docs/pt-br/reference/errors/astro-response-headers-reassigned.mdx
@@ -1,0 +1,10 @@
+---
+title: Astro.response.headers não deve ser reatribuído.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **AstroResponseHeadersReassigned**: Cabeçalhos individuais podem ser adicionados e removidos de `Astro.response.headers`, mas ele não deve ser substituído por outra instância de `Headers` completamente.
+
+## O que deu errado?
+Lançado quando um valor está sendo definido como o campo `headers` no objeto `ResponseInit` disponível como `Astro.response`.

--- a/src/content/docs/pt-br/reference/errors/cant-render-page.mdx
+++ b/src/content/docs/pt-br/reference/errors/cant-render-page.mdx
@@ -1,0 +1,10 @@
+---
+title: Astro não pode renderizar a rota.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **CantRenderPage**: Astro não conseguiu encontrar um conteúdo para renderizar nesta rota. Não há arquivo ou redirecionamento associado a esta rota.
+
+## O que deu errado?
+Astro não conseguiu encontrar um arquivo associado com conteúdo ao tentar renderizar a rota. Este é um erro do Astro e não um erro do usuário. Se ao reiniciar o servidor de desenvolvimento não resolver o problema, por favor, abra uma issue.

--- a/src/content/docs/pt-br/reference/errors/collection-does-not-exist-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/collection-does-not-exist-error.mdx
@@ -1,0 +1,14 @@
+---
+title: Coleção não existente
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+:::caution[Obsoleto]
+Coleções que não existem não resultam mais em um erro. Ao invés disso, um aviso é apresentado.
+:::
+
+> Uma coleção consultada via `getCollection()` não existe.
+
+## O que deu errado?
+Ao consultar uma coleção, certifique-se de que um diretório de coleção com o nome solicitado existe em `src/content/`.

--- a/src/content/docs/pt-br/reference/errors/content-collection-type-mismatch-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/content-collection-type-mismatch-error.mdx
@@ -1,0 +1,14 @@
+---
+title: A coleção contém entradas de um tipo diferente.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ContentCollectionTypeMismatchError**: A coleção COLLECTION contém entradas do tipo EXPECTED_TYPE, mas está configurada como uma coleção do tipo ACTUAL_TYPE.
+
+## O que deu errado?
+Coleções de conteúdo devem conter entradas do tipo configurado. Por padrão, as coleções são `type: 'content'`. Tente adicionar `type: 'data'` à configuração da sua coleção para coleções de dados.
+
+**Veja também:**
+-  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#defining-collections)
+

--- a/src/content/docs/pt-br/reference/errors/content-collection-type-mismatch-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/content-collection-type-mismatch-error.mdx
@@ -10,5 +10,5 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 Coleções de conteúdo devem conter entradas do tipo configurado. Por padrão, as coleções são `type: 'content'`. Tente adicionar `type: 'data'` à configuração da sua coleção para coleções de dados.
 
 **Veja também:**
--  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#defining-collections)
+-  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#definindo-coleções)
 

--- a/src/content/docs/pt-br/reference/errors/could-not-transform-image.mdx
+++ b/src/content/docs/pt-br/reference/errors/could-not-transform-image.mdx
@@ -1,0 +1,16 @@
+---
+title: Não foi possível transformar a imagem.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **CouldNotTransformImage**: Não foi possível transformar a imagem `IMAGE_PATH`. Veja o rastreamento de pilha de erros para mais informações.
+
+## O que deu errado?
+O Astro não conseguiu transformar uma das suas imagens. Muitas vezes, isso é causado por uma imagem corrompida ou malformada. Reexportar a imagem do seu editor de imagens pode resolver esse problema.
+
+Dependendo do serviço de imagens que você está usando, o rastreamento de pilha de erros pode conter mais informações sobre o erro específico encontrado.
+
+**Veja também:**
+-  [Imagens](/pt-br/guides/images/)
+

--- a/src/content/docs/pt-br/reference/errors/data-collection-entry-parse-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/data-collection-entry-parse-error.mdx
@@ -1,0 +1,12 @@
+---
+title: Falha ao analisar a entrada da coleção de dados.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_ENTRY_NAME` falhou ao ser analisado.
+
+## O que deu errado?
+As entradas de coleção do `type: 'data'` devem retornar um objeto com JSON válido (para entradas `.json`) ou YAML (para entradas `.yaml`).
+
+

--- a/src/content/docs/pt-br/reference/errors/duplicate-content-entry-slug-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/duplicate-content-entry-slug-error.mdx
@@ -1,0 +1,11 @@
+---
+title: Slug de entrada de conteúdo duplicado.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `COLLECTION_NAME` contém várias entradas com o mesmo slug: `SLUG`. Os slugs devem ser únicos.
+
+## O que deu errado?
+As entradas da coleção de conteúdo devem ter slugs únicos. Duplicatas são frequentemente causadas pela propriedade `slug` no frontmatter.
+

--- a/src/content/docs/pt-br/reference/errors/failed-to-fetch-remote-image-dimensions.mdx
+++ b/src/content/docs/pt-br/reference/errors/failed-to-fetch-remote-image-dimensions.mdx
@@ -1,0 +1,11 @@
+---
+title: Falha ao recuperar dimensões da imagem remota
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Falha ao obter as dimensões para `IMAGE_URL`.
+
+## O que deu errado?
+Houve falha ao obter as dimensões da imagem remota. Isso é normalmente causado por uma URL incorreta ou pela tentativa de inferir o tamanho de uma imagem na pasta pública, e isso não é possível.
+

--- a/src/content/docs/pt-br/reference/errors/failed-to-find-page-map-ssr.mdx
+++ b/src/content/docs/pt-br/reference/errors/failed-to-find-page-map-ssr.mdx
@@ -1,0 +1,11 @@
+---
+title: Astro não conseguiu encontrar a página correta para renderizar
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **FailedToFindPageMapSSR**: Astro não conseguiu encontrar a página correta para renderizar, provavelmente porque ela não foi mapeada corretamente para uso em SSR. Este é um erro interno. Por favor, abra uma issue.
+
+## O que deu errado?
+Astro não conseguiu encontrar a página correta para renderizar, provavelmente porque ela não foi mapeada corretamente para uso em SSR. Este é um erro interno.
+

--- a/src/content/docs/pt-br/reference/errors/i18n-not-enabled.mdx
+++ b/src/content/docs/pt-br/reference/errors/i18n-not-enabled.mdx
@@ -1,0 +1,26 @@
+---
+title: i18n Não Habilitado
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **i18nNotEnabled**: O módulo `astro:i18n` não pode ser usado sem habilitar o i18n na sua configuração do Astro.
+
+## O que deu errado?
+O módulo `astro:i18n` não pode ser usado sem habilitar o i18n na sua configuração do Astro. Para habilitar o i18n, adicione um locale padrão e uma lista de `locales` suportados na sua configuração do Astro:
+```js
+import { defineConfig } from 'astro'
+export default defineConfig({
+ i18n: {
+	 defaultLocale: 'en',
+	 locales: ['en', 'pt-br'],
+	},
+})
+```
+
+Para mais informações sobre o suporte à internacionalização no Astro, veja nosso guia de Internacionalização.
+
+***Veja também:***
+-  [Internacionalização](/pt-br/guides/internationalization/)
+-  [Referência de Configuração `i18n`](/pt-br/reference/configuration-reference/#i18n)
+

--- a/src/content/docs/pt-br/reference/errors/invalid-dynamic-route.mdx
+++ b/src/content/docs/pt-br/reference/errors/invalid-dynamic-route.mdx
@@ -1,0 +1,14 @@
+---
+title: Rota dinâmica inválida.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidDynamicRoute**: O parâmetro INVALID_PARAM para a rota ROUTE é inválido. Recebido **RECEIVED**.
+
+## O que deu errado?
+Um parâmetro de rota dinâmica é inválido. Isso é frequentemente causado por um parâmetro `undefined` ou um [parâmetro rest](/pt-br/guides/routing/#rest-parameters) ausente.
+
+**Veja também:**
+-  [Rotas dinâmicas](/pt-br/guides/routing/#dynamic-routes)
+

--- a/src/content/docs/pt-br/reference/errors/invalid-dynamic-route.mdx
+++ b/src/content/docs/pt-br/reference/errors/invalid-dynamic-route.mdx
@@ -7,8 +7,8 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 > **InvalidDynamicRoute**: O parâmetro INVALID_PARAM para a rota ROUTE é inválido. Recebido **RECEIVED**.
 
 ## O que deu errado?
-Um parâmetro de rota dinâmica é inválido. Isso é frequentemente causado por um parâmetro `undefined` ou um [parâmetro rest](/pt-br/guides/routing/#rest-parameters) ausente.
+Um parâmetro de rota dinâmica é inválido. Isso é frequentemente causado por um parâmetro `undefined` ou um [parâmetro rest](/pt-br/guides/routing/#parâmetros-rest) ausente.
 
 **Veja também:**
--  [Rotas dinâmicas](/pt-br/guides/routing/#dynamic-routes)
+-  [Rotas dinâmicas](/pt-br/guides/routing/#rotas-dinâmicas)
 

--- a/src/content/docs/pt-br/reference/errors/invalid-get-static-paths-entry.mdx
+++ b/src/content/docs/pt-br/reference/errors/invalid-get-static-paths-entry.mdx
@@ -1,0 +1,22 @@
+---
+title: Entrada inválida no valor de retorno de getStaticPaths
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **InvalidGetStaticPathsEntry**: Entrada inválida retornada por getStaticPaths. Esperava-se um objeto, foi obtido `ENTRY_TYPE`
+
+## O que deu errado?
+O valor de retorno de `getStaticPaths` deve ser um array de objetos. Na maioria dos casos, este erro ocorre porque um array de arrays foi retornado. use [`.flatMap()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) ou uma chamada de [`.flat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) pode ser útil.
+
+```ts title="pages/blog/[id].astro"
+export async function getStaticPaths() {
+	return [ // <-- Array
+		{ params: { slug: "blog" } }, // <-- Objeto
+		{ params: { slug: "about" } }
+	];
+}
+```
+
+**Veja também:**
+-  [`getStaticPaths()`](/pt-br/reference/api-reference/#getstaticpaths)

--- a/src/content/docs/pt-br/reference/errors/locals-not-an-object.mdx
+++ b/src/content/docs/pt-br/reference/errors/locals-not-an-object.mdx
@@ -1,4 +1,4 @@
- ---
+---
 title: O valor atribuído a locals não é aceito.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts

--- a/src/content/docs/pt-br/reference/errors/locals-not-an-object.mdx
+++ b/src/content/docs/pt-br/reference/errors/locals-not-an-object.mdx
@@ -1,0 +1,19 @@
+ ---
+title: O valor atribuído a locals não é aceito.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **LocalsNotAnObject**: `locals` só pode ser atribuído a um `object`. Outros valores, como `number`, `string`, etc., não são aceitos.
+
+## O que deu errado?
+Este erro é lançado quando `locals` é sobrescrito com algo que não é um `object`
+
+Veja um exemplo com este erro:
+```ts
+import {defineMiddleware} from "astro:middleware";
+export const onRequest = defineMiddleware((context, next) => {
+  context.locals = 1541; // <-- 
+  return next();
+});
+```

--- a/src/content/docs/pt-br/reference/errors/locals-not-serializable.mdx
+++ b/src/content/docs/pt-br/reference/errors/locals-not-serializable.mdx
@@ -1,0 +1,23 @@
+---
+title: Astro.locals não é serializável
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **LocalsNotSerializable**: As informações armazenadas em `Astro.locals` para o caminho "`HREF`" não são serializáveis. Certifique-se de armazenar apenas dados serializáveis. (E03034)
+
+## O que deu errado?
+Em modo de desenvolvimento, é lançado erro quando um usuário tenta armazenar algo que não é serializável em `locals`.
+
+Por exemplo:
+```ts
+import {defineMiddleware} from "astro/middleware";
+export const onRequest = defineMiddleware((context, next) => {
+  context.locals = {
+    foo() {
+      alert("Olá mundo!")
+    }
+  };
+  return next();
+});
+```

--- a/src/content/docs/pt-br/reference/errors/middleware-cant-be-loaded.mdx
+++ b/src/content/docs/pt-br/reference/errors/middleware-cant-be-loaded.mdx
@@ -1,0 +1,19 @@
+---
+title: Não é possível carregar o middleware.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MiddlewareCantBeLoaded**: Um erro desconhecido foi lançado ao carregar seu middleware.
+
+## O que deu errado?
+Em modo de desenvolvimento, é lançado erro quando um middleware lança um erro enquanto tenta ser carregado.
+
+Por exemplo:
+```ts
+import {defineMiddleware} from "astro:middleware";
+throw new Error("Error thrown while loading the middleware.")
+export const onRequest = defineMiddleware(() => {
+  return "string"
+});
+```

--- a/src/content/docs/pt-br/reference/errors/middleware-no-data-or-next-called.mdx
+++ b/src/content/docs/pt-br/reference/errors/middleware-no-data-or-next-called.mdx
@@ -1,0 +1,19 @@
+---
+title: O middleware não retornou uma Response.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MiddlewareNoDataOrNextCalled**: Certifique-se de que seu middleware retorna um objeto `Response` diretamente, ou retornando a `Response` ao chamar a função `next`.
+
+## O que deu errado?
+É lançado erro quando o middleware não retorna nenhum dado ou não chama a função `next`.
+
+Por exemplo:
+```ts
+import {defineMiddleware} from "astro:middleware";
+export const onRequest = defineMiddleware((context, _) => {
+	// não retorna nada e nem chama `next`
+	context.locals.someData = false;
+});
+```

--- a/src/content/docs/pt-br/reference/errors/middleware-not-aresponse.mdx
+++ b/src/content/docs/pt-br/reference/errors/middleware-not-aresponse.mdx
@@ -1,0 +1,18 @@
+---
+title: O middleware retornou algo que não é um objeto Response.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MiddlewareNotAResponse**: Qualquer dado retornado do middleware deve ser um objeto `Response` válido.
+
+## O que deu errado?
+Em modo de desenvolvimento, é lançado erro quando o middleware retorna algo que não é um objeto `Response`.
+
+Por exemplo:
+```ts
+import {defineMiddleware} from "astro:middleware";
+export const onRequest = defineMiddleware(() => {
+  return "string"
+});
+```

--- a/src/content/docs/pt-br/reference/errors/missing-index-for-internationalization.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-index-for-internationalization.mdx
@@ -1,0 +1,15 @@
+---
+title: Página de índice não encontrada.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MissingIndexForInternationalization**: Não foi possível encontrar a página de índice. Uma página de índice raiz é necessária para criar um redirecionamento para a URL de índice do locale padrão. (`/DEFAULT_LOCALE`)
+
+## O que deu errado?
+O Astro não conseguiu encontrar a URL de índice do seu site. Uma página de índice é necessária para que o Astro possa criar um redirecionamento da página de índice principal, para a página de índice localizada do locale padrão ao usar [`i18n.routing.prefixDefaultLocale`](/pt-br/reference/configuration-reference/#i18nroutingprefixdefaultlocale).
+
+**Veja também:**
+-  [Internacionalização](/pt-br/guides/internationalization/#routing)
+-  [Referência de Configuração `i18n.routing`](/pt-br/reference/configuration-reference/#i18nrouting)
+

--- a/src/content/docs/pt-br/reference/errors/missing-locale.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-locale.mdx
@@ -1,0 +1,11 @@
+---
+title: O locale fornecido não existe.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MissingLocale**: O locale/caminho `LOCALE` não existe na configuração `i18n.locales`.
+
+## O que deu errado?
+O Astro não consegue encontrar o `locale` solicitado. Todos os locales suportados devem estar configurados em [i18n.locales](/pt-br/reference/configuration-reference/#i18nlocales) e ter diretórios correspondentes dentro de `src/pages/`.
+

--- a/src/content/docs/pt-br/reference/errors/missing-sharp.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-sharp.mdx
@@ -1,0 +1,27 @@
+---
+title: Não foi possível encontrar o Sharp.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MissingSharp**: Não foi possível encontrar o Sharp. Por favor, instale o Sharp (`sharp`) manualmente no seu projeto ou migre para outro serviço de imagens.
+
+## O que deu errado?
+O Sharp é o serviço de imagens padrão usado para `astro:assets`. Ao usar um [gerenciador de pacotes estrito](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) como o pnpm, o Sharp deve ser instalado manualmente no seu projeto para utilizar o processamento de imagens.
+
+Se você não está usando `astro:assets` para processamento de imagens e não deseja instalar o Sharp, você pode configurar o seguinte serviço de passagem de imagens que não realiza processamento:
+
+```js
+import { defineConfig, passthroughImageService } from "astro/config";
+export default defineConfig({
+ image: {
+   service: passthroughImageService(),
+ },
+});
+```
+
+**Veja também:**
+-  [Serviço de Imagens Padrão](/pt-br/guides/images/#default-image-service)
+-  [Componente de Imagem](/pt-br/guides/images/#image--astroassets)
+-  [API de Serviços de Imagem](/pt-br/reference/image-service-reference/)
+

--- a/src/content/docs/pt-br/reference/errors/missing-sharp.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-sharp.mdx
@@ -21,7 +21,7 @@ export default defineConfig({
 ```
 
 **Veja também:**
--  [Serviço de Imagens Padrão](/pt-br/guides/images/#default-image-service)
+-  [Serviço de Imagens Padrão](/pt-br/guides/images/#serviço-de-imagem-padrão)
 -  [Componente de Imagem](/pt-br/guides/images/#image--astroassets)
 -  [API de Serviços de Imagem](/pt-br/reference/image-service-reference/)
 

--- a/src/content/docs/pt-br/reference/errors/mixed-content-data-collection-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/mixed-content-data-collection-error.mdx
@@ -1,0 +1,14 @@
+---
+title: Conteúdo e dados não podem estar na mesma coleção.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MixedContentDataCollectionError**: **COLLECTION_NAME** contém uma mistura de entradas de conteúdo e dados. Todas as entradas devem ser do mesmo tipo.
+
+## O que deu errado?
+Uma coleção de conteúdo não pode conter uma mistura de entradas de conteúdo e dados. Você deve armazenar entradas em coleções separadas por tipo.
+
+**Veja também:**
+-  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#defining-collections)
+

--- a/src/content/docs/pt-br/reference/errors/mixed-content-data-collection-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/mixed-content-data-collection-error.mdx
@@ -10,5 +10,5 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 Uma coleção de conteúdo não pode conter uma mistura de entradas de conteúdo e dados. Você deve armazenar entradas em coleções separadas por tipo.
 
 **Veja também:**
--  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#defining-collections)
+-  [Definindo coleções de conteúdo](/pt-br/guides/content-collections/#definindo-coleções)
 

--- a/src/content/docs/pt-br/reference/errors/no-prerendered-routes-with-domains.mdx
+++ b/src/content/docs/pt-br/reference/errors/no-prerendered-routes-with-domains.mdx
@@ -1,0 +1,11 @@
+---
+title: Rotas pré-renderizadas não são suportadas quando domínios de internacionalização estão habilitados.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoPrerenderedRoutesWithDomains**: Páginas estáticas ainda não são suportadas com múltiplos domínios. Se você deseja habilitar esse recurso, você precisa desabilitar a pré-renderização para a página COMPONENT
+
+## O que deu errado?
+Páginas estáticas ainda não são suportadas com domínios `i18n`. Se você deseja habilitar esse recurso, você precisa desabilitar a pré-renderização.
+

--- a/src/content/docs/pt-br/reference/errors/redirect-with-no-location.mdx
+++ b/src/content/docs/pt-br/reference/errors/redirect-with-no-location.mdx
@@ -1,0 +1,12 @@
+---
+title: Um redirecionamento deve ser fornecido com um local através do cabeçalho Location.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## O que deu errado?
+Um redirecionamento deve ser fornecido com um local através do cabeçalho `Location`.
+
+**Veja também:**
+-  [Astro.redirect](/pt-br/reference/api-reference/#astroredirect)
+

--- a/src/content/docs/pt-br/reference/errors/unhandled-rejection.mdx
+++ b/src/content/docs/pt-br/reference/errors/unhandled-rejection.mdx
@@ -1,0 +1,11 @@
+---
+title: Rejeição não tratada
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnhandledRejection**: O Astro detectou uma rejeição não tratada. Aqui está o rastreamento de pilha:<br/>STACK
+
+## O que deu errado?
+O Astro não conseguiu encontrar nenhum código para lidar com uma `Promise` rejeitada. Certifique-se de que todas as suas promessas tenham um manipulador `await` ou `.catch()`.
+

--- a/src/content/docs/pt-br/reference/errors/unsupported-config-transform-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/unsupported-config-transform-error.mdx
@@ -1,0 +1,14 @@
+---
+title: Transformação não suportada na configuração de conteúdo.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnsupportedConfigTransformError**: Funções `transform()` na sua configuração de conteúdo devem retornar JSON válido ou tipos de dados compatíveis com a biblioteca `devalue` (incluindo tipos Date, Maps e Sets).<br/>Erro completo: PARSE_ERROR
+
+## O que deu errado?
+Funções `transform()` na sua configuração de conteúdo devem retornar JSON válido ou tipos de dados compatíveis com a biblioteca `devalue` (incluindo tipos Date, Maps e Sets).
+
+**Veja também:**
+-  [biblioteca devalue](https://github.com/rich-harris/devalue)
+


### PR DESCRIPTION
#### Description (required)

Added missing error pages:

- [x] reference/errors/astro-glob-no-match.mdx
- [x] reference/errors/astro-glob-used-outside.mdx
- [x] reference/errors/astro-response-headers-reassigned.mdx
- [x] reference/errors/cant-render-page.mdx
- [x] reference/errors/collection-does-not-exist-error.mdx
- [x] reference/errors/content-collection-type-mismatch-error.mdx
- [x] reference/errors/could-not-transform-image.mdx
- [x] reference/errors/data-collection-entry-parse-error.mdx
- [x] reference/errors/duplicate-content-entry-slug-error.mdx
- [x] reference/errors/failed-to-fetch-remote-image-dimensions.mdx
- [x] reference/errors/failed-to-find-page-map-ssr.mdx
- [x] reference/errors/i18n-not-enabled.mdx
- [x] reference/errors/invalid-dynamic-route.mdx
- [x] reference/errors/invalid-get-static-paths-entry.mdx
- [x] reference/errors/locals-not-an-object.mdx
- [x] reference/errors/locals-not-serializable.mdx
- [x] reference/errors/middleware-cant-be-loaded.mdx
- [x] reference/errors/middleware-no-data-or-next-called.mdx
- [x] reference/errors/middleware-not-aresponse.mdx
- [x] reference/errors/missing-index-for-internationalization.mdx
- [x] reference/errors/missing-locale.mdx
- [x] reference/errors/missing-sharp.mdx
- [x] reference/errors/mixed-content-data-collection-error.mdx
- [x] reference/errors/no-prerendered-routes-with-domains.mdx
- [x] reference/errors/redirect-with-no-location.mdx
- [x] reference/errors/unhandled-rejection.mdx
- [x] reference/errors/unsupported-config-transform-error.mdx


---

Discord user: jeff_drumgod