### PR TITLE
i18n(zh-cn): Update `configuration-reference.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/configuration-reference.mdx
+++ b/src/content/docs/zh-cn/reference/configuration-reference.mdx
@@ -43,7 +43,9 @@ export default defineConfig({
 **类型**：`string`
 </p>
 
-你要部署到的基本路径。Astro 在开发过程中会匹配这个路径名，这样你的开发环境就会尽可能地与你的构建环境匹配。在下面的例子中，`astro dev` 会在 `/docs` 处启动你的服务器。
+你要部署到的基本路径。Astro 在开发过程中会匹配这个路径名，这样你的开发环境就会尽可能地与你的构建环境匹配。
+
+在下面的例子中，`astro dev` 会在 `/docs` 处启动你的服务器。
 
 ```js
 {
@@ -160,8 +162,8 @@ export default defineConfig({
 
 指定构建的输出目标。
 
-- `static`- 构建静态网站，部署到任何静态托管服务器上；
-- `server` - 构建应用，部署到支持 SSR（服务器端渲染）的托管服务器上；
+- `static`- 构建静态网站，部署到任何静态托管服务器上。
+- `server` - 构建应用，部署到支持 SSR（服务器端渲染）的托管服务器上。
 - `hybrid` - 构建包含少量服务端渲染页面的静态网站。
 
 ```js
@@ -185,7 +187,7 @@ export default defineConfig({
 
 使用构建适配器将其部署到你最喜爱的服务器、无服务器或边缘主机。导入我们的第一方适配器 [Netlify](/zh-cn/guides/deploy/netlify/#ssr-适配器)、[Vercel](/zh-cn/guides/deploy/vercel/#ssr-适配器)，以及更多的适配器来使用 Astro SSR。
 
-[有关 SSR 的更多信息，请参见我们的服务器端渲染指南](/zh-cn/guides/server-side-rendering/)，以及[我们的部署指南](/zh-cn/guides/deploy/)以获得完整的主机列表。
+有关 SSR 的更多信息，[请参见我们的服务器端渲染指南](/zh-cn/guides/server-side-rendering/)，以及[我们的部署指南](/zh-cn/guides/deploy/)以获得完整的主机列表。
 
 ```js
 import netlify from '@astrojs/netlify';
@@ -604,9 +606,7 @@ export default defineConfig({
 <Since v="2.6.0" />
 </p>
 
-指定是否在构建期间将重定向输出到 HTML 中。
-
-此选项仅适用于 `output: 'static'` 模式；在 SSR 中，重定向会被作为和其他响应一样对待。
+指定是否在构建期间将重定向输出到 HTML 中。此选项仅适用于 `output: 'static'` 模式；在 SSR 中，重定向会被作为和其他响应一样对待。
 
 此选项主要适用于具有用于重定向的特殊配置文件且不需要（或不希望）基于 HTML 的重定向的适配器。
 
@@ -901,10 +901,10 @@ prefetch: {
 
 `remotePatterns` 可以通过以下四个属性进行配置：
 
-1. `protocol`
-2. `hostname`
-3. `port`
-4. `pathname`
+1. protocol
+2. hostname
+3. port
+4. pathname
 
 ```js
 {
@@ -1361,63 +1361,7 @@ Astro 提供了实验性标志，以便用户提前使用新功能。这些标�
 - `/blog/post/0` 由文件基础路由 `/blog/post/[pid]` 构建（而不是注入路由 `/blog/[...slug]`）
 - `/posts` 由重定向到 `/blog` 构建（而不是文件基础路由 `/[page]`）
 
-
 在路由冲突的情况下，两个具有相同路由优先级的路由试图构建相同的 URL，Astro 将记录警告，标识出冲突的路由。
-
-### experimental.rewriting
-
-<p>
-
-**类型：** `boolean`<br />
-**默认值：** `false`<br />
-<Since v="4.8.0" />
-</p>
-
-启用一个路由功能，用于在 Astro 页面、端点和 Astro 中间件中重写请求，使你可以对路由进行编程控制。
-
-```js
-{
-  experimental: {
-    rewriting: true,
-  },
-}
-```
-
-在你的 `.astro` 文件中使用 `Astro.rewrite` 来重定向到不同的页面：
-
-```astro "rewrite"
----
-// src/pages/dashboard.astro
-if (!Astro.props.allowed) {
-	return Astro.rewrite("/")
-}
----
-```
-
-在你的端点文件中使用 `context.rewrite` 来重定向到不同的页面：
-
-```js
-// src/pages/api.js
-export function GET(ctx) {
-	if (!ctx.locals.allowed) {
-		return ctx.rewrite("/")
-	}
-}
-```
-
-在你的中间件文件中使用 `next("/")` 来重定向到不同的页面，然后调用下一个中间件函数：
-
-```js
-// src/middleware.js
-export function onRequest(ctx, next) {
-	if (!ctx.cookies.get("allowed")) {
-		return next("/") // 新签名
-	}
-	return next();
-}
-```
-
-要全面了解并对这个实验性 API 提供反馈，请查看 [Rerouting RFC](https://github.com/withastro/roadmap/blob/feat/reroute/proposals/0047-rerouting.md)。
 
 ### experimental.env
 

--- a/src/content/docs/zh-cn/reference/configuration-reference.mdx
+++ b/src/content/docs/zh-cn/reference/configuration-reference.mdx
@@ -1715,7 +1715,7 @@ const countries = defineCollection({
 export const collections = { countries };
 ```
 
-对于更高级的加载逻辑，你可以定义一个 loader 对象。这允许增量更新和条件加载，同时还可以完全访问数据存储。请查看 [Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md#loaders) 中的 API。
+对于更高级的加载逻辑，你可以定义一个 loader 对象。这允许增量更新和条件加载，同时还可以完全访问数据存储。请查看 [Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md#loaders) 中的 API。
 
 #### 迁移现有内容集合以使用 Content Layer API
 
@@ -1779,4 +1779,4 @@ export const collections = { countries };
 
 #### 了解更多
 
-要全面了解并 [对这个实验性 API 提供反馈](https://github.com/withastro/roadmap/pull/982)，请查看 [Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md)。
+要全面了解并 [对这个实验性 API 提供反馈](https://github.com/withastro/roadmap/pull/982)，请查看 [Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md)。


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update `configuration-reference.mdx`

To make the `zh-cn` translation status change, I review the doc and find other typos to commit.

#### Related issues & labels (optional)

- #9383 
- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
