### PR TITLE
i18n(ko-KR): update `error-reference.mdx`

### DIFF
--- a/src/content/docs/ko/reference/error-reference.mdx
+++ b/src/content/docs/ko/reference/error-reference.mdx
@@ -75,6 +75,7 @@ import DontEditWarning from '~/components/DontEditWarning.astro'
 - [**CantRenderPage**](/ko/reference/errors/cant-render-page/)<br/>Astro가 경로를 렌더링할 수 없습니다.
 - [**UnhandledRejection**](/ko/reference/errors/unhandled-rejection/)<br/>처리될 수 없는 오류가 발생했습니다.
 - [**i18nNotEnabled**](/ko/reference/errors/i18n-not-enabled/)<br/>i18n이 활성화되지 않았습니다.
+- [**i18nNoLocaleFoundInPath**](/ko/reference/errors/i18n-no-locale-found-in-path/)<br/>경로에 로케일이 포함되어 있지 않습니다.
 - [**RouteNotFound**](/ko/reference/errors/route-not-found/)<br/>경로를 찾을 수 없습니다.
 - [**EnvInvalidVariables**](/ko/reference/errors/env-invalid-variables/)<br/>잘못된 환경 변수
 - [**EnvInvalidVariable**](/ko/reference/errors/env-invalid-variable/)<br/>잘못된 환경 변수

--- a/src/content/docs/ko/reference/errors/i18n-no-locale-found-in-path.mdx
+++ b/src/content/docs/ko/reference/errors/i18n-no-locale-found-in-path.mdx
@@ -1,0 +1,13 @@
+---
+title: The path doesn't contain any locale
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **i18nNoLocaleFoundInPath**: You tried to use an i18n utility on a path that doesn't contain any locale. You can use `pathHasLocale` first to determine if the path has a locale.
+
+## 무엇이 잘못되었나요?
+i18n 유틸리티가 로케일을 포함하지 않는 URL 경로에서 로케일을 사용하려고 했습니다. i18n 유틸리티를 사용하기 전에 pathHasLocale을 사용하여 먼저 로케일에 대한 URL을 확인하면 이 오류를 방지할 수 있습니다.
+
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- update `error-reference.mdx`
- add `i18n-no-locale-found-in-path.mdx`
- #8477

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
