### PR TITLE
Update Lunaria to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@astrojs/starlight": "^0.24.4",
     "@docsearch/js": "^3.5.2",
     "@fontsource/ibm-plex-mono": "^4.5.10",
-    "@lunariajs/core": "^0.1.0",
+    "@lunariajs/core": "^0.1.1",
     "canvas-confetti": "^1.6.0",
     "jsdoc-api": "^7.1.1",
     "rehype-autolink-headings": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.5.10
         version: 4.5.10
       '@lunariajs/core':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       canvas-confetti:
         specifier: ^1.6.0
         version: 1.6.0
@@ -842,8 +842,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@lunariajs/core@0.1.0':
-    resolution: {integrity: sha512-UP2K3fjgmPP4eN92ZcreAzWitRfeqhMMSHeh2GK2FtzReYWoHeth7cogzNv9Glb64UA2PFJkZ3fU5DAdX53w+g==}
+  '@lunariajs/core@0.1.1':
+    resolution: {integrity: sha512-sAqM9+DVsLe3xHM9wu2pEnKGYMs/bWS9qpR+CGHol3RihOELnOQTzHddXbdB1MtgesbI8dnQuG64Ocd8KkWsng==}
     engines: {node: '>=18.17.0'}
     hasBin: true
 
@@ -4644,13 +4644,13 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lunariajs/core@0.1.0':
+  '@lunariajs/core@0.1.1':
     dependencies:
       '@clack/core': 0.3.4
       fast-glob: 3.3.2
@@ -7925,7 +7925,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
#### Description (required)

This PR updates Lunaria to `v0.1.1` which is important since it fixes a nasty regression in how we link to GitHub's source history.