### PR TITLE
Fix language tags on dotenv examples for Astro DB

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -671,7 +671,7 @@ Details of the libSQL connection (e.g. encryption key, replication, sync interva
 
 For example, to have a local file work as an embedded replica to an encrypted libSQL server, you can set the following environment variables:
 
-```env title=".env"
+```dotenv title=".env"
 ASTRO_DB_REMOTE_URL=file://local-copy.db?encryptionKey=your-encryption-key&syncInterval=60&syncUrl=libsql%3A%2F%2Fyour.server.io
 ASTRO_DB_APP_TOKEN=token-to-your-remote-url
 ```
@@ -690,7 +690,7 @@ libSQL supports both HTTP and WebSockets as the transport protocol for a remote 
 
 libSQL has native support for encrypted databases. Passing this search parameter will enable encryption using the given key:
 
-```env title=".env"
+```dotenv title=".env"
 ASTRO_DB_REMOTE_URL=file:path/to/file.db?encryptionKey=your-encryption-key
 ```
 
@@ -702,7 +702,7 @@ Use this property to pass a separate connection URL to turn the DB into an embed
 
 For example, to have an in-memory embedded replica of a database on `libsql://your.server.io`, you can set the connection URL as such:
 
-```env title=".env"
+```dotenv title=".env"
 ASTRO_DB_REMOTE_URL=memory:?syncUrl=libsql%3A%2F%2Fyour.server.io
 ```
 
@@ -712,7 +712,7 @@ Interval between embedded replicas synchronizations in seconds. By default it on
 
 This property is only used when `syncUrl` is also set. For example, to set an in-memory embedded replica to synchronize every minute set the following environment variable:
 
-```env title=".env"
+```dotenv title=".env"
 ASTRO_DB_REMOTE_URL=memory:?syncUrl=libsql%3A%2F%2Fyour.server.io&syncInterval=60
 ```
 


### PR DESCRIPTION
#### Description

Fix the language tag from `env` to `dotenv` found on T&D