### PR TITLE
fix: update `cloudinary.mdx`

### DIFF
--- a/src/content/docs/en/guides/media/cloudinary.mdx
+++ b/src/content/docs/en/guides/media/cloudinary.mdx
@@ -37,7 +37,7 @@ Install the Cloudinary Astro SDK by running the appropriate command for your pac
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install astro-cloudinary
+  pnpm add astro-cloudinary
   ```
   </Fragment>
   <Fragment slot="yarn">
@@ -98,7 +98,7 @@ See [Cloudinary's `<CldVideoPlayer>` documentation](https://astro.cloudinary.dev
 
 To enable file uploading in your website or app's UI, add the `<CldUploadWidget>` which will embed the [Cloudinary Upload Widget](https://cloudinary.com/documentation/upload_widget).
 
-The following example creates a widget to allow unsigned uploads by passing an unsigned [Upload Preset](https://cloudinary.com/documentation/upload_presets#banner):
+The following example creates a widget to allow unsigned uploads by passing an unsigned [Upload Preset](https://cloudinary.com/documentation/upload_presets):
 
 ```jsx title="Component.astro"
 ---
@@ -117,7 +117,7 @@ See [Cloudinary's `<CldUploadWidget>` documentation](https://astro.cloudinary.de
 
 The Cloudinary Astro SDK provides the `cldAssetsLoader` content loader to load Cloudinary assets for content collections.
 
-To load a collection of images or videos, set `loader: `cldAssetsLoader ({})` with a `folder`, if required:
+To load a collection of images or videos, set `loader: cldAssetsLoader ({})` with a `folder`, if required:
 
 ```jsx title="config.ts"
 import { defineCollection } from 'astro:content';
@@ -177,7 +177,7 @@ Install the Cloudinary Node.js SDK by running the appropriate command for your p
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  pnpm install cloudinary
+  pnpm add cloudinary
   ```
   </Fragment>
   <Fragment slot="yarn">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
## replace `pnpm install` with `pnpm add`

The pnpm official documentation recommends using the `add` command instead of `install` when installing new packages as follows:

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

Currently it works the same without any differences, but the document clearly distinguishes these two commands.

This means that you have the flexibility to adapt to changes, such as changing or removing commands in future versions.

## other updates

- fix wrong external link
- fix wrong inline code highlight