### PR TITLE
Update Netlify logo in left sidebar with UTM link

### DIFF
--- a/src/components/LeftSidebar/Sponsors.astro
+++ b/src/components/LeftSidebar/Sponsors.astro
@@ -4,7 +4,7 @@ import UIString from '../UIString.astro';
 
 <div dir="ltr" lang="en" class="sponsors">
 	<h2 class="sponsors-title"><UIString key="leftSidebar.sponsoredBy" /></h2>
-	<a href="https://www.netlify.com/?utm_campaign=devex-jl&utm_source=astro&utm_medium=docs" aria-label="Netlify">
+	<a href="https://www.netlify.com/?utm_campaign=Astro-2024&utm_source=astro-referral" aria-label="Netlify">
 		<svg xmlns="http://www.w3.org/2000/svg" width="96" viewBox="0 0 256 105" aria-hidden="true">
 			<path
 				fill="#32E6E2"

--- a/src/components/LeftSidebar/Sponsors.astro
+++ b/src/components/LeftSidebar/Sponsors.astro
@@ -4,7 +4,7 @@ import UIString from '../UIString.astro';
 
 <div dir="ltr" lang="en" class="sponsors">
 	<h2 class="sponsors-title"><UIString key="leftSidebar.sponsoredBy" /></h2>
-	<a href="https://netlify.com/" aria-label="Netlify">
+	<a href="https://www.netlify.com/?utm_campaign=devex-jl&utm_source=astro&utm_medium=docs" aria-label="Netlify">
 		<svg xmlns="http://www.w3.org/2000/svg" width="96" viewBox="0 0 256 105" aria-hidden="true">
 			<path
 				fill="#32E6E2"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Netlify has become our official deployment partner. We originally update sponsors with the standard homepage URL for the href but since then we have received a UTM link to replace this with. This PR updates that href URL.