### PR TITLE
Update to the `astro-actions` page, adding documentation for `isActionError`.

### DIFF
--- a/src/content/docs/en/reference/modules/astro-actions.mdx
+++ b/src/content/docs/en/reference/modules/astro-actions.mdx
@@ -125,11 +125,11 @@ export const server = {
 
 <p>
 
-**Type:** <code>(error?: unknown | ActionInputError) => boolean</code><br/>
+**Type:** <code>(error?: unknown | <a href="#actionerror">ActionError</a>) => boolean</code><br/>
 <Since v="4.15.0" />
 </p>
 
-The `isInputError()` utility is used to check whether your action failed input validation and raised an `ActionInputError` error. When the `input` validator is a `z.object()`, input errors include a `fields` object with error messages grouped by name.
+The `isInputError()` utility is used to check whether an `ActionError` is an input validation error. When the `input` validator is a `z.object()`, input errors include a `fields` object with error messages grouped by name.
 
 <ReadMore>See the [form input errors guide](/en/guides/actions/#displaying-form-input-errors) for more on using `isInputError()`.</ReadMore>
 

--- a/src/content/docs/en/reference/modules/astro-actions.mdx
+++ b/src/content/docs/en/reference/modules/astro-actions.mdx
@@ -141,7 +141,7 @@ The `isInputError()` utility is used to check whether your action failed input v
 <Since v="4.15.0" />
 </p>
 
-The `isActionError()` utility is used to check whether your action raised an `ActionError` within the [handler property](/en/reference/modules/astro-actions/#handler-property). You should throw errors in your handler using the [`ActionError`](/en/reference/modules/astro-actions/#actionerror) constructor.
+The `isActionError()` utility is used to check whether your action raised an `ActionError` within the [handler property](/en/reference/modules/astro-actions/#handler-property). This is useful when narrowing the type of a generic error in a `try / catch` block.
 
 
 ### `ActionError`

--- a/src/content/docs/en/reference/modules/astro-actions.mdx
+++ b/src/content/docs/en/reference/modules/astro-actions.mdx
@@ -21,6 +21,7 @@ import {
   actions,
   defineAction,
   isInputError,
+  isActionError,
   ActionError,
  } from 'astro:actions';
 ```
@@ -124,13 +125,24 @@ export const server = {
 
 <p>
 
+**Type:** <code>(error?: unknown | ActionInputError) => boolean</code><br/>
+<Since v="4.15.0" />
+</p>
+
+The `isInputError()` utility is used to check whether your action failed input validation and raised an `ActionInputError` error. When the `input` validator is a `z.object()`, input errors include a `fields` object with error messages grouped by name.
+
+<ReadMore>See the [form input errors guide](/en/guides/actions/#displaying-form-input-errors) for more on using `isInputError()`.</ReadMore>
+
+### `isActionError()`
+
+<p>
+
 **Type:** <code>(error?: unknown | <a href="#actionerror">ActionError</a>) => boolean</code><br/>
 <Since v="4.15.0" />
 </p>
 
-The `isInputError()` utility is used to check whether an `ActionError` is an input validation error. When the `input` validator is a `z.object()`, input errors include a `fields` object with error messages grouped by name.
+The `isActionError()` utility is used to check whether your action raised an `ActionError` within the [handler property](/en/reference/modules/astro-actions/#handler-property). You should throw errors in your handler using the [`ActionError`](/en/reference/modules/astro-actions/#actionerror) constructor.
 
-<ReadMore>See the [form input errors guide](/en/guides/actions/#displaying-form-input-errors) for more on using `isInputError()`.</ReadMore>
 
 ### `ActionError`
 


### PR DESCRIPTION
Update to the `astro-actions` page, adding documentation for `isActionError` and also correcting the error raised with `isInputError`.

#### Description (required)

As per [this discord chat](https://discord.com/channels/830184174198718474/853350631389265940/1308047322789318697) I am documenting the `isActionError` utility function. Furthermore, I am updating the documentation for `isInputError` that shows it checking for `ActionInputError` as is found in the [source code](https://github.com/withastro/astro/blob/f64934086e84966bcfd02b699d64a80cb8392fa2/packages/astro/src/actions/runtime/virtual/shared.ts#L107).