### PR TITLE
Minor: fix wrong cache file name in zerops.yml script

### DIFF
--- a/src/content/docs/en/guides/deploy/zerops.mdx
+++ b/src/content/docs/en/guides/deploy/zerops.mdx
@@ -98,7 +98,7 @@ The following example shows configuring the required build and run operations fo
               - node_modules
             cache:
               - node_modules
-              - pnpm-lock.json
+              - pnpm-lock.yaml
           run:
             start: node dist/server/entry.mjs
           envVariables:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- It's supposed to be `pnpm-lock.yaml`, not `pnpm-lock.json`

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
