### PR TITLE
fix: wrong codeblock in `astro-content.mdx`

### DIFF
--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -329,7 +329,7 @@ const { Content, headings, remarkPluginFrontmatter } = await entry.render();
 A string union of all collection names defined in your `src/content/config.*` file. This type can be useful when defining a generic function that accepts any collection name.
 
 ```ts
-import type { CollectionKey, getCollection } from 'astro:content';
+import { type CollectionKey, getCollection } from 'astro:content';
 
 async function getCollection(collection: CollectionKey) {
   return getCollection(collection);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- update wrong codeblock in `astro-content.mdx`

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
