### PR TITLE
update redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -27,7 +27,7 @@
 /:lang/migrate                                       /:lang/guides/upgrade-to/v1/
 /:lang/recipes/studio                                /:lang/guides/astro-db/
 /:lang/community-resources/talks/                    /:lang/community-resources/content/
-/:lang:/reference/api-reference/#astrocanonicalurl   /:lang:/reference/api-reference/#astrourl
+/:lang:/reference/components-reference/              /:lang:/guides/syntax-highlighting/
 
 # Very old docs site redirects
 # Once upon a time these URLs existed, so we try to keep them meaning something.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a redirect for the recently deleted "components-reference" page.

Since the content on that page went to various pages, redirecting to the new Syntax Highlighting page at least takes people to the built in `<Code />` and `<Prism />` components.

Also removes a redirect *from* an anchor link that is not doing anything.