### PR TITLE
updates indexes and foreignkeys example

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/db.mdx
+++ b/src/content/docs/en/guides/integrations-guide/db.mdx
@@ -135,11 +135,13 @@ Table indexes are used for improve lookup speeds on a given column or combinatio
 import { defineTable, column } from 'astro:db';
 
 const Comment = defineTable({
-  authorId: column.number(),
-  body: column.text(),
-  indexes: {
-    author_idx: { on: ['authorId'], unique: true },
-  }
+    columns: {
+        authorId: column.number(),
+        body: column.text(),
+    },
+    indexes: {
+        author_idx: { on: ["authorId"], unique: true },
+    },
 });
 ```
 
@@ -162,23 +164,27 @@ Foreign keys are used to establish a relationship between two tables. The `forei
 import { defineTable, column } from 'astro:db';
 
 const Author = defineTable({
-  firstName: column.text(),
-  lastName: column.text(),
+    columns:{
+        firstName: column.text(),
+        lastName: column.text(),
+    }
 });
 
 const Comment = defineTable({
-  authorFirstName: column.text(),
-  authorLastName: column.text(),
-  body: column.text(),
-  foreignKeys: [
-    {
-      columns: ['authorFirstName', 'authorLastName'],
-      references: () => [
-        Author.columns.firstName,
-        Author.columns.lastName
-      ],
+    columns:{
+        authorFirstName: column.text(),
+        authorLastName: column.text(),
+        body: column.text(),
     },
-  ]
+    foreignKeys: [
+        {
+            columns: ['authorFirstName', 'authorLastName'],
+            references: () => [
+                Author.columns.firstName,
+                Author.columns.lastName
+            ],
+        },
+    ]
 });
 ```
 

--- a/src/content/docs/en/guides/integrations-guide/db.mdx
+++ b/src/content/docs/en/guides/integrations-guide/db.mdx
@@ -135,13 +135,13 @@ Table indexes are used for improve lookup speeds on a given column or combinatio
 import { defineTable, column } from 'astro:db';
 
 const Comment = defineTable({
-    columns: {
-        authorId: column.number(),
-        body: column.text(),
-    },
-    indexes: {
-        author_idx: { on: ["authorId"], unique: true },
-    },
+  columns: {
+    authorId: column.number(),
+    body: column.text(),
+  },
+  indexes: {
+    author_idx: { on: ["authorId"], unique: true },
+  },
 });
 ```
 
@@ -164,27 +164,24 @@ Foreign keys are used to establish a relationship between two tables. The `forei
 import { defineTable, column } from 'astro:db';
 
 const Author = defineTable({
-    columns:{
-        firstName: column.text(),
-        lastName: column.text(),
-    }
+  columns: {
+    firstName: column.text(),
+    lastName: column.text(),
+  },
 });
 
 const Comment = defineTable({
-    columns:{
-        authorFirstName: column.text(),
-        authorLastName: column.text(),
-        body: column.text(),
+  columns: {
+    authorFirstName: column.text(),
+    authorLastName: column.text(),
+    body: column.text(),
+  },
+  foreignKeys: [
+    {
+      columns: ["authorFirstName", "authorLastName"],
+      references: () => [Author.columns.firstName, Author.columns.lastName],
     },
-    foreignKeys: [
-        {
-            columns: ['authorFirstName', 'authorLastName'],
-            references: () => [
-                Author.columns.firstName,
-                Author.columns.lastName
-            ],
-        },
-    ]
+  ],
 });
 ```
 


### PR DESCRIPTION
#### Description (required)

There is `columns` key is missing. All the columns are not wrapped into the `columns` key and are directly used in the `defineTable` object

<!-- #### First-time contributor to Astro Docs? -->
Discord Username: _withden
<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
