### PR TITLE
Update Lunaria version and fix dashboard link

### DIFF
--- a/lunaria/components.ts
+++ b/lunaria/components.ts
@@ -188,7 +188,7 @@ export const OutdatedFiles = (
 											${localization.missingKeys.map((key) => html`<li>${key}</li>`)}
 										</ul>
 									</details>
-								`
+							  `
 							: html` ${ContentDetailsLinks(file, lang, lunaria)} `}
 					</li>
 				`;
@@ -252,7 +252,9 @@ export const TableContentStatus = (
 	const isMissingKeys = 'missingKeys' in localization && localization.missingKeys.length > 0;
 	const status = isMissingKeys ? 'outdated' : localization.status;
 	const links = lunaria.gitHostingLinks();
-	return html`<td>${EmojiFileLink(links.create(localization.path), status)}</td>`;
+	const link =
+		status === 'missing' ? links.create(localization.path) : links.source(localization.path);
+	return html`<td>${EmojiFileLink(link, status)}</td>`;
 };
 
 export const ContentDetailsLinks = (
@@ -305,10 +307,10 @@ export const EmojiFileLink = (
 	return href
 		? html`<a href="${href}" title="${statusTextOpts[type]}">
 				<span aria-hidden="true">${statusEmojiOpts[type]}</span>
-			</a>`
+		  </a>`
 		: html`<span title="${statusTextOpts[type]}">
 				<span aria-hidden="true">${statusEmojiOpts[type]}</span>
-			</span>`;
+		  </span>`;
 };
 
 export const Link = (href: string, text: string): string => {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@astrojs/starlight": "^0.29.0",
     "@docsearch/js": "^3.5.2",
     "@expressive-code/plugin-collapsible-sections": "^0.38.3",
-    "@lunariajs/core": "https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7",
+    "@lunariajs/core": "https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f",
     "canvas-confetti": "^1.6.0",
     "jsdoc-api": "^7.1.1",
     "rehype-autolink-headings": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.38.3
         version: 0.38.3
       '@lunariajs/core':
-        specifier: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7
-        version: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7
+        specifier: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f
+        version: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f
       canvas-confetti:
         specifier: ^1.6.0
         version: 1.6.0
@@ -774,8 +774,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7':
-    resolution: {tarball: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7}
+  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f':
+    resolution: {tarball: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f}
     version: 0.1.1
     engines: {node: '>=18.17.0'}
 
@@ -4573,7 +4573,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@ae1b8a7':
+  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@62a858f':
     dependencies:
       consola: 3.2.3
       jiti: 2.3.3


### PR DESCRIPTION
#### Description (required)

This PR updates Lunaria to the latest prerelease version, which solves a few small bugs. Additionally, I fixed a link in the Lunaria dashboard, outdated files should get a link to their file contents vs a link to create a new file as it was happening (which should be reserved only when the file is missing)

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
