### PR TITLE
Add missing flags for the `astro check` command

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -244,7 +244,7 @@ For example, running `astro check --minimumFailingSeverity warning` will cause t
 
 Specifies the minimum severity to output. Defaults to `hint`.
 
-For example, running `astro check --minimumFailingSeverity warning` will show errors and warning, but not hints.
+For example, running `astro check --minimumSeverity warning` will show errors and warning, but not hints.
 
 #### `--preserveWatchOutput`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -252,7 +252,9 @@ For example, choosing `warning` will show errors and warnings, but not hints.
 
 #### `--preserveWatchOutput`
 
-If provided, the output will not be cleared between checks when in watch mode.
+Default: `false`
+
+If set to false, the output will not be cleared between checks when in watch mode.
 
 <ReadMore>Read more about [type checking in Astro](/en/guides/typescript/#type-checking).</ReadMore>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -226,6 +226,34 @@ Use these flags to customize the behavior of the command.
 
 The command will watch for any changes in your project, and will report any errors.
 
+#### `--root <path-to-dir>`
+
+Specify a different root directory to check. Uses the current working directory by default.
+
+#### `--tsconfig <path-to-file>`
+
+Specify a `tsconfig.json` or `jsconfig.json` file to use manually. If not provided, Astro will attempt to find a config, or infer the project's config automatically.
+
+#### `--minimumFailingSeverity <error|warning|hint>`
+
+Default: `error`
+
+Minimum severity needed to exit with an error code.
+
+For example, chooisng `warning` will cause the command to exit with an error if any warnings are detected.
+
+#### `--minimumSeverity <error|warning|hint>`
+
+Default: `hint`
+
+Minimum severity to output.
+
+For example, choosing `warning` will show errors and warnings, but not hints.
+
+#### `--preserveWatchOutput`
+
+If provided, the output will not be cleared between checks when in watch mode.
+
 <ReadMore>Read more about [type checking in Astro](/en/guides/typescript/#type-checking).</ReadMore>
 
 ## `astro sync`

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -228,33 +228,27 @@ The command will watch for any changes in your project, and will report any erro
 
 #### `--root <path-to-dir>`
 
-Specify a different root directory to check. Uses the current working directory by default.
+Specifies a different root directory to check. Uses the current working directory by default.
 
 #### `--tsconfig <path-to-file>`
 
-Specify a `tsconfig.json` or `jsconfig.json` file to use manually. If not provided, Astro will attempt to find a config, or infer the project's config automatically.
+Specifies a `tsconfig.json` or `jsconfig.json` file to use manually. If not provided, Astro will attempt to find a config, or infer the project's config automatically.
 
 #### `--minimumFailingSeverity <error|warning|hint>`
 
-Default: `error`
+Specifies the minimum severity needed to exit with an error code. Defaults to `error`.
 
-Minimum severity needed to exit with an error code.
-
-For example, chooisng `warning` will cause the command to exit with an error if any warnings are detected.
+For example, running `astro check --minimumFailingSeverity warning` will cause the command to exit with an error if any warnings are detected.
 
 #### `--minimumSeverity <error|warning|hint>`
 
-Default: `hint`
+Specifies the minimum severity to output. Defaults to `hint`.
 
-Minimum severity to output.
-
-For example, choosing `warning` will show errors and warnings, but not hints.
+For example, running `astro check --minimumFailingSeverity warning` will show errors and warning, but not hints.
 
 #### `--preserveWatchOutput`
 
-Default: `false`
-
-If set to false, the output will not be cleared between checks when in watch mode.
+Specifies not to clear the ouput between checks when in watch mode.
 
 <ReadMore>Read more about [type checking in Astro](/en/guides/typescript/#type-checking).</ReadMore>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Added the flags that are missing from the current documentation for the `astro check` cli command
Currently, only the `--watch` flag is documented, however there are several other options available for the command (`--minimumSeverity` or `--preserveWatchOutput` for example)
<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #7542 
