### PR TITLE
Fix posts.map() return format in getStaticPaths function

### DIFF
--- a/src/content/docs/en/guides/cms/builderio.mdx
+++ b/src/content/docs/en/guides/cms/builderio.mdx
@@ -283,14 +283,10 @@ export async function getStaticPaths() {
     .catch
     // ...catch some errors...);
     ();
-  return [
-    ...posts.map(({ data: { slug, title } }) => [
-      {
-        params: { slug },
-        props: { title },
-      },
-    ]),
-  ];
+  return posts.map(({ data: { slug, title } }) => ({
+    params: { slug },
+    props: { title },
+  }))
 }
 const { slug } = Astro.params;
 const { title } = Astro.props;


### PR DESCRIPTION
## Description
This PR fixes the return format of the `posts.map()` function in the `getStaticPaths` method. The previous format was causing issues with [describe the problem if you know it].

## Changes made
- Updated the return statement in `posts.map()` to use parentheses instead of square brackets
- Removed an unnecessary nested array