### PR TITLE
i18n(fr): update `images`, `markdown-content` and `integrations-reference`

### DIFF
--- a/src/content/docs/fr/guides/images.mdx
+++ b/src/content/docs/fr/guides/images.mdx
@@ -129,7 +129,7 @@ Le format de la valeur `src` de votre fichier image dépend de l'endroit où se 
     src="https://example.com/remote-image.jpg"
     alt="texte de description"
     width="200"
-    height="150" 
+    height="150"
   />
   ```
 
@@ -143,7 +143,7 @@ Si une image est simplement décorative (c'est-à-dire qu'elle ne contribue pas 
 
 Ces propriétés définissent les dimensions à utiliser pour l'image.
 
-Lors de l'utilisation d'images dans leur format d'origine, `width` et `height` sont optionnels. Ces dimensions peuvent être automatiquement déduites des fichiers images situés dans `src/` et des images distantes avec [`inferSize` fixé à `true`](#infersize).
+Lors de l'utilisation d'images dans leur format d'origine, `width` et `height` sont optionnels. Ces dimensions peuvent être automatiquement déduites des fichiers images situés dans `src/`. Pour les images distantes, ajoutez [l'attribut `inferSize` défini sur `true`](#infersize) sur les composants `<Image />` ou `<Picture />` ou utilisez la [fonction`inferRemoteSize()`](#inferremotesize).
 
 Cependant, ces deux propriétés sont nécessaires pour les images stockées dans votre dossier `public/` car Astro n'est pas en mesure d'analyser ces fichiers.
 
@@ -265,6 +265,17 @@ import { Image } from 'astro:assets';
 ```
 
 `inferSize` peut récupérer les dimensions d'une [image distante d'un domaine qui n'a pas été autorisé](#autoriser-les-images-distantes), mais l'image elle-même ne sera pas traitée.
+
+###### inferRemoteSize()
+
+<p><Since v="4.12.0" /></p>
+
+Une fonction pour déduire les dimensions des images distantes. Cela peut être utilisé comme alternative au passage de la propriété `inferSize`.
+
+```ts
+import { inferRemoteSize } from 'astro:assets';
+const {width, height} = await inferRemoteSize("https://exemple.com/chat.png");
+```
 
 ##### Propriétés supplémentaires
 

--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -601,6 +601,10 @@ export default defineConfig({
         light: 'github-light',
         dark: 'github-dark',
       },
+      // Désactivez les couleurs par défaut
+      // https://shiki.style/guide/dual-themes#without-default-color
+      // (Ajouté dans la v4.12.0)
+      defaultColor: false,
       // Ajouter des langues personnalisées
       // Note : Shiki intègre d'innombrables langages, y compris le .astro !
       // https://shiki.style/languages
@@ -616,7 +620,7 @@ export default defineConfig({
 ```
 
 :::note[Personnalisation des thèmes Shiki]
-Les blocs de code Astro sont stylisés en utilisant la classe `.astro-code`. Lorsque vous suivez la documentation de Shiki (par exemple pour [personnaliser un thème double clair/foncé ou de multiples thèmes](https://shiki.style/guide/dual-themes#query-based-dark-mode)), assurez-vous de remplacer la classe `.shiki` dans les exemples par `.astro-code`
+Les blocs de code Astro sont stylisés en utilisant la classe `.astro-code`. Lorsque vous suivez la documentation de Shiki (par exemple pour [personnaliser un thème double clair/foncé ou de multiples thèmes](https://shiki.style/guide/dual-themes#query-based-dark-mode)), assurez-vous de remplacer la classe `.shiki` dans les exemples par `.astro-code`.
 :::
 
 #### Ajouter votre propre thème

--- a/src/content/docs/fr/reference/integrations-reference.mdx
+++ b/src/content/docs/fr/reference/integrations-reference.mdx
@@ -54,11 +54,17 @@ interface AstroIntegration {
         logger: AstroIntegrationLogger;
     }) => void | Promise<void>;
     'astro:build:done'?: (options: { dir: URL; routes: RouteData[]; logger: AstroIntegrationLogger; }) => void | Promise<void>;
+
+    // ... tous les hooks personnalisés provenant des intégrations
   };
 }
 ```
 
 ## Hooks
+
+Astro fournit des hooks que les intégrations peuvent implémenter pour s'exécuter pendant certaines parties du cycle de vie d'Astro. Les hooks Astro sont définis dans l'interface `IntegrationHooks`, qui fait partie de l'espace de noms global `Astro`.
+
+Les hooks suivants sont intégrés à Astro :
 
 ### `astro:config:setup`
 
@@ -613,6 +619,22 @@ interface RouteData {
 Une liste de toutes les pages générées. Il s'agit d'un objet avec une propriété.
 
 - `pathname` - le chemin finalisé de la page.
+
+### Custom hooks
+
+Des hooks personnalisés peuvent être ajoutés aux intégrations en étendant l'interface `IntegrationHooks` via [augmentation globale](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation).
+
+```ts
+declare global {
+  namespace Astro {
+    export interface IntegrationHook {
+      'your:hook': (params: YourHookParameters) => Promise<void>
+    }
+  }
+}
+```
+
+Astro réserve le préfixe `astro:` pour les futurs hooks intégrés. Veuillez choisir un préfixe différent lorsque vous nommez votre hook personnalisé.
 
 ## Autoriser l'installation avec `astro add`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Add changes from #8796 to French translations

Note: only `images.mdx`, `markdown-content` and `integrations-reference.mdx` are updated in this pull request because:
* `api-reference.mdx` is not yet translated
* `configuration-reference.mdx` is not yet merged so the changes have been added to #8837
* `cli-reference.mdx` is already updated in another PR, see #8830

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
