### PR TITLE
fix: line highlighting in `server-side-rendering.mdx`

### DIFF
--- a/src/content/docs/en/guides/server-side-rendering.mdx
+++ b/src/content/docs/en/guides/server-side-rendering.mdx
@@ -205,7 +205,7 @@ In `server` and `hybrid` modes, a page or API endpoint can check, set, get, and 
 
 The example below updates the value of a cookie for a page view counter:
 
-```astro title="src/pages/index.astro" {4,5,9}
+```astro title="src/pages/index.astro" {4,5,10}
 ---
 let counter = 0
 
@@ -324,5 +324,3 @@ A server endpoint, also known as an **API route**, is a special function exporte
 The function takes an [endpoint context](/en/reference/api-reference/#endpoint-context) and returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). 
 
 To learn more, see our [Endpoints Guide](/en/guides/endpoints/#server-endpoints-api-routes).
-
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

A code snippet has been updated in #9527 but not the lines to highlight. Since there is now an additional line, this should be `10` (`Astro.cookies.set`) not `9` (a blank line).

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
