### PR TITLE
i18n(fr): Fix typos in docusaurus migration guide

### DIFF
--- a/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
@@ -19,7 +19,7 @@ Docusaurus et Astro partagent certaines similitudes qui vous aideront à migrer 
 
 - Astro et Docusaurus supportent tous deux les [pages MDX](/fr/guides/markdown-content/). Vous devriez pouvoir utiliser vos fichiers `.mdx` existants pour Astro.
 
-- Astro et Docusaurus utilisent [e routage basé sur les fichiers](/fr/guides/routing/) pour générer automatiquement des routes de pages pour tout fichier MDX situé dans `src/pages`. L'utilisation de la structure de fichiers d'Astro pour votre contenu existant et lors de l'ajout de nouvelles pages devrait vous sembler familière.
+- Astro et Docusaurus utilisent [le routage basé sur les fichiers](/fr/guides/routing/) pour générer automatiquement des routes de pages pour tout fichier MDX situé dans `src/pages`. L'utilisation de la structure de fichiers d'Astro pour votre contenu existant et lors de l'ajout de nouvelles pages devrait vous sembler familière.
 
 - Astro dispose d'une [intégration officielle pour l'utilisation des composants React](/fr/guides/integrations-guide/react/). Notez que dans Astro, les fichiers React **doivent** avoir une extension `.jsx` ou `.tsx`.
 
@@ -29,7 +29,7 @@ Docusaurus et Astro partagent certaines similitudes qui vous aideront à migrer 
 
 ## Principales différences entre Docusaurus et Astro
 
-Lorsque vous reconstruisez votre site Docusaurus dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous reconstruisez votre site Docusaurus avec Astro, vous remarquerez quelques différences importantes :
 
 - Docusaurus est une application monopage (SPA) basée sur React. Les sites Astro sont des applications multi-pages construites en utilisant des [composants `.astro`](/fr/basics/astro-components/), mais peuvent aussi supporter [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS, Lit](/fr/guides/framework-components/) et le templating HTML brut.
 
@@ -39,7 +39,7 @@ Lorsque vous reconstruisez votre site Docusaurus dans Astro, vous remarquerez qu
 
 ## Passer de Docusaurus à Astro
 
-Pour convertir un site de documentation Docusaurus en Astro, par notre [modèle de démarrage officiel Starlight](https://starlight.astro.build), ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
+Pour convertir un site de documentation Docusaurus en Astro, commencez par notre [modèle de démarrage officiel Starlight](https://starlight.astro.build), ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
 
 Vous pouvez passer un argument `--template` à la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles officiels. Vous pouvez aussi [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 


### PR DESCRIPTION
#### Description (required)

[docs] Simple typos in the FR page about Docusaurus migration guide.


