### PR TITLE
Add reference for named slot functions

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -539,8 +539,6 @@ import Shout from "../components/Shout.astro";
 
 Callback functions can be passed to named slots inside a wrapping HTML element tag with a `slot` attribute. This element is only used to transfer the callback to a named slot and will not be rendered onto the page.
 
-A callback 
-
 ```astro
 <Shout message="slots!">
   <fragment slot="message">

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -549,7 +549,7 @@ A callback
 </Shout>
 ```
 
-This tag cannot be named `Fragment`, `slot` or include a dash `-`. The tag is only used to transfer the callback to a named slot, it does not get rendered onto the page.
+Use a standard HTML element for the wrapping tag, or any lower case tag (e.g. `<fragment>` instead of `<Fragment />`) that will not be interpreted as a component.  Do not use the HTML `<slot>` element as this will be interpreted as an Astro slot.
 
 ### `Astro.self`
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -537,6 +537,18 @@ import Shout from "../components/Shout.astro";
 <!-- renders as <div>SLOTS!</div> -->
 ```
 
+Callback functions can be passed to named slots using a HTML tag with a `slot` attribute:
+
+```astro
+<Shout message="slots!">
+  <fragment slot="message">
+    {(message) => <div>{message}</div>}
+  </fragment>
+</Shout>
+```
+
+This tag cannot be named `Fragment`, `slot` or include a dash `-`. The tag is only used to transfer the callback to a named slot, it does not get rendered onto the page.
+
 ### `Astro.self`
 
 `Astro.self` allows Astro components to be recursively called. This behaviour lets you render an Astro component from within itself by using `<Astro.self>` in the component template. This can be helpful for iterating over large data stores and nested data-structures.

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -537,7 +537,9 @@ import Shout from "../components/Shout.astro";
 <!-- renders as <div>SLOTS!</div> -->
 ```
 
-Callback functions can be passed to named slots using a HTML tag with a `slot` attribute:
+Callback functions can be passed to named slots inside a wrapping HTML element tag with a `slot` attribute. This element is only used to transfer the callback to a named slot and will not be rendered onto the page.
+
+A callback 
 
 ```astro
 <Shout message="slots!">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR partially addresses issue https://github.com/withastro/docs/issues/8855 by adding an example for named slot functions to the reference page for `Astro.slots.render()`

#### Related issues & labels (optional)

- Partially addresses: https://github.com/withastro/docs/issues/8855

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
