### PR TITLE
fix(v5): format `adapter-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -430,7 +430,7 @@ export default function createIntegration() {
 
 Then, consume the hook [`astro:build:ssr`](/en/reference/integrations-reference/#astrobuildssr), which will give you a `middlewareEntryPoint`, an `URL` to the physical file on the file system.
 
-```js title="my-adapter.mjs" ins={15-19}
+```js title="my-adapter.mjs" ins={15-20}
 export default function createIntegration() {
   return {
     name: '@matthewp/my-adapter',

--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -8,7 +8,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 Astro is designed to make it easy to deploy to any cloud provider for SSR (server-side rendering). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/). See the [SSR guide](/en/guides/on-demand-rendering/) to learn how to use an existing adapter.
 
-## What is an Adapter
+## What is an adapter?
 
 An adapter is a special kind of [integration](/en/reference/integrations-reference/) that provides an entrypoint for server-side rendering. An adapter does two things:
 

--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -358,15 +358,11 @@ export default function createIntegration() {
 }
 ```
 
-Astro will log a **warning** to the terminal:
+If the Sharp image service is used, Astro will log a warning and error to the terminal based on your adapter's support:
 
 ```
 [@matthewp/my-adapter] The feature is experimental and subject to issues or changes.
-```
 
-And an error if the Sharp image service is used and is not compatible with the adapter:
-
-```
 [@matthewp/my-adapter] The currently selected adapter `@matthewp/my-adapter` is not compatible with the service "Sharp". Your project will NOT be able to build.
 ```
 

--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -8,7 +8,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 Astro is designed to make it easy to deploy to any cloud provider for SSR (server-side rendering). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/). See the [SSR guide](/en/guides/on-demand-rendering/) to learn how to use an existing adapter.
 
-## What is an adapter
+## What is an Adapter
 
 An adapter is a special kind of [integration](/en/reference/integrations-reference/) that provides an entrypoint for server-side rendering. An adapter does two things:
 
@@ -50,7 +50,7 @@ interface AstroAdapter {
 	exports?: string[];
 	args?: any;
 	adapterFeatures?: AstroAdapterFeatures;
-	supportedAstroFeatures?: AstroFeatureMap;
+	supportedAstroFeatures: AstroAdapterFeatureMap;
 }
 
 export interface AstroAdapterFeatures {
@@ -58,18 +58,22 @@ export interface AstroAdapterFeatures {
 	 * Creates an edge function that will communicate with the Astro middleware.
 	 */
 	edgeMiddleware: boolean;
+	/**
+	 * Determine the type of build output the adapter is intended for. Defaults to `server`;
+	 */
+	buildOutput?: 'static' | 'server';
 }
 
-export type SupportsKind = 'unsupported' | 'stable' | 'experimental' | 'deprecated';
+export type AdapterSupportsKind = 'unsupported' | 'stable' | 'experimental' | 'deprecated' | 'limited';
 
 export type AdapterSupportWithMessage = {
-	support: Exclude<SupportsKind, 'stable'>;
+	support: Exclude<AdapterSupportsKind, 'stable'>;
 	message: string;
 };
 
-export type AdapterSupport = SupportsKind | AdapterSupportWithMessage;
+export type AdapterSupport = AdapterSupportsKind | AdapterSupportWithMessage;
 
-export type AstroFeatureMap = {
+export type AstroAdapterFeatureMap = {
   /**
    * The adapter is able to serve static pages
    */
@@ -83,12 +87,17 @@ export type AstroFeatureMap = {
    */
   serverOutput?: AdapterSupport;
   /**
+	 * The adapter is able to support i18n domains
+	 */
+	i18nDomains?: AdapterSupport;
+	/**
+	 * The adapter is able to support `getSecret` exported from `astro:env/server`
+	 */
+	envGetSecret?: AdapterSupport;
+  /**
    * The adapter supports the Sharp image service
    */
   sharpImageService?: AdapterSupport;
-   * The adapter supports `astro:env` secrets
-   */
-  envGetSecret?: AdapterSupport;
 };
 ```
 
@@ -187,7 +196,12 @@ export function start(manifest) {
 
 The following methods are provided:
 
-##### `app.render(request: Request, options?: RenderOptions)`
+##### `app.render()`
+
+<p>
+
+**Type:** `(request: Request, options?: RenderOptions) => Promise<Response>`
+</p>
 
 This method calls the Astro page that matches the request, renders it, and returns a Promise to a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object. This also works for API routes that do not render pages.
 
@@ -197,9 +211,20 @@ const response = await app.render(request);
 
 ##### `RenderOptions`
 
+<p>
+
+**Type:** `{addCookieHeader?: boolean; clientAddress?: string; locals?: object; routeData?: RouteData;}`
+</p>
+
 The `app.render()` method accepts a mandatory `request` argument, and an optional `RenderOptions` object for [`addCookieHeader`](#addcookieheader), [`clientAddress`](#clientaddress), [`locals`](#locals), and [`routeData`](#routedata).
 
 ###### `addCookieHeader`
+
+<p>
+
+**Type:** `boolean`<br />
+**Default:** `false`
+</p>
 
 Whether or not to automatically add all cookies written by `Astro.cookie.set()` to the response headers.
 
@@ -212,6 +237,12 @@ const response = await app.render(request, { addCookieHeader: true });
 
 ###### `clientAddress`
 
+<p>
+
+**Type:** `string`<br />
+**Default:** `request[Symbol.for("astro.clientAddress")]`
+</p>
+
 The client IP address that will be made available as [`Astro.clientAddress`](/en/reference/api-reference/#astroclientaddress) in pages, and as `ctx.clientAddress` in API routes and middleware.
 
 The example below reads the `x-forwarded-for` header and passes it as `clientAddress`. This value becomes available to the user as `Astro.clientAddress`.
@@ -222,6 +253,11 @@ const response = await app.render(request, { clientAddress });
 ```
 
 ###### `locals`
+
+<p>
+
+**Type:** `object`
+</p>
 
 The [`context.locals` object](/en/reference/api-reference/#contextlocals) used to store and access information during the lifecycle of a request.
 
@@ -241,6 +277,12 @@ try {
 
 ###### `routeData`
 
+<p>
+
+**Type:** `RouteData`<br />
+**Default:** `app.match(request)`
+</p>
+
 Provide a value for [`integrationRouteData`](/en/reference/integrations-reference/#integrationroutedata-type-reference) if you already know the route to render. Doing so will bypass the internal call to [`app.match`](#appmatchrequest) to determine the route to render.
 
 ```js "routeData"
@@ -253,7 +295,12 @@ if (routeData) {
 }
 ```
 
-##### `app.match(request)`
+##### `app.match()`
+
+<p>
+
+**Type:** `(request: Request) => RouteData | undefined`
+</p>
 
 This method is used to determine if a request is matched by the Astro app's routing rules.
 
@@ -278,7 +325,6 @@ You can usually call `app.render(request)` without using `.match` because Astro 
 
 Once you [publish your adapter to npm](https://docs.npmjs.com/cli/v8/commands/npm-publish), running `astro add example` will install your package with any peer dependencies specified in your `package.json`. We will also instruct users to update their project config manually.
 
-
 ## Astro features
 
 <p><Since v="3.0.0" /></p>
@@ -293,7 +339,7 @@ These operations are run based on the features supported or not supported, their
 
 The following configuration tells Astro that this adapter has experimental support for the Sharp-powered built-in image service:
 
-```js title="my-adapter.mjs" ins={9-15}
+```js title="my-adapter.mjs" ins={9-11}
 export default function createIntegration() {
   return {
     name: '@matthewp/my-adapter',
@@ -318,7 +364,7 @@ Astro will log a **warning** to the terminal:
 [@matthewp/my-adapter] The feature is experimental and subject to issues or changes.
 ```
 
-and an error if the Sharp image service is used and is not compatible with the adapter:
+And an error if the Sharp image service is used and is not compatible with the adapter:
 
 ```
 [@matthewp/my-adapter] The currently selected adapter `@matthewp/my-adapter` is not compatible with the service "Sharp". Your project will NOT be able to build.
@@ -326,7 +372,7 @@ and an error if the Sharp image service is used and is not compatible with the a
 
 A message can additionally be provided to give more context to the user:
 
-```js title="my-adapter.mjs" ins={9-15}
+```js title="my-adapter.mjs" ins={9-14}
 export default function createIntegration() {
   return {
     name: '@matthewp/my-adapter',
@@ -354,8 +400,13 @@ A set of features that changes the output of the emitted files. When an adapter 
 
 ### `edgeMiddleware`
 
+<p>
+
+**Type:** `boolean`
+</p>
+
 Defines whether any SSR middleware code will be bundled when built.
-	
+
 When enabled, this prevents middleware code from being bundled and imported by all pages during the build:
 
 ```js title="my-adapter.mjs" ins={9-11}
@@ -410,6 +461,11 @@ function createEdgeMiddleware(middlewareEntryPoint) {
 ```
 
 ### envGetSecret
+
+<p>
+
+**Type:** `SupportsKind`
+</p>
 
 This is a feature to allow your adapter to retrieve secrets configured by users in `env.schema`.
 
@@ -481,6 +537,12 @@ export function createExports(manifest: SSRManifest) {
 ```
 
 ### buildOutput
+
+<p>
+
+**Type:** `'static' | 'server'`<br />
+<Since v="5.0.0" />
+</p>
 
 This property allows you to force a specific output shape for the build. This can be useful for adapters that only work with a specific output type, for instance, your adapter might expect a static website, but uses an adapter to create host-specific files. Defaults to `server` if not specified.
 

--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -464,12 +464,12 @@ function createEdgeMiddleware(middlewareEntryPoint) {
 
 <p>
 
-**Type:** `SupportsKind`
+**Type:** `AdapterSupportsKind`
 </p>
 
 This is a feature to allow your adapter to retrieve secrets configured by users in `env.schema`.
 
-Enable the feature by passing any valid `SupportsKind` value to the adapter:
+Enable the feature by passing any valid `AdapterSupportsKind` value to the adapter:
 
 ```js title="my-adapter.mjs" ins={9-11}
 export default function createIntegration() {


### PR DESCRIPTION
While I was reading a PR related to `adapter-reference.mdx`, I thought we could update the format to be consistent with `configuration-reference.mdx` and `api-reference.mdx`. Since v5 is set to replace the current version, I thought it might be more useful to update directly to that branch.

#### Description (required)

* Add `Type:`, `Default:` and `Since` where appropriate
* I moved some types from the section heading to `Type:`
* Fix/Rename some types
* Fix some line numbers to highlight in code blocks

**A few hesitations:**
* Some properties are optional but are not explicitly marked with `undefined` as an accepted type. So in `Type:` I only put the accepted types (the property should not be added if it is `undefined`)
* `envGetSecret` is in the `Adapter features` section but the type in the `next` branch of `withastro/astro` [does not document it](https://github.com/withastro/astro/blob/948ad8eecf71f1f6de33855a6065925d7858d28d/packages/astro/src/types/public/integrations.ts#L74)... So I obviously left it in, but I'm not sure of the type (I picked up the one in the sentence below) and I'm not sure if I should add Since (v5 I guess).
* Some `Defaults:` that may not be explicit enough... I'll leave comments.

#### Related issues & labels (optional)

- Suggested label: consistency/formatting

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.0.0-beta`.

This PR targets the `5.0.0-beta` branch.

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
