### PR TITLE
feat(middleware): more explanation for `next()` rewrite

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -248,6 +248,8 @@ The `next()` function accepts the same payload of [the `Astro.rewrite()` functio
 
 When you have multiple middleware functions chained via [sequence()](#chaining-middleware), submitting a path to `next()` will rewrite the `Request` in place and the middleware will not execute again. The next middleware function in the chain will receive the new `Request` with its updated `context`:
 
+Calling `next()` with this signature will create a new `Request` object using the old `ctx.request`, this means that trying to consume `Request.body`, either before or after this rewrite, will throw a runtime error. This can likely happen with [Astro Actions that use HTML forms](/en/guides/actions/#call-actions-from-an-html-form-action). In these cases it's advised to avoid a rewrite inside the middleware.    
+
 ```js title="src/middleware.js"
 // Current URL is https://example.com/blog
 

--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -248,7 +248,7 @@ The `next()` function accepts the same payload of [the `Astro.rewrite()` functio
 
 When you have multiple middleware functions chained via [sequence()](#chaining-middleware), submitting a path to `next()` will rewrite the `Request` in place and the middleware will not execute again. The next middleware function in the chain will receive the new `Request` with its updated `context`:
 
-Calling `next()` with this signature will create a new `Request` object using the old `ctx.request`, this means that trying to consume `Request.body`, either before or after this rewrite, will throw a runtime error. This can likely happen with [Astro Actions that use HTML forms](/en/guides/actions/#call-actions-from-an-html-form-action). In these cases it's advised to avoid a rewrite inside the middleware.    
+Calling `next()` with this signature will create a new `Request` object using the old `ctx.request`. This means that trying to consume `Request.body`, either before or after this rewrite, will throw a runtime error. This error is often raised with [Astro Actions that use HTML forms](/en/guides/actions/#call-actions-from-an-html-form-action). In these cases, we recommend handling rewrites from your Astro templates using `Astro.rewrite()` instead of using middleware.    
 
 ```js title="src/middleware.js"
 // Current URL is https://example.com/blog


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

While working with Ben on its rewrite of Astro Actions, I came across a technical limitation which can't be fixed.

I thought that it would be helpful to explain this limitation in case users try to encounter it.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->
