### PR TITLE
i18n(ru): Update `wordpress.mdx` translation

### DIFF
--- a/src/content/docs/ru/guides/cms/wordpress.mdx
+++ b/src/content/docs/ru/guides/cms/wordpress.mdx
@@ -14,7 +14,7 @@ import Card from '~/components/ShowcaseCard.astro'
 
 ## Интеграция с Astro
 
-WordPress поставляется со встроенным [WordPress REST API](https://developer.wordpress.org/rest-api/) для подключения ваших данных WordPress к Astro. Вы можете дополнительно установить [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) на свой сайт, чтобы использовать GraphQL.
+WordPress поставляется со встроенным [WordPress REST API](https://developer.wordpress.org/rest-api/) для подключения ваших данных WordPress к Astro. Вы можете дополнительно установить [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) или [Gato GraphQL](https://wordpress.org/plugins/gatographql/) на свой сайт, чтобы использовать GraphQL.
 
 ### Предварительные условия
 


### PR DESCRIPTION
#### Description

This PR updates the Russian translation of the `wordpress.mdx` page, addressing outdated content identified by the Translation Tracker.

Related:
- #7674