### PR TITLE
content(vercel integration guide): document typing of newly added locals field

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -395,6 +395,21 @@ export default defineConfig({
 });
 ```
 
+The edge middleware has access to Vercel's [`RequestContext`](https://vercel.com/docs/functions/edge-middleware/middleware-api#requestcontext) as `ctx.locals.vercel.edge`. If you’re using TypeScript, you can get proper typings by updating `src/env.d.ts` to use `EdgeLocals`:
+
+```ts
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />
+
+type EdgeLocals = import('@astrojs/vercel').EdgeLocals
+
+declare namespace App {
+  interface Locals extends EdgeLocals {
+    // ...
+  }
+}
+```
+
 ### Node.js Version Support
 
 The `@astrojs/vercel` adapter supports specific Node.js versions for deploying your Astro project on Vercel. To view the supported Node.js versions on Vercel, click on the settings tab for a project and scroll down to "Node.js Version" section.


### PR DESCRIPTION
#### Description (required)
- New section to describe how to get typescript hints for locals added by adapter.
- Merges into https://github.com/withastro/docs/pull/7466, which has already been otherwise reviewed.

#### Related issues & labels (optional)
- https://github.com/withastro/astro/pull/10476