### PR TITLE
Update view-transitions.mdx

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -267,7 +267,7 @@ const anim = {
     name: 'bump',
     duration: '0.5s',
     easing: 'ease-in',
-    direction: 'reverse,
+    direction: 'reverse',
   },
   new: {
     name: 'bump',


### PR DESCRIPTION
missing ' closing string on line 270

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Just found this missing punctuation on line 270, a code example on the View Transitions page, where the string in the "direction" prop of the custom transition configuration was missing a closing '. This fix will ensure that those who copy/paste the code example don't encounter an error.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
