### PR TITLE
Added Gato GraphQL as option for WordPress

### DIFF
--- a/src/content/docs/en/guides/cms/wordpress.mdx
+++ b/src/content/docs/en/guides/cms/wordpress.mdx
@@ -14,7 +14,7 @@ import Card from '~/components/ShowcaseCard.astro'
 
 ## Integrating with Astro
 
-WordPress comes with a built-in [WordPress REST API](https://developer.wordpress.org/rest-api/) to connect your WordPress data to Astro. You can optionally install [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) on your site to use GraphQL.
+WordPress comes with a built-in [WordPress REST API](https://developer.wordpress.org/rest-api/) to connect your WordPress data to Astro. You can optionally install [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) or [Gato GraphQL](https://wordpress.org/plugins/gatographql/) on your site to use GraphQL.
 
 ### Prerequisites
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Added the [Gato GraphQL](https://wordpress.org/plugins/gatographql/) plugin as another option for getting data from WordPress using GraphQL.
