### PR TITLE
i18n(zh-cn): Update `astro-glob-used-outside.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/astro-glob-used-outside.mdx
+++ b/src/content/docs/zh-cn/reference/errors/astro-glob-used-outside.mdx
@@ -11,5 +11,4 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 `Astro.glob()` 只能在 `.astro` 文件中使用。你可以使用 [`import.meta.glob()`](https://vitejs.dev/guide/features.html#glob-import) 来达到相同的效果。
 
 **请参阅：**
-
 - [Astro.glob](/zh-cn/reference/api-reference/#astroglob)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The file is up to date! (the English version's typo cause the translation status change in #6952 )

To make the `zh-cn` translation status change, I delete an empty line to be able to commit as #9389.

#### Related issues & labels (optional)

- #6952 
- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
