### PR TITLE
[mdx] remove mention of layout frontmatter property

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -151,7 +151,7 @@ Don't forget to include a `client:directive` on your UI framework components, if
 
 See more examples of using import and export statements in the [MDX docs](https://mdxjs.com/docs/what-is-mdx/#esm).
 
-```astro title="src/blog/post-1.mdx" {4,9}
+```mdx title="src/blog/post-1.mdx" {4,9}
 ---
 title: My first post
 ---

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -134,11 +134,13 @@ The Astro MDX integration includes support for using frontmatter in MDX by defau
 
 ```mdx title="/src/pages/posts/post-1.mdx"
 ---
-layout: '../../layouts/BlogPostLayout.astro'
 title: 'My first MDX post'
+author: 'Houston'
 ---
 
 # {frontmatter.title}
+
+Written by: {frontmatter.author}
 ```
 
 ### Using Components in MDX
@@ -151,7 +153,6 @@ See more examples of using import and export statements in the [MDX docs](https:
 
 ```mdx title="src/pages/about.mdx" {5-6} /<.+\/>/
 ---
-layout: ../layouts/BaseLayout.astro
 title: About me
 ---
 import Button from '../components/Button.astro';
@@ -163,7 +164,6 @@ Here is my counter component, working in MDX:
 
 <ReactCounter client:load />
 ```
-
 
 #### Custom components with imported MDX
 

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -100,7 +100,7 @@ MDX supports using `export` statements to add variables to your MDX content or t
 
 For example, you can export a `title` field from an MDX page or component to use as a heading with `{JSX expressions}`:
 
-```mdx title="/src/pages/posts/post-1.mdx"
+```mdx title="/src/blog/posts/post-1.mdx"
 export const title = 'My first MDX post'
 
 # {title}
@@ -132,7 +132,7 @@ The following properties are available to a `.astro` component when using an `im
 
 The Astro MDX integration includes support for using frontmatter in MDX by default. Add frontmatter properties just as you would in Markdown files, and these variables are available to use in the template, and as named properties when importing the file somewhere else.
 
-```mdx title="/src/pages/posts/post-1.mdx"
+```mdx title="/src/blog/posts/post-1.mdx"
 ---
 title: 'My first MDX post'
 author: 'Houston'
@@ -186,7 +186,7 @@ With MDX, you can map Markdown syntax to custom components instead of their stan
 
 Import your custom component into your `.mdx` file, then export a `components` object that maps the standard HTML element to your custom component:
 
-```mdx title="src/pages/about.mdx"
+```mdx title="src/blog/posts/post-1.mdx"
 import Blockquote from '../components/Blockquote.astro';
 export const components = {blockquote: Blockquote}
 

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -151,17 +151,15 @@ Don't forget to include a `client:directive` on your UI framework components, if
 
 See more examples of using import and export statements in the [MDX docs](https://mdxjs.com/docs/what-is-mdx/#esm).
 
-```mdx title="src/pages/about.mdx" {5-6} /<.+\/>/
+```astro title="src/blog/post-1.mdx" {4,9}
 ---
-title: About me
+title: My first post
 ---
-import Button from '../components/Button.astro';
 import ReactCounter from '../components/ReactCounter.jsx';
 
-I live on **Mars** but feel free to <Button title="Contact me" />.
+I just started my new Astro blog! 
 
 Here is my counter component, working in MDX:
-
 <ReactCounter client:load />
 ```
 


### PR DESCRIPTION
#### Description (required)

This removes mention of the frontmatter `layout` property available to MDX files from the MDX page so we can consolidate all mention of it to the Layouts page itself.

As we are not sure how much we want to promote this, leaving it to the Layouts page still makes the information prominently available without encouraging/assuming its use. Importing and using an Astro component as a layout is a more flexible option than the "magic" special property, so it will be easier to mention any limitations and caveats in just one place.

#### Related issues & labels (optional)

- Closes #9166 

While this PR itself isn't *exactly* what the issue asked for, I do think a few recent changes to this, the layouts and the markdown pages all combined will work together to prevent people trying to use named slots in MDX with the special frontmatter property.