### PR TITLE
Add additional explanation about define:vars directive

### DIFF
--- a/src/content/docs/en/basics/astro-syntax.mdx
+++ b/src/content/docs/en/basics/astro-syntax.mdx
@@ -120,6 +120,8 @@ When using dynamic tags:
 
 - **Hydration directives are not supported.** When using [`client:*` hydration directives](/en/guides/framework-components/#hydrating-interactive-components), Astro needs to know which components to bundle for production, and the dynamic tag pattern prevents this from working.
 
+- **The [define:vars directive](/en/reference/directives-reference/#definevars) is not supported.** If you cannot wrap the children with an extra element (e.g `<div>`), then you can manually add a `style={``--myVar:${value}``}` to your Element.
+
 ### Fragments
 
 Astro supports using either `<Fragment> </Fragment>` or the shorthand `<> </>`.
@@ -172,5 +174,3 @@ In Astro, you can use standard HTML comments or JavaScript-style comments.
 :::caution
 HTML-style comments will be included in browser DOM, while JS ones will be skipped. To leave TODO messages or other development-only explanations, you may wish to use JavaScript-style comments instead.
 :::
-
-

--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -225,7 +225,6 @@ The `is:inline` directive means that `<style>` and `<script>` tags:
 
 :::caution
 The `is:inline` directive is implied whenever any attribute other than `src` is used on a `<script>` or `<style>` tag.
-
 The one exception is using the [`define:vars` directive](/en/reference/directives-reference/#definevars) on the `<style>` tag, which does not automatically imply `is:inline`.
 :::
 

--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -225,6 +225,8 @@ The `is:inline` directive means that `<style>` and `<script>` tags:
 
 :::caution
 The `is:inline` directive is implied whenever any attribute other than `src` is used on a `<script>` or `<style>` tag.
+
+The one exception is using the [`define:vars` directive](/en/reference/directives-reference/#definevars) on the `<style>` tag, which does not automatically imply `is:inline`.
 :::
 
 ```astro


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I added additional information about `define:vars` directive on two pages:

* https://docs.astro.build/en/basics/astro-syntax/#dynamic-tags

The `define:vars` directive does not work with dynamic tags and I have seen some issues related to that on the main repository so I think it should be clarified.

* https://docs.astro.build/en/reference/directives-reference/#isinline

The statement was not exact since, as stated in #3165: using `define:vars` on `<style />` tag does not automatically apply the `is:inline` directive.

#### Related issues & labels (optional)

- Closes #6477.
- Suggested label: improve-documentation

#### First-time contributor to Astro Docs? 

ar_phi

(I'm not often connected... but I should get an email when mentioned if needed.)
