### PR TITLE
Fix content collection Date string example

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -605,7 +605,7 @@ To render only the `YYYY-MM-DD` from the full UTC timestamp, use the JavaScript 
 const { frontmatter } = Astro.props;
 ---
 <h1>{frontmatter.title}</h1>
-<p>{frontmatter.pubDate.toString().slice(0,10)}</p>
+<p>{frontmatter.pubDate.toISOString().slice(0,10)}</p>
 ```
 To see an example of using `toLocaleDateString` to format the day, month, and year instead, see the [`<FormattedDate />` component](https://github.com/withastro/astro/blob/latest/examples/blog/src/components/FormattedDate.astro) in the official Astro blog template. 
 


### PR DESCRIPTION
the given method of "slicing" out the date part of a Date.toString() did give me some "Mon May 25" and not the expected 2024-05-25 I wanted.

Using the Date.toISOString() solved this for me.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
See introductional description. It's simple as that.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
