### PR TITLE
Update integrations-reference.mdx

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -299,12 +299,14 @@ Middleware is defined in a package with an `onRequest` function, as with user-de
 ```js title="@my-package/middleware.js"
 import { defineMiddleware } from 'astro:middleware';
 
-export const onRequest = defineMiddleware(async (context, request) => {
+export const onRequest = defineMiddleware(async (context, next) => {
   if(context.url.pathname === '/some-test-path') {
     return Response.json({
       ok: true
     });
   }
+
+  return next();
 });
 ```
 


### PR DESCRIPTION
I am far away from an astro expert, but it confused me that there is no next() function call, like in all the other middleware examples.

+ the example code does not work and will throw an error if the route is not some-test-path
+ also everywhere in the docs it says next instead of request(?)