### PR TITLE
Be more explicit about cookie deletion

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -238,7 +238,7 @@ Sets the cookie `key` to the given value. This will attempt to convert the cooki
 **Type:** `(key: string, options?: CookieDeleteOptions) => void`
 </p>
 
-Marks the cookie as deleted. Once a cookie is deleted `Astro.cookies.has()` will return `false` and `Astro.cookies.get()` will return an [`AstroCookie`](#astrocookie) with a `value` of `undefined`. Options available when deleting a cookie are: `domain`, `path`, `httpOnly`, `sameSite`, and `secure`.
+Marks the cookie as deleted by setting the expiration date to 0 in Unix time. Once a cookie is deleted `Astro.cookies.has()` will return `false` and `Astro.cookies.get()` will return an [`AstroCookie`](#astrocookie) with a `value` of `undefined`. Options available when deleting a cookie are: `domain`, `path`, `httpOnly`, `sameSite`, and `secure`.
 
 ##### `headers`
 


### PR DESCRIPTION
#### Description (required)

Whilst the word "delete" feels intuitive in the Astro.cookies API, it hides the fact when "deleting" a cookie, you're invalidating it by setting an expiry date in the past. It might be helpful to developers to call this out (it would have been _really_ helpful to me when using this API 😅). I'm not sure of the correct wording so feel free to update or deem it unnecessary.
