### PR TITLE
fix(guides/routing): update Page interface and add link to API reference

### DIFF
--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -426,7 +426,7 @@ interface Page<T = any> {
 }
 ```
 
-<ReadMore>Learn more about [`page` prop](/en/reference/api-reference/#the-pagination-page-prop).</ReadMore>
+<ReadMore>Learn more about [the pagination `page` prop](/en/reference/api-reference/#the-pagination-page-prop).</ReadMore>
 
 ### Nested Pagination
 

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -407,7 +407,7 @@ interface Page<T = any> {
 	total: number;
 	/** the current page number, starting from 1 */
 	currentPage: number;
-	/** number of items per page (default: 25) */
+	/** number of items per page (default: 10) */
 	size: number;
 	/** number of last page */
 	lastPage: number;
@@ -418,9 +418,15 @@ interface Page<T = any> {
 		prev: string | undefined;
 		/** url of the next page (if there is one) */
 		next: string | undefined;
+		/** url of the first page (if the current page is not the first page) */
+		first: string | undefined;
+		/** url of the next page (if the current page in not the last page) */
+		last: string | undefined;
 	};
 }
 ```
+
+<ReadMore>Learn more about [`page` prop](/en/reference/api-reference/#the-pagination-page-prop).</ReadMore>
 
 ### Nested Pagination
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Update `page.size` default (see https://github.com/withastro/astro/pull/11561)
* Add `page.url.first` and `page.url.last` to the Page interface (see https://github.com/withastro/astro/pull/11176)
* Add a `ReadMore` link to the API reference page

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #8929
- Suggested label: improve-documentation

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
