### PR TITLE
fix(api-reference): improve Astro.redirect documentation

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -372,8 +372,6 @@ Allows customizing how the cookie is serialized.
 
 ### `Astro.redirect()`
 
-<p><Since v="0.25.0" /></p>
-
 **Type:** `(path: string, status?: number) => Response`
 
 Allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) as a second parameter.
@@ -382,7 +380,7 @@ A page (and not a child component) must `return` the result of `Astro.redirect()
 
 For statically-generated sites, this will produce a client redirect using a [`<meta http-equiv="refresh">` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) and does not support status codes.
 
-When using SSR, status codes are supported. Astro will serve redirected requests with a status of `302` by default unless another code is specified.
+When using an on-demand rendering mode, status codes are supported. Astro will serve redirected requests with a default HTTP response status of `302` unless another code is specified.
 
 The following example redirects a user to a login page:
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -372,11 +372,19 @@ Allows customizing how the cookie is serialized.
 
 ### `Astro.redirect()`
 
-Allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) as a second parameter.
+<p><Since v="0.25.0" /></p>
+
+**Type:** `(path: string, status?: number) => Response`
+
+Allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) as a second parameter.
 
 A page (and not a child component) must `return` the result of `Astro.redirect()` for the redirect to occur.
 
-The following example redirects a user to a login page, using the default HTTP response status code 302:
+For statically-generated sites, this will produce a client redirect using a [`<meta http-equiv="refresh">` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) and does not support status codes.
+
+When using SSR, status codes are supported. Astro will serve redirected requests with a status of `302` by default unless another code is specified.
+
+The following example redirects a user to a login page:
 
 ```astro title="src/pages/account.astro" {8}
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improve [`Astro.redirect` documentation](https://docs.astro.build/en/reference/api-reference/#astroredirect) in `api-reference.mdx`:
* Add `<Since />` (released in `0.25.0`, see https://github.com/withastro/astro/pull/2798)
* Add the function type
* Clarify differences between SSR and static output

#### Related issues & labels (optional)

- Closes #8917
- Suggested label: improve documentation

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
