### PR TITLE
[i18nIgnore] fix: code blocks `env` language identifier

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -193,7 +193,7 @@ The steps below will guide you through the process of installing the Turso CLI, 
    Copy the `URL` value and set it as the value for `ASTRO_DB_REMOTE_URL`.
    
 
-   ```env title=".env" "libsql://andromeda-houston.turso.io"
+   ```dotenv title=".env" "libsql://andromeda-houston.turso.io"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ```
 
@@ -205,7 +205,7 @@ The steps below will guide you through the process of installing the Turso CLI, 
 
    Copy the output of the command and set it as the value for `ASTRO_DB_APP_TOKEN`.
 
-   ```env title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
+   ```dotenv title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ASTRO_DB_APP_TOKEN=eyJhbGciOiJF...3ahJpTkKDw
    ```
@@ -776,14 +776,14 @@ You can use it in any integration code that needs to query or insert into the da
    ```sh
    turso db show [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_REMOTE_URL=[your-database-url]
    ```
 5. Create a token to access your database, and use it as the environment variable `ASTRO_DB_APP_TOKEN`.
    ```sh
    turso db tokens create [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_APP_TOKEN=[your-app-token]
    ```
 6. Push your DB schema and metadata to the new Turso database.

--- a/src/content/docs/fr/guides/astro-db.mdx
+++ b/src/content/docs/fr/guides/astro-db.mdx
@@ -193,7 +193,7 @@ Les étapes ci-dessous vous guideront tout au long du processus d'installation d
    Copiez la valeur `URL` et définissez-la comme valeur pour `ASTRO_DB_REMOTE_URL`.
    
 
-   ```env title=".env" "libsql://andromeda-houston.turso.io"
+   ```dotenv title=".env" "libsql://andromeda-houston.turso.io"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ```
 
@@ -205,7 +205,7 @@ Les étapes ci-dessous vous guideront tout au long du processus d'installation d
 
    Copiez la sortie de la commande et définissez-la comme valeur pour `ASTRO_DB_APP_TOKEN`.
 
-   ```env title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
+   ```dotenv title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ASTRO_DB_APP_TOKEN=eyJhbGciOiJF...3ahJpTkKDw
    ```
@@ -776,14 +776,14 @@ Vous pouvez l'utiliser dans tout code d'intégration qui doit interroger ou ins�
    ```sh
    turso db show [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_REMOTE_URL=[your-database-url]
    ```
 5. Créez un jeton pour accéder à votre base de données et utilisez-le comme variable d'environnement `ASTRO_DB_APP_TOKEN`.
    ```sh
    turso db tokens create [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_APP_TOKEN=[your-app-token]
    ```
 6. Transférez votre schéma de base de données et vos métadonnées vers la nouvelle base de données Turso.

--- a/src/content/docs/ko/guides/astro-db.mdx
+++ b/src/content/docs/ko/guides/astro-db.mdx
@@ -193,7 +193,7 @@ Turso는 Astro DB를 구동하는 SQLite의 오픈 소스 포크인 [libSQL](htt
     `URL` 값을 복사하여 `ASTRO_DB_REMOTE_URL`의 값으로 설정합니다.
 
 
-    ```env title=".env" "libsql://andromeda-houston.turso.io"
+    ```dotenv title=".env" "libsql://andromeda-houston.turso.io"
     ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
     ```
 
@@ -205,7 +205,7 @@ Turso는 Astro DB를 구동하는 SQLite의 오픈 소스 포크인 [libSQL](htt
 
     명령의 출력을 복사하여 `ASTRO_DB_APP_TOKEN`의 값으로 설정합니다.
 
-    ```env title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
+    ```dotenv title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
     ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
     ASTRO_DB_APP_TOKEN=eyJhbGciOiJF...3ahJpTkKDw
     ```
@@ -774,14 +774,14 @@ export default async function() {
     ```sh
     turso db show [database-name]
     ```
-    ```env
+    ```dotenv
     ASTRO_DB_REMOTE_URL=[your-database-url]
     ```
 5. 데이터베이스에 액세스할 수 있는 토큰을 생성하고 환경 변수 `ASTRO_DB_APP_TOKEN`으로 사용합니다.
     ```sh
     turso db tokens create [database-name]
     ```
-    ```env
+    ```dotenv
     ASTRO_DB_APP_TOKEN=[your-app-token]
     ```
 6. DB 스키마와 메타데이터를 새 Turso 데이터베이스로 푸시하세요.

--- a/src/content/docs/zh-cn/guides/astro-db.mdx
+++ b/src/content/docs/zh-cn/guides/astro-db.mdx
@@ -193,7 +193,7 @@ Turso 是 [libSQL](https://github.com/tursodatabase/libsql) 背后的公司，li
    复制 `URL` 值并将其设置为 `ASTRO_DB_REMOTE_URL` 的值。
    
 
-   ```env title=".env" "libsql://andromeda-houston.turso.io"
+   ```dotenv title=".env" "libsql://andromeda-houston.turso.io"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ```
 
@@ -205,7 +205,7 @@ Turso 是 [libSQL](https://github.com/tursodatabase/libsql) 背后的公司，li
 
    复制命令的输出并将其设置为 `ASTRO_DB_APP_TOKEN` 的值。
 
-   ```env title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
+   ```dotenv title=".env" add={2} "eyJhbGciOiJF...3ahJpTkKDw"
    ASTRO_DB_REMOTE_URL=libsql://andromeda-houston.turso.io
    ASTRO_DB_APP_TOKEN=eyJhbGciOiJF...3ahJpTkKDw
    ```
@@ -768,14 +768,14 @@ export default async function() {
    ```sh
    turso db show [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_REMOTE_URL=[your-database-url]
    ```
 5. 创建一个令牌来访问你的数据库，并将其配置为环境变量 `ASTRO_DB_APP_TOKEN`。
    ```sh
    turso db tokens create [database-name]
    ```
-   ```env
+   ```dotenv
    ASTRO_DB_APP_TOKEN=[your-app-token]
    ```
 6. 将你的 DB 架构和元数据推送到新的 Turso 数据库。


### PR DESCRIPTION
#### Description (required)

This PR updates the language identifier of various code blocks for environment variables or dotenv files. This was initially spotted a long time ago in a T&D session but only got around to fixing it now.

The `env` language identifier is not a [supported Shiki language ID](https://shiki.matsu.io/languages#languages) and `dotenv` is the correct language identifier for these code blocks.

These fixes 2 issues:

- Removes warning messages in the build logs for each invalid code block language:

  ```sh
  [WARN] [astro-expressive-code] Found unknown code block language "env" in document "src/content/docs/en/guides/astro-db.mdx". Using "txt" instead. You can add custom languages using the "langs" config option.
  ```

- Adds proper syntax highlighting to the code blocks:

  |        | Preview         |
  | ------ | --------------- |
  | Before | <img width="691" alt="SCR-20241101-kzxw" src="https://github.com/user-attachments/assets/b1886b02-df3f-414c-9bcb-1f6ebea2e593"> |
  | After  | <img width="690" alt="SCR-20241101-kzzo" src="https://github.com/user-attachments/assets/108e1edf-1474-4cc6-bec4-11942c8ce802"> |

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: code snippet update
