### PR TITLE
Adds a note about what internal state of elements can't be preserved by transition:persist

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -118,6 +118,10 @@ In the example below, the component's internal state of the count will not be re
 <Counter client:load transition:persist initialCount={5} />
 ```
 
+:::note[Known limitations]
+Not all element state can be preserved in this way. The restart of CSS animations and reloads of iframes during view transitions cannot be avoided even with transition:persist.
+:::
+
 You can also [manually identify corresponding elements](#naming-a-transition) if the island/element is in a different component between the two pages.
 
 ```astro title="src/pages/old-page.astro" "Video" 'transition:name="media-player"'

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -119,7 +119,7 @@ In the example below, the component's internal state of the count will not be re
 ```
 
 :::note[Known limitations]
-Not all state can be preserved in this way. The restart of CSS animations and the reload of iframes cannot be avoided during view transitions even when using transition:persist.
+Not all state can be preserved in this way. The restart of CSS animations and the reload of iframes cannot be avoided during view transitions even when using `transition:persist`.
 :::
 
 You can also [manually identify corresponding elements](#naming-a-transition) if the island/element is in a different component between the two pages.

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -119,7 +119,7 @@ In the example below, the component's internal state of the count will not be re
 ```
 
 :::note[Known limitations]
-Not all element state can be preserved in this way. The restart of CSS animations and reloads of iframes during view transitions cannot be avoided even with transition:persist.
+Not all state can be preserved in this way. The restart of CSS animations and the reload of iframes cannot be avoided during view transitions even when using transition:persist.
 :::
 
 You can also [manually identify corresponding elements](#naming-a-transition) if the island/element is in a different component between the two pages.


### PR DESCRIPTION
#### Description (required)

A user on discord complained that the current text gives the impression that `transition:persist` would keep all states of an element, while he suffered from restarting animations.

He referred to this sentence, which he had taken out of context
> the [...] internal state [...] will not be reset when navigating back and forth across pages 

It might help to mention the known limitations. 
