### PR TITLE
fix(content): update code diff in migrate-to-astro/from-nuxtjs.mdx

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -274,7 +274,7 @@ See Astro's [testing guide](/en/guides/testing/) for more.
 
 To use local variables in an Astro component's HTML, change the set of two curly braces to one set of curly braces:
 
-```astro title="src/components/Component.astro" del={3} add={4}
+```astro title="src/components/Component.astro" del={4} add={5}
 ---
 const message = "Hello!"
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

While translating this page in French (#8764), I noticed an error in a code block: the `del`/`add` attributes was not matching the sentence above ("*change the set of two curly braces to one set of curly braces*"): the line numbers should be incremented by one.

See the code diff in [Nuxt Local Variables to Astro](https://docs.astro.build/en/guides/migrate-to-astro/from-nuxtjs/#nuxt-local-variables-to-astro), it should be:

![The code diff after changes](https://github.com/withastro/docs/assets/59021693/82100c77-4c84-429f-ab04-902be8fa9d53)


<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
