### PR TITLE
content collections tutorial

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -31,7 +31,7 @@
 /:lang/guides/content/                               /:lang/guides/markdown-content/
 /:lang/community-resources/talks/                    /:lang/community-resources/content/
 /:lang:/reference/components-reference/              /:lang:/guides/syntax-highlighting/
-
+/:lang:/tutorials/add-content-collections/           /:lang:/tutorial/7-collections/
 # Very old docs site redirects
 # Once upon a time these URLs existed, so we try to keep them meaning something.
 /reference/renderer-reference                   /en/reference/integrations-reference/

--- a/src/content/docs/en/tutorial/0-introduction/1.mdx
+++ b/src/content/docs/en/tutorial/0-introduction/1.mdx
@@ -42,12 +42,6 @@ Hop into the support forum channel to ask questions, or say hi and chat in `#gen
 </details>
 
 <details>
-<summary>What can I do after I complete this tutorial?</summary>
-
-At the end of this tutorial, you will have a functioning blog using Astro's built-in file-based routing. You can enhance this project's final code by [refactoring it to manage your content with content collections](/en/tutorials/add-content-collections/) or [adding view transitions to customize page navigation](/en/tutorials/add-view-transitions/).
-</details>
-
-<details>
 <summary>Where can I leave feedback about this tutorial?</summary>
 
 This tutorial is a project of our Docs team. You can find us on Discord in the `#docs` channel, or file issues to the [Docs repo on GitHub](https://github.com/withastro/docs/issues). 

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -31,19 +31,19 @@ The preferred way to create a new Astro site is through our `create astro` setup
       <Fragment slot="npm">
       ```shell
       # create a new project with npm
-      npm create astro@latest
+      npm create astro@latest -- --template minimal
       ```
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
       # create a new project with pnpm
-      pnpm create astro@latest
+      pnpm create astro@latest --template minimal
       ```
       </Fragment>
       <Fragment slot="yarn">
       ```shell
       # create a new project with yarn
-      yarn create astro
+      yarn create astro --template minimal
       ```
       </Fragment>
     </PackageManagerTabs>
@@ -56,13 +56,9 @@ The preferred way to create a new Astro site is through our `create astro` setup
     A new Astro project can only be created in a completely empty folder, so choose a name for your folder that does not already exist!
     :::
 
-4. You will see a short list of starter templates to choose from. Use the arrow keys (up and down) to navigate to the "Empty" template, and then press return (enter) to submit your choice. 
+4. When the prompt asks, "Would you like to install dependencies?" type `y`.
 
-5. When the prompt asks you if you plan on writing TypeScript, type `n`.
-
-6. When the prompt asks, "Would you like to install dependencies?" type `y`.
-
-7. When the prompt asks, "Would you like to initialize a new git repository?" type `y`.
+5. When the prompt asks, "Would you like to initialize a new git repository?" type `y`.
 </Steps>
 
 When the install wizard is complete, you no longer need this terminal. You can now open VS Code to continue.

--- a/src/content/docs/en/tutorial/6-islands/3.mdx
+++ b/src/content/docs/en/tutorial/6-islands/3.mdx
@@ -74,7 +74,7 @@ Congratulations on completing the Astro blog tutorial! Share your achievement wi
 You can enhance this project's final code with one of our tutorial extensions, or start your next Astro project!
 <CardGrid>
   <LinkCard
-    title="Extend with content collections"
+    title=" with content collections"
     description="Refactor the tutorial code to manage your blog posts with content collections."
     href="/en/tutorials/add-content-collections/"
   />

--- a/src/content/docs/en/tutorial/6-islands/4.mdx
+++ b/src/content/docs/en/tutorial/6-islands/4.mdx
@@ -1,0 +1,349 @@
+---
+type: tutorial
+title: 'Optional: Make a content collection'
+description: |-
+  Tutorial: Build your first Astro blog —
+  Convert your blog from file-based routing to content collections
+i18nReady: true
+---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+import Box from '~/components/tutorial/Box.astro';
+import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
+import PreCheck from '~/components/tutorial/PreCheck.astro';
+import Option from '~/components/tutorial/Option.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Now that you have a blog using Astro's [built-in file-based routing](/en/guides/routing/#static-routes), you will update it to use a [content collection](/en/guides/content-collections/). Content collections are a powerful way to manage groups of similar content, such as blog posts.
+
+<PreCheck>
+  - Move your folder of blog posts into `src/blog/`
+  - Create a schema to define your blog post frontmatter
+  - Use `getCollection()` to get blog post content and metadata
+</PreCheck>
+
+## Learn: Pages vs Collections
+
+Even when using content collections, you will still use the `src/pages/` folder for individual pages, such as your About Me page. But, moving your blog posts outside of this special folder will allow you to use more powerful and performant APIs to generate your blog post index and display your individual blog posts.
+
+At the same time, you'll receive better guidance and autocompletion in your code editor because you will have a **[schema](/en/guides/content-collections/#defining-the-collection-schema)** to define a common structure for each post that Astro will help you enforce through [Zod](https://zod.dev/), a schema declaration and validation library for TypeScript. In your schema, you can specify when frontmatter properties are required, such as a description or an author, and which data type each property must be, such as a string or an array. This leads to catching many mistakes sooner, with descriptive error messages telling you exactly what the problem is.
+
+Read more about [Astro's content collections](/en/guides/content-collections/) in our guide, or get started with the instructions below to convert a basic blog from `src/pages/posts/` to `src/blog/`.
+
+<Box icon="question-mark">
+### Test your knowledge
+
+1. Which type of page would you probably keep in `src/pages/`?
+
+    <MultipleChoice>
+      <Option>
+        Blog posts that all contain the same basic structure and metadata
+      </Option>
+      <Option>
+        Product pages in an eCommerce site
+      </Option>
+      <Option isCorrect>
+        A contact page, because you do not have multiple similar pages of this type
+      </Option>
+    </MultipleChoice>
+
+2. Which is **not** a benefit of moving blog posts to a content collection?
+
+    <MultipleChoice>
+      <Option isCorrect>
+         Pages are automatically created for each file
+      </Option>
+      <Option>
+        Better error messages, because Astro knows more about each file
+      </Option>
+      <Option>
+        Better data fetching, with a more performant function
+      </Option>
+    </MultipleChoice>
+
+3. Content collections uses TypeScript . . .
+    <MultipleChoice>
+      <Option>
+        To make me feel bad
+      </Option>
+      <Option isCorrect>
+        To understand and validate my collections, and to provide editor tooling
+      </Option>
+      <Option>
+        Only if I have the `strictest` configuration set in `tsconfig.json`
+      </Option>
+    </MultipleChoice>
+
+</Box>
+
+The steps below show you how to extend the final product of the Build a Blog tutorial by creating a content collection for the blog posts.
+
+## Upgrade dependencies
+
+Upgrade to the latest version of Astro, and upgrade all integrations to their latest versions by running the following commands in your terminal:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      # Upgrade Astro and official integrations together
+      npx @astrojs/upgrade
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      # Upgrade Astro and official integrations together
+      pnpm dlx @astrojs/upgrade
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      # Upgrade Astro and official integrations together
+      yarn dlx @astrojs/upgrade
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+## Create a collection for your posts
+
+<Steps>
+1. Create a new **collection** (folder) called `src/blog/`. 
+
+2. Move all your existing blog posts (`.md` files) from `src/pages/posts/` into this new collection.
+
+3. Create a `src/content/config.ts` file to [define a schema](/en/guides/content-collections/#defining-the-collection-schema) for your `postsCollection`. For the existing blog tutorial code, add the following contents to the file to define all the frontmatter properties used in its blog posts:
+
+    ```ts title="src/content/config.ts"
+    // Import the glob loader
+    import { glob } from "astro/loaders";
+    // Import utilities from `astro:content`
+    import { z, defineCollection } from "astro:content";
+    // Define a `loader` and `schema` for each collection
+    const blog = defineCollection({
+        loader: glob({ pattern: '**\/[^_]*.md', base: "./src/blog" }),
+        schema: z.object({
+          title: z.string(),
+          pubDate: z.date(),
+          description: z.string(),
+          author: z.string(),
+          image: z.object({
+            url: z.string(),
+            alt: z.string()
+          }),
+          tags: z.array(z.string())
+        })
+    });
+    // Export a single `collections` object to register your collection(s)
+    export const collections = { blog };
+    ```
+
+4. In order for Astro to recognize your schema, quit the dev server (`CTRL + C`) and run the following command: [`npx astro sync`](/en/reference/cli-reference/#astro-sync). This will define the `astro:content` module. Restart the dev server to continue with the tutorial.
+</Steps>
+
+## Generate pages from a collection
+
+<Steps>
+1. Create a page file called `src/pages/posts/[...slug].astro`. Your Markdown and MDX files no longer automatically become pages using Astro's file-based routing when they are inside a collection, so you must create a page responsible for generating each individual blog post.
+
+2. Add the following code to [query your collection](/en/guides/content-collections/#querying-collections) to make each blog post's slug and page content available to each page it will generate:
+
+    ```astro title="src/pages/posts/[...slug].astro"
+    ---
+    import { getCollection } from 'astro:content';
+
+    export async function getStaticPaths() {
+      const posts = await getCollection('blog');
+      return posts.map(post => ({
+        params: { slug: post.id }, props: { post },
+      }));
+    }
+
+    const { post } = Astro.props;
+    const { Content } = await render(post);
+    ---
+    ```
+
+3. Render your post `<Content />` within the layout for Markdown pages. This allows you to specify a common layout for all of your posts.
+
+    ```astro title="src/pages/posts/[...slug].astro" ins={3,15-17}
+    ---
+    import { getCollection } from 'astro:content';
+    import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';
+
+    export async function getStaticPaths() {
+      const posts = await getCollection('posts');
+      return posts.map(post => ({
+        params: { slug: post.id }, props: { post },
+      }));
+    }
+
+    const { post } = Astro.props;
+    const { Content } = await render(post);
+    ---
+    <MarkdownPostLayout frontmatter={post.data}>
+      <Content />
+    </MarkdownPostLayout>
+    ```
+
+4. Remove the `layout` definition in each individual post's frontmatter. Your content is now wrapped in a layout when rendered, and this property is no longer needed.
+
+    ```md title="src/content/posts/post-1.md" del={2}
+    ---
+    layout: ../../layouts/MarkdownPostLayout.astro
+    title: 'My First Blog Post'
+    pubDate: 2022-07-01
+    ...
+    ---
+    ```
+</Steps>
+
+## Replace `import.meta.glob()` with `getCollection()`
+
+<Steps>
+5. Anywhere you have a list of blog posts, like the tutorial's Blog page (`src/pages/blog.astro/`), you will need to replace `import.meta.glob()` with [`getCollection()`](/en/reference/modules/astro-content/#getcollection) as the way to fetch content and metadata from your Markdown files.
+
+    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"blog\")" "/posts/${post.id}/" del={7} ins={2,8}
+    ---
+    import { getCollection } from "astro:content";
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    import BlogPost from "../components/BlogPost.astro";
+
+    const pageTitle = "My Astro Learning Blog";
+    const allPosts = Object.values(await import.meta.glob("../pages/posts/*.md", { eager: true }));
+    const allPosts = await getCollection("blog");
+    ---
+    ```
+
+6. You will also need to update references to the data returned for each `post`. You will now find your frontmatter values on the `data` property of each object. Also, when using collections each `post` object will have a page `slug`, not a full URL.
+
+    ```astro title="src/pages/blog.astro" "data" "/posts/$\{post.id\}/" del={14} ins={15}
+    ---
+    import { getCollection } from "astro:content";
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    import BlogPost from "../components/BlogPost.astro";
+
+    const pageTitle = "My Astro Learning Blog";
+    const allPosts = await getCollection("blog");
+    ---
+    <BaseLayout pageTitle={pageTitle}>
+      <p>This is where I will post about my journey learning Astro.</p>
+      <ul>
+        {
+          allPosts.map((post) => (
+            <BlogPost url={post.url} title={post.frontmatter.title} />)}
+            <BlogPost url={`/posts/${post.id}/`} title={post.data.title} />
+          ))
+        }
+      </ul>
+    </BaseLayout> 
+    ```
+
+7. The tutorial blog project also dynamically generates a page for each tag using `src/pages/tags/[tag].astro` and displays a list of tags at `src/pages/tags/index.astro`. 
+   
+          Apply the same changes as above to these two files:
+      
+          - fetch data about all your blog posts using `getCollection("blog")` instead of using `import.meta.glob()`
+          - access all frontmatter values using `data` instead of `frontmatter`
+          - create a page URL by adding the post's `slug` to the `/posts/` path
+        
+        The page that generates individual tag pages now becomes:
+
+        ```astro title="src/pages/tags/[tag].astro" "post.data.tags" "getCollection(\"blog\")" "post.data.title" ins={2} "/posts/${post.id}/"
+        ---
+        import { getCollection } from "astro:content";
+        import BaseLayout from "../../layouts/BaseLayout.astro";
+        import BlogPost from "../../components/BlogPost.astro";
+
+        export async function getStaticPaths() {
+          const allPosts = await getCollection("blog");
+          const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+
+          return uniqueTags.map((tag) => {
+            const filteredPosts = allPosts.filter((post) =>
+              post.data.tags.includes(tag)
+            );
+            return {
+              params: { tag },
+              props: { posts: filteredPosts },
+            };
+          });
+        }
+        
+        const { tag } = Astro.params;
+        const { posts } = Astro.props;
+        ---
+
+        <BaseLayout pageTitle={tag}>
+          <p>Posts tagged with {tag}</p>
+          <ul>
+            { posts.map((post) => <BlogPost url={`/posts/${post.id}/`} title={post.data.title} />) }
+          </ul>
+        </BaseLayout>
+        ```
+
+        <Box icon="puzzle-piece">
+          ### Try it yourself - Update the query in the Tag Index page
+
+          Import and use `getCollection` to fetch the tags used in the blog posts on `src/pages/tags/index.astro`, following the [same steps as above](#replace-importmetaglob-with-getcollection).
+
+          <details>
+          <summary>Show me the code.</summary>
+          ```astro title="src/pages/tags/index.astro" "post.data" "getCollection(\"blog\")" ins={2}
+          ---
+          import { getCollection } from "astro:content";
+          import BaseLayout from "../../layouts/BaseLayout.astro";     
+          const allPosts = await getCollection("blog");
+          const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+          const pageTitle = "Tag Index";
+          ---
+          <!-- ... -->
+          ```
+          </details>
+      </Box>
+</Steps>
+
+## Update any frontmatter values to match your schema
+
+If necessary, update any frontmatter values throughout your project, such as in your layout, that do not match your collections schema. 
+
+In the blog tutorial example, `pubDate` was a string. Now, according to the schema that defines types for the post frontmatter, `pubDate` will be a `Date`
+object.
+
+To render the date in the blog post layout, convert it to a string:
+
+```astro title="src/layouts/MarkdownPostLayout.astro" ins="toString()"
+<!-- ... -->
+<BaseLayout pageTitle={frontmatter.title}>
+    <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
+    <p><em>{frontmatter.description}</em></p>
+    <p>Written by: {frontmatter.author}</p>
+    <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+<!-- ... -->
+```
+
+## Update the RSS function
+
+The tutorial blog project includes an RSS feed. This function must also use `getCollection()` to return information from your blog posts. You will then generate the RSS items using the `data` object returned.
+
+    ```js title="src/pages/rss.xml.js" del={2,11} ins={3,6,12-17}
+    import rss from '@astrojs/rss';
+    import { pagesGlobToRssItems } from '@astrojs/rss';
+    import { getCollection } from 'astro:content';
+
+    export async function GET(context) {
+      const posts = await getCollection("blog");
+      return rss({
+        title: 'Astro Learner | Blog',
+        description: 'My journey learning Astro',
+        site: context.site,
+        items: await pagesGlobToRssItems(import.meta.glob('./**/*.md')),
+        items: posts.map((post) => ({
+          title: post.data.title,
+          pubDate: post.data.pubDate,
+          description: post.data.description,
+          link: `/posts/${post.id}/`,
+        })),
+        customData: `<language>en-us</language>`,
+      })
+    }
+    ```
+
+For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-layer) of the tutorial repo.

--- a/src/content/docs/en/tutorial/7-collections/index.mdx
+++ b/src/content/docs/en/tutorial/7-collections/index.mdx
@@ -1,0 +1,351 @@
+---
+type: tutorial
+unitTitle: Convert to Content Collections
+title: 'Optional: Unit 7 - Content Collections'
+description: |-
+  Tutorial: Build your first Astro blog —
+  Convert your blog from file-based routing to content collections
+i18nReady: true
+---
+---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+import Box from '~/components/tutorial/Box.astro';
+import MultipleChoice from '~/components/tutorial/MultipleChoice.astro';
+import PreCheck from '~/components/tutorial/PreCheck.astro';
+import Option from '~/components/tutorial/Option.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Now that you have a blog using Astro's [built-in file-based routing](/en/guides/routing/#static-routes), you will update it to use a [content collection](/en/guides/content-collections/). Content collections are a powerful way to manage groups of similar content, such as blog posts.
+
+<PreCheck>
+  - Move your folder of blog posts into `src/blog/`
+  - Create a schema to define your blog post frontmatter
+  - Use `getCollection()` to get blog post content and metadata
+</PreCheck>
+
+## Learn: Pages vs Collections
+
+Even when using content collections, you will still use the `src/pages/` folder for individual pages, such as your About Me page. But, moving your blog posts outside of this special folder will allow you to use more powerful and performant APIs to generate your blog post index and display your individual blog posts.
+
+At the same time, you'll receive better guidance and autocompletion in your code editor because you will have a **[schema](/en/guides/content-collections/#defining-the-collection-schema)** to define a common structure for each post that Astro will help you enforce through [Zod](https://zod.dev/), a schema declaration and validation library for TypeScript. In your schema, you can specify when frontmatter properties are required, such as a description or an author, and which data type each property must be, such as a string or an array. This leads to catching many mistakes sooner, with descriptive error messages telling you exactly what the problem is.
+
+Read more about [Astro's content collections](/en/guides/content-collections/) in our guide, or get started with the instructions below to convert a basic blog from `src/pages/posts/` to `src/blog/`.
+
+<Box icon="question-mark">
+### Test your knowledge
+
+1. Which type of page would you probably keep in `src/pages/`?
+
+    <MultipleChoice>
+      <Option>
+        Blog posts that all contain the same basic structure and metadata
+      </Option>
+      <Option>
+        Product pages in an eCommerce site
+      </Option>
+      <Option isCorrect>
+        A contact page, because you do not have multiple similar pages of this type
+      </Option>
+    </MultipleChoice>
+
+2. Which is **not** a benefit of moving blog posts to a content collection?
+
+    <MultipleChoice>
+      <Option isCorrect>
+         Pages are automatically created for each file
+      </Option>
+      <Option>
+        Better error messages, because Astro knows more about each file
+      </Option>
+      <Option>
+        Better data fetching, with a more performant function
+      </Option>
+    </MultipleChoice>
+
+3. Content collections uses TypeScript . . .
+    <MultipleChoice>
+      <Option>
+        To make me feel bad
+      </Option>
+      <Option isCorrect>
+        To understand and validate my collections, and to provide editor tooling
+      </Option>
+      <Option>
+        Only if I have the `strictest` configuration set in `tsconfig.json`
+      </Option>
+    </MultipleChoice>
+
+</Box>
+
+The steps below show you how to extend the final product of the Build a Blog tutorial by creating a content collection for the blog posts.
+
+## Upgrade dependencies
+
+Upgrade to the latest version of Astro, and upgrade all integrations to their latest versions by running the following commands in your terminal:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      # Upgrade Astro and official integrations together
+      npx @astrojs/upgrade
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      # Upgrade Astro and official integrations together
+      pnpm dlx @astrojs/upgrade
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      # Upgrade Astro and official integrations together
+      yarn dlx @astrojs/upgrade
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+## Create a collection for your posts
+
+<Steps>
+1. Create a new **collection** (folder) called `src/blog/`. 
+
+2. Move all your existing blog posts (`.md` files) from `src/pages/posts/` into this new collection.
+
+3. Create a `src/content/config.ts` file to [define a schema](/en/guides/content-collections/#defining-the-collection-schema) for your `postsCollection`. For the existing blog tutorial code, add the following contents to the file to define all the frontmatter properties used in its blog posts:
+
+    ```ts title="src/content/config.ts"
+    // Import the glob loader
+    import { glob } from "astro/loaders";
+    // Import utilities from `astro:content`
+    import { z, defineCollection } from "astro:content";
+    // Define a `loader` and `schema` for each collection
+    const blog = defineCollection({
+        loader: glob({ pattern: '**\/[^_]*.md', base: "./src/blog" }),
+        schema: z.object({
+          title: z.string(),
+          pubDate: z.date(),
+          description: z.string(),
+          author: z.string(),
+          image: z.object({
+            url: z.string(),
+            alt: z.string()
+          }),
+          tags: z.array(z.string())
+        })
+    });
+    // Export a single `collections` object to register your collection(s)
+    export const collections = { blog };
+    ```
+
+4. In order for Astro to recognize your schema, quit the dev server (`CTRL + C`) and run the following command: [`npx astro sync`](/en/reference/cli-reference/#astro-sync). This will define the `astro:content` module. Restart the dev server to continue with the tutorial.
+</Steps>
+
+## Generate pages from a collection
+
+<Steps>
+1. Create a page file called `src/pages/posts/[...slug].astro`. Your Markdown and MDX files no longer automatically become pages using Astro's file-based routing when they are inside a collection, so you must create a page responsible for generating each individual blog post.
+
+2. Add the following code to [query your collection](/en/guides/content-collections/#querying-collections) to make each blog post's slug and page content available to each page it will generate:
+
+    ```astro title="src/pages/posts/[...slug].astro"
+    ---
+    import { getCollection } from 'astro:content';
+
+    export async function getStaticPaths() {
+      const posts = await getCollection('blog');
+      return posts.map(post => ({
+        params: { slug: post.id }, props: { post },
+      }));
+    }
+
+    const { post } = Astro.props;
+    const { Content } = await render(post);
+    ---
+    ```
+
+3. Render your post `<Content />` within the layout for Markdown pages. This allows you to specify a common layout for all of your posts.
+
+    ```astro title="src/pages/posts/[...slug].astro" ins={3,15-17}
+    ---
+    import { getCollection } from 'astro:content';
+    import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';
+
+    export async function getStaticPaths() {
+      const posts = await getCollection('posts');
+      return posts.map(post => ({
+        params: { slug: post.id }, props: { post },
+      }));
+    }
+
+    const { post } = Astro.props;
+    const { Content } = await render(post);
+    ---
+    <MarkdownPostLayout frontmatter={post.data}>
+      <Content />
+    </MarkdownPostLayout>
+    ```
+
+4. Remove the `layout` definition in each individual post's frontmatter. Your content is now wrapped in a layout when rendered, and this property is no longer needed.
+
+    ```md title="src/content/posts/post-1.md" del={2}
+    ---
+    layout: ../../layouts/MarkdownPostLayout.astro
+    title: 'My First Blog Post'
+    pubDate: 2022-07-01
+    ...
+    ---
+    ```
+</Steps>
+
+## Replace `import.meta.glob()` with `getCollection()`
+
+<Steps>
+5. Anywhere you have a list of blog posts, like the tutorial's Blog page (`src/pages/blog.astro/`), you will need to replace `import.meta.glob()` with [`getCollection()`](/en/reference/modules/astro-content/#getcollection) as the way to fetch content and metadata from your Markdown files.
+
+    ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"blog\")" "/posts/${post.id}/" del={7} ins={2,8}
+    ---
+    import { getCollection } from "astro:content";
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    import BlogPost from "../components/BlogPost.astro";
+
+    const pageTitle = "My Astro Learning Blog";
+    const allPosts = Object.values(await import.meta.glob("../pages/posts/*.md", { eager: true }));
+    const allPosts = await getCollection("blog");
+    ---
+    ```
+
+6. You will also need to update references to the data returned for each `post`. You will now find your frontmatter values on the `data` property of each object. Also, when using collections each `post` object will have a page `slug`, not a full URL.
+
+    ```astro title="src/pages/blog.astro" "data" "/posts/$\{post.id\}/" del={14} ins={15}
+    ---
+    import { getCollection } from "astro:content";
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    import BlogPost from "../components/BlogPost.astro";
+
+    const pageTitle = "My Astro Learning Blog";
+    const allPosts = await getCollection("blog");
+    ---
+    <BaseLayout pageTitle={pageTitle}>
+      <p>This is where I will post about my journey learning Astro.</p>
+      <ul>
+        {
+          allPosts.map((post) => (
+            <BlogPost url={post.url} title={post.frontmatter.title} />)}
+            <BlogPost url={`/posts/${post.id}/`} title={post.data.title} />
+          ))
+        }
+      </ul>
+    </BaseLayout> 
+    ```
+
+7. The tutorial blog project also dynamically generates a page for each tag using `src/pages/tags/[tag].astro` and displays a list of tags at `src/pages/tags/index.astro`. 
+   
+          Apply the same changes as above to these two files:
+      
+          - fetch data about all your blog posts using `getCollection("blog")` instead of using `import.meta.glob()`
+          - access all frontmatter values using `data` instead of `frontmatter`
+          - create a page URL by adding the post's `slug` to the `/posts/` path
+        
+        The page that generates individual tag pages now becomes:
+
+        ```astro title="src/pages/tags/[tag].astro" "post.data.tags" "getCollection(\"blog\")" "post.data.title" ins={2} "/posts/${post.id}/"
+        ---
+        import { getCollection } from "astro:content";
+        import BaseLayout from "../../layouts/BaseLayout.astro";
+        import BlogPost from "../../components/BlogPost.astro";
+
+        export async function getStaticPaths() {
+          const allPosts = await getCollection("blog");
+          const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+
+          return uniqueTags.map((tag) => {
+            const filteredPosts = allPosts.filter((post) =>
+              post.data.tags.includes(tag)
+            );
+            return {
+              params: { tag },
+              props: { posts: filteredPosts },
+            };
+          });
+        }
+        
+        const { tag } = Astro.params;
+        const { posts } = Astro.props;
+        ---
+
+        <BaseLayout pageTitle={tag}>
+          <p>Posts tagged with {tag}</p>
+          <ul>
+            { posts.map((post) => <BlogPost url={`/posts/${post.id}/`} title={post.data.title} />) }
+          </ul>
+        </BaseLayout>
+        ```
+
+        <Box icon="puzzle-piece">
+          ### Try it yourself - Update the query in the Tag Index page
+
+          Import and use `getCollection` to fetch the tags used in the blog posts on `src/pages/tags/index.astro`, following the [same steps as above](#replace-importmetaglob-with-getcollection).
+
+          <details>
+          <summary>Show me the code.</summary>
+          ```astro title="src/pages/tags/index.astro" "post.data" "getCollection(\"blog\")" ins={2}
+          ---
+          import { getCollection } from "astro:content";
+          import BaseLayout from "../../layouts/BaseLayout.astro";     
+          const allPosts = await getCollection("blog");
+          const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+          const pageTitle = "Tag Index";
+          ---
+          <!-- ... -->
+          ```
+          </details>
+      </Box>
+</Steps>
+
+## Update any frontmatter values to match your schema
+
+If necessary, update any frontmatter values throughout your project, such as in your layout, that do not match your collections schema. 
+
+In the blog tutorial example, `pubDate` was a string. Now, according to the schema that defines types for the post frontmatter, `pubDate` will be a `Date`
+object.
+
+To render the date in the blog post layout, convert it to a string:
+
+```astro title="src/layouts/MarkdownPostLayout.astro" ins="toString()"
+<!-- ... -->
+<BaseLayout pageTitle={frontmatter.title}>
+    <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
+    <p><em>{frontmatter.description}</em></p>
+    <p>Written by: {frontmatter.author}</p>
+    <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+<!-- ... -->
+```
+
+## Update the RSS function
+
+The tutorial blog project includes an RSS feed. This function must also use `getCollection()` to return information from your blog posts. You will then generate the RSS items using the `data` object returned.
+
+    ```js title="src/pages/rss.xml.js" del={2,11} ins={3,6,12-17}
+    import rss from '@astrojs/rss';
+    import { pagesGlobToRssItems } from '@astrojs/rss';
+    import { getCollection } from 'astro:content';
+
+    export async function GET(context) {
+      const posts = await getCollection("blog");
+      return rss({
+        title: 'Astro Learner | Blog',
+        description: 'My journey learning Astro',
+        site: context.site,
+        items: await pagesGlobToRssItems(import.meta.glob('./**/*.md')),
+        items: posts.map((post) => ({
+          title: post.data.title,
+          pubDate: post.data.pubDate,
+          description: post.data.description,
+          link: `/posts/${post.id}/`,
+        })),
+        customData: `<language>en-us</language>`,
+      })
+    }
+    ```
+
+For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-layer) of the tutorial repo.


### PR DESCRIPTION
#### Description (required)

This removes the individual "Extend the tutorial with Content Collections" tutorial and instead add a "bonus/optional" section to the existing blog tutorial

In particular:

- at this draft stage, provides TWO alternatives (we need to choose only one!) for adding this to the tutorial: as "6.4" or as an optional unit 7
- lightly edits text for context, now that it is part of the existing tutorial
- includes `create astro` updates introduced in https://github.com/withastro/astro/pull/12083 (minimal option must be chosen via template flag, is no longer a menu item; Typescript template is automatically set to `strict`)
- Includes a redirect
- updates the tutorial extension as a "next step" card at the end of the tutorial


Still to do:
- update any code samples as necessary now that the template uses the `strict` TypeScript setting
- choose a strategy for where this content is added (new unit? Bonus after Congratulations?)
- make sure the redirect is correct for our chosen location of the new content!