### PR TITLE
Fix typo

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -691,7 +691,7 @@ const content = await myPost.compiledContent();
 
 <SourcePR number="11827" title="Prevent usage of `astro:content` in the client "/>
 
-In Astro 4.x, it was possible to access the `astro:client` module on the client.
+In Astro 4.x, it was possible to access the `astro:content` module on the client.
 
 Astro 5.0 removes this access as it was never intentionally exposed for client use. Using `astro:content` this way had limitations and bloated client bundles.
 


### PR DESCRIPTION
Probably should be astro:content instead of astro:client

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The docs had `astro:client` instead of `astro:content` in one place.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
