### PR TITLE
docker.mdx: use `--omit=dev` for npm over deprecated `--production`

### DIFF
--- a/src/content/docs/en/recipes/docker.mdx
+++ b/src/content/docs/en/recipes/docker.mdx
@@ -148,10 +148,10 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 FROM base AS prod-deps
-RUN npm install --production
+RUN npm install --omit=dev
 
 FROM base AS build-deps
-RUN npm install --production=false
+RUN npm install
 
 FROM build-deps AS build
 COPY . .


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This fixes npm warnings that I get using the current suggested Dockerfile, see warnings:

```
[linux/arm64 build-deps 1/1] 
RUN npm install --production=false
npm WARN config production Use `--omit=dev` instead.
RUN npm install --production
npm WARN config production Use `--omit=dev` instead.
```


#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
