### PR TITLE
fix minor detail in tutorial 3

### DIFF
--- a/src/content/docs/en/tutorial/3-components/1.mdx
+++ b/src/content/docs/en/tutorial/3-components/1.mdx
@@ -52,9 +52,12 @@ To hold `.astro` files that will generate HTML but that will not become new page
 <Steps>
 1. Go back to `index.astro` and import your new component inside the code fence:
 
-    ```astro title="src/pages/index.astro"
+    ```astro title="src/pages/index.astro" ins={2}
     ---
     import Navigation from '../components/Navigation.astro';
+    import "../styles/global.css";
+
+    const pageTitle = "Home Page";
     ---
     ```
 


### PR DESCRIPTION
#### Description (required)

The code wasn't referencing the previous state of `index.astro` from tutorial 2.
