### PR TITLE
Fix Algolia DocSearch result categorisation

### DIFF
--- a/src/components/starlight/Search.astro
+++ b/src/components/starlight/Search.astro
@@ -35,7 +35,10 @@ const docSearchStrings = getDocSearchStrings(Astro);
 		appId: '7AFBU8EPJU',
 		indexName: 'astro',
 		apiKey: '4440670147c44d744fd8da35ff652518',
-		searchParameters: { facetFilters: [[`lang:${location.pathname.split('/')[1]}`]] },
+		searchParameters: {
+			facetFilters: [[`lang:${location.pathname.split('/')[1]}`]],
+			attributesToHighlight: ['hierarchy.lvl0'],
+		},
 		insights: true,
 		getMissingResultsUrl: ({ query }: { query: string }) =>
 			`https://github.com/withastro/docs/issues/new?title=Missing+results+for+query+%22${encodeURIComponent(


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR explicitly sets `attributesToHighlight` in the DocSearch client, which brings back categorisation of search results. Not 100% clear what changed on Algolia’s end to require this, but this should at least address the search issues users have been reporting.

Shout out to @levimichael for helping us out with this!