### PR TITLE
directives-reference/added-client-only-tip

### DIFF
--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -171,9 +171,13 @@ If the component is already hidden and shown by a media query in your CSS, then 
 ```
 ### `client:only`
 
-`client:only={string}` **skips** HTML server-rendering, and renders only on the client. It acts similar to `client:load` in that it loads, renders and hydrates the component immediately on page load.
+`client:only={string}` **skips** HTML server-rendering, and renders only on the client. It acts similarly to `client:load` in that it loads, renders, and hydrates the component immediately on page load.
 
 **You must pass the component's correct framework as a value!** Because Astro doesn't run the component during your build / on the server, Astro doesn't know what framework your component uses unless you tell it explicitly.
+
+:::tip 
+`client:only` is useful if you need to access certain browser APIs within your component (like `Date()`) or are facing hydration mismatch errors from your framework components.
+:::
 
 ```astro
 <SomeReactComponent client:only="react" />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Added a tip to explain a couple of common use cases for `client:only`

(also fixed a few grammatical errors I noticed nearby)

#### Related issues & labels (optional)

- Suggested label: docs

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
