### PR TITLE
docs: fix import typo in solid-js integration guide

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -127,7 +127,7 @@ You can enable [Solid DevTools](https://github.com/thetarnav/solid-devtools) in 
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
-import solid from '@astrojs/solid';
+import solid from '@astrojs/solid-js';
 
 export default defineConfig({
   // ...


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

This PR fixes a typo in the `import` statement in the SolidJS integration guide. Specifically in the `devtools` section: https://docs.astro.build/en/guides/integrations-guide/solid-js/#devtools

![image](https://github.com/user-attachments/assets/7709995f-34bb-4cc8-a7c5-47307caabaa2)


#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: `typo/link/grammar - quick fix!`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

 #### First-time contributor to Astro Docs?

Yes

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
discord: spitlbeans