### PR TITLE
Add info about --viteMode flag

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -24,7 +24,7 @@ In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBOD
 
 Astro includes a few environment variables out-of-the-box:
 
-- `import.meta.env.MODE`: The mode your site is running in. By default, this is `development` when running `astro dev` and `production` when running `astro build`. You can override this value using `--viteMode <mode>` CLI flag.
+- `import.meta.env.MODE`: The mode your site is running in. By default, this is `development` when running `astro dev` and `production` when running `astro build`. You can override this value using the [`--viteMode <mode>` CLI flag](/en/reference/cli-reference/#--vitemode-mode).
 - `import.meta.env.PROD`: `true` if your site is running in production; `false` otherwise.
 - `import.meta.env.DEV`: `true` if your site is running in development; `false` otherwise. Always the opposite of `import.meta.env.PROD`.
 - `import.meta.env.BASE_URL`: The base url your site is being served from. This is determined by the [`base` config option](/en/reference/configuration-reference/#base).
@@ -43,7 +43,7 @@ const isDev = import.meta.env.DEV;
 ### `.env` files
 Environment variables can be loaded from `.env` files in your project directory.
 
-You can also attach a mode to the filename, like `.env.production` or `.env.staging`, which makes the environment variables only take effect in that mode. By default, Astro loads `.env.development` when running `astro dev` and `.env.production` when running `astro build`. The mode can be configured by passing `--viteMode <mode>` flag to these commands.
+You can also attach a mode to the filename, like `.env.production` or `.env.staging`, which makes the environment variables only take effect in that mode. By default, Astro loads `.env.development` when running `astro dev` and `.env.production` when running `astro build`. The mode can be configured by passing the [`--viteMode <mode>` flag](en/reference/cli-reference/#--vitemode-mode) to these commands.
 
 Just create a `.env` file in the project directory and add some variables to it.
 

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -17,14 +17,14 @@ PUBLIC_ANYBODY=there
 In this example, `PUBLIC_ANYBODY` (accessible via `import.meta.env.PUBLIC_ANYBODY`) will be available in server or client code, while `SECRET_PASSWORD` (accessible via `import.meta.env.SECRET_PASSWORD`) will be server-side only.
 
 :::caution
-`.env` files are not loaded inside [configuration files](/en/guides/configuring-astro/#environment-variables). 
+`.env` files are not loaded inside [configuration files](/en/guides/configuring-astro/#environment-variables).
 :::
 
 ## Default environment variables
 
 Astro includes a few environment variables out-of-the-box:
 
-- `import.meta.env.MODE`: The mode your site is running in. This is `development` when running `astro dev` and `production` when running `astro build`.
+- `import.meta.env.MODE`: The mode your site is running in. By default, this is `development` when running `astro dev` and `production` when running `astro build`. You can override this value using `--viteMode <mode>` CLI flag.
 - `import.meta.env.PROD`: `true` if your site is running in production; `false` otherwise.
 - `import.meta.env.DEV`: `true` if your site is running in development; `false` otherwise. Always the opposite of `import.meta.env.PROD`.
 - `import.meta.env.BASE_URL`: The base url your site is being served from. This is determined by the [`base` config option](/en/reference/configuration-reference/#base).
@@ -43,7 +43,7 @@ const isDev = import.meta.env.DEV;
 ### `.env` files
 Environment variables can be loaded from `.env` files in your project directory.
 
-You can also attach a mode (either `production` or `development`) to the filename, like `.env.production` or `.env.development`, which makes the environment variables only take effect in that mode.
+You can also attach a mode to the filename, like `.env.production` or `.env.staging`, which makes the environment variables only take effect in that mode. By default, Astro loads `.env.development` when running `astro dev` and `.env.production` when running `astro build`. The mode can be configured by passing `--viteMode <mode>` flag to these commands.
 
 Just create a `.env` file in the project directory and add some variables to it.
 
@@ -95,7 +95,7 @@ When using SSR, environment variables can be accessed at runtime based on the SS
 
 ## IntelliSense for TypeScript
 
-By default, Astro provides type definition for `import.meta.env` in `astro/client.d.ts`. 
+By default, Astro provides type definition for `import.meta.env` in `astro/client.d.ts`.
 
 While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables which are prefixed with `PUBLIC_`.
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -196,11 +196,31 @@ If you started your project using [the `create astro` wizard](/en/install/auto/#
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
+<h3>Flags</h3>
+
+Use these flags to customize the behavior of the command.
+
+#### `--viteMode <mode>`
+
+It defines [mode](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config.
+
+<ReadMore>Read more about [Vite modes](https://vitejs.dev/guide/env-and-mode#modes).</ReadMore>
+
 ## `astro build`
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If [SSR is enabled](/en/guides/server-side-rendering/), this will generate the necessary server files to serve your site.
 
 Can be combined with the [common flags](#common-flags) documented below.
+
+<h3>Flags</h3>
+
+Use these flags to customize the behavior of the command.
+
+#### `--viteMode <mode>`
+
+It defines [mode](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config.
+
+<ReadMore>Read more about [Vite modes](https://vitejs.dev/guide/env-and-mode#modes).</ReadMore>
 
 ## `astro preview`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -201,8 +201,9 @@ Runs Astro's development server. This is a local HTTP server that doesn't bundle
 Use these flags to customize the behavior of the command.
 
 #### `--viteMode <mode>`
+<p><Since v="4.8.0" /></p>
 
-It defines [mode](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config.
+Configures the [`mode`](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config. Defaults to `development`.
 
 <ReadMore>Read more about [Vite modes](https://vitejs.dev/guide/env-and-mode#modes).</ReadMore>
 
@@ -217,8 +218,9 @@ Can be combined with the [common flags](#common-flags) documented below.
 Use these flags to customize the behavior of the command.
 
 #### `--viteMode <mode>`
+<p><Since v="4.8.0" /></p>
 
-It defines [mode](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config.
+Configures the [`mode`](https://vitejs.dev/config/shared-options.html#mode) property of the internal Vite config. Defaults to `production`.
 
 <ReadMore>Read more about [Vite modes](https://vitejs.dev/guide/env-and-mode#modes).</ReadMore>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
These doc changes describe a new flag for the `build` and `dev` commands and add additional information about `.env` files loading.

#### Related issues & labels (optional)

- Suggested label: merge-on-release

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: (not yet known) See astro PR [#10871](https://github.com/withastro/astro/pull/10871).

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
