### PR TITLE
Document new `astro:route:setup` hook

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -626,7 +626,7 @@ A list of all generated pages. It is an object with one property.
 
 **When:** In `astro dev`, whenever a route is requested. In `astro build`, while bundling and transforming a route file.
 
-**Why:** To update a route's option, i.e. `prerender` to configure [on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).
+**Why:** To update a route's option, i.e. `prerender` to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).
 
 ```js
 'astro:route:setup'?: (options: { route: RouteOptions }) => void | Promise<void>;
@@ -640,7 +640,7 @@ An object with a readonly `component` property and a `prerender` property.
 
 The `component` property is a readonly string path relative to the project root, e.g `"src/pages/blog/[...slug].astro"`.
 
-The `prerender` property is used to configure [on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route. The value may be a `boolean` or `undefined` depending if there's an explicit `export const prerender` value set in the file. If the final value after running all the hooks is `undefined`, it will fall back to a prerender default based on the [`output` option](/en/reference/configuration-reference/#output).
+The `prerender` property is used to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route. The value may be a `boolean` or `undefined` depending if there's an explicit `export const prerender` value set in the file. If the final value after running all the hooks is `undefined`, it will fall back to a prerender default based on the [`output` option](/en/reference/configuration-reference/#output).
 
 ### Custom hooks
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -626,7 +626,7 @@ A list of all generated pages. It is an object with one property.
 
 **When:** In `astro dev`, whenever a route is requested. In `astro build`, while bundling and transforming a route file.
 
-**Why:** To update a route's option, i.e. `prerender` to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).
+**Why:** To set options for a route at build or request time, such as enabling [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).
 
 ```js
 'astro:route:setup'?: (options: { route: RouteOptions }) => void | Promise<void>;
@@ -636,7 +636,7 @@ A list of all generated pages. It is an object with one property.
 
 **Type:** `RouteOptions`
 
-An object with a readonly `component` property and a `prerender` property.
+An object with a `component` property to identify the route and the following additional values to allow you to configure the generated route: `prerender`.
 
 The `component` property is a readonly string path relative to the project root, e.g `"src/pages/blog/[...slug].astro"`.
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -648,7 +648,7 @@ The `component` property is a readonly string path relative to the project root,
 <Since v="4.14.0" />
 </p>
 
-The `prerender` property is used to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route.  If the route file contains an explicit `export const prerender` value, the value will be used as the default instead of `undefined`.
+The `prerender` property is used to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route. If the route file contains an explicit `export const prerender` value, the value will be used as the default instead of `undefined`.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -622,6 +622,8 @@ A list of all generated pages. It is an object with one property.
 
 ### `astro:route:setup`
 
+<p><Since v="4.14.0" /></p>
+
 **When:** In `astro dev`, whenever a route is requested. In `astro build`, while bundling and transforming a route file.
 
 **Why:** To update a route's option, i.e. `prerender` to configure [on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -638,9 +638,40 @@ A list of all generated pages. It is an object with one property.
 
 An object with a `component` property to identify the route and the following additional values to allow you to configure the generated route: `prerender`.
 
-The `component` property is a readonly string path relative to the project root, e.g `"src/pages/blog/[...slug].astro"`.
+The `component` property is a readonly string path relative to the project root, e.g `"src/pages/blog/[slug].astro"`.
 
-The `prerender` property is used to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route. The value may be a `boolean` or `undefined` depending if there's an explicit `export const prerender` value set in the file. If the final value after running all the hooks is `undefined`, it will fall back to a prerender default based on the [`output` option](/en/reference/configuration-reference/#output).
+##### `route.prerender`
+
+<p>
+**Type:** `boolean`<br />
+**Default:** `undefined`<br />
+<Since v="4.14.0" />
+</p>
+
+The `prerender` property is used to configure [on-demand server rendering](/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route.  If the route file contains an explicit `export const prerender` value, the value will be used as the default instead of `undefined`.
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [setPrerender()],
+});
+
+function setPrerender() {
+  return {
+    name: 'set-prerender',
+    hooks: {
+      'astro:route:setup': ({ route }) => {
+        if (route.component.endsWith('/blog/[slug].astro')) {
+          route.prerender = true;
+        }
+      },
+    },
+  };
+}
+```
+ 
+If the final value after running all the hooks is `undefined`, the route will fall back to a prerender default based on the [`output` option](/en/reference/configuration-reference/#output): prerendered for `hybrid` mode, and on-demand rendered for `server` mode.
 
 ### Custom hooks
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -37,6 +37,7 @@ interface AstroIntegration {
       logger: AstroIntegrationLogger;
     }) => void | Promise<void>;
     'astro:config:done'?: (options: { config: AstroConfig; setAdapter: (adapter: AstroAdapter) => void; logger: AstroIntegrationLogger; }) => void | Promise<void>;
+    'astro:route:setup'?: (options: { route: RouteOptions; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:setup'?: (options: { server: vite.ViteDevServer; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:start'?: (options: { address: AddressInfo; logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:server:done'?: (options: { logger: AstroIntegrationLogger; }) => void | Promise<void>;
@@ -618,6 +619,26 @@ interface RouteData {
 A list of all generated pages. It is an object with one property.
 
 - `pathname` - the finalized path of the page.
+
+### `astro:route:setup`
+
+**When:** In `astro dev`, whenever a route is requested. In `astro build`, while bundling and transforming a route file.
+
+**Why:** To update a route's option, i.e. `prerender` to configure [on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode).
+
+```js
+'astro:route:setup'?: (options: { route: RouteOptions }) => void | Promise<void>;
+```
+
+#### `route` option
+
+**Type:** `RouteOptions`
+
+An object with a readonly `component` property and a `prerender` property.
+
+The `component` property is a readonly string path relative to the project root, e.g `"src/pages/blog/[...slug].astro"`.
+
+The `prerender` property is used to configure [on-demand server rendering](https://docs.astro.build/en/guides/server-side-rendering/#opting-in-to-pre-rendering-in-server-mode) for a route. The value may be a `boolean` or `undefined` depending if there's an explicit `export const prerender` value set in the file. If the final value after running all the hooks is `undefined`, it will fall back to a prerender default based on the [`output` option](/en/reference/configuration-reference/#output).
 
 ### Custom hooks
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds documentation for the new `astro:route:setup` hook based on the core PR below.

The main use of this new hook is to configure route options dynamically (in this case, only the `prerender` option for now). See the core PR for more info!

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

#### For Astro version: `4.14`. See astro PR https://github.com/withastro/astro/pull/11657




