### PR TITLE
fix code block for consistency

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -89,8 +89,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
 2. Filter your list of posts to only include posts that contain the page's own tag.
 
-    ```astro title="/src/pages/tags/[tag].astro" ins={4}
-    ---
+    ```astro title="src/pages/tags/[tag].astro" ins={3}
     const { tag } = Astro.params;
     const { posts } = Astro.props;
     const filteredPosts = posts.filter((post) => post.frontmatter.tags?.includes(tag));

--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -89,7 +89,8 @@ You can create entire sets of pages dynamically using `.astro` files that export
 
 2. Filter your list of posts to only include posts that contain the page's own tag.
 
-    ```astro title="src/pages/tags/[tag].astro" ins={3}
+    ```astro title="src/pages/tags/[tag].astro" ins={4}
+    ---
     const { tag } = Astro.params;
     const { posts } = Astro.props;
     const filteredPosts = posts.filter((post) => post.frontmatter.tags?.includes(tag));


### PR DESCRIPTION
#### Description (required)
**Typo**
inconsistent backslash in title of code-block removed
dashes removed for YAML, since there is content "above"
