### PR TITLE
Remove obsolete warning about using `import.meta` in config files

### DIFF
--- a/src/content/docs/en/guides/configuring-astro.mdx
+++ b/src/content/docs/en/guides/configuring-astro.mdx
@@ -116,10 +116,6 @@ export default defineConfig({
 })
 ```
 
-:::note 
-Vite-specific `import.meta` properties, like `import.meta.env` or `import.meta.glob`, are _not_ accessible from your configuration file. We recommend alternatives like [dotenv](https://github.com/motdotla/dotenv) or [fast-glob](https://github.com/mrmlnc/fast-glob) for these respective use cases. In addition, [tsconfig path aliases](https://www.typescriptlang.org/tsconfig#paths) will not be resolved. Use relative paths for module imports in this file.
-:::
-
 ## Customising Output Filenames
 
 For code that Astro processes, like imported JavaScript or CSS files, you can customise output filenames using [`entryFileNames`](https://rollupjs.org/guide/en/#outputentryfilenames), [`chunkFileNames`](https://rollupjs.org/guide/en/#outputchunkfilenames), and [`assetFileNames`](https://rollupjs.org/guide/en/#outputassetfilenames) in a `vite.build.rollupOptions` entry in your `astro.config.*` file.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

The Astro config file is now loaded with Vite if Node fails to resolve it:

- https://github.com/withastro/astro/blob/5248ed1fb35bc1407660a189f23155812787f9e4/packages/astro/src/core/config/config.ts#L146
- https://github.com/withastro/astro/blob/5248ed1fb35bc1407660a189f23155812787f9e4/packages/astro/src/core/config/vite-load.ts#L40-L66

When referencing Vite-specific properties like `import.meta.env.anything` or calling `import.meta.glob(…)`, Node throws an error unless the presence of the former variables is checked e.g. via optional chaining: `import.meta.env?.anything` or `import.meta.glob?.(…)`. In the latter cases, nullishness of those values is anticipated explicitly, while the former, more common usages should be handled by Vite as the fallback mechanism triggers.

_(Previously, Vite was [only used for TS-based configs](https://github.com/withastro/astro/pull/5377/files#diff-fd8d6e4dae76cfab252a32fdf56bf4b35cbbfcefbdc9867498cd1ed956db8eb2R101-R119), but the code has changed since then.)_

#### Related issues & labels (optional)

- Suggested label: 'improve documentation'

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

#### First-time contributor to Astro Docs?

Yes.

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
