### PR TITLE
Fix typo in `routing.mdx`

### DIFF
--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -442,7 +442,7 @@ When you use the `paginate()` function, each page will be passed its data via a 
 - **page.url.first** - link to the first page in the set
 - **page.url.last** - link to the last page in the set
 
-```astro /(?<=const.*)(page)/ /page\\.[a-zA-Z]+(?:\\.(?:prev|next))?/
+```astro /(?<=const.*)(page)/ /page\\.[a-zA-Z]+(?:\\.(?:prev|next|first|last))?/
 ---
 // src/pages/astronauts/[page].astro
 // Paginate same list of { astronaut } objects as the previous example


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fix typo in `routing.mdx`

the hightlight RegExp now is including the keyword `first` and `last`.

#### Related issues & labels (optional)

Suggested label: `typo/link/grammar - quick fix!`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
