### PR TITLE
fix: Update `aws.mdx` typo

### DIFF
--- a/src/content/docs/en/guides/deploy/aws.mdx
+++ b/src/content/docs/en/guides/deploy/aws.mdx
@@ -218,5 +218,5 @@ There are many ways to set up continuous deployment for AWS. One possibility for
 ## Community Resources
 
 - [Deploy Astro to AWS Amplify](https://www.launchfa.st/blog/deploy-astro-aws-amplify)
-- [Deploy Astro to AWS Elasic Beanstalk](https://www.launchfa.st/blog/deploy-astro-aws-elastic-beanstalk)
+- [Deploy Astro to AWS Elastic Beanstalk](https://www.launchfa.st/blog/deploy-astro-aws-elastic-beanstalk)
 - [Deploy Astro to Amazon ECS on AWS Fargate](https://www.launchfa.st/blog/deploy-astro-aws-fargate)


### PR DESCRIPTION
Updates a small typo on the `aws.mdx` guide.