### PR TITLE
i18n(es): add `prerender-client-address-not-available`

### DIFF
--- a/src/content/docs/es/reference/errors/prerender-client-address-not-available.mdx
+++ b/src/content/docs/es/reference/errors/prerender-client-address-not-available.mdx
@@ -1,0 +1,18 @@
+---
+title: Astro.clientAddress cannot be used inside prerendered routes.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+
+> **PrerenderClientAddressNotAvailable**: `Astro.clientAddress` no se puede usar dentro de rutas prerrenderizadas
+
+## ¿Qué salió mal?
+La propiedad `Astro.clientAddress` no se puede usar dentro de rutas prerrenderizadas.
+
+**Ver también:**
+-  [Optando por la prerrenderización](/es/guides/server-side-rendering/#optando-por-la-pre-renderización-en-el-modo-server)
+-  [Astro.clientAddress](/es/reference/api-reference/#astroclientaddress)
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translates error page `prerender-client-address-not-available`<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes # N/A<!-- Add an issue number if this PR will close it. -->
- Suggested label: i18n <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
