### PR TITLE
Update main CTA text in landing page

### DIFF
--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -12,7 +12,7 @@ hero:
   title: Astro Docs
   tagline: Guides, resources, and API references to help you build with Astro.
   actions:
-    - text: Get started
+    - text: Install Astro
       icon: rocket
       link: /en/install/auto/
       variant: primary


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the main call-to-action link text in the docs landing page.

The current link reads “Get started”, but that is the same text as the CTA on https://astro.build/ which means users can be presented by two consecutive “Get started” choices.

The new link text is “Install Astro”, which is also a more precise description of the link destination as it points to the install guide.
