### PR TITLE
docs: use `PackageManagerTabs` for `install-and-setup.mdx` code-blocks

### DIFF
--- a/src/content/docs/en/install-and-setup.mdx
+++ b/src/content/docs/en/install-and-setup.mdx
@@ -3,7 +3,8 @@ title: Install and set up Astro
 description: 'How to install Astro and start working in a new project.'
 i18nReady: true
 ---
-import { Tabs, TabItem, FileTree, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+import { CardGrid, FileTree, LinkCard, Steps } from '@astrojs/starlight/components';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import ReadMore from '~/components/ReadMore.astro';
 
 The [`create astro` CLI command](#install-from-the-cli-wizard) is the fastest way to start a new Astro project from scratch. It will walk you through every step of setting up your new Astro project and allow you to choose from a few different official starter templates. 
@@ -33,26 +34,26 @@ Astro is built with Vite which targets browsers with modern JavaScript support b
 <Steps>
 1. Run the following command in your terminal to start our handy install wizard:
 
-    <Tabs>
-      <TabItem label="npm">
+    <PackageManagerTabs>
+      <Fragment slot="npm">
       ```shell
       # create a new project with npm
       npm create astro@latest
       ```
-      </TabItem>
-      <TabItem label="pnpm">
+      </Fragment>
+      <Fragment label="pnpm">
       ```shell
       # create a new project with pnpm
       pnpm create astro@latest
       ```
-      </TabItem>
-      <TabItem label="yarn">
+      </Fragment>
+      <Fragment label="yarn">
       ```shell
       # create a new project with yarn
       yarn create astro
       ```
-      </TabItem>
-    </Tabs>
+      </Fragment>
+    </PackageManagerTabs>
 
     You can run `create astro` anywhere on your machine, so there's no need to create a new empty directory for your project before you begin. If you don't have an empty directory yet for your new project, the wizard will help create one for you automatically.
 
@@ -72,8 +73,8 @@ You can also start a new astro project based on an [official example](https://gi
 
 2. Run the following command in your terminal, substituting the official Astro starter template name, or the GitHub username and repository of the theme you want to use:
 
-    <Tabs>
-      <TabItem label="npm">
+    <PackageManagerTabs>
+      <Fragment label="npm">
       ```shell
       # create a new project with an official example
       npm create astro@latest -- --template <example-name>
@@ -81,8 +82,8 @@ You can also start a new astro project based on an [official example](https://gi
       # create a new project based on a GitHub repository’s main branch
       npm create astro@latest -- --template <github-username>/<github-repo>
       ```
-      </TabItem>
-      <TabItem label="pnpm">
+      </Fragment>
+      <Fragment label="pnpm">
       ```shell
       # create a new project with an official example
       pnpm create astro@latest --template <example-name>
@@ -90,8 +91,8 @@ You can also start a new astro project based on an [official example](https://gi
       # create a new project based on a GitHub repository’s main branch
       pnpm create astro@latest --template <github-username>/<github-repo>
       ```
-      </TabItem>
-      <TabItem label="yarn">
+      </Fragment>
+      <Fragment label="yarn">
       ```shell
       # create a new project with an official example
       yarn create astro --template <example-name>
@@ -99,8 +100,8 @@ You can also start a new astro project based on an [official example](https://gi
       # create a new project based on a GitHub repository’s main branch
       yarn create astro --template <github-username>/<github-repo>
       ```
-      </TabItem>
-    </Tabs>
+      </Fragment>
+    </PackageManagerTabs>
 
     By default, this command will use the template repository’s `main` branch. To use a different branch name, pass it as part of the `--template` argument: `<github-username>/<github-repo>#<branch>`.
 
@@ -122,23 +123,23 @@ Astro comes with a built-in development server that has everything you need for 
 
 Every starter template comes with a pre-configured script that will run `astro dev` for you. After navigating into your project directory, use your favorite package manager to run this command and start the Astro development server.
 
-<Tabs>
-  <TabItem label="npm">
+<PackageManagerTabs>
+  <Fragment label="npm">
   ```shell
   npm run dev
   ```
-  </TabItem>
-  <TabItem label="pnpm">
+  </Fragment>
+  <Fragment label="pnpm">
   ```shell
   pnpm run dev
   ```
-  </TabItem>
-  <TabItem label="yarn">
+  </Fragment>
+  <Fragment label="yarn">
   ```shell
   yarn run dev
   ```
-  </TabItem>
-</Tabs>
+  </Fragment>
+</PackageManagerTabs>
 
 
 If all goes well, Astro will now be serving your project on [http://localhost:4321/](http://localhost:4321/). Visit that link in your browser and see your new site!
@@ -180,23 +181,23 @@ You don't need to write TypeScript code in your Astro projects to benefit from i
 
 To check the version of your site that will be created at build time, quit the dev server (<kbd>Ctrl</kbd> + <kbd>C</kbd>) and run the appropriate build command for your package manager in your terminal:
 
-    <Tabs>
-      <TabItem label="npm">
+    <PackageManagerTabs>
+      <Fragment label="npm">
       ```shell
       npm run build
       ```
-      </TabItem>
-      <TabItem label="pnpm">
+      </Fragment>
+      <Fragment label="pnpm">
       ```shell
       pnpm build
       ```
-      </TabItem>
-      <TabItem label="yarn">
+      </Fragment>
+      <Fragment label="yarn">
       ```shell
       yarn run build
       ```
-      </TabItem>
-    </Tabs>
+      </Fragment>
+    </PackageManagerTabs>
 
 Astro will build a deploy-ready version of your site in a separate folder (`dist/` by default) and you can watch its progress in the terminal. This will alert you to any build errors in your project before you deploy to production. If TypeScript is configured to `strict` or `strictest`, the `build` script will also check your project for type errors.
 
@@ -268,23 +269,23 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
 
     Once you are in your new directory, create your project `package.json` file. This is how you will manage your project dependencies, including Astro. If you aren't familiar with this file format, run the following command to create one.
 
-    <Tabs>
-      <TabItem label="npm">
+    <PackageManagerTabs>
+      <Fragment label="npm">
       ```shell
       npm init --yes
       ```
-      </TabItem>
-      <TabItem label="pnpm">
+      </Fragment>
+      <Fragment label="pnpm">
       ```shell
       pnpm init 
       ```
-      </TabItem>
-      <TabItem label="yarn">
+      </Fragment>
+      <Fragment label="yarn">
       ```shell
       yarn init --yes
       ```
-      </TabItem>
-    </Tabs>
+      </Fragment>
+    </PackageManagerTabs>
 
 2. Install Astro
 
@@ -294,23 +295,23 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
     Astro must be installed locally, not globally. Make sure you are *not* running `npm install -g astro` `pnpm add -g astro` or `yarn add global astro`.
     :::
 
-    <Tabs>
-      <TabItem label="npm">
+    <PackageManagerTabs>
+      <Fragment label="npm">
       ```shell
       npm install astro
       ```
-      </TabItem>
-      <TabItem label="pnpm">
+      </Fragment>
+      <Fragment label="pnpm">
       ```shell
       pnpm add astro
       ```
-      </TabItem>
-      <TabItem label="yarn">
+      </Fragment>
+      <Fragment label="yarn">
       ```shell
       yarn add astro
       ```
-      </TabItem>
-    </Tabs>
+      </Fragment>
+    </PackageManagerTabs>
 
     Then, replace any placeholder "scripts" section of your `package.json` with the following:
 

--- a/src/content/docs/en/install-and-setup.mdx
+++ b/src/content/docs/en/install-and-setup.mdx
@@ -41,13 +41,13 @@ Astro is built with Vite which targets browsers with modern JavaScript support b
       npm create astro@latest
       ```
       </Fragment>
-      <Fragment label="pnpm">
+      <Fragment slot="pnpm">
       ```shell
       # create a new project with pnpm
       pnpm create astro@latest
       ```
       </Fragment>
-      <Fragment label="yarn">
+      <Fragment slot="yarn">
       ```shell
       # create a new project with yarn
       yarn create astro
@@ -74,7 +74,7 @@ You can also start a new astro project based on an [official example](https://gi
 2. Run the following command in your terminal, substituting the official Astro starter template name, or the GitHub username and repository of the theme you want to use:
 
     <PackageManagerTabs>
-      <Fragment label="npm">
+      <Fragment slot="npm">
       ```shell
       # create a new project with an official example
       npm create astro@latest -- --template <example-name>
@@ -83,7 +83,7 @@ You can also start a new astro project based on an [official example](https://gi
       npm create astro@latest -- --template <github-username>/<github-repo>
       ```
       </Fragment>
-      <Fragment label="pnpm">
+      <Fragment slot="pnpm">
       ```shell
       # create a new project with an official example
       pnpm create astro@latest --template <example-name>
@@ -92,7 +92,7 @@ You can also start a new astro project based on an [official example](https://gi
       pnpm create astro@latest --template <github-username>/<github-repo>
       ```
       </Fragment>
-      <Fragment label="yarn">
+      <Fragment slot="yarn">
       ```shell
       # create a new project with an official example
       yarn create astro --template <example-name>
@@ -124,17 +124,17 @@ Astro comes with a built-in development server that has everything you need for 
 Every starter template comes with a pre-configured script that will run `astro dev` for you. After navigating into your project directory, use your favorite package manager to run this command and start the Astro development server.
 
 <PackageManagerTabs>
-  <Fragment label="npm">
+  <Fragment slot="npm">
   ```shell
   npm run dev
   ```
   </Fragment>
-  <Fragment label="pnpm">
+  <Fragment slot="pnpm">
   ```shell
   pnpm run dev
   ```
   </Fragment>
-  <Fragment label="yarn">
+  <Fragment slot="yarn">
   ```shell
   yarn run dev
   ```
@@ -182,17 +182,17 @@ You don't need to write TypeScript code in your Astro projects to benefit from i
 To check the version of your site that will be created at build time, quit the dev server (<kbd>Ctrl</kbd> + <kbd>C</kbd>) and run the appropriate build command for your package manager in your terminal:
 
     <PackageManagerTabs>
-      <Fragment label="npm">
+      <Fragment slot="npm">
       ```shell
       npm run build
       ```
       </Fragment>
-      <Fragment label="pnpm">
+      <Fragment slot="pnpm">
       ```shell
       pnpm build
       ```
       </Fragment>
-      <Fragment label="yarn">
+      <Fragment slot="yarn">
       ```shell
       yarn run build
       ```
@@ -270,17 +270,17 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
     Once you are in your new directory, create your project `package.json` file. This is how you will manage your project dependencies, including Astro. If you aren't familiar with this file format, run the following command to create one.
 
     <PackageManagerTabs>
-      <Fragment label="npm">
+      <Fragment slot="npm">
       ```shell
       npm init --yes
       ```
       </Fragment>
-      <Fragment label="pnpm">
+      <Fragment slot="pnpm">
       ```shell
       pnpm init 
       ```
       </Fragment>
-      <Fragment label="yarn">
+      <Fragment slot="yarn">
       ```shell
       yarn init --yes
       ```
@@ -296,17 +296,17 @@ If you prefer not to use our automatic `create astro` CLI tool, you can set up y
     :::
 
     <PackageManagerTabs>
-      <Fragment label="npm">
+      <Fragment slot="npm">
       ```shell
       npm install astro
       ```
       </Fragment>
-      <Fragment label="pnpm">
+      <Fragment slot="pnpm">
       ```shell
       pnpm add astro
       ```
       </Fragment>
-      <Fragment label="yarn">
+      <Fragment slot="yarn">
       ```shell
       yarn add astro
       ```


### PR DESCRIPTION
#### Description (required)

- update `install-and-setup.mdx` to make use of the `PackageManagerTabs` component.

#### Related issues & labels (optional)
- Suggested label: design