### PR TITLE
i18n(fr): update `cli-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/cli-reference.mdx
+++ b/src/content/docs/fr/reference/cli-reference.mdx
@@ -474,8 +474,8 @@ interface AstroInlineConfig extends AstroUserConfig {
 
 <p>
 
-**Type:** `string | false`<br />
-**Défaut:** `undefined`
+**Type :** `string | false`<br />
+**Par défaut :** `undefined`
 </p>
 
 Un chemin personnalisé vers le fichier de configuration d'Astro.
@@ -492,8 +492,8 @@ La configuration en ligne passée dans cet objet sera prioritaire lors de la fus
 
 <p>
 
-**Type:** `"development" | "production"`<br />
-**Défaut:** `"development"` lors de l'exécution de `astro dev`, `"production"` lors de l'exécution de `astro build`
+**Type :** `"development" | "production"`<br />
+**Par défaut :** `"development"` lors de l'exécution de `astro dev`, `"production"` lors de l'exécution de `astro build`
 </p>
 
 Le mode utilisé lors de la construction de votre site pour générer du code "developpement" ou "production".
@@ -502,8 +502,8 @@ Le mode utilisé lors de la construction de votre site pour générer du code "d
 
 <p>
 
-**Type:** `"debug" | "info" | "warn" | "error" | "silent"`<br />
-**Défaut:** `"info"`
+**Type :** `"debug" | "info" | "warn" | "error" | "silent"`<br />
+**Par défaut :** `"info"`
 </p>
 
 Le niveau de journalisation pour filtrer les messages enregistrés par Astro.
@@ -564,7 +564,7 @@ Renvoie une promesse (`Promise`) qui se résout une fois que toutes les demandes
 
 ### `build()`
 
-**Type:** `(inlineConfig: AstroInlineConfig) => Promise<void>`
+**Type :** `(inlineConfig: AstroInlineConfig) => Promise<void>`
 
 Similaire à [`astro build`](#astro-build), il construit votre site pour le deploiement.
 

--- a/src/content/docs/fr/reference/cli-reference.mdx
+++ b/src/content/docs/fr/reference/cli-reference.mdx
@@ -480,9 +480,9 @@ interface AstroInlineConfig extends AstroUserConfig {
 
 Un chemin personnalisé vers le fichier de configuration d'Astro.
 
-Si cette valeur est indéfinie (par défaut) ou non définie, Astro recherchera un fichier `astro.config.(js,mjs,ts)` relatif à la `root` et chargera le fichier de configuration s'il est trouvé.
+Si cette valeur est indéfinie (par défaut) ou non définie, Astro recherchera un fichier `astro.config.(js,mjs,ts,mts)` relatif à la `root` et chargera le fichier de configuration s'il est trouvé.
 
-Si un chemin relatif est défini, il sera résolu en fonction du répertoire de travail courant.
+Si un chemin relatif est défini, il sera résolu en fonction de l'option `root`.
 
 Mettre `false` pour désactiver le chargement de tout fichier de configuration.
 
@@ -516,7 +516,7 @@ Le niveau de journalisation pour filtrer les messages enregistrés par Astro.
 
 ### `dev()`
 
-**Type:** `(inlineConfig: AstroInlineConfig) => AstroDevServer`
+**Type :** `(inlineConfig: AstroInlineConfig) => Promise<DevServer>`
 
 Similaire à [`astro dev`](#astro-dev), il fait tourner le serveur de développement d'Astro.
 
@@ -531,9 +531,40 @@ const devServer = await dev({
 await devServer.stop();
 ```
 
+#### `DevServer`
+
+```ts
+export interface DevServer {
+	address: AddressInfo;
+	handle: (req: http.IncomingMessage, res: http.ServerResponse<http.IncomingMessage>) => void;
+	watcher: vite.FSWatcher;
+	stop(): Promise<void>;
+}
+```
+
+##### `address`
+
+L'adresse que le serveur de développement écoute.
+
+Cette propriété contient la valeur renvoyée par la méthode [`net.Server#address()`](https://nodejs.org/api/net.html#serveraddress) de Node.
+
+##### `handle()`
+
+Une méthode pour gérer les requêtes HTTP Node brutes. Vous pouvez appeler `handle()` avec un objet [`http.IncomingMessage`](https://nodejs.org/api/http.html#class-httpincomingmessage) et un objet [`http.ServerResponse`](https://nodejs.org/api/http.html#class-httpserverresponse) au lieu d'envoyer une requête via le réseau.
+
+##### `watcher`
+
+L'[observateur de fichiers Chokidar](https://github.com/paulmillr/chokidar#getting-started) tel qu'il est exposé par [le serveur de développement de Vite](https://vitejs.dev/guide/api-javascript#vitedevserver).
+
+##### `stop()`
+
+Arrête le serveur de développement. Cela ferme toutes les connexions inactives et arrête d'écouter les nouvelles connexions.
+
+Renvoie une promesse (`Promise`) qui se résout une fois que toutes les demandes en attente ont été satisfaites et que toutes les connexions inactives ont été fermées.
+
 ### `build()`
 
-**Type:** `(inlineConfig: AstroInlineConfig) => void`
+**Type:** `(inlineConfig: AstroInlineConfig) => Promise<void>`
 
 Similaire à [`astro build`](#astro-build), il construit votre site pour le deploiement.
 
@@ -547,9 +578,12 @@ await build({
 
 ### `preview()`
 
-**Type:** `(inlineConfig: AstroInlineConfig) => AstroPreviewServer`
+**Type :** `(inlineConfig: AstroInlineConfig) => Promise<PreviewServer>`
 
-Similaire à [`astro preview`](#astro-preview), il démarre un serveur local pour servir votre répertoire statique `dist/`.
+Similaire à [`astro preview`](#astro-preview), il démarre un serveur local pour servir la sortie de votre construction.
+
+Si aucun adaptateur n'est défini dans la configuration, le serveur d'aperçu ne servira que les fichiers statiques créés.
+Si un adaptateur est défini dans la configuration, le serveur d'aperçu est fourni par l'adaptateur. Les adaptateurs ne sont pas tenus de fournir un serveur d'aperçu, cette fonctionnalité peut donc ne pas être disponible en fonction de l'adaptateur choisi.
 
 ```js
 import { preview } from "astro";
@@ -562,20 +596,49 @@ const previewServer = await preview({
 await previewServer.stop();
 ```
 
+#### `PreviewServer`
+
+```ts
+export interface PreviewServer {
+	host?: string;
+	port: number;
+	closed(): Promise<void>;
+	stop(): Promise<void>;
+}
+```
+
+##### `host`
+
+L'hôte sur lequel le serveur écoute les connexions.
+
+Les adaptateurs sont autorisés à laisser ce champ non défini. La valeur de `host` est spécifique à l'implémentation.
+
+##### `port`
+
+Le port sur lequel le serveur écoute les connexions.
+
+##### `stop()`
+
+Demande au serveur de prévisualisation de se fermer, de cesser d'accepter les demandes et de supprimer les connexions inactives.
+
+La `Promise` renvoyée est résolue lorsque la demande de fermeture a été envoyée. Cela ne signifie pas que le serveur est déjà fermé. Utilisez la méthode [`closed()`](#closed) si vous devez vous assurer que le serveur est complètement fermé.
+
+##### `closed()`
+
+Renvoie une promesse (`Promise`) qui se résoudra une fois le serveur fermé et sera rejetée si une erreur se produit sur le serveur.
+
 ### `sync()`
 
-**Type:** `(inlineConfig: AstroInlineConfig) => number`
+**Type :** `(inlineConfig: AstroInlineConfig) => Promise<void>`
 
 Similaire à [`astro sync`](#astro-sync), il génère des types TypeScript pour tous les modules Astro.
 
 ```js
 import { sync } from "astro";
 
-const exitCode = await sync({
+await sync({
   root: "./my-project",
 });
-
-process.exit(exitCode)
 ```
 
 ## Astro Studio CLI


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Add changes from #9308 to French translation of `cli-reference.mdx`
* Add missing space before colon for `Type` and `Default` in French translation (I also replaced `Défaut` with `Par défaut` because it seems more correct to me in French... and this is the syntax we use most often it seems).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
