### PR TITLE
Add missing markdoc closing tag and image node attributes in "Create a custom Markdoc image tag"

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -519,7 +519,7 @@ The following steps will create a custom Markdoc image tag to display a `<figure
 3. Use the `image` tag in Markdoc files to display a figure with caption, providing all the necessary attributes for your component:
 
     ```md
-    {% image src="./astro-logo.png" alt="Astro Logo" width="100" height="100" caption="a caption!" %}
+    {% image src="./astro-logo.png" alt="Astro Logo" width="100" height="100" caption="a caption!" /%}
     ```
 </Steps>
 

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -509,7 +509,18 @@ The following steps will create a custom Markdoc image tag to display a `<figure
     export default defineMarkdocConfig({
       tags: {
         image: {
-          attributes: nodes.image.attributes,
+          attributes: {
+            width: {
+              type: String,
+            },
+            height: {
+              type: String,
+            },
+            caption: {
+              type: String,
+            },
+            ...nodes.image.attributes
+          },
           render: component('./src/components/MarkdocFigure.astro'),
         },
       },


### PR DESCRIPTION
#### Description (required)

Originally posted in a [discord support question](https://discord.com/channels/830184174198718474/1298411077985370196/1298411077985370196):

As is, the docs instructions for creating a custom Markdoc image tag cause two failures. See [repro](https://stackblitz.com/edit/github-r72f4w?file=src%2Fcontent%2Fdocs%2Fintro.mdoc)

1. one complains about a missing Markdoc closing tag.
2. The other...

```
[ERROR] **src/content/docs/intro.mdoc** contains invalid content:
- Invalid attribute: 'width'
- Invalid attribute: 'height'
- Invalid attribute: 'caption'
```

...seems to be because the Markdoc image tag is configured in `markdoc.config.mjs` using only the default attributes for Markdoc's image tag, which don't include `width`, `height`, or `caption`. `console.log(nodes.image.attributes)` yields:

```
{
  src: { type: [Function: String], required: true },
  alt: { type: [Function: String] },
  title: { type: [Function: String] }
}
```

This PR:

1. adds the missing Markdoc closing tag
2. Adds the missing attributes to the Markdoc image tag configuration.

See [repro with fixes](https://stackblitz.com/edit/github-r72f4w-nxkyrr?file=markdoc.config.js)

Note: I wasn't sure whether to specify `type: Number` for the `width` and `height` attributes. They can be passed as numbers, but in this PR I left them as strings, because as long as they can be interpreted as numbers, the Image component will use them, and if they are `"foo"`, they're just ignored.

#### Related issues & labels (optional)

- Suggested label: code snippet update

