### PR TITLE
[i18nIgnore] fix(db): use `where` correctly

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -231,10 +231,10 @@ You can also query your database from an API endpoint. This example deletes a ro
 ```ts
 // src/pages/api/comments/[id].ts
 import type { APIRoute } from "astro";
-import { db, Comment } from 'astro:db';
+import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where({ id: ctx.params.id });
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id ));
   return new Response(null, { status: 204 });
 }
 ```

--- a/src/content/docs/ja/guides/astro-db.mdx
+++ b/src/content/docs/ja/guides/astro-db.mdx
@@ -231,10 +231,10 @@ APIエンドポイントからデータベースをクエリすることも可�
 ```ts
 // src/pages/api/comments/[id].ts
 import type { APIRoute } from "astro";
-import { db, Comment } from 'astro:db';
+import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where({ id: ctx.params.id });
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id ));
   return new Response(null, { status: 204 });
 }
 ```

--- a/src/content/docs/ko/guides/astro-db.mdx
+++ b/src/content/docs/ko/guides/astro-db.mdx
@@ -231,10 +231,10 @@ API 엔드포인트에서 데이터베이스를 쿼리할 수도 있습니다. �
 ```ts
 // src/pages/api/comments/[id].ts
 import type { APIRoute } from "astro";
-import { db, Comment } from 'astro:db';
+import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where({ id: ctx.params.id });
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id ));
   return new Response(null, { status: 204 });
 }
 ```

--- a/src/content/docs/ru/guides/astro-db.mdx
+++ b/src/content/docs/ru/guides/astro-db.mdx
@@ -233,7 +233,7 @@ import type { APIRoute } from "astro";
 import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where(eq(Comment.id, ctx.params.id );
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id ));
   return new Response(null, { status: 204 });
 }
 ```

--- a/src/content/docs/ru/guides/astro-db.mdx
+++ b/src/content/docs/ru/guides/astro-db.mdx
@@ -230,10 +230,10 @@ const comments = await db.select().from(Comment);
 ```ts
 // src/pages/api/comments/[id].ts
 import type { APIRoute } from "astro";
-import { db, Comment } from 'astro:db';
+import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where({ id: ctx.params.id });
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id );
   return new Response(null, { status: 204 });
 }
 ```

--- a/src/content/docs/zh-cn/guides/astro-db.mdx
+++ b/src/content/docs/zh-cn/guides/astro-db.mdx
@@ -232,10 +232,10 @@ const comments = await db.select().from(Comment);
 ```ts
 // src/pages/api/comments/[id].ts
 import type { APIRoute } from "astro";
-import { db, Comment } from 'astro:db';
+import { db, Comment, eq } from 'astro:db';
 
 export const DELETE: APIRoute = async (ctx) => {
-  await db.delete(Comment).where({ id: ctx.params.id });
+  await db.delete(Comment).where(eq(Comment.id, ctx.params.id ));
   return new Response(null, { status: 204 });
 }
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates a section of the Astro DB documentation. The section that shows how to delete a comment is incorrect. The `where` function doesn't accept a "raw" object, but we should always use the utility functions provided.

Reference: https://orm.drizzle.team/docs/sql#sql-in-where

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

Filed here https://github.com/withastro/astro/issues/10489

