### PR TITLE
Mark functionPerRoute as deprecated

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -376,6 +376,10 @@ export default defineConfig({
 
 ### Function bundling configuration
 
+:::caution[Deprecated]
+The `functionPerRoute` option is deprecated and will be removed in Astro 5. Additionally it doesn't work with some Astro features such as i18n domains and request rewriting. It's advised to disable it.
+:::
+
 The Vercel adapter combines all of your routes into a single function by default.
 
 You also have the option to split builds into a separate function for each route using the `functionPerRoute` option. This reduces the size of each function, meaning you are less likely to exceed the size limit for an individual function. Also, code starts are faster.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Marks the `functionPerRoute` option as deprecated in the Vercel page.

#### Related issues & labels (optional)

N/A
