### PR TITLE
edit: move DB "Columns" section after "Tables"

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -49,9 +49,36 @@ export default defineDb({
 })
 ```
 
+### Tables
+
+Data in Astro DB is stored using SQL tables. Tables structure your data into rows and columns, where columns enforce the type of each row value.
+
+When you define a table, Astro will generate a TypeScript interface to query that table from your project. The result is full TypeScript support when you access your data with property autocompletion and type-checking.
+
+To configure a database table, import and use the `defineTable()` and `column` utilities from `astro:db`.
+
+This example configures a `Comment` table with required text columns for `author` and `body`. Then, make it available to your project through the `defineDb()` export.
+
+```ts title="db/config.ts" "Comment"
+import { defineDb, defineTable, column } from 'astro:db';
+
+const Comment = defineTable({
+  columns: {
+    author: column.text(),
+    body: column.text(),
+  }
+})
+
+export default defineDb({
+  tables: { Comment },
+})
+```
+
+<ReadMore>See the [table configuration reference](/en/guides/integrations-guide/db/#table-configuration-reference) for a complete reference of table options.</ReadMore>
+
 ### Columns
 
-Data in Astro DB is stored using SQL tables. Tables structure your data into rows and columns, where columns enforce the type of each row value. Astro DB supports the following column types:
+Astro DB supports the following column types:
 
 ```ts title="db/config.ts" "column.text()" "column.number()" "column.boolean()" "column.date()" "column.json()"
 import { defineTable, column } from 'astro:db';
@@ -71,31 +98,6 @@ const Comment = defineTable({
   }
 });
 ```
-
-### Tables
-
-Tables power Astro's automatic TypeScript typings for your content. When you define a table, Astro will automatically generate and apply a TypeScript interface to it. The result is full TypeScript support when you query your data, including property autocompletion and type-checking.
-
-To configure an individual database table, import and use the `defineTable()` and `column` utilities from `astro:db`.
-
-This example configures a `Comment` table with required text columns for `author` and `body` and then makes it available to your project through the `defineDb()` export.
-
-```ts title="db/config.ts" "Comment"
-import { defineDb, defineTable, column } from 'astro:db';
-
-const Comment = defineTable({
-  columns: {
-    author: column.text(),
-    body: column.text(),
-  }
-})
-
-export default defineDb({
-  tables: { Comment },
-})
-```
-
-<ReadMore>See the [table configuration reference](/en/guides/integrations-guide/db/#table-configuration-reference) for a complete reference of table options.</ReadMore>
 
 ### Table References
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

There are a couple reasons I'd like to move the "columns" section after "tables:"

1. **Order of explanation.** It's impossible to describe a column without first describing a table, and this was clear from the preamble. It's also odd to show users all available column types before explaining how a table can be configured in the first place. By moving the column preamble into the "tables" section, and pushing the "columns" snippet below, the user is presented with the most minimal example for configuration before reading the details.

2. **Copy / paste warriors.** While watching a user walk through the docs ([t3dotgg](https://www.twitch.tv/theo)), they reached the "columns" section of the docs and naturally copied the snippet to build their config. Trouble is, this snippet includes a number of complex column types, while the simpler Tables snippet would make for an easier demo. By presenting the sample Tables config first, users can copy the simplest demo.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
