### PR TITLE
fix: remove unused import and add missing syntax

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -5,8 +5,6 @@ i18nReady: true
 import Since from '~/components/Since.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import ReadMore from '~/components/ReadMore.astro'
-import Badge from '~/components/Badge.astro';
-
 
 You can use the Command-Line Interface (CLI) provided by Astro to develop, build, and preview your project from a terminal window.
 
@@ -537,10 +535,9 @@ process.exit(exitCode)
 
 ## Astro Studio CLI
 
-
 ### `astro login`
 
-Authenticate with Astro Studio. This is required to run all database management commands, including [astro link](#astro-link).
+Authenticate with Astro Studio. This is required to run all database management commands, including [`astro link`](#astro-link).
 
 ### `astro link`
 


### PR DESCRIPTION
# Remove unused import and add missing syntax

## Description (required)

This PR removes the unused import of the Badge component from the `cli-reference.mdx` file as well as some extra line breaks. It also adds the code syntax to the `astro link` command at the end of the file, to match the other occurrences of commands inside the main text.
