### PR TITLE
[mdx] Adds usage information, taken out of the Markdown guide

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -96,7 +96,7 @@ It also adds extra features to standard MDX, including support for Markdown-styl
 
 ### Using Exported Variables in MDX
 
-MDX supports using `export` statements to add variables to your MDX content.
+MDX supports using `export` statements to add variables to your MDX content or to export data to a component that imports it.
 
 For example, you can export a `title` field from an MDX page or component to use as a heading with `{JSX expressions}`:
 
@@ -106,19 +106,11 @@ export const title = 'My first MDX post'
 # {title}
 ```
 
-MDX files can also use an `export` statement to export data to a component that imports it.
+Or you can use that exported `title` in your page using `import` and `import.meta.glob()` statements:
 
-For example, you can export a `title` field from an MDX page or component.
-
-```mdx title="/src/pages/posts/post-1.mdx"
-export const title = 'My first MDX post'
-```
-
-This `title` will be accessible from `import` and `import.meta.glob()` statements:
-
-```astro title="// src/pages/index.astro"
+```astro title="src/pages/index.astro"
 ---
-const matches = await import.meta.glob('./*.mdx', { eager: true });
+const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
 const posts = Object.values(posts);
 ---
 
@@ -129,7 +121,7 @@ const posts = Object.values(posts);
 
 The following properties are available to a `.astro` component when using an `import` statement or `import.meta.glob()`:
 
-- **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.md`).
+- **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.mdx`).
 - **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - Contains any data specified in the file’s YAML frontmatter.
 - **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
@@ -138,7 +130,7 @@ The following properties are available to a `.astro` component when using an `im
 
 ### Using Frontmatter Variables in MDX
 
-The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are availble to use in the template, and as named properties when importing the file somewhere else.
+The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are available to use in the template, and as named properties when importing the file somewhere else.
 
 ```mdx title="/src/pages/posts/post-1.mdx"
 ---

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -14,7 +14,7 @@ This **[Astro integration][astro-integration]** enables the usage of [MDX](https
 
 ## Why MDX?
 
-MDX allows you to [use variables, JSX expressions and components within Markdown content](/en/guides/markdown-content/#mdx-only-features) in Astro. If you have existing content authored in MDX, this integration allows you to bring those files to your Astro project.
+MDX allows you to use variables, JSX expressions and components within Markdown content in Astro. If you have existing content authored in MDX, this integration allows you to bring those files to your Astro project.
 
 ## Installation
 
@@ -84,13 +84,136 @@ For other editors, use the [MDX language server](https://github.com/mdx-js/mdx-a
 
 ## Usage
 
-With the Astro MDX integration, you can [add MDX pages to your project](/en/guides/markdown-content/#markdown-and-mdx-pages) by adding `.mdx` files within your `src/pages/` directory. You can also [import `.mdx` files](/en/guides/markdown-content/#importing-markdown) into `.astro` files.
-
-Astro's MDX integration adds extra features to standard MDX, including Markdown-style frontmatter. This allows you to use most of Astro's built-in Markdown features like a [special frontmatter `layout` property](/en/guides/markdown-content/#frontmatter-layout).
-
-See how MDX works in Astro with examples in our [Markdown & MDX guide](/en/guides/markdown-content/).
-
 Visit the [MDX docs](https://mdxjs.com/docs/what-is-mdx/) to learn about using standard MDX features.
+
+## MDX in Astro
+
+Adding the MDX integration enhances your Markdown authoring with JSX variables, expressions and components.
+
+It also adds extra features to standard MDX, including support for Markdown-style frontmatter in MDX. This allows you to use most of [Astro's built-in Markdown features](/en/guides/markdown-content/).
+
+`.mdx` files must be written in [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) rather than Astro’s HTML-like syntax.
+
+### Using Exported Variables in MDX
+
+MDX supports using `export` statements to add variables to your MDX content.
+
+For example, you can export a `title` field from an MDX page or component to use as a heading with `{JSX expressions}`:
+
+```mdx title="/src/pages/posts/post-1.mdx"
+export const title = 'My first MDX post'
+
+# {title}
+```
+
+MDX files can also use an `export` statement to export data to a component that imports it.
+
+For example, you can export a `title` field from an MDX page or component.
+
+```mdx title="/src/pages/posts/post-1.mdx"
+export const title = 'My first MDX post'
+```
+
+This `title` will be accessible from `import` and `import.meta.glob()` statements:
+
+```astro title="// src/pages/index.astro"
+---
+const matches = await import.meta.glob('./*.mdx', { eager: true });
+const posts = Object.values(posts);
+---
+
+{posts.map(post => <p>{post.title}</p>)}
+```
+
+#### Exported Properties
+
+The following properties are available to a `.astro` component when using an `import` statement or `import.meta.glob()`:
+
+- **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.md`).
+- **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
+- **`frontmatter`** - Contains any data specified in the file’s YAML frontmatter.
+- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
+- **`<Content />`** - A component that returns the full, rendered contents of the file.
+- **(any `export` value)** - MDX files can also export data with an `export` statement.
+
+### Using Frontmatter Variables in MDX
+
+The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are availble to use in the template, and as named properties when importing the file somewhere else.
+
+```mdx title="/src/pages/posts/post-1.mdx"
+---
+layout: '../../layouts/BlogPostLayout.astro'
+title: 'My first MDX post'
+---
+
+# {frontmatter.title}
+```
+
+### Using Components in MDX
+
+After installing the MDX integration, you can import and use both [Astro components](/en/basics/astro-components/) and [UI framework components](/en/guides/framework-components/#using-framework-components) in MDX (`.mdx`) files just as you would use them in any other Astro component.
+
+Don't forget to include a `client:directive` on your UI framework components, if necessary!
+
+See more examples of using import and export statements in the [MDX docs](https://mdxjs.com/docs/what-is-mdx/#esm).
+
+```mdx title="src/pages/about.mdx" {5-6} /<.+\/>/
+---
+layout: ../layouts/BaseLayout.astro
+title: About me
+---
+import Button from '../components/Button.astro';
+import ReactCounter from '../components/ReactCounter.jsx';
+
+I live on **Mars** but feel free to <Button title="Contact me" />.
+
+Here is my counter component, working in MDX:
+
+<ReactCounter client:load />
+```
+
+
+#### Custom components with imported MDX
+
+When rendering imported MDX content, [custom components](#assigning-custom-components-to-html-elements) can be passed via the `components` prop.
+
+```astro title="src/pages/page.astro" "components={{...components, h1: Heading }}"
+---
+import { Content, components } from '../content.mdx';
+import Heading from '../Heading.astro';
+---
+<!-- Creates a custom <h1> for the # syntax, _and_ applies any custom components defined in `content.mdx` -->
+<Content components={{...components, h1: Heading }} />
+```
+
+:::note
+Custom components defined and exported in an MDX file must be imported and then passed back to the `<Content />` component via the `components` property.
+:::
+
+#### Assigning Custom Components to HTML elements
+
+With MDX, you can map Markdown syntax to custom components instead of their standard HTML elements. This allows you to write in standard Markdown syntax, but apply special component styling to selected elements.
+
+Import your custom component into your `.mdx` file, then export a `components` object that maps the standard HTML element to your custom component:
+
+```mdx title="src/pages/about.mdx"
+import Blockquote from '../components/Blockquote.astro';
+export const components = {blockquote: Blockquote}
+
+> This quote will be a custom Blockquote
+```
+
+
+```astro title="src/components/Blockquote.astro"
+---
+const props = Astro.props;
+---
+<blockquote {...props} class="bg-blue-50 p-4">
+  <span class="text-4xl text-blue-600 mb-2">“</span>
+  <slot /> <!-- Be sure to add a `<slot/>` for child content! -->
+</blockquote>
+```
+Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that can be overwritten as custom components.
 
 ## Configuration
 

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -1,6 +1,6 @@
 ---
-title: Markdown & MDX
-description: Learn how to create content using Markdown or MDX with Astro
+title: Markdown in Astro
+description: Learn how to create content using Markdown in Astro
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
@@ -9,223 +9,27 @@ import RecipeLinks from "~/components/RecipeLinks.astro";
 import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-[Markdown](https://daringfireball.net/projects/markdown/) is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for standard Markdown files that can also include [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) to define custom metadata such as a title, description, and tags.
+[Markdown](https://daringfireball.net/projects/markdown/) is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for Markdown files that can also include [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) to define custom properties such as a title, description, and tags.
 
-With the [@astrojs/mdx integration](/en/guides/integrations-guide/mdx/) installed, Astro also supports [MDX](https://mdxjs.com/) (`.mdx`) files which bring added features like support for JavaScript expressions and components in your Markdown content.
+In Astro, you can author content in Markdown, then render it in `.astro` components. This combines a familiar writing format designed for content with the flexibility of Astro's component syntax and architecture.
 
-Use either or both types of files to write your Markdown content!
+For additional functionality, such as including components and JSX expressions in Markdown, add the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/) to write your Markdown content using [MDX](https://mdxjs.com/).
 
-## Markdown and MDX Pages
+## Organizing Markdown files
 
-### Content collections
+Your local Markdown files can be kept anywhere within your `src/` directory. Local Markdown can be imported into `.astro` components using an `import` statement for a single file and [Vite's `import.meta.glob()`](https://vitejs.dev/guide/features.html#glob-import) to query multiple files at once.
 
-You can manage your Markdown and MDX files in Astro in a special `src/content/` folder. [Content collections](/en/guides/content-collections/) help you organize your content, validate your frontmatter, and provide automatic TypeScript type-safety while working with your content.
+If you have groups of related Markdown files, consider [defining them as collections](/en/guides/content-collections/). This gives you several advantages, including the ability to store Markdown files anywhere on your filesystem or remotely.
 
-<FileTree>
-- src/content/
-  - **newsletter/**
-    - week-1.md
-    - week-2.md
-  - **authors/**
-    - grace-hopper.md
-    - alan-turing.md
-</FileTree>
+Collections also allow you to use content-specfic, optimized API for querying and rendering your content. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
 
+{/* <ReadMore>See more about [when to use content collections](/en/guides/content-collections/#when-to-create-a-collection) instead of file imports.</ReadMore> */}
 
+## Dynamic JSX-like expressions
 
-See more about using [content collections in Astro](/en/guides/content-collections/).
+After importing or querying Markdown files, you can write dynamic HTML templates in your `.astro` components that include frontmatter data and body content.
 
-
-### File-based Routing
-
-Astro treats any `.md` (or alternative supported extension) or `.mdx` file inside of the `/src/pages/` directory as a page.
-
-Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file.
-
-```markdown
----
-# Example: src/pages/page-1.md
-title: Hello, World
----
-
-# Hi there!
-
-This Markdown file creates a page at `your-domain.com/page-1/`
-
-It probably isn't styled much, but Markdown does support:
-- **bold** and _italics._
-- lists
-- [links](https://astro.build)
-- and more!
-```
-
-<ReadMore>Read more about Astro's [file-based routing](/en/guides/routing/) or options for creating [dynamic routes](/en/guides/routing/#dynamic-routes).</ReadMore>
-
-
-## Markdown Features
-
-Astro provides some extra, built-in Markdown features available when using Markdown and MDX files.
-
-### Frontmatter `layout`
-
-Astro provides [Markdown and MDX pages](/en/basics/astro-pages/#markdownmdx-pages) (located within `src/pages/`) with a special frontmatter `layout` property that can specify a relative path (or [alias](/en/guides/imports/#aliases)) to an Astro [layout component](/en/basics/layouts/#markdown-layouts).
-
-```markdown {3}
----
-# src/pages/posts/post-1.md
-layout: ../../layouts/BlogPostLayout.astro
-title: Astro in brief
-author: Himanshu
-description: Find out what makes Astro awesome!
----
-This is a post written in Markdown.
-```
-
-[Specific properties are then available to the layout component](/en/basics/layouts/#markdown-layout-props)  through `Astro.props`. For example, you can access frontmatter properties through `Astro.props.frontmatter`:
-
-```astro /frontmatter(?:.\w+)?/
----
-// src/layouts/BlogPostLayout.astro
-const {frontmatter} = Astro.props;
----
-<html>
-  <!-- ... -->
-  <h1>{frontmatter.title}</h1>
-  <h2>Post author: {frontmatter.author}</h2>
-  <p>{frontmatter.description}</p>
-  <slot /> <!-- Markdown content is injected here -->
-   <!-- ... -->
-</html>
-```
-
-You can also [style your Markdown](/en/guides/styling/#markdown-styling) in your layout component.
-
-<ReadMore>Learn more about [Markdown Layouts](/en/basics/layouts/#markdown-layouts).</ReadMore>
-
-### Heading IDs
-
-Using headings in Markdown and MDX will automatically give you anchor links so you can link directly to certain sections of your page.
-
-```markdown title="src/pages/page-1.md"
----
-title: My page of content
----
-## Introduction
-
-I can link internally to [my conclusion](#conclusion) on the same page when writing Markdown.
-
-## Conclusion
-
-I can use the URL `https://example.com/page-1/#introduction` to navigate directly to my Introduction on the page.
-```
-
-Astro generates heading `id`s based on `github-slugger`. You can find more examples in [the github-slugger documentation](https://github.com/Flet/github-slugger#usage).
-
-### Escaping special characters
-
-Certain characters have a special meaning in Markdown and MDX. You may need to use a different syntax if you want to display them. To do this, you can use [HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) for these characters instead.
-
-For example, to prevent `<` being interpreted as the beginning of an HTML element, write `&lt;`. Or, to prevent `{` being interpreted as the beginning of a JavaScript expression in MDX, write `&lcub;`.
-
-## MDX-only Features
-
-Adding the Astro [MDX integration](/en/guides/integrations-guide/mdx/) enhances your Markdown authoring with JSX variables, expressions and components.
-
-It also adds extra features to standard MDX, including support for [Markdown-style frontmatter in MDX](https://mdxjs.com/guides/frontmatter/). This allows you to use most of Astro's built-in Markdown features like a [frontmatter `layout`](#frontmatter-layout) property.
-
-`.mdx` files must be written in [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) rather than Astro’s HTML-like syntax.
-
-### Using Exported Variables in MDX
-
-MDX supports using `export` statements to add variables to your MDX content. These variables are accessible both in the template itself and as named properties when [importing the file](#importing-markdown) somewhere else.
-
-For example, you can export a `title` field from an MDX page or component to use as a heading with `{JSX expressions}`:
-
-```mdx title="/src/pages/posts/post-1.mdx"
-export const title = 'My first MDX post'
-
-# {title}
-```
-### Using Frontmatter Variables in MDX
-
-The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are accessible to use in the template, in its [`layout` component](#frontmatter-layout), and as named properties when [importing the file](#importing-markdown) somewhere else.
-
-```mdx title="/src/pages/posts/post-1.mdx"
----
-layout: '../../layouts/BlogPostLayout.astro'
-title: 'My first MDX post'
----
-
-# {frontmatter.title}
-```
-
-### Using Components in MDX
-
-After installing the MDX integration, you can import and use both [Astro components](/en/basics/astro-components/#component-props) and [UI framework components](/en/guides/framework-components/#using-framework-components) in MDX (`.mdx`) files just as you would use them in any other Astro component.
-
-Don't forget to include a `client:directive` on your UI framework components, if necessary!
-
-See more examples of using import and export statements in the [MDX docs](https://mdxjs.com/docs/what-is-mdx/#esm).
-
-```mdx title="src/pages/about.mdx" {5-6} /<.+\/>/
----
-layout: ../layouts/BaseLayout.astro
-title: About me
----
-import Button from '../components/Button.astro';
-import ReactCounter from '../components/ReactCounter.jsx';
-
-I live on **Mars** but feel free to <Button title="Contact me" />.
-
-Here is my counter component, working in MDX:
-
-<ReactCounter client:load />
-```
-
-#### Assigning Custom Components to HTML elements
-
-With MDX, you can map Markdown syntax to custom components instead of their standard HTML elements. This allows you to write in standard Markdown syntax, but apply special component styling to selected elements.
-
-Import your custom component into your `.mdx` file, then export a `components` object that maps the standard HTML element to your custom component:
-
-```mdx title="src/pages/about.mdx"
-import Blockquote from '../components/Blockquote.astro';
-export const components = {blockquote: Blockquote}
-
-> This quote will be a custom Blockquote
-```
-
-
-```astro title="src/components/Blockquote.astro"
----
-const props = Astro.props;
----
-<blockquote {...props} class="bg-blue-50 p-4">
-  <span class="text-4xl text-blue-600 mb-2">“</span>
-  <slot /> <!-- Be sure to add a `<slot/>` for child content! -->
-</blockquote>
-```
-Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that can be overwritten as custom components.
-
-## Importing Markdown
-
-You can import Markdown and MDX files directly into your Astro files. This gives you access to their Markdown content, as well as other properties such as frontmatter values that can be used within Astro's JSX-like expressions.
-
-You can import one specific page with an `import` statement, or multiple pages with [`Astro.glob()`](/en/guides/imports/#astroglob).
-
-```astro title="src/pages/index.astro"
----
-// Import a single file
-import * as myPost from '../pages/post/my-post.md';
-
-// Import multiple files with Astro.glob
-const posts = await Astro.glob('../pages/post/*.md');
----
-```
-
-When you import Markdown and MDX files in an Astro component, you get an object containing their [exported properties](#exported-properties).
-
-```md title="/src/pages/posts/great-post.md"
+```md title="/src/posts/great-post.md"
 ---
 title: 'The greatest post of all time'
 author: 'Ben'
@@ -237,8 +41,7 @@ Here is my _great_ post!
 ```astro title="src/pages/my-posts.astro"
 ---
 import * as greatPost from '../pages/post/great-post.md';
-
-const posts = await Astro.glob('../pages/post/*.md');
+const posts = Object.values(await import.meta.glob('../post/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>
@@ -250,176 +53,96 @@ const posts = await Astro.glob('../pages/post/*.md');
 </ul>
 ```
 
-In MDX files, you can access properties from both frontmatter and `export` statements:
+### Available Properties
 
-```mdx title="/src/pages/posts/mdx-post.mdx"
----
-title: 'The greatest post of all time'
-author: 'Ben'
----
-export const description = 'Get comfortable! This is going to be a great read.'
+#### Querying collections
 
-Here is my _great_ post!
-```
+When fetching data from your collections via helper functions, your Markdown's frontmatter properties are available on a `data` object (e.g. `post.data.title`). Additionally, `body` contains the raw, uncompiled body content as a string.
 
-```astro title="src/pages/my-posts.astro"
----
-import * as greatPost from '../pages/post/mdx-post.mdx';
----
+<ReadMore>See the full [CollectionEntry type](/en/reference/api-reference/#collection-entry-type).</ReadMore>
 
-<p>{greatPost.frontmatter.title}</p>
-<p>Written by: {greatPost.frontmatter.author}</p>
-<p>{greatPost.description}</p>
-```
+#### Importing Markdown
 
-You can optionally provide a type for the `frontmatter` variable using a TypeScript generic:
-
-```astro title="src/pages/index.astro" ins={2-5} ins="<Frontmatter>"
----
-interface Frontmatter {
-  title: string;
-  description?: string;
-}
-const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
----
-
-<ul>
-  {posts.map(post => <li>{post.frontmatter.title}</li>)}
-  <!-- post.frontmatter.title will be `string`! -->
-</ul>
-```
-
-### Exported Properties
-
-:::note[Using an Astro layout?]
-See the [properties exported to an Astro layout component](/en/basics/layouts/#markdown-layout-props) when using Astro's special [frontmatter layout](#frontmatter-layout).
-:::
-
-The following properties are available to a `.astro` component when using an `import` statement or `Astro.glob()`:
+The following exported properties are available in your `.astro` component when importing Markdown using `import` or `import.meta.glob()`:
 
 - **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.md`).
-- **`url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
+- **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - Contains any data specified in the file’s YAML frontmatter.
-- **`getHeadings`** - An async function that returns an array of all headings (i.e. `h1 -> h6` elements) in the file. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links. This list follows the type: `{ depth: number; slug: string; text: string }[]`.
-- **`Content`** - A component that returns the full, rendered contents of the file.
-- **(Markdown only) `rawContent()`** - A function that returns the raw Markdown document as a string.
-- **(Markdown only) `compiledContent()`** - A function that returns the Markdown document compiled to an HTML string. Note this does not include layouts configured in your frontmatter! Only the markdown document itself will be returned as HTML.
-- **(MDX only)** - MDX files can also export data with an `export` statement.
+- **`<Content />`** - A component that returns the full, rendered contents of the file.
+- **`rawContent()`** - A function that returns the raw Markdown document as a string.
+- **`compiledContent()`** - A function that returns the Markdown document compiled to an HTML string.
+- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
+
+An example Markdown blog post may pass the following `Astro.props` object:
+
+```js
+Astro.props = {
+  file: "/home/user/projects/.../file.md",
+  url: "/en/guides/markdown-content/",
+  frontmatter: {
+    /** Frontmatter from a blog post */
+    title: "Astro 0.18 Release",
+    date: "Tuesday, July 27 2021",
+    author: "Matthew Phillips",
+    description: "Astro 0.18 is our biggest release since Astro launch.",
+  },
+  getHeadings: () => [
+    {"depth": 1, "text": "Astro 0.18 Release", "slug": "astro-018-release"},
+    {"depth": 2, "text": "Responsive partial hydration", "slug": "responsive-partial-hydration"}
+    /* ... */
+  ],
+  rawContent: () => "# Astro 0.18 Release\nA little over a month ago, the first public beta [...]",
+  compiledContent: () => "<h1>Astro 0.18 Release</h1>\n<p>A little over a month ago, the first public beta [...]</p>",
+}
+```
 
 
-### The `Content` Component
+## The `<Content />` Component
 
-Import `Content` to render a component that returns the full rendered contents of a Markdown or MDX file:
+The `<Content />` component is availble by importing `Content` from a Markdown file. This component returns the file's full body content, rendered to HTML. You can optionally rename `Content` to any component name you prefer.
+
+You can similarly [render the HTML content of a Markdown collection entry](/en/guides/collection-queries/#rendering-body-content) by rendering a `<Content />` component.
 
 ```astro title="src/pages/content.astro" "Content"
 ---
+// Import statement
 import {Content as PromoBanner} from '../components/promoBanner.md';
----
 
+// Collections query
+import { getEntry, render } from 'astro:content';
+
+const product = await getEntry('products', 'shirt');
+const { Content } = await render();
+---
 <h2>Today's promo</h2>
 <PromoBanner />
+
+<p>Sale Ends: {entry.data.saleEndDate.toDateString()}</p>
+<Content />
 ```
 
-#### Example: Dynamic page routing
+## Heading IDs
 
-Instead of putting your Markdown/MDX files in the `src/pages/` directory to create page routes, you can [generate pages dynamically](/en/guides/routing/#dynamic-routes).
+Writing headings in Markdown will automatically give you anchor links so you can link directly to certain sections of your page.
 
-To access your Markdown content, pass the `<Content/>` component through the Astro page’s `props`. You can then retrieve the component from `Astro.props` and render it in your page template.
-
-```astro title="src/pages/[slug].astro" {9-11} "Content" "Astro.props.post"
+```markdown title="src/pages/page-1.md"
 ---
-export async function getStaticPaths() {
-  const posts = await Astro.glob('../posts/**/*.md')
-
-  return posts.map(post => ({
-    params: {
-      slug: post.frontmatter.slug
-    },
-    props: {
-      post
-    },
-  }))
-}
-
-const { Content } = Astro.props.post
+title: My page of content
 ---
-<article>
-  <Content/>
-</article>
+## Introduction
+
+I can link internally to [my conclusion](#conclusion) on the same page when writing Markdown.
+
+## Conclusion
+
+I can visit `https://example.com/page-1/#introduction` in a browser to navigate directly to my Introduction.
 ```
 
+Astro generates heading `id`s based on `github-slugger`. You can find more examples in [the github-slugger documentation](https://github.com/Flet/github-slugger#usage).
 
-### MDX-only Exports
+### Heading IDs and plugins
 
-MDX files can also export data with an `export` statement.
-
-For example, you can export a `title` field from an MDX page or component.
-
-```mdx title="/src/pages/posts/post-1.mdx"
-export const title = 'My first MDX post'
-```
-
-This `title` will be accessible from `import` and [Astro.glob()](/en/reference/api-reference/#astroglob) statements:
-
-```astro
----
-// src/pages/index.astro
-const posts = await Astro.glob('./*.mdx');
----
-
-{posts.map(post => <p>{post.title}</p>)}
-```
-
-### Custom components with imported MDX
-
-When rendering imported MDX content, [custom components](#assigning-custom-components-to-html-elements) can be passed via the `components` prop.
-
-```astro title="src/pages/page.astro" "components={{...components, h1: Heading }}"
----
-import { Content, components } from '../content.mdx';
-import Heading from '../Heading.astro';
----
-<!-- Creates a custom <h1> for the # syntax, _and_ applies any custom components defined in `content.mdx` -->
-<Content components={{...components, h1: Heading }} />
-```
-
-:::note
-Custom components defined and exported in an MDX file must be imported and then passed back to the `<Content />` component via the `components` property.
-:::
-
-## Configuring Markdown and MDX
-
-Markdown support in Astro is powered by [remark](https://remark.js.org/), a powerful parsing and processing tool with an active ecosystem. Other Markdown parsers like Pandoc and markdown-it are not currently supported.
-
-Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [SmartyPants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text, and formatting for [quotations and em-dashes](https://daringfireball.net/projects/smartypants/).
-
-You can customize how remark parses your Markdown in `astro.config.mjs`. See the full list of [Markdown configuration options](/en/reference/configuration-reference/#markdown-options).
-
-### Markdown Plugins
-
-Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and [styling your Markdown](/en/guides/styling/#markdown-styling).
-
-We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins! See each plugin's own README for specific installation instructions.
-
-This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) and [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) to both Markdown and MDX files:
-
-```js title="astro.config.mjs"
-import { defineConfig } from 'astro/config';
-import remarkToc from 'remark-toc';
-import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
-
-export default defineConfig({
-  markdown: {
-    // Applied to .md and .mdx files
-    remarkPlugins: [ [remarkToc, { heading: 'toc', maxDepth: 3 } ] ],
-    rehypePlugins: [rehypeAccessibleEmojis],
-  },
-});
-```
-
-#### Heading IDs and plugins
-
-Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#exported-properties).
+Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#available-properties).
 
 You can customize these heading IDs by adding a rehype plugin that injects `id` attributes (e.g. `rehype-slug`). Your custom IDs, instead of Astro's defaults, will be reflected in the HTML output and the items returned by `getHeadings()`.
 
@@ -440,11 +163,36 @@ export default defineConfig({
 });
 ```
 
-:::note
-`getHeadings()` only returns the headings written directly in a Markdown or MDX file itself. If an MDX file imports components that contain their own headings, these will not be returned by `getHeadings()`.
-:::
+## Markdown Plugins
 
-#### Customizing a plugin
+Markdown support in Astro is powered by [remark](https://remark.js.org/), a powerful parsing and processing tool with an active ecosystem. Other Markdown parsers like Pandoc and markdown-it are not currently supported.
+
+Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [SmartyPants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text, and formatting for [quotations and em-dashes](https://daringfireball.net/projects/smartypants/).
+
+You can customize how remark parses your Markdown in `astro.config.mjs`. See the full list of [Markdown configuration options](/en/reference/configuration-reference/#markdown-options).
+
+### Adding remark and rehype plugins
+
+Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and [styling your Markdown](/en/guides/styling/#markdown-styling).
+
+We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins! See each plugin's own README for specific installation instructions.
+
+This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) and [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) to Markdown files:
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+import remarkToc from 'remark-toc';
+import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
+
+export default defineConfig({
+  markdown: {
+    remarkPlugins: [ [remarkToc, { heading: 'toc', maxDepth: 3 } ] ],
+    rehypePlugins: [rehypeAccessibleEmojis],
+  },
+});
+```
+
+### Customizing a plugin
 
 In order to customize a plugin, provide an options object after it in a nested array.
 
@@ -572,7 +320,7 @@ export default defineConfig({
 });
 ```
 
-### Syntax Highlighting
+## Syntax Highlighting
 
 Astro comes with built-in support for [Shiki](https://shiki.style/) and [Prism](https://prismjs.com/). This provides syntax highlighting for:
 
@@ -582,7 +330,7 @@ Astro comes with built-in support for [Shiki](https://shiki.style/) and [Prism](
 
 Shiki is enabled by default, preconfigured with the `github-dark` theme. The compiled output will be limited to inline `style`s without any extraneous CSS classes, stylesheets, or client-side JS.
 
-#### Shiki configuration
+### Shiki configuration
 
 Shiki is our default syntax highlighter. You can configure all options via the `shikiConfig` object like so:
 
@@ -640,7 +388,7 @@ export default defineConfig({
 
 We also suggest reading [Shiki's own theme documentation](https://shiki.style/themes) to explore more about themes, light vs dark mode toggles, or styling via CSS variables.
 
-#### Change Default Syntax Highlighting Mode
+### Default Syntax Highlighter
 
 If you'd like to switch to `'prism'` by default, or disable syntax highlighting entirely, you can use the `markdown.syntaxHighlighting` config object:
 
@@ -655,7 +403,7 @@ export default defineConfig({
 });
 ```
 
-#### Prism configuration
+#### Using Prism instead of Shiki
 
 If you opt to use Prism, Astro will apply Prism's CSS classes instead. Note that **you need to bring your own CSS stylesheet** for syntax highlighting to appear!
 
@@ -671,9 +419,11 @@ You can also visit the [list of languages supported by Prism](https://prismjs.co
 
 ## Fetching Remote Markdown
 
-Astro was primarily designed for local Markdown files that could be saved inside of your project directory. However, there may be certain cases where you need to fetch Markdown from a remote source. For example, you may need to fetch and render Markdown from a remote API when you build your website (or when a user makes a request to your website, when using [SSR](/en/guides/server-side-rendering/)).
+**Astro does not include built-in support for remote Markdown outside of content collections!**
 
-**Astro does not include built-in support for remote Markdown!** To fetch remote Markdown and render it to HTML, you will need to install and configure your own Markdown parser from npm. This **will not** inherit from any of Astro's built-in Markdown and MDX settings that you have configured. Be sure that you understand these limitations before implementing this in your project.
+To fetch remote Markdown directly and render it to HTML, you will need to install and configure your own Markdown parser from NPM. This **will not** inherit from any of Astro's built-in Markdown settings that you have configured.
+
+Be sure that you understand these limitations before implementing this in your project, and consider fetching your remote Markdown using a [content collections loader instead](/en/guides/defining-collections/#defining-the-collection-loader).
 
 ```astro title="src/pages/remote-example.astro"
 ---
@@ -687,3 +437,62 @@ const content = marked.parse(markdown);
 ---
 <article set:html={content} />
 ```
+
+## Individual Markdown pages
+
+Astro treats [any supported file inside of the `/src/pages/` directory](/en/basics/astro-pages/#supported-page-files) as a page, including `.md` and other Markdown file types.
+
+Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file and display the Markdown content rendered to HTML.
+
+```markdown title="src/pages/page-1.md"
+---
+title: Hello, World
+---
+
+# Hi there!
+
+This Markdown file creates a page at `your-domain.com/page-1/`
+
+It probably isn't styled much, but Markdown does support:
+- **bold** and _italics._
+- lists
+- [links](https://astro.build)
+- <p>HTML elements</p>
+- and more!
+```
+
+[Content collections](/en/guides/content-collections/) and [importing Markdown into `.astro` components](#dynamic-jsx-like-expressions) provide more features for rendering your Markdown and are the recommended way to handle most of your content. However, there may be times when you want the convenience of just adding a file to `src/pages/` and having a simple page automatically created for you.
+
+### Frontmatter `layout` property
+
+To help with the limited functionality of Markdown pages, Astro provides a special frontmatter `layout` property which is a relative path to an Astro [Markdown layout component](/en/basics/layouts/#markdownmdx-layouts). If your Markdown file is located within `src/pages/`, create a layout component and add it in this layout property to provide a page shell around your Markdown content.
+
+```markdown title="src/pages/posts/post-1.md" {2}
+---
+layout: ../../layouts/BlogPostLayout.astro
+title: Astro in brief
+author: Himanshu
+description: Find out what makes Astro awesome!
+---
+This is a post written in Markdown.
+```
+
+This layout component is a regular Astro component with [specific properties automatically available](/en/basics/layouts/#markdown-layout-props) through `Astro.props` for your Astro template. For example, you can access your Markdown file's frontmatter properties through `Astro.props.frontmatter`:
+
+```astro title="src/layouts/BlogPostLayout.astro" /frontmatter(?:.\w+)?/
+---
+const {frontmatter} = Astro.props;
+---
+<html>
+  <!-- ... -->
+  <h1>{frontmatter.title}</h1>
+  <h2>Post author: {frontmatter.author}</h2>
+  <p>{frontmatter.description}</p>
+  <slot /> <!-- Markdown content is injected here -->
+  <!-- ... -->
+</html>
+```
+
+You can also [style your Markdown](/en/guides/styling/#markdown-styling) in your layout component.
+
+<ReadMore>Learn more about [Markdown Layouts](/en/basics/layouts/#markdown-layouts).</ReadMore>

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -1,6 +1,6 @@
 ---
-title: Markdown in Astro
-description: Learn how to create content using Markdown in Astro
+title: Markdown & MDX
+description: Learn how to create content using Markdown or MDX with Astro
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
@@ -9,121 +9,102 @@ import RecipeLinks from "~/components/RecipeLinks.astro";
 import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-[Markdown](https://daringfireball.net/projects/markdown/) is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for Markdown files that can also include [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) to define custom properties such as a title, description, and tags.
+[Markdown](https://daringfireball.net/projects/markdown/) is commonly used to author text-heavy content like blog posts and documentation. Astro includes built-in support for standard Markdown files that can also include [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) to define custom metadata such as a title, description, and tags.
 
-In Astro, you can author content in Markdown, then render it in `.astro` components. This combines a familiar writing format designed for content with the flexibility of Astro's component syntax and architecture.
+With the [@astrojs/mdx integration](/en/guides/integrations-guide/mdx/) installed, Astro also supports [MDX](https://mdxjs.com/) (`.mdx`) files which bring added features like support for JavaScript expressions and components in your Markdown content.
 
-For additional functionality, such as including components and JSX expressions in Markdown, add the [`@astrojs/mdx` integration](/en/guides/integrations-guide/mdx/) to write your Markdown content using [MDX](https://mdxjs.com/).
+Use either or both types of files to write your Markdown content!
 
-## Organizing Markdown files
+## Markdown and MDX Pages
 
-Your local Markdown files can be kept anywhere within your `src/` directory. Local Markdown can be imported into `.astro` components using an `import` statement for a single file and [Vite's `import.meta.glob()`](https://vitejs.dev/guide/features.html#glob-import) to query multiple files at once.
+### Content collections
 
-If you have groups of related Markdown files, consider [defining them as collections](/en/guides/content-collections/). This gives you several advantages, including the ability to store Markdown files anywhere on your filesystem or remotely.
+You can manage your Markdown and MDX files in Astro in a special `src/content/` folder. [Content collections](/en/guides/content-collections/) help you organize your content, validate your frontmatter, and provide automatic TypeScript type-safety while working with your content.
 
-Collections also allow you to use content-specfic, optimized API for querying and rendering your content. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
+<FileTree>
+- src/content/
+  - **newsletter/**
+    - week-1.md
+    - week-2.md
+  - **authors/**
+    - grace-hopper.md
+    - alan-turing.md
+</FileTree>
 
-{/* <ReadMore>See more about [when to use content collections](/en/guides/content-collections/#when-to-create-a-collection) instead of file imports.</ReadMore> */}
 
-## Dynamic JSX-like expressions
 
-After importing or querying Markdown files, you can write dynamic HTML templates in your `.astro` components that include frontmatter data and body content.
+See more about using [content collections in Astro](/en/guides/content-collections/).
 
-```md title="/src/posts/great-post.md"
+
+### File-based Routing
+
+Astro treats any `.md` (or alternative supported extension) or `.mdx` file inside of the `/src/pages/` directory as a page.
+
+Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file.
+
+```markdown
 ---
-title: 'The greatest post of all time'
-author: 'Ben'
+# Example: src/pages/page-1.md
+title: Hello, World
 ---
 
-Here is my _great_ post!
+# Hi there!
+
+This Markdown file creates a page at `your-domain.com/page-1/`
+
+It probably isn't styled much, but Markdown does support:
+- **bold** and _italics._
+- lists
+- [links](https://astro.build)
+- and more!
 ```
 
-```astro title="src/pages/my-posts.astro"
----
-import * as greatPost from '../pages/post/great-post.md';
-const posts = Object.values(await import.meta.glob('../post/*.md', { eager: true }));
----
+<ReadMore>Read more about Astro's [file-based routing](/en/guides/routing/) or options for creating [dynamic routes](/en/guides/routing/#dynamic-routes).</ReadMore>
 
-<p>{greatPost.frontmatter.title}</p>
-<p>Written by: {greatPost.frontmatter.author}</p>
 
-<p>Post Archive:</p>
-<ul>
-  {posts.map(post => <li><a href={post.url}>{post.frontmatter.title}</a></li>)}
-</ul>
+## Markdown Features
+
+Astro provides some extra, built-in Markdown features available when using Markdown and MDX files.
+
+### Frontmatter `layout`
+
+Astro provides [Markdown and MDX pages](/en/basics/astro-pages/#markdownmdx-pages) (located within `src/pages/`) with a special frontmatter `layout` property that can specify a relative path (or [alias](/en/guides/imports/#aliases)) to an Astro [layout component](/en/basics/layouts/#markdown-layouts).
+
+```markdown {3}
+---
+# src/pages/posts/post-1.md
+layout: ../../layouts/BlogPostLayout.astro
+title: Astro in brief
+author: Himanshu
+description: Find out what makes Astro awesome!
+---
+This is a post written in Markdown.
 ```
 
-### Available Properties
+[Specific properties are then available to the layout component](/en/basics/layouts/#markdown-layout-props)  through `Astro.props`. For example, you can access frontmatter properties through `Astro.props.frontmatter`:
 
-#### Querying collections
-
-When fetching data from your collections via helper functions, your Markdown's frontmatter properties are available on a `data` object (e.g. `post.data.title`). Additionally, `body` contains the raw, uncompiled body content as a string.
-
-<ReadMore>See the full [CollectionEntry type](/en/reference/api-reference/#collection-entry-type).</ReadMore>
-
-#### Importing Markdown
-
-The following exported properties are available in your `.astro` component when importing Markdown using `import` or `import.meta.glob()`:
-
-- **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.md`).
-- **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
-- **`frontmatter`** - Contains any data specified in the file’s YAML frontmatter.
-- **`<Content />`** - A component that returns the full, rendered contents of the file.
-- **`rawContent()`** - A function that returns the raw Markdown document as a string.
-- **`compiledContent()`** - A function that returns the Markdown document compiled to an HTML string.
-- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
-
-An example Markdown blog post may pass the following `Astro.props` object:
-
-```js
-Astro.props = {
-  file: "/home/user/projects/.../file.md",
-  url: "/en/guides/markdown-content/",
-  frontmatter: {
-    /** Frontmatter from a blog post */
-    title: "Astro 0.18 Release",
-    date: "Tuesday, July 27 2021",
-    author: "Matthew Phillips",
-    description: "Astro 0.18 is our biggest release since Astro launch.",
-  },
-  getHeadings: () => [
-    {"depth": 1, "text": "Astro 0.18 Release", "slug": "astro-018-release"},
-    {"depth": 2, "text": "Responsive partial hydration", "slug": "responsive-partial-hydration"}
-    /* ... */
-  ],
-  rawContent: () => "# Astro 0.18 Release\nA little over a month ago, the first public beta [...]",
-  compiledContent: () => "<h1>Astro 0.18 Release</h1>\n<p>A little over a month ago, the first public beta [...]</p>",
-}
+```astro /frontmatter(?:.\w+)?/
+---
+// src/layouts/BlogPostLayout.astro
+const {frontmatter} = Astro.props;
+---
+<html>
+  <!-- ... -->
+  <h1>{frontmatter.title}</h1>
+  <h2>Post author: {frontmatter.author}</h2>
+  <p>{frontmatter.description}</p>
+  <slot /> <!-- Markdown content is injected here -->
+   <!-- ... -->
+</html>
 ```
 
+You can also [style your Markdown](/en/guides/styling/#markdown-styling) in your layout component.
 
-## The `<Content />` Component
+<ReadMore>Learn more about [Markdown Layouts](/en/basics/layouts/#markdown-layouts).</ReadMore>
 
-The `<Content />` component is availble by importing `Content` from a Markdown file. This component returns the file's full body content, rendered to HTML. You can optionally rename `Content` to any component name you prefer.
+### Heading IDs
 
-You can similarly [render the HTML content of a Markdown collection entry](/en/guides/collection-queries/#rendering-body-content) by rendering a `<Content />` component.
-
-```astro title="src/pages/content.astro" "Content"
----
-// Import statement
-import {Content as PromoBanner} from '../components/promoBanner.md';
-
-// Collections query
-import { getEntry, render } from 'astro:content';
-
-const product = await getEntry('products', 'shirt');
-const { Content } = await render();
----
-<h2>Today's promo</h2>
-<PromoBanner />
-
-<p>Sale Ends: {entry.data.saleEndDate.toDateString()}</p>
-<Content />
-```
-
-## Heading IDs
-
-Writing headings in Markdown will automatically give you anchor links so you can link directly to certain sections of your page.
+Using headings in Markdown and MDX will automatically give you anchor links so you can link directly to certain sections of your page.
 
 ```markdown title="src/pages/page-1.md"
 ---
@@ -135,14 +116,310 @@ I can link internally to [my conclusion](#conclusion) on the same page when writ
 
 ## Conclusion
 
-I can visit `https://example.com/page-1/#introduction` in a browser to navigate directly to my Introduction.
+I can use the URL `https://example.com/page-1/#introduction` to navigate directly to my Introduction on the page.
 ```
 
 Astro generates heading `id`s based on `github-slugger`. You can find more examples in [the github-slugger documentation](https://github.com/Flet/github-slugger#usage).
 
-### Heading IDs and plugins
+### Escaping special characters
 
-Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#available-properties).
+Certain characters have a special meaning in Markdown and MDX. You may need to use a different syntax if you want to display them. To do this, you can use [HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) for these characters instead.
+
+For example, to prevent `<` being interpreted as the beginning of an HTML element, write `&lt;`. Or, to prevent `{` being interpreted as the beginning of a JavaScript expression in MDX, write `&lcub;`.
+
+## MDX-only Features
+
+Adding the Astro [MDX integration](/en/guides/integrations-guide/mdx/) enhances your Markdown authoring with JSX variables, expressions and components.
+
+It also adds extra features to standard MDX, including support for [Markdown-style frontmatter in MDX](https://mdxjs.com/guides/frontmatter/). This allows you to use most of Astro's built-in Markdown features like a [frontmatter `layout`](#frontmatter-layout) property.
+
+`.mdx` files must be written in [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) rather than Astro’s HTML-like syntax.
+
+### Using Exported Variables in MDX
+
+MDX supports using `export` statements to add variables to your MDX content. These variables are accessible both in the template itself and as named properties when [importing the file](#importing-markdown) somewhere else.
+
+For example, you can export a `title` field from an MDX page or component to use as a heading with `{JSX expressions}`:
+
+```mdx title="/src/pages/posts/post-1.mdx"
+export const title = 'My first MDX post'
+
+# {title}
+```
+### Using Frontmatter Variables in MDX
+
+The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are accessible to use in the template, in its [`layout` component](#frontmatter-layout), and as named properties when [importing the file](#importing-markdown) somewhere else.
+
+```mdx title="/src/pages/posts/post-1.mdx"
+---
+layout: '../../layouts/BlogPostLayout.astro'
+title: 'My first MDX post'
+---
+
+# {frontmatter.title}
+```
+
+### Using Components in MDX
+
+After installing the MDX integration, you can import and use both [Astro components](/en/basics/astro-components/#component-props) and [UI framework components](/en/guides/framework-components/#using-framework-components) in MDX (`.mdx`) files just as you would use them in any other Astro component.
+
+Don't forget to include a `client:directive` on your UI framework components, if necessary!
+
+See more examples of using import and export statements in the [MDX docs](https://mdxjs.com/docs/what-is-mdx/#esm).
+
+```mdx title="src/pages/about.mdx" {5-6} /<.+\/>/
+---
+layout: ../layouts/BaseLayout.astro
+title: About me
+---
+import Button from '../components/Button.astro';
+import ReactCounter from '../components/ReactCounter.jsx';
+
+I live on **Mars** but feel free to <Button title="Contact me" />.
+
+Here is my counter component, working in MDX:
+
+<ReactCounter client:load />
+```
+
+#### Assigning Custom Components to HTML elements
+
+With MDX, you can map Markdown syntax to custom components instead of their standard HTML elements. This allows you to write in standard Markdown syntax, but apply special component styling to selected elements.
+
+Import your custom component into your `.mdx` file, then export a `components` object that maps the standard HTML element to your custom component:
+
+```mdx title="src/pages/about.mdx"
+import Blockquote from '../components/Blockquote.astro';
+export const components = {blockquote: Blockquote}
+
+> This quote will be a custom Blockquote
+```
+
+
+```astro title="src/components/Blockquote.astro"
+---
+const props = Astro.props;
+---
+<blockquote {...props} class="bg-blue-50 p-4">
+  <span class="text-4xl text-blue-600 mb-2">“</span>
+  <slot /> <!-- Be sure to add a `<slot/>` for child content! -->
+</blockquote>
+```
+Visit the [MDX website](https://mdxjs.com/table-of-components/) for a full list of HTML elements that can be overwritten as custom components.
+
+## Importing Markdown
+
+You can import Markdown and MDX files directly into your Astro files. This gives you access to their Markdown content, as well as other properties such as frontmatter values that can be used within Astro's JSX-like expressions.
+
+You can import one specific page with an `import` statement, or multiple pages with [`Astro.glob()`](/en/guides/imports/#astroglob).
+
+```astro title="src/pages/index.astro"
+---
+// Import a single file
+import * as myPost from '../pages/post/my-post.md';
+
+// Import multiple files with Astro.glob
+const posts = await Astro.glob('../pages/post/*.md');
+---
+```
+
+When you import Markdown and MDX files in an Astro component, you get an object containing their [exported properties](#exported-properties).
+
+```md title="/src/pages/posts/great-post.md"
+---
+title: 'The greatest post of all time'
+author: 'Ben'
+---
+
+Here is my _great_ post!
+```
+
+```astro title="src/pages/my-posts.astro"
+---
+import * as greatPost from '../pages/post/great-post.md';
+
+const posts = await Astro.glob('../pages/post/*.md');
+---
+
+<p>{greatPost.frontmatter.title}</p>
+<p>Written by: {greatPost.frontmatter.author}</p>
+
+<p>Post Archive:</p>
+<ul>
+  {posts.map(post => <li><a href={post.url}>{post.frontmatter.title}</a></li>)}
+</ul>
+```
+
+In MDX files, you can access properties from both frontmatter and `export` statements:
+
+```mdx title="/src/pages/posts/mdx-post.mdx"
+---
+title: 'The greatest post of all time'
+author: 'Ben'
+---
+export const description = 'Get comfortable! This is going to be a great read.'
+
+Here is my _great_ post!
+```
+
+```astro title="src/pages/my-posts.astro"
+---
+import * as greatPost from '../pages/post/mdx-post.mdx';
+---
+
+<p>{greatPost.frontmatter.title}</p>
+<p>Written by: {greatPost.frontmatter.author}</p>
+<p>{greatPost.description}</p>
+```
+
+You can optionally provide a type for the `frontmatter` variable using a TypeScript generic:
+
+```astro title="src/pages/index.astro" ins={2-5} ins="<Frontmatter>"
+---
+interface Frontmatter {
+  title: string;
+  description?: string;
+}
+const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
+---
+
+<ul>
+  {posts.map(post => <li>{post.frontmatter.title}</li>)}
+  <!-- post.frontmatter.title will be `string`! -->
+</ul>
+```
+
+### Exported Properties
+
+:::note[Using an Astro layout?]
+See the [properties exported to an Astro layout component](/en/basics/layouts/#markdown-layout-props) when using Astro's special [frontmatter layout](#frontmatter-layout).
+:::
+
+The following properties are available to a `.astro` component when using an `import` statement or `Astro.glob()`:
+
+- **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.md`).
+- **`url`** - If it's a page, the URL of the page (e.g. `/en/guides/markdown-content`).
+- **`frontmatter`** - Contains any data specified in the file’s YAML frontmatter.
+- **`getHeadings`** - An async function that returns an array of all headings (i.e. `h1 -> h6` elements) in the file. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links. This list follows the type: `{ depth: number; slug: string; text: string }[]`.
+- **`Content`** - A component that returns the full, rendered contents of the file.
+- **(Markdown only) `rawContent()`** - A function that returns the raw Markdown document as a string.
+- **(Markdown only) `compiledContent()`** - A function that returns the Markdown document compiled to an HTML string. Note this does not include layouts configured in your frontmatter! Only the markdown document itself will be returned as HTML.
+- **(MDX only)** - MDX files can also export data with an `export` statement.
+
+
+### The `Content` Component
+
+Import `Content` to render a component that returns the full rendered contents of a Markdown or MDX file:
+
+```astro title="src/pages/content.astro" "Content"
+---
+import {Content as PromoBanner} from '../components/promoBanner.md';
+---
+
+<h2>Today's promo</h2>
+<PromoBanner />
+```
+
+#### Example: Dynamic page routing
+
+Instead of putting your Markdown/MDX files in the `src/pages/` directory to create page routes, you can [generate pages dynamically](/en/guides/routing/#dynamic-routes).
+
+To access your Markdown content, pass the `<Content/>` component through the Astro page’s `props`. You can then retrieve the component from `Astro.props` and render it in your page template.
+
+```astro title="src/pages/[slug].astro" {9-11} "Content" "Astro.props.post"
+---
+export async function getStaticPaths() {
+  const posts = await Astro.glob('../posts/**/*.md')
+
+  return posts.map(post => ({
+    params: {
+      slug: post.frontmatter.slug
+    },
+    props: {
+      post
+    },
+  }))
+}
+
+const { Content } = Astro.props.post
+---
+<article>
+  <Content/>
+</article>
+```
+
+
+### MDX-only Exports
+
+MDX files can also export data with an `export` statement.
+
+For example, you can export a `title` field from an MDX page or component.
+
+```mdx title="/src/pages/posts/post-1.mdx"
+export const title = 'My first MDX post'
+```
+
+This `title` will be accessible from `import` and [Astro.glob()](/en/reference/api-reference/#astroglob) statements:
+
+```astro
+---
+// src/pages/index.astro
+const posts = await Astro.glob('./*.mdx');
+---
+
+{posts.map(post => <p>{post.title}</p>)}
+```
+
+### Custom components with imported MDX
+
+When rendering imported MDX content, [custom components](#assigning-custom-components-to-html-elements) can be passed via the `components` prop.
+
+```astro title="src/pages/page.astro" "components={{...components, h1: Heading }}"
+---
+import { Content, components } from '../content.mdx';
+import Heading from '../Heading.astro';
+---
+<!-- Creates a custom <h1> for the # syntax, _and_ applies any custom components defined in `content.mdx` -->
+<Content components={{...components, h1: Heading }} />
+```
+
+:::note
+Custom components defined and exported in an MDX file must be imported and then passed back to the `<Content />` component via the `components` property.
+:::
+
+## Configuring Markdown and MDX
+
+Markdown support in Astro is powered by [remark](https://remark.js.org/), a powerful parsing and processing tool with an active ecosystem. Other Markdown parsers like Pandoc and markdown-it are not currently supported.
+
+Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [SmartyPants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text, and formatting for [quotations and em-dashes](https://daringfireball.net/projects/smartypants/).
+
+You can customize how remark parses your Markdown in `astro.config.mjs`. See the full list of [Markdown configuration options](/en/reference/configuration-reference/#markdown-options).
+
+### Markdown Plugins
+
+Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown and MDX. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and [styling your Markdown](/en/guides/styling/#markdown-styling).
+
+We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins! See each plugin's own README for specific installation instructions.
+
+This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) and [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) to both Markdown and MDX files:
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+import remarkToc from 'remark-toc';
+import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
+
+export default defineConfig({
+  markdown: {
+    // Applied to .md and .mdx files
+    remarkPlugins: [ [remarkToc, { heading: 'toc', maxDepth: 3 } ] ],
+    rehypePlugins: [rehypeAccessibleEmojis],
+  },
+});
+```
+
+#### Heading IDs and plugins
+
+Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#exported-properties).
 
 You can customize these heading IDs by adding a rehype plugin that injects `id` attributes (e.g. `rehype-slug`). Your custom IDs, instead of Astro's defaults, will be reflected in the HTML output and the items returned by `getHeadings()`.
 
@@ -163,36 +440,11 @@ export default defineConfig({
 });
 ```
 
-## Markdown Plugins
+:::note
+`getHeadings()` only returns the headings written directly in a Markdown or MDX file itself. If an MDX file imports components that contain their own headings, these will not be returned by `getHeadings()`.
+:::
 
-Markdown support in Astro is powered by [remark](https://remark.js.org/), a powerful parsing and processing tool with an active ecosystem. Other Markdown parsers like Pandoc and markdown-it are not currently supported.
-
-Astro applies the [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) and [SmartyPants](https://github.com/silvenon/remark-smartypants) plugins by default. This brings some niceties like generating clickable links from text, and formatting for [quotations and em-dashes](https://daringfireball.net/projects/smartypants/).
-
-You can customize how remark parses your Markdown in `astro.config.mjs`. See the full list of [Markdown configuration options](/en/reference/configuration-reference/#markdown-options).
-
-### Adding remark and rehype plugins
-
-Astro supports adding third-party [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) plugins for Markdown. These plugins allow you to extend your Markdown with new capabilities, like [auto-generating a table of contents](https://github.com/remarkjs/remark-toc), [applying accessible emoji labels](https://github.com/florianeckerstorfer/remark-a11y-emoji), and [styling your Markdown](/en/guides/styling/#markdown-styling).
-
-We encourage you to browse [awesome-remark](https://github.com/remarkjs/awesome-remark) and [awesome-rehype](https://github.com/rehypejs/awesome-rehype) for popular plugins! See each plugin's own README for specific installation instructions.
-
-This example applies [`remark-toc`](https://github.com/remarkjs/remark-toc) and [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) to Markdown files:
-
-```js title="astro.config.mjs"
-import { defineConfig } from 'astro/config';
-import remarkToc from 'remark-toc';
-import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
-
-export default defineConfig({
-  markdown: {
-    remarkPlugins: [ [remarkToc, { heading: 'toc', maxDepth: 3 } ] ],
-    rehypePlugins: [rehypeAccessibleEmojis],
-  },
-});
-```
-
-### Customizing a plugin
+#### Customizing a plugin
 
 In order to customize a plugin, provide an options object after it in a nested array.
 
@@ -320,7 +572,7 @@ export default defineConfig({
 });
 ```
 
-## Syntax Highlighting
+### Syntax Highlighting
 
 Astro comes with built-in support for [Shiki](https://shiki.style/) and [Prism](https://prismjs.com/). This provides syntax highlighting for:
 
@@ -330,7 +582,7 @@ Astro comes with built-in support for [Shiki](https://shiki.style/) and [Prism](
 
 Shiki is enabled by default, preconfigured with the `github-dark` theme. The compiled output will be limited to inline `style`s without any extraneous CSS classes, stylesheets, or client-side JS.
 
-### Shiki configuration
+#### Shiki configuration
 
 Shiki is our default syntax highlighter. You can configure all options via the `shikiConfig` object like so:
 
@@ -388,7 +640,7 @@ export default defineConfig({
 
 We also suggest reading [Shiki's own theme documentation](https://shiki.style/themes) to explore more about themes, light vs dark mode toggles, or styling via CSS variables.
 
-### Default Syntax Highlighter
+#### Change Default Syntax Highlighting Mode
 
 If you'd like to switch to `'prism'` by default, or disable syntax highlighting entirely, you can use the `markdown.syntaxHighlighting` config object:
 
@@ -403,7 +655,7 @@ export default defineConfig({
 });
 ```
 
-#### Using Prism instead of Shiki
+#### Prism configuration
 
 If you opt to use Prism, Astro will apply Prism's CSS classes instead. Note that **you need to bring your own CSS stylesheet** for syntax highlighting to appear!
 
@@ -419,11 +671,9 @@ You can also visit the [list of languages supported by Prism](https://prismjs.co
 
 ## Fetching Remote Markdown
 
-**Astro does not include built-in support for remote Markdown outside of content collections!**
+Astro was primarily designed for local Markdown files that could be saved inside of your project directory. However, there may be certain cases where you need to fetch Markdown from a remote source. For example, you may need to fetch and render Markdown from a remote API when you build your website (or when a user makes a request to your website, when using [SSR](/en/guides/server-side-rendering/)).
 
-To fetch remote Markdown directly and render it to HTML, you will need to install and configure your own Markdown parser from NPM. This **will not** inherit from any of Astro's built-in Markdown settings that you have configured.
-
-Be sure that you understand these limitations before implementing this in your project, and consider fetching your remote Markdown using a [content collections loader instead](/en/guides/defining-collections/#defining-the-collection-loader).
+**Astro does not include built-in support for remote Markdown!** To fetch remote Markdown and render it to HTML, you will need to install and configure your own Markdown parser from npm. This **will not** inherit from any of Astro's built-in Markdown and MDX settings that you have configured. Be sure that you understand these limitations before implementing this in your project.
 
 ```astro title="src/pages/remote-example.astro"
 ---
@@ -437,62 +687,3 @@ const content = marked.parse(markdown);
 ---
 <article set:html={content} />
 ```
-
-## Individual Markdown pages
-
-Astro treats [any supported file inside of the `/src/pages/` directory](/en/basics/astro-pages/#supported-page-files) as a page, including `.md` and other Markdown file types.
-
-Placing a file in this directory, or any sub-directory, will automatically build a page route using the pathname of the file and display the Markdown content rendered to HTML.
-
-```markdown title="src/pages/page-1.md"
----
-title: Hello, World
----
-
-# Hi there!
-
-This Markdown file creates a page at `your-domain.com/page-1/`
-
-It probably isn't styled much, but Markdown does support:
-- **bold** and _italics._
-- lists
-- [links](https://astro.build)
-- <p>HTML elements</p>
-- and more!
-```
-
-[Content collections](/en/guides/content-collections/) and [importing Markdown into `.astro` components](#dynamic-jsx-like-expressions) provide more features for rendering your Markdown and are the recommended way to handle most of your content. However, there may be times when you want the convenience of just adding a file to `src/pages/` and having a simple page automatically created for you.
-
-### Frontmatter `layout` property
-
-To help with the limited functionality of Markdown pages, Astro provides a special frontmatter `layout` property which is a relative path to an Astro [Markdown layout component](/en/basics/layouts/#markdownmdx-layouts). If your Markdown file is located within `src/pages/`, create a layout component and add it in this layout property to provide a page shell around your Markdown content.
-
-```markdown title="src/pages/posts/post-1.md" {2}
----
-layout: ../../layouts/BlogPostLayout.astro
-title: Astro in brief
-author: Himanshu
-description: Find out what makes Astro awesome!
----
-This is a post written in Markdown.
-```
-
-This layout component is a regular Astro component with [specific properties automatically available](/en/basics/layouts/#markdown-layout-props) through `Astro.props` for your Astro template. For example, you can access your Markdown file's frontmatter properties through `Astro.props.frontmatter`:
-
-```astro title="src/layouts/BlogPostLayout.astro" /frontmatter(?:.\w+)?/
----
-const {frontmatter} = Astro.props;
----
-<html>
-  <!-- ... -->
-  <h1>{frontmatter.title}</h1>
-  <h2>Post author: {frontmatter.author}</h2>
-  <p>{frontmatter.description}</p>
-  <slot /> <!-- Markdown content is injected here -->
-  <!-- ... -->
-</html>
-```
-
-You can also [style your Markdown](/en/guides/styling/#markdown-styling) in your layout component.
-
-<ReadMore>Learn more about [Markdown Layouts](/en/basics/layouts/#markdown-layouts).</ReadMore>

--- a/src/content/docs/en/guides/troubleshooting.mdx
+++ b/src/content/docs/en/guides/troubleshooting.mdx
@@ -217,6 +217,12 @@ You may notice an imported component's `<script>` or `<style>` tags included in 
 
 Astro's build process works on the module graph: once a component is included in the template, its `<script>` and `<style>` tags are processed, optimized, and bundled, whether it appears in the final output or not. This does not apply to scripts when the `is:inline` directive is applied.
 
+## Escaping special characters in Markdown
+
+Certain characters have a special meaning in Markdown. You may need to use a different syntax if you want to display them. To do this, you can use [HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) for these characters instead.
+
+For example, to prevent `<` being interpreted as the beginning of an HTML element, write `&lt;`.
+
 ## Creating minimal reproductions
 
 When troubleshooting your code, it can be helpful to create a **minimal reproduction** of the issue that you can share. This is a smaller, simplified Astro project that demonstrates your issue. Having a working reproduction in a new project helps to confirm that this is a repeatable problem, and is not caused by something else in your personal environment or existing project.


### PR DESCRIPTION
#### Description (required)

Separates some content out from the Markdown page and puts it on the MDX page and the troubleshooting page.

I can't make the corresponding Markdown page changes here/yet because that's a lot of link resolving that I've already fixed on the beta docs branch. :smile:  

So that means this content will be duplicated until I can resolve them, but I think that's fine. It will give translators a chance to translate these early, and when the Markdown page is updated with content removed, it won't be a problem.