### PR TITLE
i18n(ru): Update `content.mdx` translation

### DIFF
--- a/src/content/docs/ru/community-resources/content.mdx
+++ b/src/content/docs/ru/community-resources/content.mdx
@@ -79,3 +79,5 @@ import Badge from '~/components/Badge.astro';
 ### Интернационализация и локализация
 - [Как сделать ваш сайт на Astro многоязычным с помощью Crowdin: руководство по локализации Astro](https://crowdin.com/blog/2023/06/21/astro-localization-and-i18n)
 - [Перевод маршрутов в Astro для коллекций контента и подстраниц](https://www.webdesign-sopelnik.de/en/blog/translate-routes-for-astro-content-collections-or-subpages-with-trailingslash-and-base-support/)
+### Astro DB
+- [Создание гостевой книги с помощью Astro DB](https://ryantrimble.com/blog/creating-a-guestbook-with-astro-db/)


### PR DESCRIPTION
#### Description

This PR updates the Russian translation of the `routing.mdx` page, addressing outdated content identified by the Translation Tracker.

Related:
- #7449 