### PR TITLE
Document type checking for the `astro.config` file

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -36,6 +36,10 @@ Add Astro DB to a new or existing Astro project (requires `astro@4.5` or later) 
 
 If you prefer, you can [install `@astrojs/db` manually](/en/guides/integrations-guide/db/#manual-installation) instead.
 
+### TypeScript setup
+
+Astro DB uses type generation for a rich editor experience when querying your database. [If you use the `strictest` TypeScript configuration in your `tsconfig.json`](/en/guides/typescript/#setup), you will need to change your `astro.config.mjs` file to an `astro.config.ts` file. This ensures types exposed by the integration are discovered. No action is required for other TypeScript configurations.
+
 ## Define your database
 
 Astro DB is a complete solution to configuring, developing and querying your data. A local database is created whenever you run `astro dev`, using LibSQL to manage your data without the need for Docker or a network connection.

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -19,6 +19,10 @@ Astro starter projects include a `tsconfig.json` file in your project. Even if y
 
 Three extensible `tsconfig.json` templates are included in Astro: `base`, `strict`, and `strictest`. The `base` template enables support for modern JavaScript features and is also used as a basis for the other templates. We recommend using `strict` or `strictest` if you plan to write TypeScript in your project. You can view and compare the three template configurations at [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 
+:::tip
+We also recommend using the `.ts` extension for your `astro.config.ts` file when using `strict` or `strictest` TypeScript configurations. This surfaces type hints in your editor and ensures that generated types are correctly injected for certain features, including Astro DB.
+:::
+
 To inherit from one of the templates, use [the `extends` setting](https://www.typescriptlang.org/tsconfig#extends):
 
 ```json title="tsconfig.json"
@@ -67,6 +71,20 @@ Then, add the following to your `tsconfig.json`:
 
 To check that the plugin is working, create a `.ts` file and import an Astro component into it. You should have no warning messages from your editor.
 
+### Types in your Astro config file
+
+You may want type hints and errors in your `astro.config.*` file as well. When using the `strict` or `strictest` TypeScript configurations, you can use the `.ts` extension instead of the `.mjs` extension to enable TypeScript parsing. The `.ts` extension is also necessary to support generated types from Astro integrations, [including Astro DB](/en/guides/astro-db/).
+
+Alternatively, you can enable TypeScript support in your `astro.config.mjs` file by adding the `allowJs` property to your `tsconfig.json` file:
+
+```json title="tsconfig.json" {4}
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}
+```
 
 ### UI Frameworks
 

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -19,10 +19,6 @@ Astro starter projects include a `tsconfig.json` file in your project. Even if y
 
 Three extensible `tsconfig.json` templates are included in Astro: `base`, `strict`, and `strictest`. The `base` template enables support for modern JavaScript features and is also used as a basis for the other templates. We recommend using `strict` or `strictest` if you plan to write TypeScript in your project. You can view and compare the three template configurations at [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 
-:::tip
-We also recommend using the `.ts` extension for your `astro.config.ts` file when using `strict` or `strictest` TypeScript configurations. This surfaces type hints in your editor and ensures that generated types are correctly injected for certain features, including Astro DB.
-:::
-
 To inherit from one of the templates, use [the `extends` setting](https://www.typescriptlang.org/tsconfig#extends):
 
 ```json title="tsconfig.json"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We [got a user bug](https://github.com/withastro/astro/issues/10507) when using Astro DB with the `strictest` type settings and an `.mjs` extension for the Astro config. This seemed like a symptom of a larger problem: if you use`.mjs`, your Astro config is not type checked. Made two tweaks here:
- Add a TypeScript setup section to Astro DB to tell `strictest` users to use a `.ts` extension
- Add a "types in your Astro config file" section to TypeScript to call out options for inferred types

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
