### PR TITLE
i18n(zh-cn): Update `2.mdx` Adjust the extra `../`

### DIFF
--- a/src/content/docs/zh-cn/tutorial/4-layouts/2.mdx
+++ b/src/content/docs/zh-cn/tutorial/4-layouts/2.mdx
@@ -135,7 +135,7 @@ const { frontmatter } = Astro.props;
     <details>
         <summary>显示填写好空白处的代码！</summary>
 
-        1.  ```markdown title="src/pages/posts/learning-astro.md" "../layouts" "pubDate:"
+        1.  ```markdown title="src/pages/posts/learning-astro.md" "layouts" "pubDate:"
             ---
             layout: ../../layouts/MyMarkdownLayout.astro
             title: "Learning About Markdown in Astro"


### PR DESCRIPTION
#### Description

Hello, I am Mengke. When I was learning Astro, I found a mistake in the `zh-cn` documentation.

There is a superfluous "../" in the answer to the question.

<img width="678" alt="image" src="https://github.com/user-attachments/assets/6371b0f9-64f6-4d0e-9f4e-4d8b0d52d9b8">
