### PR TITLE
Adds Hookdeck website and docs as an example production site

### DIFF
--- a/src/content/docs/en/integrations/integrations.mdx
+++ b/src/content/docs/en/integrations/integrations.mdx
@@ -32,6 +32,8 @@ Check out our new [integrations library](https://astro.build/integrations/), and
 
 [Elian Codes](https://www.elian.codes/) - Astro / Vercel / UnoCSS
 
+[Hookdeck Website and Docs](https://hookdeck.com/) - Astro / Vercel / Markdoc
+
 
 ## Blog Posts / Videos
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I believe [hookdeck.com](https://hookdeck.com) and [hookdeck.com/docs](https://hookdeck.com/docs) are good production examples of what's possible with Astro.

I'm `leggetter` in the Astro Discord.

Website

![CleanShot 2024-03-27 at 11 27 31@2x](https://github.com/withastro/docs/assets/328367/179f2048-8124-4963-9f14-96b626bb11f9)

Docs

![CleanShot 2024-03-27 at 11 27 48@2x](https://github.com/withastro/docs/assets/328367/22c1dff2-9c04-4ce9-88fd-f83f9b562503)

