### PR TITLE
Format example code indentation

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -213,10 +213,10 @@ Even if it looks challenging, you can try following along with the steps to buil
 
    return uniqueTags.map((tag) => {
      const filteredPosts = allPosts.filter((post) => post.frontmatter.tags.includes(tag));
-       return {
-         params: { tag },
-         props: { posts: filteredPosts },
-       };
+     return {
+       params: { tag },
+       props: { posts: filteredPosts },
+     };
    });
    ```
 4. A `getStaticPaths` function should always return a list of objects containing `params` (what to call each page route) and optionally any `props` (data that you want to pass to those pages). Earlier, you defined each tag name that you knew was used in your blog and passed the entire list of posts as props to each page.


### PR DESCRIPTION
#### Description (required)

The indentation for `return` is incorrect and could possibly lead readers to think that `return` is part of the `filter` function.

#### Related issues & labels (optional)

- Suggested label: `consistency/formatting`, `improve documentation`

Discord: `artt`