### PR TITLE
update PR template: changes in one language only

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 <!-- Please describe the change you are proposing, and why -->
 
+<!-- Please make changes in **one language** only -->
+
 #### Related issues & labels (optional)
 
 - Closes #<!-- Add an issue number if this PR will close it. -->


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds one line to the PR template:

```
<!-- Please make changes in **one language** only -->
```

This won't catch all the PRs, but will be enough to stop some people from submitting to multiple languages at once.

This also doesn't explicitly say "Changes to English only.. etc." because I don't want anything too long that people won't read. ONE LANGUAGE is enough that some people will notice it, and it will improve some of the PRs we get before they're made.
