### PR TITLE
i18n(fr): fix broken link in `guides/framework-components`

### DIFF
--- a/src/content/docs/fr/guides/framework-components.mdx
+++ b/src/content/docs/fr/guides/framework-components.mdx
@@ -6,7 +6,7 @@ description: 'Apprenez à utiliser React, Svelte, etc.. avec Astro'
 import IntegrationsNav from '~/components/IntegrationsNav.astro'
 import ReadMore from '~/components/ReadMore.astro'
 
-Construisez votre site Astro sans sacrifier votre Framework favori. Créez des iles Astro](/fr/concepts/islands/) avec le framework UI de votre choix.
+Construisez votre site Astro sans sacrifier votre Framework favori. Créez des [îles](/fr/concepts/islands/) Astro avec le framework UI de votre choix.
 
 ## Intégrations officielles de Framework UI
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR fixes a broken link due to a markup issue in the French version of the `guides/framework-components` [page](https://docs.astro.build/fr/guides/framework-components/).

<img width="665" alt="image" src="https://github.com/user-attachments/assets/e4cf039c-6545-4091-b529-a0bfe4175d82">

This PR does a few things:

- Fix the Markdown markup issue
- Move the link to only the "îles" word to match the [English version](https://docs.astro.build/en/guides/framework-components/) only linking the word "islands"
- `i` → `î` in the "îles" word to fix a typo

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->