### PR TITLE
feat: add use of `first` and `last` APIs to routing guide

### DIFF
--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -439,6 +439,8 @@ When you use the `paginate()` function, each page will be passed its data via a 
 - **page.data** - array containing the page’s slice of data that you passed to the `paginate()` function
 - **page.url.next** - link to the next page in the set
 - **page.url.prev** - link to the previous page in the set
+- **page.url.first** - link to the first page in the set
+- **page.url.last** - link to the last page in the set
 
 ```astro /(?<=const.*)(page)/ /page\\.[a-zA-Z]+(?:\\.(?:prev|next))?/
 ---
@@ -451,8 +453,10 @@ const { page } = Astro.props;
 <ul>
   {page.data.map(({ astronaut }) => <li>{astronaut}</li>)}
 </ul>
+{page.url.first ? <a href={page.url.first}>First</a> : null}
 {page.url.prev ? <a href={page.url.prev}>Previous</a> : null}
 {page.url.next ? <a href={page.url.next}>Next</a> : null}
+{page.url.last ? <a href={page.url.last}>Last</a> : null}
 ```
 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

In v4.12 we added `page.url.first` and `page.url.last`. While they are documented, they aren't used in the routing guide.

This PR adds that


