### PR TITLE
Clarify how to add images to the RSS feed

### DIFF
--- a/src/content/docs/en/guides/rss.mdx
+++ b/src/content/docs/en/guides/rss.mdx
@@ -165,7 +165,7 @@ The `content` key contains the full content of the post as HTML. This allows you
 A package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) will make sure that your content is properly sanitized, escaped, and encoded. In the process, such a package might also remove some harmless elements and attributes, so make sure to verify the output and configure the package according to your needs.
 :::
 
-When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result:
+When using content collections, render the post `body` using a standard Markdown parser like [`markdown-it`](https://github.com/markdown-it/markdown-it) and sanitize the result, including any extra tags (e.g. `<img>`) needed to render your content:
 
 ```js title="src/pages/rss.xml.js" ins={3, 4, 5, 16}
 import rss from '@astrojs/rss';
@@ -183,7 +183,9 @@ export async function GET(context) {
     items: blog.map((post) => ({
       link: `/blog/${post.slug}/`,
       // Note: this will not process components or JSX expressions in MDX files.
-      content: sanitizeHtml(parser.render(post.body)),
+      content: sanitizeHtml(parser.render(post.body), {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img'])
+      }),
       ...post.data,
     })),
   });


### PR DESCRIPTION
#### Description

When following the docs to add an RSS feed, I was left without any images. This PR adds some clarification around `allowedTags` and how to get images into your RSS feed.

#### Related issues & labels

- Closes #7099 

#### First-time contributor to Astro Docs?

First time contributor, and I am on the Discord as `tommypalmer` 🚀 