### PR TITLE
add hint regarding style and script tag locations in layout components

### DIFF
--- a/src/content/docs/en/basics/layouts.mdx
+++ b/src/content/docs/en/basics/layouts.mdx
@@ -14,6 +14,8 @@ We conventionally use the term "layout" for Astro components that provide common
 
  But, there is nothing special about a layout component! They can [accept props](/en/basics/astro-components/#component-props) and [import and use other components](/en/basics/astro-components/#component-structure) like any other Astro component. They can include [UI frameworks components](/en/guides/framework-components/) and [client-side scripts](/en/guides/client-side-scripts/). They do not even have to provide a full page shell, and can instead be used as partial UI templates.
 
+If a layout component contains a page shell, the `<html>` element must be the parent of all other elements in the component. All [`<style>`](https://docs.astro.build/en/guides/styling/#styling-in-astro) or [`<script>`](https://docs.astro.build/en/guides/client-side-scripts/#using-script-in-astro) elements must be enclosed by the `<html>` tags.
+
 Layout components are commonly placed in a `src/layouts` directory in your project for organization, but this is not a requirement; you can choose to place them anywhere in your project. You can even colocate layout components alongside your pages by [prefixing the layout names with `_`](/en/guides/routing/#excluding-pages).
 
 ## Sample Layout

--- a/src/content/docs/en/basics/layouts.mdx
+++ b/src/content/docs/en/basics/layouts.mdx
@@ -45,6 +45,11 @@ const { title } = Astro.props;
     </article>
     <Footer />
   </body>
+  <style>
+    h1 {
+      font-size: 2rem;
+    }
+  </style>
 </html>
 ```
 

--- a/src/content/docs/en/basics/layouts.mdx
+++ b/src/content/docs/en/basics/layouts.mdx
@@ -14,7 +14,7 @@ We conventionally use the term "layout" for Astro components that provide common
 
  But, there is nothing special about a layout component! They can [accept props](/en/basics/astro-components/#component-props) and [import and use other components](/en/basics/astro-components/#component-structure) like any other Astro component. They can include [UI frameworks components](/en/guides/framework-components/) and [client-side scripts](/en/guides/client-side-scripts/). They do not even have to provide a full page shell, and can instead be used as partial UI templates.
 
-If a layout component contains a page shell, the `<html>` element must be the parent of all other elements in the component. All [`<style>`](https://docs.astro.build/en/guides/styling/#styling-in-astro) or [`<script>`](https://docs.astro.build/en/guides/client-side-scripts/#using-script-in-astro) elements must be enclosed by the `<html>` tags.
+However, if a layout component does contain a page shell, its `<html>` element must be the parent of all other elements in the component. All [`<style>`](/en/guides/styling/#styling-in-astro) or [`<script>`](/en/guides/client-side-scripts/#using-script-in-astro) elements must be enclosed by the `<html>` tags.
 
 Layout components are commonly placed in a `src/layouts` directory in your project for organization, but this is not a requirement; you can choose to place them anywhere in your project. You can even colocate layout components alongside your pages by [prefixing the layout names with `_`](/en/guides/routing/#excluding-pages).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR adds a paragraph to the layout component page, explaining how `<script>` and `<style>` tags should be included in a component containing an `<html>` shell.

#### Related issues & labels (optional)

- Closes #8603 
- Suggested label: add new content

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

Discord: lukets4328
