### PR TITLE
use `connectedCallback` instead of `constructor`

### DIFF
--- a/src/content/docs/en/guides/client-side-scripts.mdx
+++ b/src/content/docs/en/guides/client-side-scripts.mdx
@@ -166,8 +166,7 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
 <script>
   // Define the behaviour for our new type of HTML element.
   class AstroHeart extends HTMLElement {
-    constructor() {
-			super();
+    connectedCallback() {
       let count = 0;
 
       const heartButton = this.querySelector('button');
@@ -215,9 +214,7 @@ const { message = 'Welcome, world!' } = Astro.props;
 
 <script>
   class AstroGreet extends HTMLElement {
-    constructor() {
-			super();
-
+    connectedCallback() {
       // Read the message from the data attribute.
       const message = this.dataset.message;
       const button = this.querySelector('button');


### PR DESCRIPTION
#### Description (required)

Changed `constructor` to `connectedCallback`. It's less code and more correct.

The [custom elements spec](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance) explicitly recommends implementing setup logic in `connectedCallback` rather than the constructor. See also: https://nolanlawson.com/2024/01/13/web-component-gotcha-constructor-vs-connectedcallback/

#### Related issues & labels (optional)

- Suggested label: improve documentation