### PR TITLE
fix `Alpine.js` examples link

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/en/guides/integrations-guide/alpinejs.mdx
@@ -156,7 +156,7 @@ interface Window {
 
 ## Examples
 
-* The [Astro Alpine.js example](https://github.com/withastro/astro/tree/latest/examples/framework-alpine) shows how to use Alpine.js in an Astro project.
+* The [Astro Alpine.js example](https://github.com/withastro/astro/tree/main/examples/framework-alpine) shows how to use Alpine.js in an Astro project.
 
 [astro-integration]: /en/guides/integrations-guide/
 


### PR DESCRIPTION
#### Description (required)
`Alpine.js` examples link pointed to `latest` instead of `main`. This PR fixes it.

