### PR TITLE
Add config file types to Project Structure page

### DIFF
--- a/src/content/docs/en/basics/project-structure.mdx
+++ b/src/content/docs/en/basics/project-structure.mdx
@@ -118,6 +118,10 @@ For help creating a new `package.json` file for your project, check out the [man
 
 This file is generated in every starter template and includes configuration options for your Astro project. Here you can specify integrations to use, build options, server options, and more.
 
+Astro supports several file formats for its JavaScript configuration file: `astro.config.js`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. We recommend using `.mjs` in most cases or `.ts` if you want to write TypeScript in your config file.
+
+TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project tsconfig options.
+
 See the [Configuring Astro Guide](/en/guides/configuring-astro/) for details on setting configurations.
 
 ### `tsconfig.json`

--- a/src/content/docs/en/basics/project-structure.mdx
+++ b/src/content/docs/en/basics/project-structure.mdx
@@ -120,7 +120,7 @@ This file is generated in every starter template and includes configuration opti
 
 Astro supports several file formats for its JavaScript configuration file: `astro.config.js`, `astro.config.mjs`, `astro.config.cjs` and `astro.config.ts`. We recommend using `.mjs` in most cases or `.ts` if you want to write TypeScript in your config file.
 
-TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project tsconfig options.
+TypeScript config file loading is handled using [`tsm`](https://github.com/lukeed/tsm) and will respect your project's `tsconfig` options.
 
 See the [Configuring Astro Guide](/en/guides/configuring-astro/) for details on setting configurations.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We're working on ways to reorganize, or link to, the content in the "[Configuring Astro](https://docs.astro.build/en/guides/configuring-astro/)" guide.

As recommended by @sarah11918 in https://github.com/withastro/docs/issues/8918#issuecomment-2255579753, this PR will add the info on supported config file types from the "Configuring Astro" guide to the "[Project Structure](https://docs.astro.build/en/basics/project-structure/)" basics page. This will give new users a quick reference when they're learning how to set up their projects.

#### Related issues & labels (optional)

- https://github.com/withastro/docs/issues/8918
- Suggested label: [consistency/formatting](https://github.com/withastro/docs/labels/consistency%2Fformatting), [good first issue](https://github.com/withastro/docs/labels/good%20first%20issue) <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs?

If you are a member of the Astro Discord, please add your username in the description so we can welcome you there!
https://astro.build/chat

br3ndonland