### PR TITLE
[i18nIgnore] Docs(en-only): Added missing word on routing guide

### DIFF
--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -300,7 +300,7 @@ if (!isLoggedIn(cookie)) {
 
 <p><Since v="4.13.0" /></p>
 
-A rewrite allows you serve a different route without redirecting the browser to a different page. The browser will show the original address in the URL bar, but will instead display the content of the URL provided to [`Astro.rewrite()`](/en/reference/api-reference/#astrorewrite).
+A rewrite allows you to serve a different route without redirecting the browser to a different page. The browser will show the original address in the URL bar, but will instead display the content of the URL provided to [`Astro.rewrite()`](/en/reference/api-reference/#astrorewrite).
 
 :::tip
 For content that has permanently moved, or to direct your user to a different page with a new URL (e.g. a user dashboard after logging in), use a [redirect](#redirects) instead.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Added a missing word in the first sentence of the **rewrites** section in the routing guide on the en docs.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: typo/link/grammar - quick fix!, 4.0