### PR TITLE
docs: fix entry variable

### DIFF
--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -1757,7 +1757,7 @@ import { getEntry, render } from 'astro:content';
 
 const post = await getEntry('blog', Astro.params.slug);
 
-const { Content, headings } = await render(entry);
+const { Content, headings } = await render(post);
 ---
 
 <Content />


### PR DESCRIPTION
#### Description (required)
Fixes the documentation in the [Querying and rendering with the Content Layer API section](https://docs.astro.build/en/reference/configuration-reference/#querying-and-rendering-with-the-content-layer-api) section, where a variable named `entry` was used without a prior definition. It has been updated to correctly reference the `post` variable instead.

![image](https://github.com/user-attachments/assets/80de0c51-cdf7-4a43-9e2d-d734475e1c02)

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
Username of Astro Discord: fbuireu
