### PR TITLE
docs: 9766 explain Astro Actions cookie size limitation

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -561,7 +561,9 @@ const result = Astro.getActionResult(actions.addToCart);
 ```
 
 :::caution
-Action data is passed using a persisted cookie. **This cookie is not encrypted.** In general, we recommend returning the minimum information required from your action `handler` to avoid vulnerabilities, and persist other sensitive information in a database.
+Action data is passed using a persisted cookie. **This cookie is not encrypted** and is limited to 4 KB in size, although the exact limit may vary between browsers. 
+
+In general, we recommend returning the minimum information required from your action `handler` to avoid vulnerabilities, and persist other sensitive information in a database.
 
 For example, you might return the name of a product in an `addToCart` action, rather than returning the entire `product` object:
 


### PR DESCRIPTION
#### Description

Add the size limitation of cookies to the Astro Actions page - specifically the "Update the UI with a form action result" section - as this limitation can currently cause a the Action to silently fail.

Discord username: rstainsby

#### Related issues & labels

https://github.com/withastro/docs/issues/9766

Closes #9766

Suggested label: Improves Documentation
