### PR TITLE
db: document isDbError()

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/db.mdx
+++ b/src/content/docs/en/guides/integrations-guide/db.mdx
@@ -221,3 +221,32 @@ Execute a `.ts` or `.js` file to read or write to your database. This accepts a 
 - `--remote` Run against your Studio project database. Omit to run against your development server.
 
 Execute a raw SQL query against your database. Use the `--remote` flag to run against your Studio project database, or omit the flag to run against your development server.
+
+## Astro DB utility reference
+
+### `isDbError()`
+
+The `isDbError()` function checks if an error is a libSQL database exception. This may include a foreign key constraint error when using references, or missing fields when inserting data. You can combine `isDbError()` with a try / catch block to handle database errors in your application:
+
+```ts
+// src/pages/api/comment/[id].ts
+import { db, Comment, isDbError } from 'astro:db';
+import type { APIRoute } from 'astro';
+
+export const POST: APIRoute = (ctx) => {
+  try {
+    await db.insert(Comment).values({
+      id: ctx.params.id,
+      content: 'Hello, world!'
+    });
+  } catch (e) {
+    if (isDbError(e)) {
+      return new Response(`Cannot insert comment with id ${id}\n\n${e.message}`, { status: 400 });
+    }
+    return new Response('An unexpected error occurred', { status: 500 });
+  }
+
+  return new Response(null, { status: 201 });
+};
+```
+---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Document the new `isDbError()` utility for exception handling. This is under a new API reference header on `@astrojs/db`. To be honest, I worry this isn't discoverable, but I know it's a bit too advanced to put on the Astro DB page. Seemed like the best compromise.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
