### PR TITLE
i18n(fr): fix typo in `guides/middleware.mdx`

### DIFF
--- a/src/content/docs/fr/guides/middleware.mdx
+++ b/src/content/docs/fr/guides/middleware.mdx
@@ -208,7 +208,7 @@ Utilisez `context.rewrite()` dans un middleware pour afficher le contenu d'une a
 ```js title="src/middleware.js"
 import { isLoggedIn } from "~/auth.js"
 export function onRequest (context, next) {
-  if (!isLoggedIn(context) {
+  if (!isLoggedIn(context)) {
     // Si l'utilisateur n'est pas connecté, mettre à jour la requête pour afficher la route `/login` et
     // ajouter un en-tête pour indiquer où l'utilisateur doit être envoyé après une connexion réussie.
     // Ré-exécuter le middleware.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Fix typo in `guides/middleware.mdx`  (see #8994)

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
