### PR TITLE
Clarify on demand rendering features for middleware

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-**Middleware** allows you to intercept requests and responses and inject behaviors dynamically every time a page or endpoint is about to be rendered. This rendering occurs at build time for all prerendered pages, but occurs when the route is requested for pages rendered on demand.
+**Middleware** allows you to intercept requests and responses and inject behaviors dynamically every time a page or endpoint is about to be rendered. This rendering occurs at build time for all prerendered pages, but occurs when the route is requested for pages rendered on demand, making [additional SSR features like cookies and headers](/en/guides/server-side-rendering/#on-demand-rendering-features) available.
 
 Middleware also allows you to set and share request-specific information across endpoints and pages by mutating a `locals` object that is available in all Astro components and API endpoints. This object is available even when this middleware runs at build time.
 


### PR DESCRIPTION
#### Description (required)

Adding this to the description to clarify that when you use middleware on an on-demand rendered page, you will not have access to things like cookies/headers/...

#### Related issues & labels (optional)

- Closes #8264 
- Suggested label: Middleware

Discord: tledoux
