### PR TITLE
Fix typing mismatch in Integration API docs

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -35,7 +35,7 @@ interface AstroIntegration {
       injectScript: (stage: InjectedScriptStage, content: string) => void;
       injectRoute: ({ pattern: string, entrypoint: string }) => void;
       logger: AstroIntegrationLogger;
-    }) => void;
+    }) => void | Promise<void>;
     'astro:config:done'?: (options: { config: AstroConfig; setAdapter: (adapter: AstroAdapter) => void; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:setup'?: (options: { server: vite.ViteDevServer; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:start'?: (options: { address: AddressInfo; logger: AstroIntegrationLogger; }) => void | Promise<void>;
@@ -82,7 +82,7 @@ interface AstroIntegration {
   injectScript: (stage: InjectedScriptStage, content: string) => void;
   injectRoute: ({ pattern: string, entrypoint: string }) => void;
   logger: AstroIntegrationLogger;
-}) => void;
+}) => void | Promise<void>;
 ```
 
 #### `config` option


### PR DESCRIPTION
While reading through the integration docs, I noticed that `astro:config:setup` appeared synchronous in the documentation, while the actual type allows a `Promise`. 
