### PR TITLE
docs: add note about client:only `fallback` slot

### DIFF
--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -201,7 +201,7 @@ If the component is already hidden and shown by a media query in your CSS, then 
 
 For components that render only on the client, it is also possible to display fallback content while they are loading. Use `slot="fallback"` on any child element to create content that will be displayed only until your client component is available:
 
-``` title="src/pages/index.astro" {2}
+```astro {2}
 <ClientComponent client:only="vue">
   <div slot="fallback">Loading</div>
 </ClientComponent>

--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -197,6 +197,16 @@ If the component is already hidden and shown by a media query in your CSS, then 
 <SomeLitComponent client:only="lit" />
 ```
 
+#### Display loading content
+
+For components that render only on the client, it is also possible to display fallback content while they are loading. Use `slot="fallback"` on any child element to create content that will be displayed only until your client component is available:
+
+``` title="src/pages/index.astro" {2}
+<ClientComponent client:only="vue">
+  <div slot="fallback">Loading</div>
+</ClientComponent>
+```
+
 ### Custom Client Directives
 
 Since Astro 2.6.0, integrations can also add custom `client:*` directives to change how and when components should be hydrated.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

adds note about `fallback` slot to `client:only` docs. copied directly from the suggestion in #8805

#### Related issues & labels (optional)
closes #8805

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
