### PR TITLE
i18n(ru): Add `studio.mdx` translation

### DIFF
--- a/src/content/docs/ru/recipes/studio.mdx
+++ b/src/content/docs/ru/recipes/studio.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Astro Studio'
+description: Интерактивная панель для управления Astro DB.
+i18nReady: true
+---
+import ReadMore from '~/components/ReadMore.astro';
+
+[Веб-портал Astro Studio](http://studio.astro.build) позволяет вам подключаться и управлять вашими удаленными [базами данных Astro DB](/ru/guides/astro-db/) через веб-интерфейс или с использованием [CLI-команд](/ru/reference/cli-reference/#astro-studio-cli).
+
+Из вашей панели управления Studio у вас есть доступ к управлению учетной записью, справочным статьям и консоли сообщений поддержки.
+
+Посетите [Astro Studio](http://studio.astro.build), чтобы зарегистрироваться или войти в систему.
+
+## Развертывание с подключением к Studio
+
+Вы можете развернуть свой проект Astro DB с живым подключением к вашей базе данных Studio. Это возможно на любой платформе развертывания с использованием статических сборок или [адаптера SSR](/ru/guides/server-side-rendering/).
+
+Сначала настройте свою команду сборки для подключения к Studio с использованием флага `--remote`. В этом примере флаг применяется к скрипту `"build"` в файле `package.json` вашего проекта. Если ваша платформа развертывания принимает команду сборки, убедитесь, что она установлена на `npm run build`.
+
+
+```json title="package.json" "--remote"
+{
+  "scripts": {
+    "build": "astro build --remote"
+  }
+}
+```
+
+### Создание токена приложения Studio
+
+Для доступа к вашей базе данных Studio из продакшн-развертывания вам нужно создать токен приложения. Вы можете создать токен приложения на панели управления вашего проекта Studio, перейдя на вкладку **Settings** и выбрав **Tokens**.
+
+Скопируйте сгенерированный токен и примените его в качестве переменной окружения / секрета окружения на вашей платформе развертывания, используя имя `ASTRO_STUDIO_APP_TOKEN`.
+
+## Настройте действие GitHub CI.
+
+Вы можете автоматически отправлять изменения схемы в вашу базу данных Studio с использованием действия Studio CI. Это позволит убедиться, что изменения могут быть внесены безопасно, и поддерживать конфигурацию в актуальном состоянии при каждом слиянии с `main`.
+
+[Следуйте документации GitHub](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository), чтобы настроить новый секрет в вашем репозитории с именем `ASTRO_STUDIO_APP_TOKEN` и вашим токеном приложения Studio в качестве значения секрета.
+
+После того как секрет настроен, создайте новый файл рабочего процесса GitHub Actions в директории проекта `.github/workflows` для проверки репозитория и установки Node.js в качестве шагов, а также используйте действие `withastro/action-studio` для синхронизации изменений схемы. 
+
+После настройки секрета создайте новый файл рабочего процесса GitHub Actions в директории проекта `.github/workflows` для проверки репозитория и установки Node.js в качестве шагов, а также используйте действие `withastro/action-studio` для синхронизации изменений схемы. 
+
+Действие запустит `astro db verify` на всех [событиях-триггерах](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows), чтобы убедиться, что изменения схемы могут быть применены безопасно. Если вы специально добавите триггер **[push](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push)**, действие перенесет эти изменения в базу данных Studio.
+
+Приведенный пример GitHub Action `_studio.yml` отправляет изменения при каждом обновлении ветки `main`:
+
+
+```yaml title=".github/workflows/_studio.yml"
+name: Astro Studio
+
+env:
+  ASTRO_STUDIO_APP_TOKEN: ${{secrets.ASTRO_STUDIO_APP_TOKEN }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  DB:
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: jaid/action-npm-install@v1.2.1
+      - uses: withastro/action-studio@main
+```


### PR DESCRIPTION
#### Description

This PR adds the Russian translation of the `studio.mdx` page, addressing missing content identified by the Translation Tracker.