### PR TITLE
i18n(ru): Update `cli-reference.mdx` translation

### DIFF
--- a/src/content/docs/ru/reference/cli-reference.mdx
+++ b/src/content/docs/ru/reference/cli-reference.mdx
@@ -185,7 +185,9 @@ Global Flags
 Запуск `astro dev`, `astro build` или `astro check` также запустит команду `sync`.
 :::
 
-Генерирует типы TypeScript для всех модулей Astro. Это настраивает [`src/env.d.ts` файл](/ru/guides/typescript/#настройка) для определения типов и определяет модуль `astro:content` для [API Коллекции Контента](/ru/guides/content-collections/).
+Генерирует типы TypeScript для всех модулей Astro. Это настраивает [`src/env.d.ts` файл](/ru/guides/typescript/#настройка) для определения типов и определяет модули для функций, которые зависят от сгенерированных типов:
+- Модуль `astro:content` для [API Коллекций Контента](/ru/guides/content-collections/).
+- Модуль `astro:db` для [Astro DB](/ru/guides/astro-db/).
 
 ## `astro add`
 


### PR DESCRIPTION
#### Description

This PR updates the Russian translation of the `cli-reference.mdx` page, addressing outdated content identified by the Translation Tracker.

Related:
- #7395