### PR TITLE
content-collections: Add example to render list of contents

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -476,7 +476,7 @@ const { Content, headings } = await entry.render();
 
 Sometimes, you don't just want to [render one Content to HTML](#rendering-content-to-html) but a list of contents, like on the index page of a blog.
 
-```astro {5}
+```astro
 ---
 // src/pages/render-list-example.astro
 import { getCollection } from 'astro:content';

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -458,7 +458,7 @@ const { post } = Astro.props;
 
 ### Rendering content to HTML
 
-Sometimes, you don't just want to [render one Content to HTML](#rendering-content-to-html) but a list of contents, like on the index page of a blog.
+Once queried, you can render Markdown and MDX entries to HTML using the entry `render()` function property. Calling this function gives you access to rendered content and metadata, including both a `<Content />` component and a list of all rendered headings.
 
 ```astro {5}
 ---
@@ -474,7 +474,7 @@ const { Content, headings } = await entry.render();
 
 ### Render a list of contents
 
-Once queried, you can render Markdown and MDX entries to HTML using the entry `render()` function property. Calling this function gives you access to rendered content and metadata, including both a `<Content />` component and a list of all rendered headings.
+Sometimes, you don't just want to [render one Content to HTML](#rendering-content-to-html) but a list of contents, like on the index page of a blog.
 
 ```astro {5}
 ---

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -458,7 +458,7 @@ const { post } = Astro.props;
 
 ### Rendering content to HTML
 
-Once queried, you can render Markdown and MDX entries to HTML using the entry `render()` function property. Calling this function gives you access to rendered content and metadata, including both a `<Content />` component and a list of all rendered headings.
+Sometimes, you don't just want to [render one Content to HTML](#rendering-content-to-html) but a list of contents, like on the index page of a blog.
 
 ```astro {5}
 ---
@@ -469,6 +469,34 @@ const { Content, headings } = await entry.render();
 ---
 <p>Published on: {entry.data.published.toDateString()}</p>
 <Content />
+```
+
+
+### Render a list of contents
+
+Once queried, you can render Markdown and MDX entries to HTML using the entry `render()` function property. Calling this function gives you access to rendered content and metadata, including both a `<Content />` component and a list of all rendered headings.
+
+```astro {5}
+---
+// src/pages/render-list-example.astro
+import { getCollection } from 'astro:content';
+const blogpostsCollection = await getCollection('blog')
+const blogposts = []
+for (const blogpost of blogpostsCollection) {
+  const { Content } = await blogpost.render()
+  blogposts.push({
+    slug: blogpost.slug,
+    title: blogpost.data.title,
+    Content: Content,
+  })
+}
+---
+<h1>Blogposts ({blogposts.length})</h1>
+{
+  blogposts.map(({ slug, title, Content }) => (
+    <article><Content /></article>
+  ))
+}
 ```
 
 


### PR DESCRIPTION
#### Description (required)

I was looking all over for an example on how to use the `render()` function to render a list of blog posts like on any old WordPress index page.

It turns out, one can just pass the `Content` component in a custom object and render this as `<Content/>` just like always.

I think it would be great to mention this somewhere. I cannot be the only one searching for this? :-D.

Please feel free to change this PR as you see fit.


**=> [This is the section in the preview](https://docs-git-fork-tordans-patch-4-astrodotbuild.vercel.app/en/guides/content-collections/#render-a-list-of-contents)**


#### Related issues & labels (optional)

./.