### PR TITLE
fix: fix broken link

### DIFF
--- a/src/content/docs/ja/guides/fonts.mdx
+++ b/src/content/docs/ja/guides/fonts.mdx
@@ -49,7 +49,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 [Fontsource](https://fontsource.org/)プロジェクトにより、Google Fontsやその他のオープンソースのフォントを簡単に使用できます。使用したいフォントをnpmモジュールとしてインストールできます。
 
-1. [Fontsourceのカタログ](https://fontsource.org/fonts)で使用したいフォントを探します。例として、ここでは[Twinkle Star](https://fontsource.org/fonts/twinkle-star)を使用します。
+1. [Fontsourceのカタログ](https://fontsource.org/)で使用したいフォントを探します。例として、ここでは[Twinkle Star](https://fontsource.org/fonts/twinkle-star)を使用します。
 
 2. 選択したフォントのパッケージをインストールしてください。
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixed a broken link to the Fontsource font catalogue in the Japanese document.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)
No Issue has been created as it is only a fix for broken links.
- Suggested label: bug

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

# Additional information

In addition to the Japanese document, I found some broken links to other documents, but I didn't know whether I should put them in one PR or not, so I fixed only the links to the Japanese document. Additional corrections may be made in this PR if it is acceptable to publish them together.

