### PR TITLE
Update message format in `cli-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -116,10 +116,10 @@ astro dev [...flags]
 Flags
                  --port  Specify which port to run on. Defaults to 4321.
                  --host  Listen on all addresses, including LAN and public addresses.
-                 --host <custom-address>  Expose on a network IP address at <custom-address>
+--host <custom-address>  Expose on a network IP address at <custom-address>
                  --open  Automatically open the app in the browser on server start
                 --force  Clear the content layer cache, forcing a full rebuild.
-                --help (-h)  See all available flags.
+            --help (-h)  See all available flags.
 ```
 
 :::note


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update message format in `cli-reference.mdx`

I notice the CLI message in the editor is going to be like this (Align to message's blank in the middle):

![截屏2024-11-14 15 57 11](https://github.com/user-attachments/assets/fe864164-ca47-4105-910b-cc5851455956)

So I add the indent for code to fit the CLI's output message format.

#### Related issues & labels (optional)

- #9895 
- Suggested label: `consistency/formatting`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
