### PR TITLE
Add recipe to use Boostrap with Astro

### DIFF
--- a/src/content/docs/en/community-resources/content.mdx
+++ b/src/content/docs/en/community-resources/content.mdx
@@ -53,6 +53,7 @@ Have you published a recipe or guide for working with Astro? [Edit this page](ht
 ### CSS
 - [Use UnoCSS in Astro](https://www.elian.codes/blog/23-02-11-implementing-unocss-in-astro/)
 - [Add dark mode to Astro with Tailwind CSS](https://www.kevinzunigacuellar.com/blog/dark-mode-in-astro/)
+- [Use Bootstrap with Astro](https://www.drsys.de/use-bootstrap-with-astro/)
 ### Authentication
 - [Add Github OAuth with Lucia](https://lucia-auth.com/tutorials/github-oauth/astro)
 - [Add username and password authentication with Lucia](https://lucia-auth.com/tutorials/username-and-password/astro)


### PR DESCRIPTION
#### Description

[Bootstrap](https://getbootstrap.com/) is still one of the most popular CSS frameworks and I was surprised to not find a recipe on the Astro Docs. So after figuring out how to integrate it properly in Astro, I decided to write a recipe myself.

There is an [astro-bootstrap](https://astro-bootstrap.github.io/) integration, but this is not how I would recommend developers to use Bootstrap in Astro.

#### First-time contributor to Astro Docs? 

Astro Discord username: druettiger