### PR TITLE
Replace rehype-minify-html with rehype-preset-minify in mdx docs

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -111,7 +111,7 @@ All [`markdown` configuration options](/en/reference/configuration-reference/#ma
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import remarkToc from 'remark-toc';
-import rehypeMinifyHtml from 'rehype-minify-html';
+import rehypePresetMinify from 'rehype-preset-minify';
 
 export default defineConfig({
   // ...
@@ -120,7 +120,7 @@ export default defineConfig({
       syntaxHighlight: 'shiki',
       shikiConfig: { theme: 'dracula' },
       remarkPlugins: [remarkToc],
-      rehypePlugins: [rehypeMinifyHtml],
+      rehypePlugins: [rehypePresetMinify],
       remarkRehype: { footnoteLabel: 'Footnotes' },
       gfm: false,
     }),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`rehype-minify-html` doesn't exist. Replace with equivalent module.

<!-- Please make changes in **one language** only -->


<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
