### PR TITLE
i18n(fr): update error-reference.mdx & env-invalid-variables.mdx

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -85,7 +85,6 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**i18nNoLocaleFoundInPath**](/fr/reference/errors/i18n-no-locale-found-in-path/)<br/>Le chemin d'accès ne contient aucune locale
 - [**RouteNotFound**](/fr/reference/errors/route-not-found/)<br/>Route non trouvée.
 - [**EnvInvalidVariables**](/fr/reference/errors/env-invalid-variables/)<br/>Variables d'environnement non valides
-- [**EnvInvalidVariable**](/fr/reference/errors/env-invalid-variable/)<br/>Variable d'environnement invalide
 - [**EnvUnsupportedGetSecret**](/fr/reference/errors/env-unsupported-get-secret/)<br/>astro:env getSecret non supportée
 - [**ServerOnlyModule**](/fr/reference/errors/server-only-module/)<br/>Le module n'est disponible que côté serveur
 - [**RewriteWithBodyUsed**](/fr/reference/errors/rewrite-with-body-used/)<br/>Impossible d'utiliser Astro.rewrite après que le corps de la requête a été lu

--- a/src/content/docs/fr/reference/errors/env-invalid-variables.mdx
+++ b/src/content/docs/fr/reference/errors/env-invalid-variables.mdx
@@ -4,9 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **EnvInvalidVariables**: The following environment variables do not match the data type and/or properties defined in `experimental.env.schema`:<br/><br/>VARIABLES<br/>
+> The following environment variables defined in `experimental.env.schema` are invalid.
 
 ## Qu'est-ce qui a mal tourné ?
 Certaines variables d'environnement ne correspondent pas au type de données et/ou aux propriétés définies dans `experimental.env.schema`.
-
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Add changes made in #8835 to French translations of `error-reference.mdx` and `env-invalid-variables.mdx`

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
