### PR TITLE
Fix search category for integration guides

### DIFF
--- a/src/util/getPageCategory.ts
+++ b/src/util/getPageCategory.ts
@@ -9,7 +9,7 @@ const categories = [
 	['guides/backend/', 'Recipes'],
 	['guides/cms/', 'Recipes'],
 	['guides/deploy/', 'Recipes'],
-	['guides/integrations-guide/', 'Recipes'],
+	['guides/integrations-guide/', 'Learn'],
 	['guides/migrate-to-astro/', 'Recipes'],
 	['guides/upgrade-to/', 'Upgrade Guides'],
 	['recipes/', 'Recipes'],


### PR DESCRIPTION
This PR marks pages under `/guides/integrations-guide/*` as part of our “Learn” category for search purposes. This includes individual integration pages like `@astrojs/mdx` etc.

The category had previously been changed to “Recipes” when integration guides were grouped with our guides to deployment, CMS etc. but after the recent sidebar shuffle, restoring these to “Learn” makes sense.

Note that this change will only take effect after merging this PR and reindexing Algolia. That happens automatically every Monday, but we can run a manual reindex if this feels high enough priority.