### PR TITLE
Added `prerender = false` option to rendering-modes.mdx documentation

### DIFF
--- a/src/content/docs/en/basics/rendering-modes.mdx
+++ b/src/content/docs/en/basics/rendering-modes.mdx
@@ -47,6 +47,38 @@ Since they are generated per visit, these routes can be customized for each view
 
 - **Frequently changing content**: Generate individual pages without requiring a static rebuild of your site. This is useful when the content of a page updates frequently, for example displaying data from an API called dynamically with `fetch()`.
 
+When using `hybrid` output mode, pages will still be pre-rendered by default. Top opt-out of pre-rendering add `export const prerender =  false` to any page or endpoint.
+
+```astro
+---
+export const prerender = false;
+
+if (Astro.request.method === 'POST') {
+  // handle form submission
+}
+---
+
+<form method="POST">
+  <input type="text" name="name" />
+  <input type="email" name="email" />
+  <button type="submit">Submit</button>
+</form>
+```
+
+or
+
+```astro
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ params, request }) => {
+  const content: // get dynamic content 
+  return new Response(JSON.stringify(content)
+  )
+}
+```
+
 Both `server` and `hybrid` output modes allow you to include [Astro islands](/en/concepts/islands/) for interactivity (or even entire embedded client-side rendered apps!) in your choice of [UI frameworks](/en/guides/framework-components/). With [middleware](/en/guides/middleware/) and Astro's [View Transitions API](/en/guides/view-transitions/) for animations and preserving state across route navigations, even highly interactive apps are possible.
 
 :::tip


### PR DESCRIPTION
#### Description (required)

Added `prerender = false` to documentation to opt-out of pre-rendering in Hybrid mode.

#### Related issues & labels (optional)

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

marceloverdijk

