### PR TITLE
Rename ViewTransitions to ClientRouter

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -10,7 +10,7 @@ import { Steps } from '@astrojs/starlight/components'
 
 Astro supports **opt-in, per-page, view transitions** with just a few lines of code. View transitions update your page content without the browser's normal, full-page navigation refresh and provide seamless animations between pages. 
 
-Astro provides a `<ViewTransitions />` routing component that can be added to a single page's `<head>` to control page transitions as you navigate away to another page. It provides a lightweight client-side router that [intercepts navigation](#client-side-navigation-process) and allows you to customize the transition between pages.
+Astro provides a `<ClientRouter />` routing component that can be added to a single page's `<head>` to control page transitions as you navigate away to another page. It provides a lightweight client-side router that [intercepts navigation](#client-side-navigation-process) and allows you to customize the transition between pages.
 
 Add this component to a reusable `.astro` component, such as a common head or layout, for [animated page transitions across your entire site (SPA mode)](#full-site-view-transitions-spa-mode).
 
@@ -30,16 +30,16 @@ By default, every page will use regular, full-page, browser navigation. You must
 
 ## Adding View Transitions to a Page
 
-Opt in to using view transitions on individual pages by importing and adding the `<ViewTransitions />` routing component to `<head>` on every desired page.
+Opt in to using view transitions on individual pages by importing and adding the `<ClientRouter />` routing component to `<head>` on every desired page.
 
 ```astro title="src/pages/index.astro" ins={2,7}
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 <html lang="en">
   <head>
     <title>My Homepage</title>
-    <ViewTransitions />
+    <ClientRouter />
   </head>
   <body>
     <h1>Welcome to my website!</h1>
@@ -49,13 +49,13 @@ import { ViewTransitions } from 'astro:transitions';
 
 ## Full site view transitions (SPA mode)
 
-Import and add the `<ViewTransitions />` component to your common `<head>` or shared layout component. Astro will create default page animations based on the similarities between the old and new page, and will also provide fallback behavior for unsupported browsers.
+Import and add the `<ClientRouter />` component to your common `<head>` or shared layout component. Astro will create default page animations based on the similarities between the old and new page, and will also provide fallback behavior for unsupported browsers.
 
 The example below shows adding Astro's default page navigation animations site-wide, including the default fallback control option for non-supporting browsers, by importing and adding this component to a `<CommonHead />` Astro component:
 
 ```astro title="src/components/CommonHead.astro" ins={2,12}
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
@@ -65,7 +65,7 @@ import { ViewTransitions } from 'astro:transitions';
 <meta name="title" content={title} />
 <meta name="description" content={description} />
 
-<ViewTransitions />
+<ClientRouter />
 ```
 
 No other configuration is necessary to enable Astro's default client-side navigation!
@@ -227,12 +227,12 @@ The following example shows all the necessary properties to define a custom `bum
 
 ```astro title="src/layouts/Layout.astro"
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 
 <html lang="en">
   <head>
-    <ViewTransitions />
+    <ClientRouter />
   </head>
   <body>
     <slot />
@@ -289,7 +289,7 @@ You have great flexibility when defining custom animations. To achieve your desi
 
 ## Router control
 
-The `<ViewTransitions />` router handles navigation by listening to:
+The `<ClientRouter />` router handles navigation by listening to:
 
 - Clicks on `<a>` elements.
 - Backwards and forwards navigation events.
@@ -302,9 +302,9 @@ The following options allow you to further control when navigation occurs within
 
 ### Preventing client-side navigation
 
-There are some cases where you cannot navigate via client-side routing since both pages involved must use the `<ViewTransitions />` router to prevent a full-page reload. You may also not want client-side routing on every navigation change and would prefer a traditional page navigation on select routes instead.
+There are some cases where you cannot navigate via client-side routing since both pages involved must use the `<ClientRouter />` router to prevent a full-page reload. You may also not want client-side routing on every navigation change and would prefer a traditional page navigation on select routes instead.
 
-You can opt out of client-side routing on a per-link basis by adding the `data-astro-reload` attribute to any `<a>` or `<form>` tag. This attribute will override any existing `<ViewTransitions />` component and instead trigger a browser refresh during navigation.
+You can opt out of client-side routing on a per-link basis by adding the `data-astro-reload` attribute to any `<a>` or `<form>` tag. This attribute will override any existing `<ClientRouter />` component and instead trigger a browser refresh during navigation.
 
 The following example shows preventing client-side routing when navigating to an article from the home page only. This still allows you to have animation on shared elements, such as a hero image, when navigating to the same page from an article listing page:
 
@@ -320,7 +320,7 @@ Links with the `data-astro-reload` attribute will be ignored by the router and a
 
 ### Trigger navigation
 
-You can also trigger client-side navigation via events not normally listened to by the `<ViewTransitions />` router using `navigate`. This function from the `astro:transitions/client` module can be used in scripts, and in framework components that are hydrated with a [client directive](/en/reference/directives-reference/#client-directives).
+You can also trigger client-side navigation via events not normally listened to by the `<ClientRouter />` router using `navigate`. This function from the `astro:transitions/client` module can be used in scripts, and in framework components that are hydrated with a [client directive](/en/reference/directives-reference/#client-directives).
 
 The following example shows an Astro component that navigates a visitor to another page they select from a menu:
 ```astro title="src/components/Form.astro"
@@ -343,11 +343,11 @@ The following example shows an Astro component that navigates a visitor to anoth
 ```astro title="src/pages/index.astro"
 ---
 import Form from "../components/Form.astro";
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 ---
 <html>
 	<head>
-		<ViewTransitions />
+		<ClientRouter />
 	</head>
 	<body>
 		<Form />
@@ -371,16 +371,16 @@ export default function Form() {
   );
 }
 ```
-The `<Form />` component can then be rendered on an Astro page that uses the `<ViewTransitions />` router, with a client directive:
+The `<Form />` component can then be rendered on an Astro page that uses the `<ClientRouter />` router, with a client directive:
 
 ```astro title="src/pages/index.astro"
 ---
 import Form from "../components/Form.jsx";
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 ---
 <html>
 	<head>
-		<ViewTransitions />
+		<ClientRouter />
 	</head>
 	<body>
 		<Form client:load />
@@ -404,7 +404,7 @@ For backward and forward navigation through the browser history, you can combine
 
 Normally, each time you navigate, a new entry is written to the browser's history. This allows navigation between pages using the browser's `back` and `forward` buttons. 
 
-The `<ViewTransitions />` router allows you to overwrite history entries by adding the `data-astro-history` attribute to any individual `<a>` tag.
+The `<ClientRouter />` router allows you to overwrite history entries by adding the `data-astro-history` attribute to any individual `<a>` tag.
 
 The `data-astro-history` attribute can be set to the same three values as the [`history` option of the `navigate()` function](#trigger-navigation): 
 
@@ -425,7 +425,7 @@ This has the effect that if you go back from the `/main` page, the browser will 
 
 <p><Since v="4.0.0" /></p>
 
-The `<ViewTransitions />` router will trigger in-page transitions from `<form>` elements, supporting both `GET` and `POST` requests.
+The `<ClientRouter />` router will trigger in-page transitions from `<form>` elements, supporting both `GET` and `POST` requests.
 
 By default, Astro submits your form data as `multipart/form-data` when your `method` is set to `POST`. If you want to match the default behavior of web browsers, use the `enctype` attribute to submit your data encoded as `application/x-www-form-urlencoded`:
 
@@ -445,9 +445,9 @@ You can opt out of router transitions on any individual form using the `data-ast
 
 ## Fallback control
 
-The `<ViewTransitions />` router works best in browsers that support View Transitions (i.e. Chromium browsers), but also includes default fallback support for other browsers. Even if the browser does not support the View Transitions API, Astro will still provide in-browser navigation using one of the fallback options for a comparable experience.
+The `<ClientRouter />` router works best in browsers that support View Transitions (i.e. Chromium browsers), but also includes default fallback support for other browsers. Even if the browser does not support the View Transitions API, Astro will still provide in-browser navigation using one of the fallback options for a comparable experience.
 
-You can override Astro's default fallback support by adding a `fallback` property on the `<ViewTransitions />` component and setting it to `swap` or `none`:
+You can override Astro's default fallback support by adding a `fallback` property on the `<ClientRouter />` component and setting it to `swap` or `none`:
 
 - `animate` (default, recommended) - Astro will simulate view transitions using custom attributes before updating page content.
 - `swap` - Astro will not attempt to animate the page. Instead, the old page will be immediately replaced by the new one.
@@ -455,11 +455,11 @@ You can override Astro's default fallback support by adding a `fallback` propert
 
 ```astro
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 <title>My site</title>
 
-<ViewTransitions fallback="swap" />
+<ClientRouter fallback="swap" />
 ```
 
 :::note[Known limitations]
@@ -468,7 +468,7 @@ The `initial` browser animation is not simulated by Astro. So any element using 
 
 ## Client-side navigation process
 
-When using the `<ViewTransitions />` router, the following steps occur to produce Astro's client-side navigation:
+When using the `<ClientRouter />` router, the following steps occur to produce Astro's client-side navigation:
 
 <Steps>
 1. A visitor to your site triggers navigation by any of the following actions:
@@ -504,7 +504,7 @@ When you add view transitions to an existing Astro project, some of your scripts
 
 ### Script order
 
-When navigating between pages with the `<ViewTransitions />` component, scripts are run in sequential order to match browser behavior. 
+When navigating between pages with the `<ClientRouter />` component, scripts are run in sequential order to match browser behavior. 
 
 ### Script re-execution
 
@@ -692,7 +692,7 @@ document.addEventListener('astro:after-swap',
 
 An event that fires at the end of page navigation, after the new page is visible to the user and blocking styles and scripts are loaded. You can listen to this event on the `document`.
 
-The `<ViewTransitions />` component fires this event both on initial page navigation for a pre-rendered page and on any subsequent navigation, either forwards or backwards.
+The `<ClientRouter />` component fires this event both on initial page navigation for a pre-rendered page and on any subsequent navigation, either forwards or backwards.
 
 You can use this event to run code on every page navigation, for example to set up event listeners that would otherwise be lost during navigation.
 
@@ -713,9 +713,9 @@ Enabling client-side routing and animating page transitions both come with acces
 
 <p><Since v="3.2.0" /></p>
 
-The `<ViewTransitions />` component includes a route announcer for page navigation during client-side routing. No configuration or action is needed to enable this.
+The `<ClientRouter />` component includes a route announcer for page navigation during client-side routing. No configuration or action is needed to enable this.
 
-Assistive technologies let visitors know that the page has changed by announcing the new page title after navigation. When using server-side routing with traditional full-page browser refreshes, this happens by default after the new page loads. In client-side routing, the `<ViewTransitions />` component performs this action.
+Assistive technologies let visitors know that the page has changed by announcing the new page title after navigation. When using server-side routing with traditional full-page browser refreshes, this happens by default after the new page loads. In client-side routing, the `<ClientRouter />` component performs this action.
 
 To add route announcement to client-side routing, the component adds an element to the new page with the `aria-live` attribute set to `assertive`. This tells AT (assistive technology) to announce immediately. The component also checks for the following, in priority order, to determine the announcement text:
 
@@ -727,4 +727,4 @@ We strongly recommend you always include a `<title>` in each page for accessibil
 
 ### `prefers-reduced-motion`
 
-Astro's `<ViewTransitions />` component includes a CSS media query that disables *all* view transition animations, including fallback animation, whenever the [`prefer-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) setting is detected. Instead, the browser will simply swap the DOM elements without an animation.
+Astro's `<ClientRouter />` component includes a CSS media query that disables *all* view transition animations, including fallback animation, whenever the [`prefer-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) setting is detected. Instead, the browser will simply swap the DOM elements without an animation.

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -2927,20 +2927,20 @@ const { Content } = await entry.render();
 <Content />
 ```
 
-### `<ViewTransitions />`
+### `<ClientRouter />`
 
 <p><Since v="2.9.0" /></p>
 
-Opt in to using view transitions on individual pages by importing and adding the `<ViewTransitions />` routing component to `<head>` on every desired page.
+Opt in to using view transitions on individual pages by importing and adding the `<ClientRouter />` routing component to `<head>` on every desired page.
 
 ```astro title="src/pages/index.astro" ins={2,7}
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 <html lang="en">
   <head>
     <title>My Homepage</title>
-    <ViewTransitions />
+    <ClientRouter />
   </head>
   <body>
     <h1>Welcome to my website!</h1>

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -745,7 +745,7 @@ This option is scoped to the entire project, to only disable the toolbar for you
 </p>
 
 Enable prefetching for links on your site to provide faster page transitions.
-(Enabled by default on pages using the `<ViewTransitions />` router. Set `prefetch: false` to opt out of this behaviour.)
+(Enabled by default on pages using the `<ClientRouter />` router. Set `prefetch: false` to opt out of this behaviour.)
 
 This configuration automatically adds a prefetch script to every page in the project
 giving you access to the `data-astro-prefetch` attribute.
@@ -766,7 +766,7 @@ See the [Prefetch guide](/en/guides/prefetch/) for more information.
 </p>
 
 Enable prefetching for all links, including those without the `data-astro-prefetch` attribute.
-This value defaults to `true` when using the `<ViewTransitions />` router. Otherwise, the default value is `false`.
+This value defaults to `true` when using the `<ClientRouter />` router. Otherwise, the default value is `false`.
 
 ```js
 prefetch: {

--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -17,7 +17,7 @@ import ReadMore from '~/components/ReadMore.astro'
 **View transitions** are a way to control what happens when visitors navigate between pages on your site. Astro's View Transitions API allows you to add optional navigation features including smooth page transitions and animations, controlling the browser's history stack of visited pages, and preventing full-page refreshes in order to persist some page elements and state while updating the content displayed.
 
 <PreCheck>
-  - Import and add the `<ViewTransitions />` router to a common `head` element
+  - Import and add the `<ClientRouter />` router to a common `head` element
   - Add event listeners during the navigation process to trigger `<script>`s when needed
   - Add page transition animations using transition directives
   - Opt out of client-side routing for an individual page link
@@ -61,7 +61,7 @@ Read more about [Astro's view transitions](/en/guides/view-transitions/) in our 
         Requires more than 2 lines of code to implement site-wide by default
       </Option>
       <Option isCorrect>
-        Changes the default type of page navigation on a page that contains the `<ViewTransitions />` router in its `<head>`
+        Changes the default type of page navigation on a page that contains the `<ClientRouter />` router in its `<head>`
       </Option>
       <Option>
         Does not add back accessibility features normally provided by the browser, such as route announcement and respect for `prefers-reduced-motion`
@@ -139,16 +139,16 @@ The steps below show you how to extend the final product of the Build a Blog tut
     If you are using your own project, then be sure to update any dependencies you have installed. The example blog tutorial codebase only uses the Preact integration.
     :::
 </Steps>
-### Add the `<ViewTransitions />` router
+### Add the `<ClientRouter />` router
 <Steps>
 
-2. Import and add the `<ViewTransitions />` component to the `<head>` of your page layout. 
+2. Import and add the `<ClientRouter />` component to the `<head>` of your page layout. 
 
-    In the Blog tutorial example, the `<head>` element is found in `src/layouts/BaseLayout.astro`. The `ViewTransitions` router must be first imported into the component's frontmatter. Then, add the routing component inside the `<head>` element.
+    In the Blog tutorial example, the `<head>` element is found in `src/layouts/BaseLayout.astro`. The `ClientRouter` router must be first imported into the component's frontmatter. Then, add the routing component inside the `<head>` element.
 
     ```astro title="src/layouts/BaseLayout.astro" ins={2,15}
     ---
-    import { ViewTransitions } from "astro:transitions";
+    import { ClientRouter } from "astro:transitions";
     import Header from "../components/Header.astro";
     import Footer from "../components/Footer.astro";
     import "../styles/global.css";
@@ -161,7 +161,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content={Astro.generator} />
         <title>{pageTitle}</title>
-        <ViewTransitions />
+        <ClientRouter />
       </head>
       <body>
         <Header />
@@ -247,7 +247,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
       });
     </script>
     ```
-    Now, the theme toggle is interactive on every page when using the `<ViewTransitions />` router, after the page has finished loading.
+    Now, the theme toggle is interactive on every page when using the `<ClientRouter />` router, after the page has finished loading.
 
 6. Check for theme earlier to prevent flashing in dark mode.
 
@@ -273,7 +273,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
     ```
 
 </Steps>
-    Now, every page change **that uses the `<ViewTransitions />` router for client-side navigation** (and therefore access to the `astro:after-swap` event) will be able to detect `theme: dark` from the browser's `localStorage` and update the current page accordingly before the page is rendered for the viewer.
+    Now, every page change **that uses the `<ClientRouter />` router for client-side navigation** (and therefore access to the `astro:after-swap` event) will be able to detect `theme: dark` from the browser's `localStorage` and update the current page accordingly before the page is rendered for the viewer.
 
     <Box icon="question-mark">
       ### Test your knowledge
@@ -315,7 +315,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
     import Header from "../components/Header.astro";
     import Footer from "../components/Footer.astro";
     import "../styles/global.css";
-    import { ViewTransitions } from "astro:transitions";
+    import { ClientRouter } from "astro:transitions";
     const { pageTitle } = Astro.props;
     ---
 
@@ -326,7 +326,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
         <meta name="viewport" content="width=device-width" />
         <meta name="generator" content={Astro.generator} />
         <title>{pageTitle}</title>
-        <ViewTransitions />
+        <ClientRouter />
       </head>
       <body>
         <Header />
@@ -397,9 +397,9 @@ With view transitions, some scripts may no longer re-run after page navigation l
 
 9. Prevent client-side routing and instead require the browser to reload when navigating to your About page.
 
-    Sometimes you will want a full browser reload when visitors click a certain link. For example, you may be linking to a page that does not also use the `<ViewTransitions />` router, or to a file directly such as a `.pdf`. 
+    Sometimes you will want a full browser reload when visitors click a certain link. For example, you may be linking to a page that does not also use the `<ClientRouter />` router, or to a file directly such as a `.pdf`. 
 
-    To make it so that your browser refreshes every time you click the navigation link to go to your About page, add the `data-astro-reload` attribute to the `<a>` tag in your `<Navigation />` component. This will override the `<ViewTransitions />` router entirely, and any of the view transition animations, for this one link.
+    To make it so that your browser refreshes every time you click the navigation link to go to your About page, add the `data-astro-reload` attribute to the `<a>` tag in your `<Navigation />` component. This will override the `<ClientRouter />` router entirely, and any of the view transition animations, for this one link.
 
      ```astro title="src/components/Navigation.astro" ins='data-astro-reload'
       ---


### PR DESCRIPTION
#### Description (required)

Renames `ViewTransitions` component to `ClientRouter` in all of the documentation.

#### For Astro version: `5.x`. See astro PR [#11980](https://github.com/withastro/astro/pull/11980).

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
