### PR TITLE
fix: add caution

### DIFF
--- a/src/content/docs/en/reference/container-reference.mdx
+++ b/src/content/docs/en/reference/container-reference.mdx
@@ -68,7 +68,11 @@ For each official Astro integration, import and use the `getContainerRenderer()`
 
 For renderer packages outside the `@astrojs` npm org, look in their documentation for `getContainerRenderer()` or a similar function provided.
 
-When using `vite` (`vitest`, Astro integrations, etc.), the renderers are loaded with the function `loadRenderers()` from the virtual module `astro:container`. Outside `vite`, you'll have to load the renderers manually.
+When using `vite` (`vitest`, Astro integrations, etc.), the renderers are loaded with the function `loadRenderers()` from the virtual module `astro:container`.
+ 
+:::caution
+Outside `vite` or for on-demand usage, you'll have to [load the renderers manually](#adding-a-renderer-manually).
+:::
 
 The following example provides the necessary object to render an Astro component that renders a React component and a Svelte component: 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

More than once users were incorrectly using the containers API, I figured that adding a `caution` block could help user to understand which API to use, and when.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->
