### PR TITLE
Clarify framework dependency for JSX files

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -15,10 +15,9 @@ The following file types are supported out-of-the-box by Astro:
 - Astro Components (`.astro`)
 - Markdown (`.md`, `.markdown`, etc.)
 - JavaScript (`.js`, `.mjs`)
-- TypeScript (`.ts`, `.tsx`)
+- TypeScript (`.ts`)
 - NPM Packages
 - JSON (`.json`)
-- JSX (`.jsx`, `.tsx`)
 - CSS (`.css`)
 - CSS Modules (`.module.css`)
 - Images & Assets (`.svg`, `.jpg`, `.png`, etc.)
@@ -40,6 +39,13 @@ import { getUser } from './user.js';
 ```
 
 JavaScript can be imported using normal ESM `import` & `export` syntax.
+
+:::note[Importing JSX files]
+
+An appropriate [UI framework](/en/guides/framework-components/) ([React](/en/guides/integrations-guide/react/), [Preact](/en/guides/integrations-guide/preact/), or [Solid](/en/guides/integrations-guide/solid-js/)) is required to render JSX/TSX files.
+Use `.jsx`/`.tsx` extensions where appropriate, as Astro does not support JSX in `.js`/`.ts` files.
+
+:::
 
 ### TypeScript
 
@@ -64,20 +70,6 @@ import MyComponent from "./MyComponent"; // MyComponent.tsx
 
 <ReadMore>Read more about [TypeScript support in Astro](/en/guides/typescript/).</ReadMore>
 
-
-### JSX / TSX
-
-```js
-import { MyComponent } from './MyComponent.jsx';
-```
-
-Astro includes built-in support for JSX (`*.jsx` and `*.tsx`) files in your project. JSX syntax is automatically transpiled to JavaScript.
-
-While Astro understands JSX syntax out-of-the-box, you will need to include a framework integration to properly render frameworks like React, Preact and Solid. Check out our [Using Integrations](/en/guides/integrations-guide/) guide to learn more.
-
-:::note
-**Astro does not support JSX in `.js`/`.ts` files.** JSX will only be handled inside of files that end with the `.jsx` and `.tsx` file extensions.
-:::
 
 ### NPM Packages
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Clarifies that a UI framework is required to import and render JSX/TSX files. My first PR here! I'm happy to make any amendments as seen fit :)

I just joined the Astro Discord, username is `footnuke` 

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #8939
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
