### PR TITLE
Remove self-referential link in astro-pages.mdx

### DIFF
--- a/src/content/docs/en/basics/astro-pages.mdx
+++ b/src/content/docs/en/basics/astro-pages.mdx
@@ -71,7 +71,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 ## Markdown/MDX Pages
 
-Astro also treats any Markdown (`.md`) files inside of `src/pages/` as pages in your final website. If you have the [MDX Integration installed](/en/guides/integrations-guide/mdx/#installation), it also treats MDX (`.mdx`) files the same way. These are commonly used for text-heavy pages like blog posts and documentation.
+Astro also treats any Markdown (`.md`) files inside of `src/pages/` as pages in your final website. If you have the [MDX Integration installed](/en/guides/integrations-guide/mdx/#installation), it also treats MDX (`.mdx`) files the same way.
 
 :::tip
 Consider creating [content collections](/en/guides/content-collections/) instead of pages for directories of related Markdown files that share a similar structure, such as blog posts or product items.

--- a/src/content/docs/en/basics/astro-pages.mdx
+++ b/src/content/docs/en/basics/astro-pages.mdx
@@ -73,9 +73,11 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 Astro also treats any Markdown (`.md`) files inside of `src/pages/` as pages in your final website. If you have the [MDX Integration installed](/en/guides/integrations-guide/mdx/#installation), it also treats MDX (`.mdx`) files the same way. These are commonly used for text-heavy pages like blog posts and documentation.
 
-[Collections of Markdown or MDX page content](/en/guides/content-collections/) in `src/content/` can be used to [generate pages dynamically](/en/guides/routing/#dynamic-routes).
+:::tip
+Consider creating [content collections](/en/guides/content-collections/) instead of pages for directories of related Markdown files that share a similar structure, such as blog posts or product items.
+:::
 
-Page layouts are especially useful for [Markdown files](#markdownmdx-pages). Markdown files can use the special `layout` frontmatter property to specify a [layout component](/en/basics/layouts/) that will wrap their Markdown content in a full `<html>...</html>` page document.
+Markdown files can use the special `layout` frontmatter property to specify a [layout component](/en/basics/layouts/) that will wrap their Markdown content in a full `<html>...</html>` page document.
 
 ```md {3}
 ---


### PR DESCRIPTION
Removed a section linking to itself.

Took the opportunity to provide better, and future-proof, content collections nudging.