### PR TITLE
i18n(fr): update `configuration-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/configuration-reference.mdx
+++ b/src/content/docs/fr/reference/configuration-reference.mdx
@@ -1000,7 +1000,6 @@ Consultez le [guide de coloration syntaxique du code](/fr/guides/syntax-highligh
 </p>
 
 Quel surligneur de syntaxe utiliser pour les blocs de code Markdown (\`\`\`), le cas échéant. Cela détermine les classes CSS qu'Astro appliquera à vos blocs de code Markdown.
-
 - `shiki` - utiliser le colorateur [Shiki](https://shiki.style) (thème `github-dark` configuré par défaut)
 - `prism` - utiliser le colorateur [Prism](https://prismjs.com/) et [fournir votre propre feuille de style Prism](/fr/guides/syntax-highlighting/#ajouter-une-feuille-de-style-prism)
 - `false` - n'appliquer aucune coloration syntaxique.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Removes the blank line between the sentence and the list (see #9933)

Note: #9933 also fixes the escaping for \`\`\` but this was already fixed in the French translation (see #9934).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
