### PR TITLE
Use await import for resolving prettier-plugin-astro

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -105,7 +105,7 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
     ```js title=".prettierrc.mjs"
     /** @type {import("prettier").Config} */
     export default {
-      plugins: ['prettier-plugin-astro'],
+      plugins: [await import('prettier-plugin-astro')],
       overrides: [
         {
           files: '*.astro',


### PR DESCRIPTION
#### Description

Because of [this issue](https://github.com/prettier/prettier/issues/15085) when using a string reference of a prettier transitive dependency, Prettier may fail to resolve the given plugins.

I noticed this myself when also combining it with `prettier-plugin-tailwindcss`. 

This change fixes the issue as stated [here](https://github.com/prettier/prettier/issues/15085#issuecomment-1636993346)


Relevant versions:
```
├── @astrojs/check@0.9.3
├── @astrojs/sitemap@3.1.6
├── @astrojs/tailwind@5.1.0
├── astro@4.15.4
├── prettier-plugin-astro@0.14.1
├── prettier-plugin-tailwindcss@0.6.6
├── prettier@3.3.3
├── tailwindcss@3.4.10
└── typescript@5.5.4
```
