### PR TITLE
Update api-reference page to refer to `ComponentProp` type utility

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2077,7 +2077,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 ## Built-in Components
 
-Astro includes several built-in components for you to use in your projects. All built-in components are available in `.astro` files via `import {} from 'astro:components';`.
+Astro includes several built-in components for you to use in your projects. All built-in components are available in `.astro` files via `import {} from 'astro:components';`. **You can reference the `Props` of these components using the [`ComponentProp` type](/en/guides/typescript/#componentprops-type) utility.**
 
 ### `<Code />`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I have made the text bold as suggested in the PR. Though, it looks like the odd-one-out among other texts. I addressed the same concern in [this](https://github.com/withastro/docs/issues/9125#issuecomment-2302629507) comment yesterday, but it was yet to receive a reply. If required, I will make the changes as needed.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes: #9125 
- Suggested label: `improve documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
