### PR TITLE
[install-and-setup] reorg page content

### DIFF
--- a/src/content/docs/en/install-and-setup.mdx
+++ b/src/content/docs/en/install-and-setup.mdx
@@ -22,9 +22,7 @@ Prefer to try Astro in your browser? Visit [astro.new](https://astro.new/) to br
 - **Text editor** - We recommend [VS Code](https://code.visualstudio.com/) with our [Official Astro extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode).
 - **Terminal** - Astro is accessed through its command-line interface (CLI).
 
-
 ## Start a new project 
-
 
 ### Install from the CLI wizard
 
@@ -108,7 +106,154 @@ You can also start a new astro project based on an [official example](https://gi
 4. You can now [start the Astro dev server](#start-the-astro-dev-server) and see a live preview of your project while you make it your own!
 </Steps>
 
-### Manual Setup
+## Edit your project
+
+To make changes to your project, open your project folder in your code editor. Working in development mode with the dev server running allows you to see updates to your site as you edit the code.
+
+You can also [customize aspects of your development environment](#configure-your-dev-environment) such as configuring TypeScript or installing the official Astro editor extensions.
+
+### Start the Astro dev server
+
+Astro comes with a built-in development server that has everything you need for project development. The `astro dev` CLI command will start the local development server so that you can see your new website in action for the very first time.
+
+Every starter template comes with a pre-configured script that will run `astro dev` for you. After navigating into your project directory, use your favorite package manager to run this command and start the Astro development server.
+
+<Tabs>
+  <TabItem label="npm">
+  ```shell
+  npm run dev
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```shell
+  pnpm run dev
+  ```
+  </TabItem>
+  <TabItem label="yarn">
+  ```shell
+  yarn run dev
+  ```
+  </TabItem>
+</Tabs>
+
+
+If all goes well, Astro will now be serving your project on [http://localhost:4321/](http://localhost:4321/). Visit that link in your browser and see your new site!
+
+### Work in development mode
+
+Astro will listen for live file changes in your `src/` directory and update your site preview as you build, so you will not need to restart the server as you make changes during development. You will always be able to see an up-to-date version of your site in your browser when the dev server is running.
+
+When viewing your site in the browser, you'll have access to the [Astro dev toolbar](/en/guides/dev-toolbar/). As you build, it will help you inspect your [islands](/en/concepts/islands/), spot accessibility issues, and more.
+
+If you aren't able to open your project in the browser after starting the dev server, go back to the terminal where you ran the `dev` command and check the message displayed. It should tell you if an error occurred, or if your project is being served at a different URL than [http://localhost:4321/](http://localhost:4321/).
+
+### Configure your dev environment
+
+Explore the guides below to customize your development experience.
+
+<CardGrid>
+  <LinkCard
+    title="Editor Setup"
+    description="Customize your code editor to improve the Astro developer experience and unlock new features."
+    href="/en/editor-setup/"
+  />
+   <LinkCard
+    title="TypeScript"
+    description="Configure Astro's built-in TypeScript support to be as strict or relaxed as you like!"
+    href="/en/guides/typescript/"
+  />
+  <LinkCard
+    title="Import Aliases"
+    description="Create convenient shortcuts for your file imports."
+    href="/en/guides/aliases/"
+  />
+  <LinkCard
+    title="Environment Variables"
+    description="Set and use environment variables in your project."
+    href="/en/guides/environment-variables/"
+  />
+    <LinkCard
+    title="Dev Toolbar"
+    description="Explore the helpful features of the dev toolbar."
+    href="/en/guides/dev-toolbar/"
+  />
+</CardGrid>
+
+## Build and preview your site
+
+To check the version of your site that will be created at build time, quit the dev server (<kbd>Ctrl</kbd> + <kbd>C</kbd>) and run the appropriate build command for your package manager in your terminal:
+
+    <Tabs>
+      <TabItem label="npm">
+      ```shell
+      npm run build
+      ```
+      </TabItem>
+      <TabItem label="pnpm">
+      ```shell
+      pnpm build
+      ```
+      </TabItem>
+      <TabItem label="yarn">
+      ```shell
+      yarn run build
+      ```
+      </TabItem>
+    </Tabs>
+
+Astro will build a deploy-ready version of your site in a separate folder (`dist/` by default) and you can watch its progress in the terminal. This will alert you to any build errors in your project before you deploy to production. If TypeScript is configured to `strict` or `strictest`, the `build` script will also check your project for type errors.
+
+When the build is finished, run the appropriate `preview` command (e.g. `npm run preview`) in your terminal and you can view the built version of your site locally in the same browser preview window.
+
+Note that this previews your code as it existed when the build command was last run. This is meant to give you a preview of how your site will look when it is [deployed to the web](#deploy-your-new-site). Any later changes you make to your code after building will **not** be reflected while you preview your site until you run the build command again.
+
+Use (<kbd>Ctrl</kbd> + <kbd>C</kbd>) to quit the preview and run another terminal command, such as restarting the dev server to go back to [working in development mode](#work-in-development-mode) which does update as you edit to show a live preview of your code changes.
+
+<ReadMore>Read more about [the Astro CLI](/en/reference/cli-reference/) and the terminal commands you will use as you build with Astro.</ReadMore>
+
+## Deploy your new site
+
+You may wish to [deploy your new site right away](/en/guides/deploy/), before you begin to add or change too much code. This is helpful to get a minimal, working version of your site published and can save you extra time and effort troubleshooting your deployment later.
+
+## Next Steps
+
+Success! You are now ready to start building with Astro! 🥳
+
+Here are a few things that we recommend exploring next. You can read them in any order. You can even leave our documentation for a bit and go play in your new Astro project codebase, coming back here whenever you run into trouble or have a question.
+
+
+### Explore Astro's Features
+
+<CardGrid>
+  <LinkCard
+    title="Understand your codebase"
+    description="Learn about Astro’s file structure in our Project Structure guide."
+    href="/en/basics/project-structure/"
+  />
+  <LinkCard
+    title="Create content collections"
+    description="Add content to your new site with frontmatter validation and automatic type-safety."
+    href="/en/guides/integrations-guide/"
+  />
+    <LinkCard
+    title="Add view transitions"
+    description="Create seamless page transitions and animations."
+    href="/en/guides/view-transitions/"
+  />
+  <LinkCard
+    title="Learn about Islands"
+    description="Read about Astro's island architecture."
+    href="/en/concepts/islands/"
+  />
+</CardGrid>
+
+### Take the introductory tutorial
+
+Build a fully functional Astro blog starting from a single blank page in our [introductory tutorial](/en/tutorial/0-introduction/).
+
+This is a great way to see how Astro works and walks you through the basics of pages, layouts, components, routing, islands, and more. It also includes an optional, beginner-friendly unit for those newer to web development concepts in general, which will guide you through installing the necessary applications on your computer, creating a GitHub account, and deploying your site.
+
+## Manual Setup
 
 This guide will walk you through the steps to manually install and configure a new Astro project.
 
@@ -143,8 +288,6 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
       ```
       </TabItem>
     </Tabs>
-
-
 
 2. Install Astro
 
@@ -287,138 +430,3 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
 8. You can now [start the Astro dev server](#start-the-astro-dev-server) and see a live preview of your project while you build!
 
 </Steps>
-
-
-## Start the Astro dev server
-
-    Astro comes with a built-in development server that has everything you need for project development. The `astro dev` CLI command will start the local development server so that you can see your new website in action for the very first time.
-
-    Every starter template comes with a pre-configured script that will run `astro dev` for you. After navigating into your project directory, use your favorite package manager to run this command and start the Astro development server.
-
-    <Tabs>
-      <TabItem label="npm">
-      ```shell
-      npm run dev
-      ```
-      </TabItem>
-      <TabItem label="pnpm">
-      ```shell
-      pnpm run dev
-      ```
-      </TabItem>
-      <TabItem label="yarn">
-      ```shell
-      yarn run dev
-      ```
-      </TabItem>
-    </Tabs>
-
-
-If all goes well, Astro will now be serving your project on [http://localhost:4321/](http://localhost:4321/). Visit that link in your browser and see your new site!
-
-## Work in development mode
-
-Astro will listen for live file changes in your `src/` directory and update your site preview as you build, so you will not need to restart the server as you make changes during development. You will always be able to see an up-to-date version of your site in your browser when the dev server is running.
-
-When viewing your site in the browser, you'll have access to the [Astro dev toolbar](/en/guides/dev-toolbar/). As you build, it will help you inspect your [islands](/en/concepts/islands/), spot accessibility issues, and more.
-
-If you aren't able to open your project in the browser after starting the dev server, go back to the terminal where you ran the `dev` command and check the message displayed. It should tell you if an error occurred, or if your project is being served at a different URL than [http://localhost:4321/](http://localhost:4321/).
-
-## Build and preview your site
-
-To check the version of your site that will be created at build time, quit the dev server (<kbd>Ctrl</kbd> + <kbd>C</kbd>) and run the appropriate build command for your package manager in your terminal:
-
-    <Tabs>
-      <TabItem label="npm">
-      ```shell
-      npm run build
-      ```
-      </TabItem>
-      <TabItem label="pnpm">
-      ```shell
-      pnpm build
-      ```
-      </TabItem>
-      <TabItem label="yarn">
-      ```shell
-      yarn run build
-      ```
-      </TabItem>
-    </Tabs>
-
-Astro will build a deploy-ready version of your site in a separate folder (`dist/` by default) and you can watch its progress in the terminal. This will alert you to any build errors in your project before you deploy to production. If TypeScript is configured to `strict` or `strictest`, the `build` script will also check your project for type errors.
-
-When the build is finished, run the appropriate `preview` command (e.g. `npm run preview`) in your terminal and you can view the built version of your site locally in the same browser preview window.
-
-Note that this previews your code as it existed when the build command was last run. This is meant to give you a preview of how your site will look when it is [deployed to the web](#deploy-your-new-site). Any later changes you make to your code after building will **not** be reflected while you preview your site until you run the build command again.
-
-Use (<kbd>Ctrl</kbd> + <kbd>C</kbd>) to quit the preview and run another terminal command, such as restarting the dev server to go back to [working in development mode](#work-in-development-mode) which does update as you edit to show a live preview of your code changes.
-
-<ReadMore>Read more about [the Astro CLI](/en/reference/cli-reference/) and the terminal commands you will use as you build with Astro.</ReadMore>
-
-## Deploy your new site
-
-You may wish to [deploy your new site right away](/en/guides/deploy/), before you begin to add or change too much code. This is helpful to get a minimal, working version of your site published and can save you extra time and effort troubleshooting your deployment later.
-
-## Next Steps
-
-Success! You are now ready to start building with Astro! 🥳
-
-Here are a few things that we recommend exploring next. You can read them in any order. You can even leave our documentation for a bit and go play in your new Astro project codebase, coming back here whenever you run into trouble or have a question.
-
-
-### Explore Astro's Features
-
-<CardGrid>
-  <LinkCard
-    title="Understand your codebase"
-    description="Learn about Astro’s file structure in our Project Structure guide."
-    href="/en/basics/project-structure/"
-  />
-  <LinkCard
-    title="Create content collections"
-    description="Add content to your new site with frontmatter validation and automatic type-safety."
-    href="/en/guides/integrations-guide/"
-  />
-    <LinkCard
-    title="Add view transitions"
-    description="Create seamless page transitions and animations."
-    href="/en/guides/view-transitions/"
-  />
-  <LinkCard
-    title="Learn about Islands"
-    description="Read about Astro's island architecture."
-    href="/en/concepts/islands/"
-  />
-</CardGrid>
-
-
-### Configure your dev environment
-
-<CardGrid>
-  <LinkCard
-    title="Editor Setup"
-    description="Customize your code editor to improve the Astro developer experience and unlock new features."
-    href="/en/editor-setup/"
-  />
-   <LinkCard
-    title="TypeScript"
-    description="Configure Astro's built-in TypeScript support to be as strict or relaxed as you like!"
-    href="/en/guides/typescript/"
-  />
-  <LinkCard
-    title="Import Aliases"
-    description="Create convenient shortcuts for your file imports."
-    href="/en/guides/aliases/"
-  />
-  <LinkCard
-    title="Environment Variables"
-    description="Set and use environment variables in your project."
-    href="/en/guides/environment-variables/"
-  />
-    <LinkCard
-    title="Dev Toolbar"
-    description="Explore the helpful features of the dev toolbar."
-    href="/en/guides/dev-toolbar/"
-  />
-</CardGrid>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Some tiny page edits, but mostly reorganizing content for the "scrollers" to put more common info up front and put less-used content lower on the page (even if it chronologically would come first in terms of the user path).