### PR TITLE
feat: add small mention of available preferences

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -139,7 +139,7 @@ You will often use these `astro` commands, or the scripts that run them, without
   </Fragment>
 </PackageManagerTabs>
 
-{/*
+{ /*
 
 ORIGINAL CONTENT That We Can Always revert to if new stuff is too friendly
 
@@ -305,6 +305,11 @@ The `list` command prints the current settings of all configurable user preferen
 ```shell
 astro preferences list
 ```
+
+### Available preferences
+
+- `devToolbar` — Enable or disable the development toolbar in the browser. (Default: `true`)
+- `checkUpdates` — Enable or disable automatic update checks for the Astro CLI. (Default: `true`)
 
 ## `astro telemetry`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -276,6 +276,27 @@ User preferences are scoped to the current project by default, stored in a local
 
 Using the `--global` flag, user preferences can also be applied to every Astro project on the current machine. Global user preferences are stored in an operating system-specific location.
 
+<h3> Available preferences </h3>
+
+- `devToolbar` — Enable or disable the development toolbar in the browser. (Default: `true`)
+- `checkUpdates` — Enable or disable automatic update checks for the Astro CLI. (Default: `true`)
+
+The `list` command prints the current settings of all configurable user preferences. It also supports a machine-readable `--json` output.
+
+```shell
+astro preferences list
+```
+
+Example terminal output:
+
+| Preference               | Value |
+| ------------------------ | ----- |
+| devToolbar.enabled       | true  <tr></tr>|
+| checkUpdates.enabled     | true  |
+
+
+You can `enable`, `disable`, or `reset` preferences to their default.
+
 For example, to disable the devToolbar in a specific Astro project:
 
 ```shell
@@ -299,17 +320,6 @@ The `reset` command resets a preference to its default value:
 ```shell
 astro preferences reset devToolbar
 ```
-
-The `list` command prints the current settings of all configurable user preferences. It also supports a machine-readable `--json` output.
-
-```shell
-astro preferences list
-```
-
-### Available preferences
-
-- `devToolbar` — Enable or disable the development toolbar in the browser. (Default: `true`)
-- `checkUpdates` — Enable or disable automatic update checks for the Astro CLI. (Default: `true`)
 
 ## `astro telemetry`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -139,7 +139,7 @@ You will often use these `astro` commands, or the scripts that run them, without
   </Fragment>
 </PackageManagerTabs>
 
-{ /*
+{/*
 
 ORIGINAL CONTENT That We Can Always revert to if new stuff is too friendly
 


### PR DESCRIPTION
#### Description (required)

Astro 4.7 adds a new preference: `checkUpdates`. We currently don't have a place where the list of preferences are listed, and in core we honestly don't add preferences all that often, so I figured just a small list in the CLI reference was good enough, happy to do something else, though.