### PR TITLE
Update instructions to migrate from Studio to Turso

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -685,7 +685,7 @@ When you're ready to deploy, see our [Deploy with a Studio Connection guide](#de
    ```env
    ASTRO_DB_APP_TOKEN=[your-app-token]
    ```
-6. Push your DB schema and metadata Turso database with your Astro DB project.
+6. Push your DB schema and metadata to the new Turso database.
    ```sh
    astro db push --remote
    ```

--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -667,9 +667,9 @@ When you're ready to deploy, see our [Deploy with a Studio Connection guide](#de
 
 1. In the [Studio dashboard](https://studio.astro.build/), navigate to the project you wish to migrate. In the settings tab, use the "Export Database" button to download a dump of your database.
 2. Follow the official instructions to [install the Turso CLI](https://docs.turso.tech/cli/installation) and [sign up or log in](https://docs.turso.tech/cli/authentication) to your Turso account.
-3. Create a new database using the `.sql` dump you downloaded in step 1.
+3. Create a new database on Turso using the `turso db create` command.
    ```sh
-   turso db create [database-name] --from-dump ./path/to/dump.sql
+   turso db create [database-name]
    ```
 4. Fetch the database URL using the Turso CLI, and use it as the environment variable `ASTRO_DB_REMOTE_URL`.
    ```sh
@@ -685,7 +685,15 @@ When you're ready to deploy, see our [Deploy with a Studio Connection guide](#de
    ```env
    ASTRO_DB_APP_TOKEN=[your-app-token]
    ```
-6. Once you have confirmed your project connects to the new database, you can safely delete the project from Astro Studio.
+6. Push your DB schema and metadata Turso database with your Astro DB project.
+   ```sh
+   astro db push --remote
+   ```
+7. Import the database dump from step 1 into your new Turso DB.
+   ```sh
+   turso db shell [database-name] < ./path/to/dump.sql
+   ```
+8. Once you have confirmed your project connects to the new database, you can safely delete the project from Astro Studio.
 
 </Steps>
 


### PR DESCRIPTION
#### Description

Following the current instructions to create a Turso DB from the exported dump using `turso db create --from-dump` will create all the tables required for the data without Astro DB being aware of those tables.
This causes a conflict later on when trying to push the schema since, as far as Astro DB knows, it hasn't created any table in the new DB. Trying to create them again fails and leaves the DB in an inconsistent state.
