### PR TITLE
Added alternative method for environment variables in Cloudflare adapter docs

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -264,6 +264,30 @@ const myVariable = env.MY_VARIABLE;
 
 See the [list of all supported bindings](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings) in the Cloudflare documentation.
 
+### Alternative usage with `import.meta.env`
+
+The recommended approach for using environment variables with Cloudflare is to utilize the `Astro.locals.runtime.env` object, as documented above.
+
+However, for developers transitioning from local development or preferring consistency with `import.meta.env` pattern, there's an alternative method that can be used:
+
+1. **Add environment variables via Cloudflare Pages dashboard**
+-  You can do so by navigating to Pages > Settings > Environment Variables
+
+2. **Add names of environment variables in vite.define**
+- This ensures that your Cloudflare environment variables are properly set
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  vite: {
+    define: {
+      'process.env.EXAMPLE_SECRET': JSON.stringify(process.env.EXAMPLE_SECRET)
+    }
+  }
+})
+```
+
+You can now access Cloudflare environment variables using `import.meta.env.EXAMPLE_SECRET`, just like you would in a local development environment with a .env file.
+
 ### Typing
 
 `wrangler` provides a `types` command to generate TypeScript types for the bindings. This allows you to type locals without the need to manually type them. Refer to the [Cloudflare documentation](https://developers.cloudflare.com/workers/wrangler/commands/#types) for more information.


### PR DESCRIPTION
#### Description

This PR adds an alternative approach for managing environment variables in the Cloudflare adapter documentation.

For developers transitioning from local development or preferring consistency with `import.meta.env` pattern, there's an alternative approach that could be documented.

#### Related issues & labels

- Closes #9984<!-- Add an issue number if this PR will close it. -->
- Suggested label: add new content