### PR TITLE
Add missing code block language identifier in `guides/astro-db`

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -162,7 +162,7 @@ You can query your database from any [Astro page](/en/basics/astro-pages/#astro-
 
 ### Drizzle ORM
 
-```
+```ts
 import { db } from 'astro:db';
 ```
 


### PR DESCRIPTION
#### Description (required)

This PR adds a missing code block `ts` language identifier spotted today during Talking & Talking in the Astro DB guide.

[Preview direct link](https://deploy-preview-9262--astro-docs-2.netlify.app/en/guides/astro-db/#drizzle-orm)

Before:

<img width="741" alt="SCR-20240829-treh" src="https://github.com/user-attachments/assets/e99a6b80-022d-4172-81f0-edd2f561fabe">


After:

<img width="741" alt="SCR-20240829-trgy" src="https://github.com/user-attachments/assets/5d2effbe-7d44-4696-8b48-279df299539b">

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->