### PR TITLE
fix(markdown-content.mdx): fix incorrect remote markdown example

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -670,10 +670,13 @@ Astro was primarily designed for local Markdown files that could be saved inside
 // Example: Fetch Markdown from a remote API
 // and render it to HTML, at runtime.
 // Using "marked" (https://github.com/markedjs/marked)
-import { marked } from 'marked';
-const response = await fetch('https://raw.githubusercontent.com/wiki/adam-p/markdown-here/Markdown-Cheatsheet.md');
-const markdown = await response.text();
-const content = marked.parse(markdown);
 ---
-<article set:html={content} />
+<script>
+  import { marked } from 'marked';
+  const response = await fetch('https://raw.githubusercontent.com/wiki/adam-p/markdown-here/Markdown-Cheatsheet.md');
+  const markdown = await response.text();
+  const content = await marked.parse(markdown);
+  document.getElementsByClassName('markdown-body')[0].innerHTML = content;
+</script>
+<article class="markdown-body"></article>
 ```


### PR DESCRIPTION
#### Description (required)

The original code may initially appear to work as `npm run dev` will re-fetch the content every time the page is refreshed, but running `npm run build` will reveal that in the actual behaviour, the content is only fetched at build time and is not in fact dynamically fetched during runtime.

The new code fixes this by moving the JavaScript outside of the component script and instead placing it in a `<script>` tag.

#### Related issues & labels (optional)

- Closes #7629 
- Suggested label: [code snippet update](https://github.com/withastro/docs/labels/code%20snippet%20update), [improve documentation](https://github.com/withastro/docs/labels/improve%20documentation)
