### PR TITLE
Added Lit with decorators usage example

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -138,7 +138,7 @@ If you want use Lit with TypeScript, add the following to your `tsconfig.json` f
 }
 ```
 
-Then you can write a Lit component like this:
+This allows you to use [Lit's experimental decorators](https://lit.dev/docs/components/decorators/) in your Lit component:
 
 ```ts title="src/components/my-element.ts"
 import { LitElement, html } from "lit";

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -128,7 +128,7 @@ Lit requires browser globals such as `HTMLElement` and `customElements` to be pr
 
 ### Experimental Decorators
 
-To use [experimental decorators in Lit](https://lit.dev/docs/components/decorators/) , add the following to your `tsconfig.json` file:
+To use [experimental decorators in Lit](https://lit.dev/docs/components/decorators/), add the following to your `tsconfig.json` file:
 
 ```json title="tsconfig.json" add={3}
 {

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -126,6 +126,34 @@ import { MyElement } from '../components/my-element.js';
 Lit requires browser globals such as `HTMLElement` and `customElements` to be present. For this reason the Lit renderer shims the server with these globals so Lit can run. You *might* run into libraries that work incorrectly because of this.
 :::
 
+### Use TypeScript
+
+If you want use Lit with TypeScript, add the following to your `tsconfig.json` file:
+
+```json title="tsconfig.json" add={3}
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+  }
+}
+```
+
+Then you can write a Lit component like this:
+
+```ts title="src/components/my-element.ts"
+import { LitElement, html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+@customElement("my-element")
+export class MyElement extends LitElement {
+    @state() name = "my-element";
+
+    override render() {
+        return html`<p>Hello world! From ${this.name}</p>`;
+    }
+}
+```
+
 ### Polyfills & Hydration
 
 The renderer automatically handles adding appropriate polyfills for support in browsers that don't have Declarative Shadow DOM. The polyfill is about *1.5kB*. If the browser does support Declarative Shadow DOM then less than 250 bytes are loaded (to feature detect support).

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -128,7 +128,7 @@ Lit requires browser globals such as `HTMLElement` and `customElements` to be pr
 
 ### Experimental Decorators
 
-If you want use Lit with TypeScript, add the following to your `tsconfig.json` file:
+To use experimental decorators in Lit,, add the following to your `tsconfig.json` file:
 
 ```json title="tsconfig.json" add={3}
 {

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -128,7 +128,7 @@ Lit requires browser globals such as `HTMLElement` and `customElements` to be pr
 
 ### Experimental Decorators
 
-To use experimental decorators in Lit,, add the following to your `tsconfig.json` file:
+To use [experimental decorators in Lit](https://lit.dev/docs/components/decorators/) , add the following to your `tsconfig.json` file:
 
 ```json title="tsconfig.json" add={3}
 {
@@ -138,7 +138,7 @@ To use experimental decorators in Lit,, add the following to your `tsconfig.json
 }
 ```
 
-This allows you to use [Lit's experimental decorators](https://lit.dev/docs/components/decorators/) in your Lit component:
+This allows you to use experimental decorators such as `@customElement` and `@state` to register a custom element and define a state property in your Lit component:
 
 ```ts title="src/components/my-element.ts"
 import { LitElement, html } from "lit";

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -126,7 +126,7 @@ import { MyElement } from '../components/my-element.js';
 Lit requires browser globals such as `HTMLElement` and `customElements` to be present. For this reason the Lit renderer shims the server with these globals so Lit can run. You *might* run into libraries that work incorrectly because of this.
 :::
 
-### Use TypeScript
+### Experimental Decorators
 
 If you want use Lit with TypeScript, add the following to your `tsconfig.json` file:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Added Lit with TypeScript usage example

When you want use TypeScript decorators in Lit component, need to enable `experimentalDecorators` in `tsconfig.json`

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
