### PR TITLE
fix(guides): typo in `view-transitions.mdx` code block title

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -225,7 +225,7 @@ export interface TransitionDirectionalAnimations {
 The following example shows all the necessary properties to define a custom `bump` animation inside a `<style is:global>` tag in your root layout file:
 
 
-```astro title="src/layouts/Layout.astro
+```astro title="src/layouts/Layout.astro"
 ---
 import { ViewTransitions } from 'astro:transitions';
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Add missing closing quote in a code block `title`

Before:

![astro-typo-before](https://github.com/user-attachments/assets/aa9bd96f-d90e-4a29-8b3c-a4a2581d3a01)

After:

![astro-typo-after](https://github.com/user-attachments/assets/9a16a908-422a-47a8-84f1-7888a6e8541c)


#### Related issues & labels (optional)

- Suggested label: consistency/formatting

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
