### PR TITLE
docs: clarify schema behavior for collection entry data

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -39,7 +39,7 @@ With an appropriate collection loader, you can fetch remote data from any extern
 
 ## TypeScript configuration for collections
 
-Content collections rely on TypeScript to provide Zod validation, Intellisense and type checking in your editor. If you are not extending one of Astro's  `strict` or `strictest` TypeScript settings, you will need to ensure the following `compilerOptions` are set in your `tsconfig.json`:
+Content collections rely on TypeScript to provide Zod validation, Intellisense and type checking in youEr editor. If you are not extending one of Astro's  `strict` or `strictest` TypeScript settings, you will need to ensure the following `compilerOptions` are set in your `tsconfig.json`:
 
 ```json title="tsconfig.json" ins={5} {6}
 {
@@ -249,6 +249,7 @@ const dogs = defineCollection({
 
 export const collections = { blog, dogs };
 ```
+If the property is not defined in the Zod schema, it will be excluded from the collection entry data.
 
 #### Defining datatypes with Zod
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -39,7 +39,7 @@ With an appropriate collection loader, you can fetch remote data from any extern
 
 ## TypeScript configuration for collections
 
-Content collections rely on TypeScript to provide Zod validation, Intellisense and type checking in youEr editor. If you are not extending one of Astro's  `strict` or `strictest` TypeScript settings, you will need to ensure the following `compilerOptions` are set in your `tsconfig.json`:
+Content collections rely on TypeScript to provide Zod validation, Intellisense and type checking in your editor. If you are not extending one of Astro's  `strict` or `strictest` TypeScript settings, you will need to ensure the following `compilerOptions` are set in your `tsconfig.json`:
 
 ```json title="tsconfig.json" ins={5} {6}
 {


### PR DESCRIPTION
#### Description (required)

This PR updates the documentation to clarify that any frontmatter or data property of collection entries must be defined using a Zod data type. If a property is not defined using Zod, it will be excluded from the collection entry data. This change aims to improve user understanding of the schema behavior and ensure data validation and consistency.

#### Related issues & labels (optional)

-Potentially Closes Astro issue [#12404]( https://github.com/withastro/astro/issues/12404)
-Suggested label: docs

