### PR TITLE
Fix Web Components examples

### DIFF
--- a/src/content/docs/en/guides/client-side-scripts.mdx
+++ b/src/content/docs/en/guides/client-side-scripts.mdx
@@ -166,6 +166,10 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
 <script>
   // Define the behaviour for our new type of HTML element.
   class AstroHeart extends HTMLElement {
+    constructor() {
+      super();
+    }
+
     connectedCallback() {
       let count = 0;
 
@@ -214,6 +218,10 @@ const { message = 'Welcome, world!' } = Astro.props;
 
 <script>
   class AstroGreet extends HTMLElement {
+    constructor() {
+      super();
+    }
+
     connectedCallback() {
       // Read the message from the data attribute.
       const message = this.dataset.message;


### PR DESCRIPTION
#### Description (required)
Add missing constructors on web components scripts examples beacuse I think they are mandatory.