### PR TITLE
[endpoints.mdx] update for hybrid mode

### DIFF
--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -94,12 +94,14 @@ export const GET: APIRoute = ({ params, request }) => {
 
 Everything described in the static file endpoints section can also be used in SSR mode: files can export a `GET` function which receives a [context object](/en/reference/api-reference/#endpoint-context) with properties similar to the `Astro` global.
 
-But, unlike in `static` mode, when you configure `server` mode, the endpoints will be built when they are requested. This unlocks new features that are unavailable at build time, and allows you to build API routes that listen for requests and securely execute code on the server at runtime.
+But, unlike in `static` mode, when you enable on-demand rendering for a route, the endpoint will be built when it is requested. This unlocks new features that are unavailable at build time, and allows you to build API routes that listen for requests and securely execute code on the server at runtime.
+
+Your routes will be rendered on demand by default in `server` mode. In `hybrid` mode, you must opt out of prerendering for each custom endpoint with `export const prerender = false`.
 
 <RecipeLinks slugs={["en/recipes/call-endpoints" ]}/>
 
 :::note
-Be sure to [enable SSR](/en/guides/server-side-rendering/) before trying these examples.
+Be sure to [enable an on-demand rendering mode](/en/guides/server-side-rendering/) before trying these examples, and opt out of prerendering in `hybrid` mode.
 :::
 
 Server endpoints can access `params` without exporting `getStaticPaths`, and they can return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object, allowing you to set status codes and headers:


### PR DESCRIPTION
#### Description (required)

This page was written before `hybrid` mode existed, and none of the examples or explanation on this page mentions needing `export const prerender = false` for server endpoints.

This PR adds that extra context to the paragraph introducing server endpoints, and also calls this out in the note that the examples need an on-demand rendered mode.

