### PR TITLE
CMS guides nav: sort alphabetically (part of #8860)

### DIFF
--- a/src/components/CMSGuidesNav.astro
+++ b/src/components/CMSGuidesNav.astro
@@ -8,21 +8,9 @@ import CardsNav from './NavGrid/CardsNav.astro';
 const lang = getLanguageFromURL(Astro.url.pathname);
 const enPages = englishPages.filter(isCmsEntry);
 
-/** Array of services we have good content for and want to show first in the list. */
-const showFirst = ['Storyblok', 'Contentful', 'ButterCMS'];
-// Reverse the array to make our logic simpler later.
-showFirst.reverse();
-
 const links = enPages
 	.sort((a, b) => {
-		// Sort services in the `showFirst` array first.
-		const aPriority = showFirst.indexOf(a.data.service);
-		const bPriority = showFirst.indexOf(b.data.service);
-		if (aPriority !== -1 || bPriority !== -1) return aPriority > bPriority ? -1 : 1;
-		// Sort full guides before stubs.
-		if (a.data.stub && !b.data.stub) return 1;
-		if (!a.data.stub && b.data.stub) return -1;
-		// If they’re both stubs, or neither stubs, sort alphabetically.
+		// Sort alphabetically.
 		return a.data.service.toLowerCase() > b.data.service.toLowerCase() ? 1 : -1;
 	})
 	.map((page) => {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

Alphabetize CMS guides' nav.

#### Related issues & labels (optional)

- Moves #8860 closer to closing
- Suggested label: site improvement

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
