### PR TITLE
Remove Outdated Link from `netlify.mdx`

### DIFF
--- a/src/content/docs/en/guides/deploy/netlify.mdx
+++ b/src/content/docs/en/guides/deploy/netlify.mdx
@@ -145,6 +145,5 @@ No special configuration is required to use Netlify Functions with Astro. Add a 
 
 ## Examples
 
-- [How to deploy an Astro site](https://www.netlify.com/blog/how-to-deploy-astro/) — Netlify Blog
 - [Deploy An Astro site with Forms, Serverless Functions, and Redirects](https://www.netlify.com/blog/deploy-an-astro-site-with-forms-serverless-functions-and-redirects/) — Netlify Blog
 - [Deployment Walkthrough Video](https://youtu.be/GrSLYq6ZTes) — Netlify YouTube channel


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The link to the Netlify blog post is now outdated, as the `functions` and `edge-functions` libraries no longer exist.
