### PR TITLE
Improve `handler()` reference docs

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2512,7 +2512,10 @@ export const server = {
 
 #### `handler()` property
 
+<p>
+
 **Type:** `(input, context) => any`
+</p>
 
 `defineAction()` requires a `handler()` function containing the server logic to run when the action is called. Data returned from the handler is automatically serialized and sent to the caller.
 
@@ -2522,7 +2525,10 @@ Return values are parsed using the [devalue library](https://github.com/Rich-Har
 
 #### `input` validator
 
+<p>
+
 **Type:** `ZodObject | undefined`
+</p>
 
 The optional `input` property accepts a Zod validator to validate handler inputs at runtime. If the action fails to validate, [a `BAD_REQUEST` error](#actionerror) is returned and the `handler` is not called.
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2495,15 +2495,15 @@ Actions help you build a type-safe backend you can call from client code and HTM
 <Since v="4.15.0" />
 </p>
 
-The `defineAction()` utility is used to define new actions from the `src/actions/index.ts` file. This accepts a `handler()` function containing the server logic to run, and an optional `input` property to validate input parameters at runtime.
+The `defineAction()` utility is used to define new actions from the `src/actions/index.ts` file. This accepts a [`handler()`](#handler-property) function containing the server logic to run, and an optional [`input`](#input-validator) property to validate input parameters at runtime.
 
 ```ts
 export const server = {
-    getGreeting: defineAction({
+  getGreeting: defineAction({
     input: z.object({
       name: z.string(),
     }),
-    handler: async (input) => {
+    handler: async (input, context) => {
       return `Hello, ${input.name}!`
     }
   })
@@ -2512,19 +2512,17 @@ export const server = {
 
 #### `handler()` property
 
-<p>
-<Since v="4.15.0" />
-</p>
+**Type:** `(input, context) => any`
 
-`defineAction()` accepts a `handler()` function containing the server logic to run when the action is called. This function can return data that is automatically serialized and sent to the caller.
+`defineAction()` requires a `handler()` function containing the server logic to run when the action is called. This function can return data that is automatically serialized and sent to the caller.
 
-Return values are parsed using the [devalue library](https://github.com/Rich-Harris/devalue). This supports JSON values, along with instances of `Date()`, `Map()`, `Set()`, or `URL()`.
+The `handler()` is called with user input as its first argument. If an [`input`](#input-validator) validator is set, the user input will be validated before being passed to the handler. The second argument is a `context` object containing most of Astro’s [standard endpoint context](#endpoint-context), excluding  `getActionResult()`, `callAction()`, and `redirect()`.
+
+Return values are parsed using the [devalue library](https://github.com/Rich-Harris/devalue). This supports JSON values and instances of `Date()`, `Map()`, `Set()`, and `URL()`.
 
 #### `input` validator
 
-<p>
-<Since v="4.15.0" />
-</p>
+**Type:** `ZodObject | undefined`
 
 The optional `input` property accepts a Zod validator to validate handler inputs at runtime. If the action fails to validate, [a `BAD_REQUEST` error](#actionerror) is returned and the `handler` is not called.
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2514,7 +2514,7 @@ export const server = {
 
 **Type:** `(input, context) => any`
 
-`defineAction()` requires a `handler()` function containing the server logic to run when the action is called. This function can return data that is automatically serialized and sent to the caller.
+`defineAction()` requires a `handler()` function containing the server logic to run when the action is called. Data returned from the handler is automatically serialized and sent to the caller.
 
 The `handler()` is called with user input as its first argument. If an [`input`](#input-validator) validator is set, the user input will be validated before being passed to the handler. The second argument is a `context` object containing most of Astro’s [standard endpoint context](#endpoint-context), excluding  `getActionResult()`, `callAction()`, and `redirect()`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR improves the `defineAction()` reference docs to better describe the signature of the `handler()` option and mention the `context` argument.

Also took the liberty of removing the extra `<Since>` components on `handler` and `input` sections — felt excessive to add those when they are properties of `defineAction()`, which means they were added at the same time.