### PR TITLE
Update add-view-transitions.mdx

### DIFF
--- a/src/content/docs/en/tutorials/add-view-transitions.mdx
+++ b/src/content/docs/en/tutorials/add-view-transitions.mdx
@@ -257,7 +257,7 @@ With view transitions, some scripts may no longer re-run after page navigation l
 
     Add this new script to the `<ThemeIcon />` component, in addition to the script that controls the theme toggle.
 
-    ```astro title="src/components/ThemeIcon.astro" ins={3-9}
+    ```astro title="src/components/ThemeIcon.astro" ins={3-12}
     <script> ... </script>
 
     <script is:inline>


### PR DESCRIPTION
In section 6 ["Check for theme earlier to prevent flashing in dark mode."](https://docs.astro.build/en/tutorials/add-view-transitions/), the demo code is missing format for 3 green lines

#### Description (required)

The screen background format should include these 3 lines:

<img width="688" alt="image" src="https://github.com/user-attachments/assets/f40908cd-f0bd-437d-be2d-fdb7476ec498">

Discord Id: FoxeyeRinx#3622

#### Related issues & labels (optional)

- Suggested label: #doc

