### PR TITLE
Update Astro+Keystatic: document to markdoc field

### DIFF
--- a/src/content/docs/en/guides/cms/keystatic.mdx
+++ b/src/content/docs/en/guides/cms/keystatic.mdx
@@ -127,12 +127,8 @@ export default config({
       format: { contentField: 'content' },
       schema: {
         title: fields.slug({ name: { label: 'Title' } }),
-        content: fields.document({
+        content: fields.markdoc({
           label: 'Content',
-          formatting: true,
-          dividers: true,
-          links: true,
-          images: true,
         }),
       },
     }),


### PR DESCRIPTION
#### Description (required)

This PR updates the Astro + Keystatic integration documentation to reflect a recent change in the Keystatic API. The `fields.document` field type has been deprecated and replaced with `fields.markdoc`.

Specifically, this PR modifies the following code snippet:

From:
```
content: fields.document({
  label: 'Content',
  formatting: true,
  dividers: true,
  links: true,
  images: true,
}),
```
to: 
```
content: fields.markdoc({
  label: 'Content',
}),
```
Reference Documentation: https://keystatic.com/docs/fields/document
#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `4.11.0`. See astro PR [#](url). --> https://github.com/amirzezo201/docs.git

#### First-time contributor to Astro Docs? 
Yes


<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
amir_zezo2001  ( discord Username )
<!-- https://astro.build/chat -->
