### PR TITLE
fix(v5): add missing import in content collection tutorial

### DIFF
--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -145,6 +145,8 @@ The steps below show you how to extend the final product of the Build a Blog tut
 5. Create a `src/content/config.ts` file to [define a schema](/en/guides/content-collections/#defining-the-collection-schema) for your `postsCollection`. For the existing blog tutorial code, add the following contents to the file to define all the frontmatter properties used in its blog posts:
 
     ```ts title="src/content/config.ts"
+    // Import the glob loader
+    import { glob } from "astro/loaders";
     // Import utilities from `astro:content`
     import { z, defineCollection } from "astro:content";
     // Define a `loader` and `schema` for each collection
@@ -179,7 +181,6 @@ The steps below show you how to extend the final product of the Build a Blog tut
     ```astro title="src/pages/posts/[...slug].astro"
     ---
     import { getCollection } from 'astro:content';
-    import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';
 
     export async function getStaticPaths() {
       const posts = await getCollection('blog');
@@ -195,7 +196,7 @@ The steps below show you how to extend the final product of the Build a Blog tut
 
 9. Render your post `<Content />` within the layout for Markdown pages. This allows you to specify a common layout for all of your posts.
 
-    ```astro title="src/pages/posts/[...slug].astro" ins={15-17}
+    ```astro title="src/pages/posts/[...slug].astro" ins={3,15-17}
     ---
     import { getCollection } from 'astro:content';
     import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

Following a request for help on Discord, I saw that an import was missing in `tutorials/content-collections.mdx` for v5. In addition, I took the opportunity to update two other code snippets.

#### Description (required)

* **Step 5:** the `glob` loader import was missing
* **Step 8:** `MarkdownPostLayout` was imported when it is not needed at this step, so I removed it
* **Step 9:** `MarkdownPostLayout` is only used in this step, so I highlighted the import in addition to its use which is already highlighted

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

#### For Astro version: `5.0`.

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
