### PR TITLE
fix: update ordered list numbering in `guides/deploy/fleek.mdx`

### DIFF
--- a/src/content/docs/en/guides/deploy/fleek.mdx
+++ b/src/content/docs/en/guides/deploy/fleek.mdx
@@ -62,9 +62,9 @@ You can deploy to Fleek through the website UI or using Fleek’s CLI (command l
     fleek sites init
     ```
 
-4. You will be prompted to either create a new Fleek Site or use an existing one. Give the site a name and select the directory where your project is located.
+5. You will be prompted to either create a new Fleek Site or use an existing one. Give the site a name and select the directory where your project is located.
 
-5. Deploy your site.
+6. Deploy your site.
 
     ```bash
     fleek sites deploy


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fix an ordered list numbering. (There were two number fours.)

It doesn't seem to affect the published page (the Steps component seems to fix the numbering). That said, it's best to fix the numbering now to avoid an error if `Steps` is ever changed.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
