### PR TITLE
Update why-astro.mdx to indicate content collections can also be JSON data

### DIFF
--- a/src/content/docs/en/concepts/why-astro.mdx
+++ b/src/content/docs/en/concepts/why-astro.mdx
@@ -16,7 +16,7 @@ Some highlights include:
 - **[UI-agnostic](/en/guides/framework-components/):** Supports React, Preact, Svelte, Vue, Solid, Lit, HTMX, web components, and more.
 - **[Server-first](/en/basics/rendering-modes/):** Moves expensive rendering off of your visitors' devices.
 - **[Zero JS, by default](/en/basics/astro-components/):** Less client-side JavaScript to slow your site down.
-- **[Content collections](/en/guides/content-collections/):** Organize, validate, and provide TypeScript type-safety for your Markdown content.
+- **[Content collections](/en/guides/content-collections/):** Organize, validate, and provide TypeScript type-safety for your JSON or Markdown content.
 - **[Customizable](/en/guides/integrations-guide/):** Tailwind, MDX, and hundreds of integrations to choose from.
 
 ## Design Principles


### PR DESCRIPTION
Indicate that content collections can be JSON data as well

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

Content collections are not restricted to Markdown (or MDX) files, so I thought it might be more accurate to indicate they can be JSON data as well.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

No related issue. Just suggesting an edit.

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs?

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

`@kyleshevlin` on Discord
