### PR TITLE
Update api-reference.mdx

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -385,6 +385,11 @@ if (!isLoggedIn(cookie)) {
 ---
 ```
 
+:::note
+`Astro.redirect()` accepts an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) as an optional second parameter. The default is 302.
+:::
+
+
 ### `Astro.canonicalURL`
 
 :::caution[Deprecated]

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -369,8 +369,12 @@ If true, the cookie is only set on https sites.
 Allows customizing how the cookie is serialized.
 
 ### `Astro.redirect()`
-`Astro.redirect()` allows you to redirect to another page. 
+
+Allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) as a second parameter.
+
 A page (and not a child component) must `return` the result of `Astro.redirect()` for the redirect to occur.
+
+The following example redirects a user to a login page, using the default HTTP response status code 302:
 
 ```astro title="src/pages/account.astro" {8}
 ---
@@ -384,11 +388,6 @@ if (!isLoggedIn(cookie)) {
 }
 ---
 ```
-
-:::note
-`Astro.redirect()` accepts an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) as an optional second parameter. The default is 302.
-:::
-
 
 ### `Astro.canonicalURL`
 


### PR DESCRIPTION
The description for Astro.redirect() makes no mention of the optional second parameter, so I added a "note" about it.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The description for Astro.redirect() makes no mention of the optional second parameter, so I propose adding a "note" that it accepts an optional HTTP Status Code (linked it to MDN), and that the default is 302.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
