### PR TITLE
Ensure that the transition:animate="none" example is technically correct

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -182,7 +182,6 @@ import CommonHead from '../components/CommonHead.astro';
 </html>
 ```
 
-
 ### Customizing Animations
 
 You can customize all aspects of a transition with any CSS animation properties.

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -182,7 +182,6 @@ import CommonHead from '../components/CommonHead.astro';
 </html>
 ```
 
-Note that explicitly setting the [transition:name](#naming-a-transition) is necessary here, as the `<html>` element is directly used within in an individual page, not in a shared layout component.
 
 ### Customizing Animations
 

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -166,7 +166,7 @@ The example below produces a slide animation for the body content while disablin
 import CommonHead from '../components/CommonHead.astro';
 ---
 
-<html transition:animate="none">
+<html transition:name="root" transition:animate="none">
   <head>
     <CommonHead />
   </head>
@@ -181,6 +181,8 @@ import CommonHead from '../components/CommonHead.astro';
   </body>
 </html>
 ```
+
+Note that explicitly setting the [transition:name](#naming-a-transition) is necessary here, as the `<html>` element is directly used within in an individual page, not in a shared layout component.
 
 ### Customizing Animations
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Hy @sarah11918 👋🏼, after some thinking I managed to come up with a imho minimal change to the example that ensures it's technically correct without introducing further complexity. The most challenging part was resisting the urge to add excessive explanation and background details below the example. 

Would you please rephrase the text as you see fit for docs?

I hope this approach works, but I would also be fine with just adding `transition:name="root"` to the example without additional context. 🤓 

#### Related issues & labels (optional)

Closes #9977
