### PR TITLE
Fix an import statement in `build-forms-api.mdx`

### DIFF
--- a/src/content/docs/en/recipes/build-forms-api.mdx
+++ b/src/content/docs/en/recipes/build-forms-api.mdx
@@ -218,8 +218,9 @@ This recipe shows you how to send form data to an API endpoint and handle that d
         ```
       </Fragment>
       <Fragment slot="react">
-        ```tsx title="src/components/FeedbackForm.tsx" "/api/feedback" add={1, 4-17, 34} add="onSubmit={submit}" "formData" "e.preventDefault();"
-        import { FormEvent, useState } from "react";
+        ```tsx title="src/components/FeedbackForm.tsx" "/api/feedback" add={1-2, 5-18, 35} add="onSubmit={submit}" "formData" "e.preventDefault();"
+        import { useState } from "react";
+        import type { FormEvent } from "react";
 
         export default function Form() {
           const [responseMessage, setResponseMessage] = useState("");


### PR DESCRIPTION
#### Description

- Fixes an import statement from the React snippet in `build-forms-api.mdx`, in order to get rid of TypeScript error

#### Related issues & labels

- Closes #8783
- Suggested label: `code snippet update`
