### PR TITLE
Remove misleading reference to {once: true} from astro:page-load example

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -664,14 +664,14 @@ An event that fires at the end of page navigation, after the new page is visible
 
 The `<ViewTransitions />` component fires this event both on initial page navigation for a pre-rendered page and on any subsequent navigation, either forwards or backwards.
 
-You can use this event to run code on every page navigation, or only once ever:
+You can use this event to run code on every page navigation. That is especially useful when it comes to setting up event listeners that would otherwise be lost during navigation.
 
-```astro "{ once: true }"
+```astro
 <script>
   document.addEventListener('astro:page-load', () => {
-    // This only runs once.
-    setupStuff();
-  }, { once: true });
+    // This runs on first page load and after every navigation.
+    setupStuff(); // e.g. add click event listeners
+  });
 </script>
 ```
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -664,7 +664,7 @@ An event that fires at the end of page navigation, after the new page is visible
 
 The `<ViewTransitions />` component fires this event both on initial page navigation for a pre-rendered page and on any subsequent navigation, either forwards or backwards.
 
-You can use this event to run code on every page navigation. That is especially useful when it comes to setting up event listeners that would otherwise be lost during navigation.
+You can use this event to run code on every page navigation, for example to set up event listeners that would otherwise be lost during navigation.
 
 ```astro
 <script>

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -670,7 +670,7 @@ You can use this event to run code on every page navigation, for example to set 
 <script>
   document.addEventListener('astro:page-load', () => {
     // This runs on first page load and after every navigation.
-    setupStuff(); // e.g. add click event listeners
+    setupStuff(); // e.g. add event listeners
   });
 </script>
 ```


### PR DESCRIPTION
#### Description (required)

It's always good to know that you can add `{once: true}` as an option to `addEventListener`.

But for the `astro:page-load` example, it's a deal-breaker. The whole point here is that the code runs every time the page loads, not just once.
While people can grasp this pretty quickly, Kapa was completely caught off guard and insisted on using `once: true` as a best practice ;-)

#### Related issues & labels (optional)

This came up in a discord discussion: https://discord.com/channels/830184174198718474/1075516604428857344/1273972688788000811

