### PR TITLE
Add tutorial on Astro content layer

### DIFF
--- a/src/content/docs/en/community-resources/content.mdx
+++ b/src/content/docs/en/community-resources/content.mdx
@@ -72,6 +72,7 @@ Have you published a recipe or guide for working with Astro? [Edit this page](ht
 - [Get VSCode, ESLint & Prettier working with Astro](https://patheticgeek.dev/blog/astro-prettier-eslint-vscode)
 - [Integrate Prettier with Astro and Tailwind CSS](https://straffesites.com/en/blog/integrate-prettier-astro-tailwindcss)
 ### Markdown
+- [An introduction to Astro's content system](https://kristianfreeman.com/an-introduction-to-astros-content-system/)
 - [Build a table of contents from Astro's Markdown headings](https://kld.dev/building-table-of-contents/)
 - [Create a Remark plugin to remove runts from your Markdown files](https://eatmon.co/blog/remove-runts-markdown/)
 - [Set Up Draft Pages Effectively in Astro with Config-Driven Content Authoring](https://akashrajpurohit.com/blog/set-up-draft-pages-effectively-in-astro-with-configdriven-content-authoring/)


### PR DESCRIPTION
#### Description (required)

Adds a tutorial on Astro's content layer to the "Markdown" section of the community-resources page

First time contributing - thanks for the great framework, team!