### PR TITLE
Add support for nesting and collapsing sidebar groups

### DIFF
--- a/config/sidebar.ts
+++ b/config/sidebar.ts
@@ -22,22 +22,30 @@ type StarlightSidebarConfig = NonNullable<Parameters<typeof starlight>[0]['sideb
 
 /** Generate a Starlight sidebar config object from our existing `nav.ts` files. */
 export function makeSidebar(): StarlightSidebarConfig {
+	let currentSubGroup: Extract<StarlightSidebarConfig[number], { items: any }>;
 	return navTranslations.en.reduce((sidebar, item) => {
 		if ('header' in item) {
-			sidebar.push({
+			const newGroup = {
 				label: item.text,
 				translations: getTranslations(item),
 				items: [],
-			});
-		} else {
-			const group = sidebar.at(-1);
-			if (group && 'items' in group) {
-				group.items.push({
-					label: item.text,
-					link: item.slug,
-					translations: getTranslations(item),
-				});
+				collapsed: item.collapsed,
+			};
+			if (item.nested) {
+				const parentGroup = sidebar.at(-1);
+				if (parentGroup && 'items' in parentGroup) {
+					parentGroup.items.push(newGroup);
+				}
+			} else {
+				sidebar.push(newGroup);
 			}
+			currentSubGroup = newGroup;
+		} else {
+			currentSubGroup.items.push({
+				label: item.text,
+				link: item.slug,
+				translations: getTranslations(item),
+			});
 		}
 		return sidebar;
 	}, [] as StarlightSidebarConfig);

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -4,7 +4,10 @@
  * English for any entries they haven’t translated.
  *
  * - All entries MUST include `text` and `key`
+ * - The first entry MUST be a heading
  * - Heading entries MUST include `header: true` and `type`
+ * - Heading entries MAY include `nested: true` to move that heading and following links under the previous unnested heading
+ * - Heading entries MAY include `collapsed: true` to mark it and its children as collapsed by default
  * - Link entries MUST include `slug` (which excludes the language code)
  *
  * For translators:

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -202,4 +202,29 @@ export default [
 		slug: 'community-resources/talks',
 		key: 'community-resources/talks',
 	},
-] as const;
+] satisfies NavEntry[];
+
+type NavEntry = {
+	/** The visible label for this link or heading. */
+	text: string;
+	/**
+	 * A unique key for this entry. Used in translation files to provide a translation for this entry’s label.
+	 * Often the same as `slug` for links (but doesn’t have to be).
+	 */
+	key: string;
+} & (
+	| {
+			/** The content collection slug for this page *without* the language code. */
+			slug: string;
+	  }
+	| {
+			/** Marks this entry as a group heading and starts a new group. */
+			header: true;
+			/** Whether this group is in the learn or API category (currently unused). */
+			type: 'learn' | 'api';
+			/** Whether this group should be nested inside the preceding group. */
+			nested?: boolean;
+			/** Whether this group should be collapsed by default. */
+			collapsed?: boolean;
+	  }
+);

--- a/src/i18n/translation-checkers.ts
+++ b/src/i18n/translation-checkers.ts
@@ -19,7 +19,10 @@ export type NavDict = Array<
 		key: NavDictionaryKeys;
 		labelIsTranslated: boolean;
 		isFallback?: boolean;
-	} & ({ slug: string } | { header: true; type: 'learn' | 'api' })
+	} & (
+		| { slug: string }
+		| { header: true; nested?: boolean; collapsed?: boolean; type: 'learn' | 'api' }
+	)
 >;
 
 /**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

### Description (required)

Updates our utility function mapping our `nav.ts` files to Starlight’s sidebar config shape to support nesting and collapsing groups.

#### Syntax

- Nesting/collapsing is controlled from `src/i18n/en/nav.ts`. Other languages continue to work the same way, providing just the key–value mapping of translations.

- Each heading (entries with `header: true`) can be marked as a nested group by adding `nested: true`.

- Each heading (entries with `header: true`) can be marked as collapsed by default by adding `collapsed: true`.

- I took a few shortcuts to keep this simple, which means nested groups have to be at the end of their containing group, i.e. the following is possible:

   ```
   Parent group     ▼
   |   Link 1
   |   Link 2
   |
   |   Sub group    ▼
   |   |   Link 3
   |   |   Link 4
   |
   |   Other group  ▼
   |   |   Link 5
   |
   Other group      ▼
   |   Link 6
   ```
   
   But this is not:
   
   ```
   Parent group     ▼
   |   Link 1
   |   Link 2
   |
   |   Sub group    ▼
   |   |   Link 3
   |   |   Link 4
   |
   |   Link 5
   |   Link 6
   |
   Other group      ▼
   |   Link 7
   ```
   
   Based on what I’ve seen so far, that seemed to align with intended usage, but let me know if it’s not!