### PR TITLE
i18n(zh-cn): Fix typo in `integrations-reference.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/integrations-reference.mdx
+++ b/src/content/docs/zh-cn/reference/integrations-reference.mdx
@@ -34,6 +34,7 @@ interface AstroIntegration {
       addDevToolbarApp: (pluginEntrypoint: string) => void;
       injectScript: (stage: InjectedScriptStage, content: string) => void;
       injectRoute: ({ pattern: string, entrypoint: string }) => void;
+      logger: AstroIntegrationLogger;
     }) => void | Promise<void>;
     'astro:config:done'?: (options: { config: AstroConfig; setAdapter: (adapter: AstroAdapter) => void; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:setup'?: (options: { server: vite.ViteDevServer; logger: AstroIntegrationLogger; }) => void | Promise<void>;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

missing a line of code.

![截屏2024-06-25 15 50 46](https://github.com/withastro/docs/assets/30520689/6c898443-a2f8-4536-ab1c-6f26c2ca0500)

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
