### PR TITLE
A typo in the code sample 4.mdx

### DIFF
--- a/src/content/docs/ru/tutorial/5-astro-api/4.mdx
+++ b/src/content/docs/ru/tutorial/5-astro-api/4.mdx
@@ -80,7 +80,7 @@ Astro предоставляет специальный пакет для быс
 
     import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 
-    export async function get() {
+    export async function GET() {
       return rss({
         title: 'Ученик Astro | Блог',
         description: 'Мое путешествие по изучению Astro',


### PR DESCRIPTION
A typo in the get code example - because of this I get the error "No API Route handler exists for the method "GET" for the route "/rss.xml". Found handlers: "Get" When building xml is not created. When editing from get to GET everything works.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
