### PR TITLE
Fix checked indicator for Option component in forced colors

### DIFF
--- a/src/components/tutorial/Option.astro
+++ b/src/components/tutorial/Option.astro
@@ -79,4 +79,10 @@ const { isCorrect } = Astro.props as Props;
 		background-image: radial-gradient(var(--sl-color-white) 50%, transparent 0%, transparent);
 		border-color: var(--sl-color-white);
 	}
+
+	@media (forced-colors: active) {
+		input[type='radio']:checked::after {
+			background-color: Highlight;
+		}
+	}
 </style>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
 
<!-- Please describe the change you are proposing, and why -->
This fix an issue on forced mode, similar to this PR that was already merged https://github.com/withastro/docs/pull/933 

<!-- Please make changes in **one language** only -->
Before (No visual checked indicator):
<img width="704" alt="image" src="https://github.com/withastro/docs/assets/85184231/ec607d1b-9258-48ee-a45b-f227b3d1b819">


After:
<img width="693" alt="image" src="https://github.com/withastro/docs/assets/85184231/4e91a3e1-7a91-4e62-aff7-d287f7e22468">

The starlight and doc website seems to have a great accessibility, great job on this!

#### Related issues & labels 

- Suggested label:  a11y

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
