### PR TITLE
example does not work, missing comma

### DIFF
--- a/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
@@ -94,7 +94,7 @@ export default defineToolbarApp({
   init(canvas) {
     const text = document.createTextNode('Hello World!');
     canvas.appendChild(text);
-  }
+  },
   beforeTogglingOff() {
     const confirmation = window.confirm('Really exit?');
     return confirmation;


### PR DESCRIPTION
The example has an error because of the missing comma; so if you copy & paste the example code to test, it won't work.