### PR TITLE
i18n(es): add `route-not-found`

### DIFF
--- a/src/content/docs/es/reference/errors/route-not-found.mdx
+++ b/src/content/docs/es/reference/errors/route-not-found.mdx
@@ -11,5 +11,3 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 ## ¿Qué salió mal?
 Astro no pudo encontrar una ruta que coincida con la proporcionada por el usuario
 
-
-

--- a/src/content/docs/es/reference/errors/route-not-found.mdx
+++ b/src/content/docs/es/reference/errors/route-not-found.mdx
@@ -1,0 +1,15 @@
+---
+title: Route not found.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+
+> **RouteNotFound**: Astro no pudo encontrar una ruta que coincida con la solicitada.
+
+## ¿Qué salió mal?
+Astro no pudo encontrar una ruta que coincida con la proporcionada por el usuario
+
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translates error page `route-not-found`<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes # N/A<!-- Add an issue number if this PR will close it. -->
- Suggested label: i18n <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
