### PR TITLE
i18n(pt-BR): Create `reference/errors` actions files

### DIFF
--- a/src/content/docs/pt-br/reference/errors/action-called-from-server-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/action-called-from-server-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Ação inesperada chamada pelo servidor.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionCalledFromServerError**: Acão chamada por uma página do servidor ou endpoint sem usar `Astro.callAction()`. Esse invólucro deve ser usado para chamar ações pelo código do servidor.
+
+## O que deu errado?
+Ação chamada por uma página do servidor ou endpoint sem usar `Astro.callAction()`.
+
+**Veja também:**
+-  [Referência `Astro.callAction()`](/pt-br/reference/api-reference/#astrocallaction)
+
+

--- a/src/content/docs/pt-br/reference/errors/action-not-found-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/action-not-found-error.mdx
@@ -1,0 +1,10 @@
+---
+title: Acão não encontrada.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionNotFoundError**: O servidor recebeu uma requisição para uma ação chamada `ACTION_NAME` mas não pôde encontrar uma correspondência. Se você renomeou uma ação, confira se você atualizou o seu arquivo `actions/index` e o código chamado para corresponder.
+
+## O que deu errado?
+O servidor recebeu uma requisição para uma ação mas não pôde encontrar uma com o mesmo nome.

--- a/src/content/docs/pt-br/reference/errors/action-query-string-invalid-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/action-query-string-invalid-error.mdx
@@ -1,0 +1,18 @@
+---
+title: Uma query string de Ação inválida foi passada pelo formulário.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+:::caution[Descontinuado]
+Esse erro é de uma versão mais antiga do Astro e não está mais em uso. Se você não puder atualizar seu projeto para uma versão mais recente, então você pode consultar [cópias sem supervisão da documentação antiga](/pt-br/upgrade-astro/#documentação-antiga-sem-manutenção) para assistência.
+:::
+
+
+> **ActionQueryStringInvalidError**: O servidor recebeu a _query string_ `?_astroAction=ACTION_NAME`, mas não pôde encontrar uma ação com esse nome. Se você mudou o nome da ação em desenvolvimento, remova este parâmetro de consulta da sua URL e atualize.
+
+## O que deu errado?
+O servidor recebeu a _query string_ `?_astroAction=name`, mas não pôde achar uma ação com esse nome. Use a propriede `.queryString` da função da ação para requisitar a URL do formulário `action`.
+
+**Veja também:**
+-  [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)

--- a/src/content/docs/pt-br/reference/errors/actions-returned-invalid-data-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/actions-returned-invalid-data-error.mdx
@@ -1,0 +1,13 @@
+---
+title: Manipulador da ação retornou dados inválidos.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionsReturnedInvalidDataError**: Manipulador da ação retornou dados inválidos. Manipuladores devem retornar tipos de dados serializáveis como objetos, arrays, strings e números. Erro processado: ERROR
+
+## O que deu errado?
+O manipulador da ação retornou dados inválidos. Manipuladores devem retornar tipos de dados serializáveis, e não podem retornar um objeto Response.
+
+**Veja também:**
+-  [Referência Manipulador de Ações](/pt-br/reference/modules/astro-actions/#handler-property)

--- a/src/content/docs/pt-br/reference/errors/actions-used-with-for-get-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/actions-used-with-for-get-error.mdx
@@ -1,0 +1,17 @@
+---
+title: An invalid Action query string was passed by a form.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+:::caution[Descontinuado]
+Descontinuado desde a versão 4.13.2.
+:::
+
+> **ActionsUsedWithForGetError**: Ação ACTION_NAME foi chamada por um formulário usando uma requisição GET, mas somente requisições POST são suportadas. Isso ocorre frequentemente se `method="POST"` está faltando no formulário.
+
+## O que deu errado?
+Ação foi chamada por um formulário usando uma requisição GET, mas somente requisições POST são suportadas. Isso frequentemente ocorre se `method="POST"` está faltando no formulário.
+
+**Veja também:**
+-  [Actions RFC](https://github.com/withastro/roadmap/blob/actions/proposals/0046-actions.md)

--- a/src/content/docs/pt-br/reference/errors/actions-without-server-output-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/actions-without-server-output-error.mdx
@@ -1,0 +1,13 @@
+---
+title: Ações devem ser usadas com o retorno do servidor.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionsWithoutServerOutputError**: Ações habilitadas sem configurar um retorno de construção do servidor. Um servidor é exigido para criar funções backend acionáveis. Para publicar rotas para um servidor, adicione um adaptador servidor em sua configuração astro.
+
+## O que deu errado?
+Seu projeto deve ter um retorno do servidor para criar funções backend com Ações.
+
+**Veja também:**
+-  [Renderização sob demanda](/pt-br/basics/rendering-modes/#renderização-sob-demanda)


### PR DESCRIPTION
#### Description (required)

create i18n/pt-br/reference/errors/action-not-found-error.mdx
create i18n/pt-br/reference/errors/action-called-from-server-error.mdx
create i18n/pt-br/reference/errors/actions-returned-invalid-data-error.mdx
create i18n/pt-br/reference/errors/actions-without-server-output-error.mdx
create i18n/pt-br/reference/errors/action-query-string-invalid-error.mdx
create i18n/pt-br/reference/errors/actions-used-with-for-get-error.mdx





