### PR TITLE
fix: Update install-and-setup.mdx

### DIFF
--- a/src/content/docs/en/install-and-setup.mdx
+++ b/src/content/docs/en/install-and-setup.mdx
@@ -58,7 +58,7 @@ Astro is built with Vite which targets browsers with modern JavaScript support b
 
     If all goes well, you will see a success message followed by some recommended next steps. Now that your project has been created, you can `cd` into your new project directory to begin using Astro.
 
-2. If you skipped the `npm install` step during the CLI wizard, then be sure to install your dependencies before continuing.
+2. If you skipped the "Install dependencies?" step during the CLI wizard, then be sure to install your dependencies before continuing.
 
 3. You can now [start the Astro dev server](#start-the-astro-dev-server) and see a live preview of your project while you build!
 </Steps>


### PR DESCRIPTION
# Update install-and-setup.mdx

Update the "Install from the CLI wizard" section, on step 2, where it says "If you skipped the `npm install` step during the CLI wizard..." to a more identifiable name reflecting the current CLI wizard, where it says "Install dependencies?" instead of "npm install" and to not be focused on npm since other package managers are available. I'm not 100% sure if the question mark should be present or not though.

Also, the backticks were removed since I believe this text would not be considered appropriate inside a code tag.

![Astro's CLI section entitled Install dependencies?](https://github.com/user-attachments/assets/981c4ceb-7782-4abb-bc8b-679d97ec34df)
