### PR TITLE
en-only - Typo fix from 'overtime' to 'over time'

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -478,7 +478,7 @@ jobs:
 </StudioHeading>
 
 
-Your table schema will change overtime as your project grows. You can safely test configuration changes locally and push to your Studio database when you deploy.
+Your table schema will change over time as your project grows. You can safely test configuration changes locally and push to your Studio database when you deploy.
 
 When [creating a Studio project from the dashboard](#astro-studio), you will have the option to create a GitHub CI action. This will automatically migrate schema changes when merging with your repository's main branch.
 


### PR DESCRIPTION
#### Description (required)

Changed `overtime` to `over time`. The first is appropriate as a noun ("They scored in overtime") while the second better fits the context ("Your table schema will change over time as your project grows.").

#### Related issues & labels (optional)

- Suggested label: [typo/link/grammar - quick fix!](https://github.com/withastro/docs/labels/typo%2Flink%2Fgrammar%20-%20quick%20fix%21)
