### PR TITLE
fix(guides): typo in `guides/imports.mdx`

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -104,7 +104,7 @@ import './style.css';
 
 Astro supports importing CSS files directly into your application. Imported styles expose no exports, but importing one will automatically add those styles to the page. This works for all CSS files by default, and can support compile-to-CSS languages like Sass & Less via plugins.
 
-<ReadMore>Read more about advanced CSS import use cases such as a direct URL reference for a CSS file, or importing CSS as a string in the [Styling guide](/en/guides/styling/#advanced)</ReadMore>`
+<ReadMore>Read more about advanced CSS import use cases such as a direct URL reference for a CSS file, or importing CSS as a string in the [Styling guide](/en/guides/styling/#advanced).</ReadMore>
 
 ### CSS Modules
 
@@ -136,7 +136,7 @@ All other assets not explicitly mentioned above can be imported via ESM `import`
 
 It can also be useful to place images in the `public/` folder as explained on the [project-structure page](/en/basics/project-structure/#public).
 
-<ReadMore>Read about appending Vite import paramaters (e.g. `?url`, `?raw`) in [Vite's static asset handling guide](https://vite.dev/guide/assets.html)</ReadMore>`
+<ReadMore>Read more about appending Vite import parameters (e.g. `?url`, `?raw`) in [Vite's static asset handling guide](https://vite.dev/guide/assets.html).</ReadMore>
 
 :::note
 Adding **alt text** to `<img>` tags is encouraged for accessibility! Don't forget to add an `alt="a helpful description"` attribute to your image elements. You can just leave the attribute empty if the image is purely decorative.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes some typo in `guides/imports.mdx` (unwanted backtick, missing period, `paramaters` > `parameters`, and I think a missing `more` in `Read about`)

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
