### PR TITLE
fix: update Craft CMS title to be consistent with others guides

### DIFF
--- a/src/content/docs/en/guides/cms/craft-cms.mdx
+++ b/src/content/docs/en/guides/cms/craft-cms.mdx
@@ -1,5 +1,5 @@
 ---
-title: Craft CMS
+title: Craft CMS & Astro
 description: Add content to your Astro project using Craft CMS as a CMS
 type: cms
 service: Craft CMS


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Spotted during T&D: All other guides use ` & Astro` in their title, Craft CMS was the only exception. So I updated its title to be consistent with the others.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: consistency/formatting

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
