### PR TITLE
Update cypress link in testing.mdx

### DIFF
--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -315,7 +315,7 @@ Then run the test again. You should see a red "x" in the output confirming that 
 
 More information about Cypress can be found in the links below:
 
-- [Introduction to Cypress](https://docs.cypress.io/guides/basics/introduction-to-cypress)
+- [Introduction to Cypress](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress)
 - [Testing Your App](https://docs.cypress.io/guides/end-to-end-testing/testing-your-app)
 
 ### NightwatchJS


### PR DESCRIPTION
#### Description (required)

https://docs.cypress.io/guides/basics/introduction-to-cypress no longer exists and instead can be found in https://docs.cypress.io/guides/core-concepts/introduction-to-cypress

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

