### PR TITLE
Update Fontsource tip to add @fontsource-variable scope

### DIFF
--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -74,7 +74,7 @@ The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts 
     </PackageManagerTabs>
 
     :::tip
-    You'll find the correct package name in the “Quick Installation” section of each font page on Fontsource's website. It will start with `@fontsource/` followed by the name of the font.
+    You'll find the correct package name in the “Quick Installation” section of each font page on Fontsource's website. It will start with `@fontsource/` or `@fontsource-variable/` followed by the name of the font.
     :::
 
 3. Import the font package in the component where you want to use the font. Usually, you will want to do this in a common layout component to make sure the font is available across your site.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Since Variable Fonts in fontsource start with @fontsource-variable/, I thought it might be better to display `It will start with @fontsource/ or @fontsource-variable/ followed by the name of the font.` instead of the tip `It will start with @fontsource/ followed by the name of the font.`

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. --> #7981 
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
