### PR TITLE
Add dev flag to css preprocessor install

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -464,7 +464,7 @@ Astro supports CSS preprocessors such as [Sass][sass], [Stylus][stylus], and [Le
 ### Sass and SCSS
 
  ```shell
- npm install sass
+ npm install -D sass
  ```
 
 Use `<style lang="scss">` or `<style lang="sass">` in `.astro` files.
@@ -472,7 +472,7 @@ Use `<style lang="scss">` or `<style lang="sass">` in `.astro` files.
 ### Stylus
 
 ```shell
-npm install stylus
+npm install -D stylus
 ```
 
 Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files.
@@ -480,7 +480,7 @@ Use `<style lang="styl">` or `<style lang="stylus">` in `.astro` files.
 ### Less
 
 ```shell
-npm install less
+npm install -D less
 ```
 
 Use `<style lang="less">` in `.astro` files.
@@ -488,7 +488,7 @@ Use `<style lang="less">` in `.astro` files.
 ### LightningCSS
 
 ```shell
-npm install lightningcss
+npm install -D lightningcss
 ```
 
 Update your `vite` configuration in `astro.config.mjs`:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
A better way to add CSS pre-processors in projects is as dev dependency as they are needed only during the development phase of the project. Same for CSS parsers like `LightningCSS`. This PR just adds the `devDependency` flag `-D` in the install script to reflect that these packages are not required in the final production build.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `code snippet update`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
