### PR TITLE
Updated recipe pages schema and components

### DIFF
--- a/src/components/RecipeLinks.astro
+++ b/src/components/RecipeLinks.astro
@@ -21,7 +21,7 @@ const recipes = Astro.props.slugs.map((slug) => {
 	if (!entry) {
 		throw new Error(`Could not find entry for slug "${slug}"`);
 	}
-	return { slug, isFallback, title: entry.data.title };
+	return { slug, isFallback, title: entry.data.title, altTitle: entry.data.altTitle };
 });
 
 const isList = recipes.length > 1;
@@ -39,7 +39,7 @@ if (!firstRecipe) {
 		{
 			!isList && (
 				<a href={`/${firstRecipe.slug}/`}>
-					{firstRecipe.title} {firstRecipe.isFallback && '(EN)'}
+					{firstRecipe.altTitle ?? firstRecipe.title} {firstRecipe.isFallback && '(EN)'}
 				</a>
 			)
 		}
@@ -50,7 +50,7 @@ if (!firstRecipe) {
 				{recipes.map((recipe) => (
 					<li>
 						<a href={`/${recipe.slug}/`}>
-							{recipe.title} {recipe.isFallback && '(EN)'}
+							{recipe.altTitle ?? recipe.title} {recipe.isFallback && '(EN)'}
 						</a>
 					</li>
 				))}

--- a/src/components/RecipesNav.astro
+++ b/src/components/RecipesNav.astro
@@ -23,7 +23,7 @@ const recipes = englishRecipes.map((fallback) => {
 		links={recipes.map(({ data, slug }) => {
 			const linkLang = slug.split('/').shift();
 			return {
-				title: data.title,
+				title: data.altTitle ?? data.title,
 				description: data.description,
 				// Fallback entries will have a slug starting with 'en/',
 				// so we replace that to link to the correct language.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -60,6 +60,7 @@ export const tutorialSchema = baseSchema.extend({
 export const recipeSchema = baseSchema.extend({
 	type: z.literal('recipe'),
 	description: z.string(),
+	altTitle: z.string().optional(),
 });
 
 export const docsCollectionSchema = z.union([


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a new schema property to recipe pages so that we can choose to display a full or alt title in our `RecipeNav` or `RecipeLinks` components

