### PR TITLE
i18n(fr): Fix escaping typo in Rss guide

### DIFF
--- a/src/content/docs/fr/guides/rss.mdx
+++ b/src/content/docs/fr/guides/rss.mdx
@@ -53,7 +53,7 @@ Le paquet [`@astrojs/rss`](https://github.com/withastro/astro/tree/main/packages
         // `<title>` champ dans le fichier xml de sortie
         title: 'Blog de Buzz',
         // `<description>` champ dans le fichier xml de sortie
-        description: 'Le guide des étoiles d'un humble astronaute',
+        description: "Le guide des étoiles d'un humble astronaute",
         // Insérez le "site" de votre projet dans le contexte du point de terminaison.
         // https://docs.astro.build/fr/reference/api-reference/#contextsite
         site: context.site,
@@ -93,7 +93,7 @@ export async function GET(context) {
   const blog = await getCollection('blog');
   return rss({
     title: 'Blog de Buzz',
-    description: 'Le guide des étoiles d'un humble astronaute',
+    description: "Le guide des étoiles d'un humble astronaute",
     site: context.site,
     items: blog.map((post) => ({
       title: post.data.title,
@@ -139,7 +139,7 @@ import rss, { pagesGlobToRssItems } from '@astrojs/rss';
 export async function GET(context) {
   return rss({
     title: 'Blog de Buzz',
-    description: 'Le guide des étoiles d'un humble astronaute',
+    description: "Le guide des étoiles d'un humble astronaute",
     site: context.site,
     items: await pagesGlobToRssItems(
       import.meta.glob('./blog/*.{md,mdx}'),
@@ -180,7 +180,7 @@ export async function GET(context) {
   const blog = await getCollection('blog');
   return rss({
     title: 'Blog de Buzz',
-    description: 'Le guide des étoiles d'un humble astronaute',
+    description: "Le guide des étoiles d'un humble astronaute",
     site: context.site,
     items: blog.map((post) => ({
       link: `/blog/${post.slug}/`,
@@ -205,7 +205,7 @@ export function GET(context) {
   const posts = Object.values(postImportResult);
   return rss({
     title: 'Blog de Buzz',
-    description: 'Le guide des étoiles d'un humble astronaute',
+    description: "Le guide des étoiles d'un humble astronaute",
     site: context.site,
     items: posts.map((post) => ({
       link: post.url,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We have some escape issues in `description` key with French in RSS Guide, that cause some highlighting problems:

![Capture d’écran 2024-07-08 à 10 55 48](https://github.com/withastro/docs/assets/18699562/771bb410-29da-4f0d-9d52-18e01e6d6aca)