### PR TITLE
Add missing li element in ul

### DIFF
--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -206,9 +206,11 @@ You can modify this interface, or create multiple interfaces, to correspond to y
         <ul>
           {
             articles.map((article) => (
-              <a href={`/blog/${article.attributes.slug}/`}>
-                {article.attributes.title}
-              </a>
+              <li>
+                <a href={`/blog/${article.attributes.slug}/`}>
+                  {article.attributes.title}
+                </a>
+              </li>
             ))
           }
         </ul>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The example is missing the `<li>` element in the `<ul>`.

#### Related issues & labels (optional)

- Suggested label: i18n


<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
