### PR TITLE
i18n(zh-cn): Update `missing-image-dimension.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/missing-image-dimension.mdx
+++ b/src/content/docs/zh-cn/reference/errors/missing-image-dimension.mdx
@@ -12,6 +12,5 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 如果你的图片位于 `src` 文件夹内，你可能是想将其导入。请参阅[导入指南](/zh-cn/guides/imports/#其他资源)获取更多信息。
 
 **请参阅：**
-
 - [图像](/zh-cn/guides/images/)
 - [图像组件#宽高是必须的](/zh-cn/guides/images/#width-和-height对于-public-中的图像是必须的)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The file is up to date! (the English version's typo cause the translation status change in #6944  )

To make the `zh-cn` translation status change, I delete an empty line to be able to commit.

#### Related issues & labels (optional)

- #6944
- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
