### PR TITLE
Make clear that transition:persist-props does not work without transition:persist

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -146,7 +146,7 @@ This allows you to control whether or not an island's props should be persisted 
 
 By default, when you add `transition:persist` to an island, the state is retained upon navigation, but your component will re-render with new props. This is useful, for example, when a component receives page-specific props such as the current page's `title`.
 
-You can override this behavior with `transition:persist-props`. Adding this directive will keep an island's existing props (not re-render with new values) in addition to maintaining its existing state.
+You can override this behavior by setting `transition:persist-props` in addition to `transition:persist`. Adding this directive will keep an island's existing props (not re-render with new values) in addition to maintaining its existing state.
 
 ### Built-in Animation Directives
 


### PR DESCRIPTION
#### Description (required)

Docs are not super clear on how to use `transition:persist-props`. Hopefully saying that it is an additional directive meant to be used together with `transition:persist` might help.

#### Related issues & labels (optional)

See https://github.com/withastro/astro/pull/10136.
