### PR TITLE
i18n(fr): add migrate-to-astro/from-create-react-app.mdx

### DIFF
--- a/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
@@ -1,0 +1,374 @@
+---
+title: Migration depuis Create React App (CRA)
+description: Astuces pour migrer un projet Create React App existant vers Astro
+type: migration
+stub: true
+framework: Create React App
+i18nReady: true
+---
+import AstroJSXTabs from '~/components/tabs/AstroJSXTabs.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+import { FileTree } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
+import Badge from "~/components/Badge.astro"
+
+L'[intégration React](/fr/guides/integrations-guide/react/) d'Astro apporte le support nécessaire pour [utiliser les composants React dans les composants Astro](/fr/guides/framework-components/), y compris des applications React complètes comme Create React App (CRA) !
+
+```astro title="src/pages/index.astro"
+---
+// Importez votre composant racine App
+import App from '../cra-project/App.jsx';
+---
+<!-- Utilisez une directive client pour charger votre application -->
+<App client:load />
+```
+
+<ReadMore>Découvrez comment [constuire une application d'une seule page (SPA) avec Astro](https://logsnag.com/blog/react-spa-with-astro) <Badge text="Externe" /> en utilisant React Router.</ReadMore>
+
+De nombreuses applications « fonctionneront simplement » comme des applications React complètes lorsque vous les ajouterez directement à votre projet Astro avec l'intégration React installée. Il s'agit d'un excellent moyen de lancer votre projet immédiatement et de maintenir votre application fonctionnelle pendant que vous migrez vers Astro.
+
+Au fil du temps, vous pouvez convertir votre structure pièce par pièce en une combinaison de composants `.astro` et `.jsx`. Vous découvrirez probablement que vous avez besoin de moins de composants React que vous ne le pensez !
+
+Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de notre documentation et notre [communauté Discord](https://astro.build/chat) pour continuer !
+
+## Principales similitudes entre CRA et Astro
+
+- La [syntaxe des fichiers `.astro` est similaire à JSX](/fr/basics/astro-syntax/#différences-entre-astro-et-jsx). Écrire pour Astro devrait sembler familier.
+
+- Astro utilise le routage basé sur des fichiers et [permet à des pages spécifiquement nommées de créer des itinéraires dynamiques](/fr/guides/routing/#routes-dynamiques).
+
+- Astro est [basé sur les composants](/fr/basics/astro-components/) et votre structure de balisage sera similaire avant et après votre migration.
+
+- Astro a des [intégrations officiellles pour React, Preact, et Solid](/fr/guides/integrations-guide/react/) afin que vous puissiez utiliser vos composants JSX existants. Notez que dans Astro, ces fichiers **doivent** utilisez un extension `.jsx` ou `.tsx`.
+
+- Astro supporte l'[installation de paquets NPM](/fr/guides/imports/#paquets-npm), y compris les bibliothèques React. Un grand nombre de vos dépendances existantes fonctionneront dans Astro.
+
+## Principales différences entre CRA et Astro
+
+Lorsque vous reconstruisez votre site CRA dans Astro, vous remarquerez quelques différences importantes :
+
+- CRA est une application d'une seule page qui utilise `index.js` comme racine de votre projet. Astro est un site multipage et `index.astro` est votre page d'accueil.
+
+- Les [composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en une « barrière de code » pour votre JavaScript et un corps exclusivement pour le HTML que vous générez.
+
+- [axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour présenter votre contenu et pour vous permettre d'opter pour l'interactivité uniquement en cas de besoin. Une application CRA existante peut être conçue pour une interactivité élevée côté client et peut nécessiter des techniques avancées d'Astro pour inclure des éléments plus difficiles à reproduire en utilisant des composants `.astro`, comme les tableaux de bord.
+
+## Ajouter votre application CRA dans Astro
+
+Votre application existante peut être générée directement dans un nouveau projet Astro, la plupart du temps sans modification du code de votre application.
+
+### Créer un nouveau projet Astro
+
+Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro et sélectionnez un nouveau projet Astro « vide ».
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro@latest
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro@latest
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn create astro@latest
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+### Ajouter des intégrations et des dépendances
+
+Ajoutez l'intégration React en utilisant la commande `astro add` de votre gestionnaire de paquets. Si votre application utilise Tailwind ou MDX, vous pouvez ajouter plusieurs intégrations Astro en utilisant la même commande :
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npx astro add react
+  npx astro add react tailwind mdx
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm astro add react
+  pnpm astro add react tailwind mdx
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn astro add react
+  yarn astro add react tailwind mdx
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Si votre application CRA nécessite des dépendances (par exemple des paquets NPM), installez-les individuellement en utilisant la ligne de commande ou en les ajoutant manuellement au fichier `package.json` de votre nouveau projet Astro puis exécuter la commande d'installation. Notez que de nombreuses dépendances React, mais pas toutes, fonctionneront dans Astro. 
+
+### Ajoutez vos fichiers d'application existants
+
+Copiez les fichiers et dossiers sources de votre projet Create React App (CRA) existant (par exemple `components`, `hooks`, `styles`, etc.) dans un nouveau dossier à l'intérieur de `src/`, en conservant sa structure de fichiers pour que votre application continue de fonctionner. Notez que toutes les extensions de fichier `.js` doivent être renommées en `.jsx` ou `.tsx`.
+
+N'incluez aucun fichier de configuration. Vous utiliserez les fichiers `astro.config.mjs`, `package.json`, et `tsconfig.json` d'Astro.
+
+Déplacez le contenu du dossier `public/` de votre application (par exemple, les ressources statiques) vers le dossier `public/` d'Astro.
+
+<FileTree>
+- public/
+  - logo.png
+  - favicon.ico
+  - ...
+- src/
+  - cra-project/
+    - App.jsx
+    - ...
+  - pages/
+    - index.astro
+- astro.config.mjs
+- package.json
+- tsconfig.json
+</FileTree>
+
+### Générer votre application
+
+Importez le composant racine de votre application dans la section frontmatter du fichier `index.astro` puis restituez le composant `<App />` dans votre modèle de page :
+
+```astro title="src/pages/index.astro"
+---
+import App from '../cra-project/App.jsx';
+---
+<App client:load />
+```
+
+:::note[Directives client]
+Votre application nécessite une [directive client](/fr/reference/directives-reference/#directives-client) pour l'interactivité. Astro générera votre application React en HTML statique jusqu'à ce que vous acceptiez le JavaScript côté client.
+
+Utilisez `client:load` pour garantir que votre application se charge immédiatement à partir du serveur, ou `client:only="react"` pour ignorer le rendu côté serveur et exécuter votre application entièrement côté client.
+:::
+
+Consultez notre guide pour [configurer Astro](/fr/guides/configuring-astro/) pour obtenir plus de détails et les options disponibles.
+
+## Convertir votre application CRA en application Astro
+
+Après avoir [ajouter votre application existante dans Astro](#ajouter-votre-application-cra-dans-astro), vous souhaiterez probablement convertir votre application elle-même en application Astro !
+
+Vous reproduirez une conception similaire basée sur des composants [en utilisant des composants Astro de mise en page en HTML pour votre structure de base](/fr/basics/astro-components/) tout en important et en incluant des composants React individuels (qui peuvent eux-mêmes être des applications entières !) pour des îles d'interactivité.
+
+Chaque migration sera différente et pourra être effectuée de manière incrémentielle sans perturber votre application opérationnelle. Convertissez des éléments individuels à votre propre rythme afin qu'une part croissante de votre application soit alimentée par des composants Astro au fil du temps.
+
+Au fur et à mesure que vous convertissez votre application React, vous déciderez quels composants React vous allez [réécrire en tant que composant Astro](#convertir-les-fichiers-jsx-en-fichiers-astro). Votre seule restriction est que les composants Astro peuvent importer des composants React, mais les composants React ne doivent importer que d'autres composants React :
+
+```astro title="src/pages/static-components.astro" ins={2,7}
+---
+import MyReactComponent from '../components/MyReactComponent.jsx';
+---
+<html>
+  <body>
+    <h1>Utilisez des composants React directement dans Astro !</h1>
+    <MyReactComponent />
+  </body>
+</html>
+```
+
+À la place d'importer des composants Astro dans des composants React, vous pouvez imbriquer des composants React dans un seul composant Astro :
+
+```astro title="src/pages/nested-components.astro" {2,3,5,8,10}
+---
+import MyReactSidebar from '../components/MyReactSidebar.jsx';
+import MyReactButton from '../components/MyReactButton.jsx';
+---
+<MyReactSidebar>
+  <p>Voici une barre latérale avec du texte et un bouton.</p>
+  <div slot="actions">
+    <MyReactButton client:idle />
+  </div>
+</MyReactSidebar>
+```
+
+
+Il vous sera peut-être utile d'en apprendre davantage sur [les îles Astro](/fr/concepts/islands/) et les [composants Astro](/fr/basics/astro-components/) avant de restructurer votre application CRA en projet Astro.
+
+
+### Comparaison : JSX vs Astro
+
+Comparez le composant CRA suivant et un composant Astro correspondant :
+
+<AstroJSXTabs>
+  <Fragment slot="jsx">
+    ```jsx title="StarCount.jsx"
+    import React, { useState, useEffect } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+
+const Component = () => {
+    const [stars, setStars] = useState(0);
+    const [message, setMessage] = useState('');
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const res = await fetch('https://api.github.com/repos/withastro/astro');
+            const json = await res.json();
+
+            setStars(json.stargazers_count || 0);
+            setMessage(json.message);
+        };
+
+        fetchData();
+    }, []);
+
+    return (
+        <>
+            <Header />
+            <p style={{
+                backgroundColor: `#f4f4f4`,
+                padding: `1em 1.5em`,
+                textAlign: `center`,
+                marginBottom: `1em`
+            }}>Astro has {stars} 🧑‍🚀</p>
+            <Footer />
+        </>
+    )
+};
+
+export default Component;
+    ```
+  </Fragment>
+  <Fragment slot="astro">
+    ```astro title="StarCount.astro"
+    ---
+    import Header from './Header.astro';
+    import Footer from './Footer.astro';
+    import './layout.css';
+    const res = await fetch('https://api.github.com/repos/withastro/astro')
+    const json = await res.json();
+    const message = json.message;
+    const stars = json.stargazers_count || 0;
+    ---
+    <Header />
+    <p class="banner">Astro has {stars} 🧑‍🚀</p>
+    <Footer />
+    <style>
+      .banner {
+        background-color: #f4f4f4; 
+        padding: 1em 1.5em;
+        text-align: center;
+        margin-bottom: 1em;
+      }
+    <style>
+    ```
+  </Fragment>
+</AstroJSXTabs>
+
+
+### Convertir les fichiers JSX en fichiers `.astro`
+
+Voici quelques astuces pour convertir un composant `.js` en un composant `.astro` :
+
+1. Utilisez le JSX renvoyé par la fonction du composant CRA existant comme base pour votre modèle HTML.
+
+2. Modifiez [toute syntaxe CRA ou JSX en syntaxe Astro](#référence-convertir-la-syntaxe-cra-en-syntaxe-astro) ou en normes web HTML. Cela comprend `{children}` et `className`, par exemple.
+
+3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans une [« barrière de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour l'[affichage conditionnel du contenu](/fr/basics/astro-syntax/#html-dynamique) est souvent écrit directement à l'intérieur du modèle HTML dans Astro.
+
+4. Utilisez [`Astro.props`](/fr/reference/api-reference/#astroprops) pour accéder à toutes les propriétés supplémentaires qui ont été précédemment transmises à votre fonction CRA.
+
+5. Décidez si les composants importés doivent également être convertis en syntaxe Astro. Vous pouvez les conserver en tant que composants React pour le moment ou pour toujours. Mais vous souhaiterez peut-être éventuellement les convertir en composants `.astro`, surtout s'ils n'ont pas besoin d'être interactifs !
+
+6. Remplacez `useEffect()` par des instructions d'importation ou par [`Astro.glob()`](/fr/reference/api-reference/#astroglob) pour interroger vos fichiers locaux. Utilisez `fetch()` pour récupérer des données externes.
+
+### Migration des tests
+
+Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de construction. Tous les tests de bout en bout rédigés précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre site CRA. Les bibliothèques de tests telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
+
+Consultez le [guide de test](/fr/guides/testing/) d'Astro pour plus d'informations.
+
+## Référence : Convertir la syntaxe CRA en syntaxe Astro
+
+### Importations CRA vers Astro
+
+Mettez à jour toutes les [importations de fichiers](/fr/guides/imports/) pour référencer exactement les chemins de fichiers relatifs. Cela peut être fait en utilisant des [alias d'importation](/fr/guides/typescript/#alias-dimportation), ou en écrivant un chemin relatif dans son intégralité. 
+
+Notez que `.astro` et plusieurs autres types de fichiers doivent être importés avec leur extension de fichier complète.
+
+```astro title="src/pages/authors/Fred.astro"
+---
+import Card from '../../components/Card.astro';
+---
+<Card />
+```
+
+### Propriétés `children` de CRA vers Astro
+
+Convertissez toutes les instances de `{children}` en `<slot />` Astro. Ce dernier n'a pas besoin de recevoir `{children}` comme propriété de fonction et restituera automatiquement le contenu enfant dans un `<slot />`.
+
+```astro title="src/components/MyComponent.astro" del={3-9} ins={11-13}
+---
+---
+export default function MyComponent(props) { 
+    return (
+      <div>
+        {props.children}
+      </div>
+    );  
+}
+
+<div>
+  <slot />
+</div>
+```
+
+Les composants React qui transmettent plusieurs ensembles d'enfants peuvent être convertis en composant Astro en utilisant des [emplacements nommés](/fr/basics/astro-components/#les-emplacements-slots-nommés).
+
+En savoir plus sur l'[utilisation spécifique de `<slot />` dans Astro](/fr/basics/astro-components/#les-emplacements-slots).
+
+### Récupération de données CRA vers Astro
+
+La récupération de données dans un composant Create React App se fait de manière similaire dans Astro, avec quelques légères différences.
+
+Vous devrez supprimer toutes les instances de hook d'effet secondaire (`useEffect`) et utiliser `Astro.glob()` ou `getCollection()`/`getEntryBySlug()` pour accéder aux données d'autres fichiers dans la source de votre projet.
+
+Pour [récupérer des données distantes](/fr/guides/data-fetching/), utilisez `fetch()`.
+
+Ces demandes de données sont effectuées dans le frontmatter du composant Astro et utilisent l'opérateur `await` de niveau supérieur (« top-level await »).
+
+```astro title="src/pages/index.astro"
+---
+import { getCollection } from 'astro:content';
+
+// Obtenir toutes les entrées de `src/content/blog/`
+const allBlogPosts = await getCollection('blog');
+
+// Obtenir toutes les entrées de `src/pages/posts/`
+const allPosts = await Astro.glob('../pages/posts/*.md');
+
+// Récupérer des données distantes
+const response = await fetch('https://randomuser.me/api/');
+const data = await response.json();
+const randomUser = data.results[0];
+---
+```
+
+En savoir plus sur les [importations de fichiers locaux avec `Astro.glob()`](/fr/guides/imports/#astroglob), l'[interrogation à l'aide de l'API Collections](/fr/guides/content-collections/#interroger-les-collections) ou la [récupération de données distantes](/fr/guides/data-fetching/).
+
+### Styles CRA vers Astro
+
+Vous devrez peut-être remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, styled-components) avec d'autres options CSS disponibles dans Astro.
+
+Si nécessaire, convertissez tous les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold;"`). Ou, utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+
+```astro title="src/components/Card.astro" del={1} ins={2}
+<div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>
+<div style="background-color: #f4f4f4; padding: 1em;">{message}</div>
+```
+
+Tailwind est pris en charge après l'installation de l'[intégration Tailwind](/fr/guides/integrations-guide/tailwind/). Aucune modification de votre code Tailwind existant n'est requise !
+
+En savoir plus sur [les styles dans Astro](/fr/guides/styling/).
+
+
+## Dépannage
+
+Votre application CRA pourrait « simplement fonctionner » dans Astro ! Mais vous devrez probablement apporter des ajustements mineurs pour dupliquer les fonctionnalités et/ou les styles de votre application existante.
+
+Si vous ne trouvez pas vos réponses dans cette documentation, veuillez visiter la [communauté Discord d'Astro](https://astro.build/chat) et posez des questions sur notre forum d'assistance !


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Translate [Migrating from Create React App](https://docs.astro.build/en/guides/migrate-to-astro/from-create-react-app/) (`migrate-to-astro/from-create-react-app.mdx`) added in #3788

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
