### PR TITLE
fix: line highlighting in `guides/deploy/sst.mdx`

### DIFF
--- a/src/content/docs/en/guides/deploy/sst.mdx
+++ b/src/content/docs/en/guides/deploy/sst.mdx
@@ -28,7 +28,7 @@ You can also read [the full Astro on AWS with SST tutorial](https://sst.dev/docs
 
 To use any [additional SST components](https://sst.dev/docs/), add them to `sst.config.ts`. 
 
-```ts {2} {4} title="sst.config.ts"
+```ts {1} {5} title="sst.config.ts"
 const bucket = new sst.aws.Bucket("MyBucket", {
   access: "public",
 });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I'm not sure about this one, but it seems that the expressive code has not been updated in #9475.

See https://github.com/withastro/docs/pull/9475/files. The code block was:

````mdx
```ts {2} {4} title="sst.config.ts"
app.stack(function Site(ctx) {
  const bucket = new Bucket(ctx.stack, "public");
  const site = new AstroSite(ctx.stack, "site", {
    bind: [bucket],
  });

  ctx.stack.addOutputs({
    url: site.url,
  });
```
````

So the highlighting should match the lines:
* `const bucket` (`{2}`)
* `bind: [bucket]` (`{4}`)

With [the new version](https://docs.astro.build/en/guides/deploy/sst/#sst-components) the highlighting does not make sense.

However, `const bucket` is no longer on a single line. So I don't know if we should:
* remove the highlighting
* edit it to highlight the words and not the lines
* update the line numbers (what i did here)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
