### PR TITLE
i18n(fr): Add `reference/errors/actions-used-with-for-get-error.mdx` from #8967

### DIFF
--- a/src/content/docs/fr/reference/errors/actions-used-with-for-get-error.mdx
+++ b/src/content/docs/fr/reference/errors/actions-used-with-for-get-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Une chaîne de requête d'action invalide a été transmise par un formulaire.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionsUsedWithForGetError**: Action ACTION_NAME was called from a form using a GET request, but only POST requests are supported. This often occurs if `method="POST"` is missing on the form.
+
+## Qu'est-ce qui a mal tourné ?
+L'action a été appelée à partir d'un formulaire à l'aide d'une requête GET, mais seules les requêtes POST sont prises en charge. Cela se produit souvent si `method="POST"` est absent du formulaire.
+
+**Voir aussi :**
+-  [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)
+
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Add `reference/errors/actions-used-with-for-get-error.mdx` from #8967
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
