### PR TITLE
i18n(zh-cn): update untranslate word in directives-reference.mdx

### DIFF
--- a/src/content/docs/zh-cn/reference/directives-reference.mdx
+++ b/src/content/docs/zh-cn/reference/directives-reference.mdx
@@ -36,7 +36,7 @@ import ReadMore from '~/components/ReadMore.astro'
 - `string`：添加到 `class` 元素
 - `Object`：添加到键值对到 `class` 元素
 - `Array`：扁平化
-- `false`, `null`, or `undefined`: skipped
+- `false`, `null`, or `undefined`: 跳过
 
 ```astro
 <!-- 原先 -->


### PR DESCRIPTION
Translated a phrase at [模板指令参考 | Docs](https://docs.astro.build/zh-cn/reference/directives-reference/#%E9%80%9A%E7%94%A8%E6%8C%87%E4%BB%A4)

 > `false`, `null`, or `undefined`: skipped
translated into:
> `false`, `null`, or `undefined`: 跳过
---

For more info see chat history
@ https://discord.com/channels/830184174198718474/973149689610371093/1250832177663443034