### PR TITLE
Fix environment variable check for Netlify

### DIFF
--- a/src/pages/open-graph/_fetchFont.ts
+++ b/src/pages/open-graph/_fetchFont.ts
@@ -32,7 +32,7 @@ export async function fetchBrandFont() {
 	} catch (error) {
 		// When running locally, if anything goes wrong, we can safely return
 		// nothing and continue with the default local fonts.
-		if (!import.meta.env.CI) return undefined;
+		if (!import.meta.env.NETLIFY) return undefined;
 		// But in production builds we want to error if we failed to download fonts.
 		throw error;
 	}

--- a/src/pages/open-graph/_fetchFont.ts
+++ b/src/pages/open-graph/_fetchFont.ts
@@ -32,7 +32,7 @@ export async function fetchBrandFont() {
 	} catch (error) {
 		// When running locally, if anything goes wrong, we can safely return
 		// nothing and continue with the default local fonts.
-		if (!import.meta.env.VERCEL) return undefined;
+		if (!import.meta.env.CI) return undefined;
 		// But in production builds we want to error if we failed to download fonts.
 		throw error;
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I forgot to add an environment variable on Netlify used for downloading our brand font for open graph images. This resulted in images building using Inter instead of Obviously as the headline font.

Example:

<img src="https://github.com/user-attachments/assets/08277b57-efcc-4d71-8390-c90d7530be90" width="600" height="315" alt="Open Graph image for the getting started page with the headline set in Inter instead of Obviously">

I have now fixed that in the Netlify dashboard, but the reason this error was possible was that we were still checking for a `VERCEL` environment variable before throwing errors. This PR updates this to check the equivalent `NETLIFY` variable instead.

I also considered using the more generic `CI` variable, but docs gets built a bunch of CI places that don’t need the custom font (our GitHub Actions, `withastro/astro` smoke tests, etc.), so I think we probably can’t.
