### PR TITLE
i18n(fr): Add `reference/errors/prerender-client-address-not-available.mdx`

### DIFF
--- a/src/content/docs/fr/reference/errors/prerender-client-address-not-available.mdx
+++ b/src/content/docs/fr/reference/errors/prerender-client-address-not-available.mdx
@@ -1,0 +1,16 @@
+---
+title: Astro.clientAddress ne peut pas être utilisé dans les itinéraires pré-rendus.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **PrerenderClientAddressNotAvailable**: `Astro.clientAddress` cannot be used inside prerendered routes
+
+## Qu'est-ce qui a mal tourné ?
+`Astro.clientAddress` ne peut pas être utilisé dans les itinéraires pré-rendus.
+
+**Voir aussi :**
+-  [Accepter d'afficher le pré-rendement](/fr/guides/server-side-rendering/#accepter-le-pré-rendu-en-mode-server)
+-  [Astro.clientAddress](/fr/reference/api-reference/#astroclientaddress)
+
+


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Add `reference/errors/prerender-client-address-not-available.mdx` from #8224

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)


- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
