### PR TITLE
docs: add alt workaround for csp trouble with inline scripts

### DIFF
--- a/src/content/docs/en/guides/troubleshooting.mdx
+++ b/src/content/docs/en/guides/troubleshooting.mdx
@@ -107,7 +107,7 @@ You may see the following error logged in the browser console:
 
 This means that your site’s [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) disallows running inline `<script>` tags, which Astro outputs by default.
 
-**Solution:** Update your CSP to include `script-src: 'unsafe-inline'` to allow inline scripts to run.
+**Solution:** Update your CSP to include `script-src: 'unsafe-inline'` to allow inline scripts to run. Alternatively, you can use a third-party integration such as [`astro-shield`](https://github.com/KindSpells/astro-shield) to generate the CSP headers for you.
 
 ## Common gotchas
 


### PR DESCRIPTION
#### Description (required)

This change introduces an alternative workaround for inlined scripts in the presence of Content-Security-Policy headers.

#### Related issues & labels (optional)

- "Closes": #2150
- Suggested label: `add new content`, `can of worms`
- Astro Discord username: castarco (Andreu)
