### PR TITLE
Craft CMS guide: add SSG guide w/ optional cache community resource

### DIFF
--- a/src/content/docs/en/guides/cms/craft-cms.mdx
+++ b/src/content/docs/en/guides/cms/craft-cms.mdx
@@ -17,4 +17,5 @@ stub: true
 ## Community Resources
 
 - [SSG Astro with Headless Craft CMS Content Fetched At Build Time](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time/)
+- [SSG Astro with Headless Craft CMS Content Fetched At Build Time Or Cached In Advance](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time-or-cached-in-advance/)
 - [SSR Astro With Headless Craft CMS](https://www.olets.dev/posts/ssr-astro-with-headless-craft-cms/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

This PR adds a new Community Resource link to the Craft CMS guide. The link is to a guide to building a static Astro site with the option of caching CMS content as an Astro content collection, which enables building Astro remotely even if Craft is local-only.

#### Related issues & labels (optional)

- Suggested label: add-new-content

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
