### PR TITLE
Update the code example of `<Code />` with `transformers` in`api-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1720,16 +1720,18 @@ const bar = ' world'
 console.log(foo + bar) // [!code focus]
 `
 ---
-<Code
-  code={code}
-  lang="js"
-  transformers={[transformerNotationFocus()]} />
-  
-  <style is:global>
-    pre.has-focused .line:not(.focused) {
-      filter: blur(1px);
-    }
-  </style>
+<div>
+  <Code
+    code={code}
+    lang="js"
+    transformers={[transformerNotationFocus()]} />
+</div>
+
+<style is:global>
+  pre.has-focused .line:not(.focused) {
+    filter: blur(1px);
+  }
+</style>
 ```
 
 ### `<Fragment />`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Update the code example of `<Code />` with `transformers`
- `<Code />` alone in the .astro file does not render correctly. 
- I don't know if this is a bug, only update the docs to make sense for people that want quickrun.

   | Before | After |
   |---|---|
   | <img width="774" alt="Steps list numbered 1, 4, 5" src="https://github.com/withastro/docs/assets/25167721/3fc8cd86-cacf-4fac-9d75-1d9cf44a2155"> | <img width="773" alt="Steps list numbered 1, 2, 3" src="https://github.com/withastro/docs/assets/25167721/2d3c55c3-8f9c-49a6-871a-e4ba48645af5"> |

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
