### PR TITLE
i18n(es): port change from EN troubleshooting to ES

### DIFF
--- a/src/content/docs/es/guides/troubleshooting.mdx
+++ b/src/content/docs/es/guides/troubleshooting.mdx
@@ -107,7 +107,7 @@ Es posible que veas el siguiente error en la consola del navegador:
 
 Esto significa que la [política de seguridad de contenido](https://developer.mozilla.org/es/docs/Web/HTTP/CSP) (CSP) de tu sitio web no permite ejecutar etiquetas `<script>` en línea, las cuales Astro genera por defecto.
 
-**Solución:** Actualiza tu CSP para incluir `script-src: 'unsafe-inline'` para permitir que los scripts en línea se ejecuten.
+**Solución:** Actualiza tu CSP para incluir `script-src: 'unsafe-inline'` para permitir que los scripts en línea se ejecuten. De forma alternativa, puedes usar integraciones de terceros tales como [`astro-shield`](https://github.com/KindSpells/astro-shield) para que generen las cabeceras CSP por ti.
 
 ## Problemas comunes
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Port a recent change (a reference to a 3rd party integration) introduced in the English version of the Troubleshooting guide to the Spanish version.

#### Related issues & labels (optional)

- Suggested label: `i18n`

