### PR TITLE
fix: newline not being interpreted while adding .astro directory to gitignore file

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -38,10 +38,6 @@ The `.astro` directory will be updated for you automatically anytime you run the
 
 :::tip
 If you're using Git for version control, we recommend ignoring the `.astro` directory by adding `.astro` to your `.gitignore`. This tells Git to ignore this directory and any files inside of it.
-
-```bash
-echo -e "\n.astro" >> .gitignore
-```
 :::
 
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -40,7 +40,7 @@ The `.astro` directory will be updated for you automatically anytime you run the
 If you're using Git for version control, we recommend ignoring the `.astro` directory by adding `.astro` to your `.gitignore`. This tells Git to ignore this directory and any files inside of it.
 
 ```bash
-echo "\n.astro" >> .gitignore
+echo -e "\n.astro" >> .gitignore
 ```
 :::
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
This PR addresses an issue in the [Content Collection](https://docs.astro.build/en/guides/content-collections/#the-astro-directory) docs where running the given command in the tip callout does not work on Bash shell - version `5.1.16(1)`. Executing the command as-is renders the newline sequence within the `.gitignore` file, i.e., `\n.astro`

We need to use the `-e` flag to tell `echo` to interpret backslashes. As a sidenote, the same command works fine on `ZSH` without any changes.
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes <!-- Add an issue number if this PR will close it. --> Didn't find any existing issue for this.
- Suggested label: `code snippet update` and/or `improve documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
