### PR TITLE
Remove unnecessary character from integrations-reference.mdx

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -346,7 +346,7 @@ When publishing your package (`@fancy/dashboard`, in this case) to npm, you must
 {
   "name": "@fancy/dashboard",
   // ...
-  "exports": { "./dashboard.astro": "./dashboard.astro" }`
+  "exports": { "./dashboard.astro": "./dashboard.astro" }
 }
 ```
 


### PR DESCRIPTION
# Remove unnecessary character from `integrations-reference.mdx`

Removes an extra backtick ("\`")  character from a code snipper in `integrations-reference.mdx`