### PR TITLE
[i18nIgnore] fix: updates the URL of a Tina CMS theme example

### DIFF
--- a/src/content/docs/en/guides/cms/tina-cms.mdx
+++ b/src/content/docs/en/guides/cms/tina-cms.mdx
@@ -162,5 +162,5 @@ To get started, you'll need an existing Astro project.
 ## Themes
 
 <Grid>
-  <Card title="Resume01" href="https://astro.build/themes/details/resume-01/" thumbnail="resume01.png"/>
+  <Card title="Resume01" href="https://astro.build/themes/details/resume01/" thumbnail="resume01.png"/>
 </Grid>

--- a/src/content/docs/es/guides/cms/tina-cms.mdx
+++ b/src/content/docs/es/guides/cms/tina-cms.mdx
@@ -162,5 +162,5 @@ Para empezar, necesitarás un proyecto Astro existente.
 ## Temas
 
 <Grid>
-  <Card title="Resume01" href="https://astro.build/themes/details/resume-01/" thumbnail="resume01.png"/>
+  <Card title="Resume01" href="https://astro.build/themes/details/resume01/" thumbnail="resume01.png"/>
 </Grid>

--- a/src/content/docs/fr/guides/cms/tina-cms.mdx
+++ b/src/content/docs/fr/guides/cms/tina-cms.mdx
@@ -162,5 +162,5 @@ Pour commencer, vous aurez besoin d'un projet Astro existant.
 ## Thèmes
 
 <Grid>
-  <Card title="Resume01" href="https://astro.build/themes/details/resume-01/" thumbnail="resume01.png"/>
+  <Card title="Resume01" href="https://astro.build/themes/details/resume01/" thumbnail="resume01.png"/>
 </Grid>

--- a/src/content/docs/ko/guides/cms/tina-cms.mdx
+++ b/src/content/docs/ko/guides/cms/tina-cms.mdx
@@ -163,5 +163,5 @@ import { Steps } from '@astrojs/starlight/components';
 ## 테마
 
 <Grid>
-  <Card title="Resume01" href="https://astro.build/themes/details/resume-01/" thumbnail="resume01.png"/>
+  <Card title="Resume01" href="https://astro.build/themes/details/resume01/" thumbnail="resume01.png"/>
 </Grid>

--- a/src/content/docs/zh-cn/guides/cms/tina-cms.mdx
+++ b/src/content/docs/zh-cn/guides/cms/tina-cms.mdx
@@ -162,5 +162,5 @@ import { Steps } from '@astrojs/starlight/components';
 ## Themes
 
 <Grid>
-  <Card title="Resume01" href="https://astro.build/themes/details/resume-01/" thumbnail="resume01.png"/>
+  <Card title="Resume01" href="https://astro.build/themes/details/resume01/" thumbnail="resume01.png"/>
 </Grid>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The URL used in [Tina CMS Themes section](https://docs.astro.build/en/guides/cms/tina-cms/#themes) appears to contain a typo or has been updated since it was added. The current URL results in a 500 error due to an extra hyphen. So I updated it in all languages.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #9510
- Suggested label: typo

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
