### PR TITLE
update:  vite resolve guide for path aliases

### DIFF
--- a/src/content/docs/en/guides/aliases.mdx
+++ b/src/content/docs/en/guides/aliases.mdx
@@ -56,7 +56,7 @@ This is not an `astro` related issue. However, since we rely on `vite` to produc
 
 To resolve this issue, add the following fields to your Astro configuration:
 
-```mjs title="astro.config.mjs" ins={1} ins={4-13}
+```ts title="astro.config.mjs" ins={1} ins={4-13}
 import { path } from 'path'
 
 export default defineConfig({
@@ -71,5 +71,3 @@ export default defineConfig({
     }
   }
 })
-
-

--- a/src/content/docs/en/guides/aliases.mdx
+++ b/src/content/docs/en/guides/aliases.mdx
@@ -46,29 +46,30 @@ import logoUrl from '@assets/logo.png?url';
 
 These aliases are also integrated automatically into [VS Code](https://code.visualstudio.com/docs/languages/jsconfig) and other editors.
 
-### Integrating with deployment services
+### Integrating with Deployment Services
 
-When using path aliases, it is likely, that your deployment __will not work__ out of the box when using `paths` aliases without further configuration.
+When using path aliases, it is likely that your deployment __will not work__ out of the box without further configuration.
 
 :::note
-This is not an `astro` related issue. However, we rely on `vite`, to produce builds of your websites, which requires further configuration to support aliases. For further reading, please check the `vite`'s [alias resolution](https://vitejs.dev/config/shared-options#resolve-alias) configuration.
+This is not an `astro` related issue. However, since we rely on `vite` to produce builds of your websites, further configuration is needed to support aliases. For more details, please check `vite`'s [alias resolution](https://vitejs.dev/config/shared-options#resolve-alias) configuration.
 :::
 
-In order to resolve this issue, we'll need to add the following fields to our astro configuration
+To resolve this issue, add the following fields to your Astro configuration:
 
-```mjs
+```mjs title="astro.config.mjs" ins={1} ins={4-13}
 import { path } from 'path'
 
 export default defineConfig({
   vite: {
     resolve: {
       alias: {
-        // your aliases should mirror the ones defined in your tsconfig.json - following the example above
+        // Your aliases should mirror the ones defined in your tsconfig.json
+        // mirroring the structure defined above, it would look like: 
         "@components": path.resolve(path.dirname(''), './src/components'),
-        "@assets": path.resolve(path.dirname(''), './src/assets')
+        "@assets": path.resolve(path.dirname(''), './src/assets'),
       }
     }
   }
 })
-```
+
 

--- a/src/content/docs/en/guides/aliases.mdx
+++ b/src/content/docs/en/guides/aliases.mdx
@@ -45,3 +45,30 @@ import logoUrl from '@assets/logo.png?url';
 ```
 
 These aliases are also integrated automatically into [VS Code](https://code.visualstudio.com/docs/languages/jsconfig) and other editors.
+
+### Integrating with deployment services
+
+When using path aliases, it is likely, that your deployment __will not work__ out of the box when using `paths` aliases without further configuration.
+
+:::note
+This is not an `astro` related issue. However, we rely on `vite`, to produce builds of your websites, which requires further configuration to support aliases. For further reading, please check the `vite`'s [alias resolution](https://vitejs.dev/config/shared-options#resolve-alias) configuration.
+:::
+
+In order to resolve this issue, we'll need to add the following fields to our astro configuration
+
+```mjs
+import { path } from 'path'
+
+export default defineConfig({
+  vite: {
+    resolve: {
+      alias: {
+        // your aliases should mirror the ones defined in your tsconfig.json - following the example above
+        "@components": path.resolve(path.dirname(''), './src/components'),
+        "@assets": path.resolve(path.dirname(''), './src/assets')
+      }
+    }
+  }
+})
+```
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Adds information on how to configure astro with vite in order to prevent failing builds when using path aliases.

This was caused by `vite` requiring a speicifc `resolve.alias` configuration, which was not mentioned anywhere in the docs. Furthermore it's super confusing for everyday users, since the build does work locally and only fails in deployment environments (i.e. vecel or render)

#### Implementation details

I've noticed that `__dirname` is not defined in `astro.config.mjs` so I've resorted to using `path.dirname('')` since it's bound to work at all config types.

I'd also like to note that defining own `vite.config.ts` does not work _(burnt me when trying to resolve the issue)_ as you need to include the vite value in the astro config itself. But I've decided not to mention this in the docs.

#### Final thoughts

In an ideal scenario, when using `npx/bunx astro add vercel/or-any-other-deployment-service` there could be a codemod which modifies the astro config for values set in tsconfig.json, as we can infer from the values in `tsconfig.json`. But  then it kind of obfuscates that you need to update these values in both places, so I'm kind of torn on this _(ideal scenario is imho to have both docs warning people like this and codemode do the rest for them on install / update)_

___

pr meta:

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes <!-- Add an issue number if this PR will close it. --> https://github.com/withastro/astro/issues/11090
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->`docs pr`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs?
yes

#### If you are a member of the Astro Discord, please add your username in the description so we can welcome you there!
`@hulla`

<!-- https://astro.build/chat -->
