### PR TITLE
fix: missing `await` in `container-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/container-reference.mdx
+++ b/src/content/docs/en/reference/container-reference.mdx
@@ -57,7 +57,7 @@ import { getContainerRenderer as reactContainerRenderer } from "@astrojs/react";
 import { getContainerRenderer as svelteContainerRenderer } from "@astrojs/svelte";
 import { loadRenderers } from "astro:container";
 
-const renderers = loadRenderers([reactContainerRenderer(), svelteContainerRenderer()]);
+const renderers = await loadRenderers([reactContainerRenderer(), svelteContainerRenderer()]);
 const container = await experimental_AstroContainer.create({
     renderers
 })


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
The `loadRenderers` function is asynchronous and returns a `Promise<SSRLoadedRenderer[]>`. Although the JSDoc for this function is correct, the async keyword is missing in the documentation here.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
