### PR TITLE
i18n(fr): Add `reference/errors/action-query-string-invalid-error.mdx` from #8967

### DIFF
--- a/src/content/docs/fr/reference/errors/action-query-string-invalid-error.mdx
+++ b/src/content/docs/fr/reference/errors/action-query-string-invalid-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Une chaîne de requête d'action invalide a été transmise par un formulaire.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionQueryStringInvalidError**: The server received the query string `?_astroAction=ACTION_NAME`, but could not find an action with that name. If you changed an action's name in development, remove this query param from your URL and refresh.
+
+## Qu'est-ce qui a mal tourné ?
+Le serveur a reçu la chaîne de requête `?_astroAction=name`, mais n'a pas trouvé d'action portant ce nom. Utilisez la propriété `.queryString` de la fonction action pour récupérer l'URL du formulaire `action`.
+
+**Voir aussi :**
+-  [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
 Add `reference/errors/action-query-string-invalid-error.mdx` from #8967
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
