### PR TITLE
i18n(es): Changed 'Coincide' to 'Haz coincidir'

### DIFF
--- a/src/content/docs/es/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/es/tutorial/5-astro-api/3.mdx
@@ -397,7 +397,7 @@ const { frontmatter } = Astro.props;
 
 ### Pon a prueba tus conocimientos
 
-Coincide cada ruta de archivo con una segunda ruta de archivo que creará una página en la misma ruta.
+Haz coincidir cada ruta de archivo con una segunda ruta de archivo que creará una página en la misma ruta.
 
 1. `src/pages/categories.astro`
 


### PR DESCRIPTION
'Coincide cada ruta...' is not a correct expression in Spanish.
