### PR TITLE
Update `shikiConfig.experimentalThemes` -> `shikiConfig.themes`

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -599,7 +599,7 @@ export default defineConfig({
       theme: 'dracula',
       // Alternatively, provide multiple themes
       // See note below for using dual light/dark themes
-      experimentalThemes: {
+      themes: {
         light: 'github-light',
         dark: 'github-dark',
       },


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
It appears that [Astro 4.5](https://github.com/withastro/astro/releases?q=4.5&expanded=true) stabilized dual theme support for Shiki and updated this property name. `experimentalThemes` did not work for me with `astro@4.8.0`.
