### PR TITLE
Fix Fathom 404 tracking

### DIFF
--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -8,6 +8,7 @@ const { isFallback, lang } = Astro.props;
 const ogImageUrl = getOgImageUrl(Astro.url.pathname, !!isFallback);
 const imageSrc = ogImageUrl ?? '/default-og-image.png';
 const canonicalImageSrc = new URL(imageSrc, Astro.site);
+const is404 = Astro.url.pathname.endsWith('/404/');
 ---
 
 <Default {...Astro.props}><slot /></Default>
@@ -19,4 +20,5 @@ const canonicalImageSrc = new URL(imageSrc, Astro.site);
 <meta name="twitter:site" content="astrodotbuild" />
 
 <!-- Fathom analytics -->
-<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>
+<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" data-canonical={!is404} defer
+></script>

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -20,5 +20,8 @@ const is404 = Astro.url.pathname.endsWith('/404/');
 <meta name="twitter:site" content="astrodotbuild" />
 
 <!-- Fathom analytics -->
-<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" data-canonical={!is404} defer
-></script>
+<script
+	src="https://cdn.usefathom.com/script.js"
+	data-site="EZBHTSIG"
+	data-canonical={is404 ? 'false' : 'true'}
+	defer></script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Fixes 404 tracking for in Fathom
- Fathom by default tracks page views using the URL of `<link rel="canonical">`
- Starlight injects a canonical like `/en/404/` or `/zh-cn/404/` for its 404 pages
- This PR tells Fathom to ignore the canonical for 404 pages so that 404 events are reported for the actual URL a user is visiting