### PR TITLE
Add info about propertiesToHash to image-service-reference.mdx

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -122,7 +122,7 @@ const service: LocalImageService = {
 export default service;
 ```
 
-At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder. Their file names will contain a hash of the properties passed to `propertiesToHash`. This property is optional and will fall back to `['src', 'width', 'height', 'format', 'quality']` if not set. If your custom image service has more options which change the generated images, you should add these to the array.
+At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder. Their file names will contain a hash of the properties passed to `propertiesToHash`. This property is optional and will default to `['src', 'width', 'height', 'format', 'quality']`. If your custom image service has more options that change the generated images, add these to the array.
 
 In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
 

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -116,12 +116,13 @@ const service: LocalImageService = {
 			loading: attributes.loading ?? 'lazy',
 			decoding: attributes.decoding ?? 'async',
 		};
-	}
+	},
+  propertiesToHash: ['src', 'width', 'height', 'format', 'quality'], 
 };
 export default service;
 ```
 
-At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder.
+At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder. Their file names will contain a hash of the properties passed to `propertiesToHash`. This property is optional and will fall back to `['src', 'width', 'height', 'format', 'quality']` if not set. If your custom image service has more options which change the generated images, you should add these to the array.
 
 In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
 


### PR DESCRIPTION
#### Description

Local image services have a property `propertiesToHash` which is missing from the docs. This change adds it along with a short explanation of what it does and what it falls back to if not passed.

#### Related issues & labels (optional)

- Closes #9169 
- Suggested label: add new  content
