### PR TITLE
Fix import in Netlify adapter guide

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -194,7 +194,7 @@ If you use `redirects` configuration in your Astro config, the Netlify adapter c
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
-import netlify from '@astrojs/netlify/static';
+import netlify from '@astrojs/netlify';
 
 export default defineConfig({
   // ...


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since v4, the Netlify adapter has used a single `@astrojs/netlify` import, rather than the separate `static` one. This was likely overlooked when the docs were updated in https://github.com/withastro/adapters/pull/84.

I tested the import like this works as described, so it’s a simple typo fix effectively.
