### PR TITLE
feat:  i18n domains

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -179,6 +179,61 @@ Setting `prefixDefaultLocale: true` will also automatically set `redirectToDefau
 You can opt out of this behavior by [setting `redirectToDefaultLocale: false`](/en/reference/configuration-reference/#i18nroutingredirecttodefaultlocale). This allows you to have a site home page that exists outside of your configured locale folder structure.
 
 
+## `domains`
+
+<p><Since v="4.9.0" /></p>
+
+This routing option allows you to customize your domains on a per-language basis for `server` rendered projects using the [`@astrojs/node`](/en/guides/integrations-guide/node/) or [`@astrojs/vercel`](/en/guides/integrations-guide/vercel/) adapter with a `site` configured.
+
+To enable this in your project, [configure i18n routing](#configure-i18n-routing) with your preferences if you have not already done so. Then, set the `experimental.i18nDomains` flag to `true` and add `i18n.domains` to map any of your supported `locales` to custom URLs:
+
+```js title="astro.config.mjs" {3-7} ins={14-21}
+import { defineConfig } from "astro/config"
+export default defineConfig({
+  site: "https://example.com",
+  output: "server", // required, with no prerendered pages
+  adapter: node({
+    mode: 'standalone',
+  }),
+  i18n: {
+    defaultLocale: "en",
+    locales: ["es", "en", "fr", "ja"],
+    routing: {
+      prefixDefaultLocale: false
+    },
+    domains: {
+        fr: "https://fr.example.com",
+        es: "https://example.es"
+    }
+  }
+})
+```
+
+All non-mapped `locales` will follow your `prefixDefaultLocales` configuration. However, even if this value is `false`, page files for your `defaultLocale` must also exist within a localized folder. For the configuration above, an `/en/` folder is required.
+
+With the above configuration:
+
+- The file `/fr/about.astro` will create the URL `https://fr.example.com/about`.
+- The file `/es/about.astro` will create the URL `https://example.es/about`.
+- The file `/ja/about.astro` will create the URL `https://example.com/ja/about`.
+- The file `/en/about.astro` will create the URL `https://example.com/about`.
+
+The above URLs will also be returned by the `getAbsoluteLocaleUrl()` and `getAbsoluteLocaleUrlList()` functions.
+
+#### Limitations
+
+This feature has some restrictions:
+- The `site` option is mandatory.
+- The `output` option must be set to `"server"`.
+- There cannot be any individual prerendered pages.
+- The adapter feature [`functionPerRoute`](/en/reference/adapter-reference/#functionperroute) is not supported.
+
+Astro relies on the following headers in order to support the feature:
+- [`X-Forwarded-Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) and [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host). Astro will use the former, and if not present, will try the latter.
+- [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) and [`URL#protocol`](https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol) of the server request.
+
+Make sure that your server proxy/hosting platform is able to provide this information. Failing to retrieve these headers will result in a 404 (status code) page.
+
 ### `manual`
 
 <p><Since v="4.6.0" /></p>
@@ -307,64 +362,6 @@ export default defineConfig({
 ```
 
 Astro will ensure that a page is built in `src/pages/fr` for every page that exists in `src/pages/es/`. If the page does not already exist, then a page with a redirect to the corresponding `es` route will be created.
-
-## `domains` (experimental)
-
-<p><Since v="4.3.0" /></p>
-
-This routing option allows you to customize your domains on a per-language basis for `server` rendered projects using the [`@astrojs/node`](/en/guides/integrations-guide/node/) or [`@astrojs/vercel`](/en/guides/integrations-guide/vercel/) adapter with a `site` configured.
-
-To enable this in your project, [configure i18n routing](#configure-i18n-routing) with your preferences if you have not already done so. Then, set the `experimental.i18nDomains` flag to `true` and add `i18n.domains` to map any of your supported `locales` to custom URLs:
-
-```js title="astro.config.mjs" {3-7} ins={14-21}
-import { defineConfig } from "astro/config"
-export default defineConfig({
-  site: "https://example.com",
-  output: "server", // required, with no prerendered pages
-  adapter: node({
-    mode: 'standalone',
-  }),
-  i18n: {
-    defaultLocale: "en",
-    locales: ["es", "en", "fr", "ja"],
-    routing: {
-      prefixDefaultLocale: false
-    },
-    domains: {
-        fr: "https://fr.example.com",
-        es: "https://example.es"
-    }
-  },
-  experimental: {
-    i18nDomains: true
-  }
-})
-```
-
-All non-mapped `locales` will follow your `prefixDefaultLocales` configuration. However, even if this value is `false`, page files for your `defaultLocale` must also exist within a localized folder. For the configuration above, an `/en/` folder is required.
-
-With the above configuration: 
-
-- The file `/fr/about.astro` will create the URL `https://fr.example.com/about`.
-- The file `/es/about.astro` will create the URL `https://example.es/about`.
-- The file `/ja/about.astro` will create the URL `https://example.com/ja/about`.
-- The file `/en/about.astro` will create the URL `https://example.com/about`.
-
-The above URLs will also be returned by the `getAbsoluteLocaleUrl()` and `getAbsoluteLocaleUrlList()` functions.
-
-#### Limitations
-
-This feature has some restrictions:
-- The `site` option is mandatory.
-- The `output` option must be set to `"server"`.
-- There cannot be any individual prerendered pages.
-- The adapter feature [`functionPerRoute`](/en/reference/adapter-reference/#functionperroute) is not supported.
-
-Astro relies on the following headers in order to support the feature:
-- [`X-Forwarded-Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) and [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host). Astro will use the former, and if not present, will try the latter.
-- [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) and [`URL#protocol`](https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol) of the server request.
-
-Make sure that your server proxy/hosting platform is able to provide this information. Failing to retrieve these headers will result in a 404 (status code) page.
 
 [`site`]: /en/reference/configuration-reference/#site
 [`i18n.locales`]: /en/reference/configuration-reference/#i18nlocales


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR makes `domains` stable, and moves the section before the `manual` routing.

#### For Astro version: `4.9.0`. See astro PR [#11022](https://github.com/withastro/astro/pull/11022).
