### PR TITLE
Update Cloudflare Adapter Documentation - New imageService Default

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -83,10 +83,10 @@ export default defineConfig({
 
 <p>
 **Type:** `'passthrough' | 'cloudflare' | 'compile' | 'custom'`<br />
-**Default:** `'passthrough'`
+**Default:** `'compile'`
 </p>
 
-Determines which image service is used by the adapter. The adapter will default to `passthrough` mode when an incompatible image service is configured. Otherwise, it will use the globally configured image service:
+Determines which image service is used by the adapter. The adapter will default to `compile` mode when an incompatible image service is configured. Otherwise, it will use the globally configured image service:
 
 * **`cloudflare`:** Uses the [Cloudflare Image Resizing](https://developers.cloudflare.com/images/image-resizing/) service.
 * **`passthrough`:** Uses the existing [`noop`](/en/guides/images/#configure-no-op-passthrough-service) service.


### PR DESCRIPTION
#### Description (required)

As documented in the [Change Log](https://github.com/withastro/adapters/blob/main/packages/cloudflare/CHANGELOG.md) Version 11.0.0 contains a breaking change regarding a new default for the imageService.  This has been changed from 'passthrough' to 'compile'

- Suggested label: documentation

mark_57166
