### PR TITLE
specify that remote images in `.md` are not optimized.

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -491,7 +491,7 @@ Alternatively, if the CDN provides a Node.js SDK, you can use that in your proje
 
 ## Images in Markdown files
 
-Use standard Markdown `![alt](src)` syntax in your `.md` files. This syntax works with Astro's [Image Service API](/en/reference/image-service-reference/) to optimize your local images and authorized remote images.
+Use standard Markdown `![alt](src)` syntax in your `.md` files. This syntax works with Astro's [Image Service API](/en/reference/image-service-reference/) to optimize your local images stored in `src/`. Remote images and images stored in the `public/` folder are not optimized.
 
 ```md
 <!-- src/pages/post-1.md -->


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This adds an explicit note about no optimization for remote and `public/` images using the standard Markdown syntax.

#### Related issues & labels (optional)

- Closes #7539 