### PR TITLE
[CONTRIBUTING.md] fix typo in directory path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Our Docs are translated into several languages and we rely on automation to noti
 
 **Pages generated from outside sources**
 
-Some of our English-language pages are generated from outside sources and maintained in another repo. Currently, these files are `configuration-reference.md` and all those under the `integrations-guides/` directory as well as our error messages.
+Some of our English-language pages are generated from outside sources and maintained in another repo. Currently, these files are `configuration-reference.md` and all those under the `integrations-guide/` directory as well as our error messages.
 
 The page's **Edit this page** button should redirect you to the file that should be changed. Alternatively, you can get the correct URL from the file's `githubURL` frontmatter property.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The `CONTRIBUTING.md` docs mention an `integrations-guides/` directory when the correct directory is `integrations-guide/`. This PR fixes that!

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

#### First-time contributor to Astro Docs?

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->

Discord username: `kanadg`

<!-- https://astro.build/chat -->
