### PR TITLE
Update required Node version on Build a Blog tutorial page

### DIFF
--- a/src/content/docs/en/tutorial/1-setup/1.mdx
+++ b/src/content/docs/en/tutorial/1-setup/1.mdx
@@ -28,7 +28,7 @@ You can access the command line through a local terminal program for your operat
 
 ### Node.js
 
-For Astro to run on your system, you will also need to have [**Node.js**](https://nodejs.org/en/) installed, version `v18.14.1` or later.
+For Astro to run on your system, you will also need to have [**Node.js**](https://nodejs.org/en/) installed, version `v18.17.1` or `v20.3.0` or later. (`v19` is not supported.)
 
 To check to see whether you already have a compatible version installed, run the following command in your terminal:
 
@@ -36,12 +36,12 @@ To check to see whether you already have a compatible version installed, run the
 node -v
 
 // Example output
-v18.14.1
+v18.17.1
 ```
 
-If the command returns a version number higher than `v18.14.1`, you're good to go!
+If the command returns a version number higher than `v18.17.1` or `v20.3.0` (excluding any `v19`), you're good to go!
 
-If the command returns an error message like `Command 'node' not found`, or a version number lower than `v18.14.1`, then you need to [install a compatible Node.js version](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+If the command returns an error message like `Command 'node' not found`, or a version number lower than the required, then you need to [install a compatible Node.js version](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
 ### Code Editor
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I updated the required Node version on the **Build a Blog** tutorial page to be in accordance with the [**Installation** docs page](https://docs.astro.build/en/install/auto/).

I checked the changelogs and noticed [the minor change in 4.6.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#minor-changes-2) which seems to support this change (even though it has a little typo: `v20.0.3` should be `v20.3.0`).

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!
<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
