### PR TITLE
change comment starter in strapi.mdx

### DIFF
--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -28,7 +28,7 @@ To get started, you will need to have the following:
 To add your Strapi URL to Astro, create a `.env` file in the root of your project (if one does not already exist) and add the following variable:
 
 ```ini title=".env"
-STRAPI_URL="http://127.0.0.1:1337" // or use your IP address
+STRAPI_URL="http://127.0.0.1:1337" # or use your IP address
 ```
 
 Restart the dev server to use this environment variable in your Astro project.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The comment in the env file for the strapi integration started with `//` instead of `#`  and this change replaced it. 

<!-- Please make changes in **one language** only -->

- Closes #9189
