### PR TITLE
Runtime API restructure

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -9,124 +9,17 @@ import Since from '~/components/Since.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import ReadMore from '~/components/ReadMore.astro';
 
-## `Astro` global
+When rendering a page, Astro provides a runtime API specific to the current render. This includes useful information such as the current page URL as well as APIs to perform actions like redirecting to another page.
 
-The `Astro` global is available in all contexts in `.astro` files. It has the following functions:
+In `.astro` components, this context is available from the `Astro` global object. Endpoint functions are also called with this same context object as their first argument, whose properties mirror many of the Astro global properties.
 
-### `Astro.glob()`
+Some properties are only available for pages rendered on demand, or may have limited functionality on prerendered pages.
 
-:::caution[Deprecated in v5.0]
-Use [Vite's `import.meta.glob`](https://vite.dev/guide/features.html#glob-import) to query project files. 
+The `Astro` global object is available to all `.astro` files. Use the `context` object in [endpoint functions](/en/guides/endpoints/) to serve static or live server endpoints and in [middleware](/en/guides/middleware/) to inject behavior when a page or end point is about to be rendered.
 
-`Astro.glob('../pages/post/*.md')` can be replaced with:
+## `Astro.props`
 
-`Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));`
-
-See the [imports guide](/en/guides/imports/#importmetaglob) for more information and usage.
-:::
-
-`Astro.glob()` is a way to load many local files into your static site setup.
-
-```astro
----
-// src/components/my-component.astro
-const posts = await Astro.glob('../pages/post/*.md'); // returns an array of posts that live at ./src/pages/post/*.md
----
-
-<div>
-{posts.slice(0, 3).map((post) => (
-  <article>
-    <h2>{post.frontmatter.title}</h2>
-    <p>{post.frontmatter.description}</p>
-    <a href={post.url}>Read more</a>
-  </article>
-))}
-</div>
-```
-
-`.glob()` only takes one parameter: a relative URL glob of which local files you'd like to import. It’s asynchronous, and returns an array of the exports from matching files.
-
-`.glob()` can't take variables or strings that interpolate them, as they aren't statically analyzable. (See [the imports guide](/en/guides/imports/#supported-values) for a workaround.) This is because `Astro.glob()` is a wrapper of Vite's [`import.meta.glob()`](https://vite.dev/guide/features.html#glob-import).
-
-:::note
-You can also use `import.meta.glob()` itself in your Astro project. You may want to do this when:
-- You need this feature in a file that isn't `.astro`, like an API route. `Astro.glob()` is only available in `.astro` files, while `import.meta.glob()` is available anywhere in the project.
-- You don't want to load each file immediately. `import.meta.glob()` can return functions that import the file content, rather than returning the content itself. Note that this import includes all styles and scripts for any imported files. These will be bundled and added to the page whether or not a file is actually used, as this is decided by static analysis, not at runtime.
-- You want access to each file's path. `import.meta.glob()` returns a map of a file's path to its content, while `Astro.glob()` returns a list of content.
-- You want to pass multiple patterns; for example, you want to add a "negative pattern" that filters out certain files. `import.meta.glob()` can optionally take an array of glob strings, rather than a single string.
-
-Read more in the [Vite documentation](https://vite.dev/guide/features.html#glob-import).
-:::
-#### Markdown Files
-
-Markdown files loaded with `Astro.glob()` return the following `MarkdownInstance` interface:
-
-```ts
-export interface MarkdownInstance<T extends Record<string, any>> {
-  /* Any data specified in this file's YAML frontmatter */
-	frontmatter: T;
-  /* The absolute file path of this file */
-	file: string;
-  /* The rendered path of this file */
-	url: string | undefined;
-  /* Astro Component that renders the contents of this file */
-	Content: AstroComponentFactory;
-  /** (Markdown only) Raw Markdown file content, excluding layout HTML and YAML frontmatter */
-	rawContent(): string;
-  /** (Markdown only) Markdown file compiled to HTML, excluding layout HTML */
-	compiledContent(): string;
-  /* Function that returns an array of the h1...h6 elements in this file */
-	getHeadings(): Promise<{ depth: number; slug: string; text: string }[]>;
-	default: AstroComponentFactory;
-}
-```
-
-You can optionally provide a type for the `frontmatter` variable using a TypeScript generic.
-
-```astro
----
-interface Frontmatter {
-  title: string;
-  description?: string;
-}
-const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
----
-
-<ul>
-  {posts.map(post => <li>{post.frontmatter.title}</li>)}
-</ul>
-```
-
-#### Astro Files
-
-Astro files have the following interface:
-
-```ts
-export interface AstroInstance {
-  /* The file path of this file */
-  file: string;
-  /* The URL for this file (if it is in the pages directory) */
-	url: string | undefined;
-	default: AstroComponentFactory;
-}
-```
-
-#### Other Files
-
-Other files may have various different interfaces, but `Astro.glob()` accepts a TypeScript generic if you know exactly what an unrecognized file type contains.
-
-```ts
----
-interface CustomDataFile {
-  default: Record<string, any>;
-}
-const data = await Astro.glob<CustomDataFile>('../data/**/*.js');
----
-```
-
-### `Astro.props`
-
-`Astro.props` is an object containing any values that have been passed as [component attributes](/en/basics/astro-components/#component-props). Layout components for `.md` and `.mdx` files receive frontmatter values as props.
+`props` is an object containing any values that have been passed as [component attributes](/en/basics/astro-components/#component-props). Layout components for `.md` and `.mdx` files receive frontmatter values as props.
 
 ```astro {3}
 ---
@@ -149,15 +42,36 @@ import Heading from '../components/Heading.astro';
 
 <ReadMore>Learn more about how [Markdown and MDX Layouts](/en/guides/markdown-content/#frontmatter-layout-property) handle props.</ReadMore>
 
-<ReadMore>Learn how to add [TypeScript type definitions for your props](/en/guides/typescript/#component-props).</ReadMore>
 
-### `Astro.params`
+`context.props` is an object containing any `props` passed from `getStaticPaths()`. Because `getStaticPaths()` is not used when building for SSR (server-side rendering), `context.props` is only available in static builds.
 
-`Astro.params` is an object containing the values of dynamic route segments matched for this request.
+```ts title="src/pages/posts/[id].json.ts"
+import type { APIContext } from 'astro';
+
+export function getStaticPaths() {
+  return [
+    { params: { id: '1' }, props: { author: 'Blu' } },
+    { params: { id: '2' }, props: { author: 'Erika' } },
+    { params: { id: '3' }, props: { author: 'Matthew' } }
+  ];
+}
+
+export function GET({ props }: APIContext) {
+	return new Response(
+    JSON.stringify({ author: props.author }),
+  );
+}
+```
+
+See also: [Data Passing with `props`](#data-passing-with-props)
+
+## `Astro.params`
+
+`params` is an object containing the values of dynamic route segments matched for this request.
 
 In static builds, this will be the `params` returned by `getStaticPaths()` used for prerendering [dynamic routes](/en/guides/routing/#dynamic-routes).
 
-```astro title="src/pages/posts/[id].astro"
+```astro title="src/pages/posts/[id].astro" "Astro.params"
 ---
 export function getStaticPaths() {
   return [
@@ -172,9 +86,28 @@ const { id } = Astro.params;
 <h1>{id}</h1>
 ```
 
+
+```ts title="src/pages/posts/[id].json.ts" "params.id"
+import type { APIContext } from 'astro';
+
+export function getStaticPaths() {
+  return [
+    { params: { id: '1' } },
+    { params: { id: '2' } },
+    { params: { id: '3' } }
+  ];
+}
+
+export function GET({ params }: APIContext) {
+	return new Response(
+    JSON.stringify({ id: params.id }),
+  );
+}
+```
+
 In SSR builds, this can be any value matching the path segments in the dynamic route pattern.
 
-```astro title="src/pages/posts/[id].astro"
+```astro title="src/pages/posts/[id].astro" "Astro.params"
 ---
 import { getPost } from '../api';
 
@@ -192,34 +125,145 @@ if (!post) {
 
 See also: [`params`](#params)
 
-### `Astro.request`
+## `Astro.url`
+
+<p>
+
+**Type:** `URL`<br />
+<Since v="1.0.0" />
+</p>
+
+`url` is a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object constructed from the current `request.url` URL string value. Useful for interacting with individual properties of the request URL, like pathname and origin. 
+
+Equivalent to doing `new URL(Astro.request.url)`.
+
+`url` will be `localhost` in dev mode if [site](/en/reference/configuration-reference/#site) is not configured for static sites, and for on-demand rendered sites using `server` or `hybrid` output.
+
+```astro
+<h1>The current URL is: {Astro.url}</h1>
+<h1>The current URL pathname is: {Astro.url.pathname}</h1>
+<h1>The current URL origin is: {Astro.url.origin}</h1>
+```
+
+You can also use `url` to create new URLs by passing it as an argument to [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).
+
+```astro title="src/pages/index.astro"
+---
+// Example: Construct a canonical URL using your production domain
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+// Example: Construct a URL for SEO meta tags using your current domain
+const socialImageURL = new URL('/images/preview.png', Astro.url);
+---
+<link rel="canonical" href={canonicalURL} />
+<meta property="og:image" content={socialImageURL} />
+```
+
+## `Astro.site`
+
+<p>
+
+**Type:** `URL | undefined`
+</p>
+
+`Astro.site` returns a `URL` made from `site` in your Astro config. If `site` in your Astro config isn't defined, `Astro.site` won't be defined.
+
+`context.site` returns a `URL` made from `site` in your Astro config. If undefined, this will return a URL generated from `localhost`.
+
+## `Astro.clientAddress`
+
+<p>
+
+**Type:** `string`<br />
+<Since v="1.0.0" />
+</p>
+
+`clientAddress` specifies the [IP address](https://en.wikipedia.org/wiki/IP_address) of the request. This property is only available for routes rendered on demand and cannot be used on prerendered pages.
+
+```astro
+---
+export const prerender = false;
+const ip = Astro.clientAddress;
+---
+
+<div>Your IP address is: <span class="address">{ ip }</span></div>
+```
+
+```ts
+export const prerender = false;
+import type { APIContext } from 'astro';
+
+export function GET({ clientAddress }: APIContext) {
+  return new Response(`Your IP address is: ${clientAddress}`);
+}
+```
+
+## `Astro.generator`
+
+<p>
+
+**Type:** `string`<br />
+<Since v="1.0.0" />
+</p>
+
+`generator` provides the current version of Astro your project is running. This is a convenient way to add a [`<meta name="generator">`](https://html.spec.whatwg.org/multipage/semantics.html#meta-generator) tag with your current version of Astro. It follows the format `"Astro v5.x.x"`.
+
+```astro mark="Astro.generator"
+<html>
+  <head>
+    <meta name="generator" content={Astro.generator} />
+  </head>
+  <body>
+    <footer>
+      <p>Built with <a href="https://astro.build">{Astro.generator}</a></p>
+    </footer>
+  </body>
+</html>
+```
+
+```ts title="src/pages/site-info.json.ts"
+import type { APIContext } from 'astro';
+
+export function GET({ generator, site }: APIContext) {
+  const body = JSON.stringify({ generator, site });
+  return new Response(body);
+}
+```
+
+## `Astro.request`
 
 <p>
 
 **Type:** `Request`
 </p>
 
-`Astro.request` is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. It can be used to get the `url`, `headers`, `method`, and even body of the request. 
+`request` is a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. It can be used to get the `url`, `headers`, `method`, and even body of the request. 
 
-```astro
+```astro wrap title="src/pages/index.astro" "Astro.request"
 <p>Received a {Astro.request.method} request to "{Astro.request.url}".</p>
-<p>Received request headers: <code>{JSON.stringify(Object.fromEntries(Astro.request.headers))}</code>
+<p>Received request headers:</p>
+<p><code>{JSON.stringify(Object.fromEntries(Astro.request.headers))}</code></p>
 ```
 
-See also: [`Astro.url`](#astrourl)
+```ts "request"
+import type { APIContext } from 'astro';
+
+export function GET({ request }: APIContext) {
+  return new Response(`Hello ${request.url}`);
+}
+```
 
 :::note
-With the default `output: 'static'` option, `Astro.request.url` does not contain search parameters, like `?foo=bar`, as it's not possible to determine them ahead of time during static builds. However in `output: 'server'` mode, `Astro.request.url` does contain search parameters as it can be determined from a server request.
+On prerendered pages, `request.url` does not contain search parameters, like `?foo=bar`, as it's not possible to determine them ahead of time during static builds. However, `request.url` does contain search parameters for pages rendered on-demand as they can be determined from a server request.
 :::
 
-### `Astro.response`
+## `Astro.response`
 
 <p>
 
 **Type:** `ResponseInit & { readonly headers: Headers }`
 </p>
 
-`Astro.response` is a standard `ResponseInit` object. It has the following structure. 
+`response` is a standard `ResponseInit` object. It has the following structure. 
 
  - `status`: The numeric status code of the response, e.g., `200`.
  - `statusText`: The status message associated with the status code, e.g., `'OK'`.
@@ -245,7 +289,7 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 ---
 ```
 
-### `Astro.cookies`
+## `Astro.cookies`
 
 <p>
 
@@ -253,9 +297,9 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 <Since v="1.4.0" />
 </p>
 
-`Astro.cookies` contains utilities for reading and manipulating cookies in [server-side rendering](/en/guides/on-demand-rendering/) mode.
+`cookies` contains utilities for reading and manipulating cookies in [server-side rendering](/en/guides/server-side-rendering/) mode.
 
-##### `get`
+### `get`
 
 <p>
 
@@ -264,7 +308,7 @@ Astro.response.headers.set('Set-Cookie', 'a=b; Path=/;');
 
 Gets the cookie as an [`AstroCookie`](#astrocookie) object, which contains the `value` and utility functions for converting the cookie to non-string types.
 
-##### `has`
+### `has`
 
 <p>
 
@@ -273,7 +317,7 @@ Gets the cookie as an [`AstroCookie`](#astrocookie) object, which contains the `
 
 Whether this cookie exists. If the cookie has been set via `Astro.cookies.set()` this will return true, otherwise it will check cookies in the `Astro.request`.
 
-##### `set`
+### `set`
 
 <p>
 
@@ -282,7 +326,7 @@ Whether this cookie exists. If the cookie has been set via `Astro.cookies.set()`
 
 Sets the cookie `key` to the given value. This will attempt to convert the cookie value to a string. Options provide ways to set [cookie features](https://www.npmjs.com/package/cookie#options-1), such as the `maxAge` or `httpOnly`.
 
-##### `delete`
+### `delete`
 
 <p>
 
@@ -293,7 +337,7 @@ Invalidates a cookie by setting the expiration date in the past (0 in Unix time)
 
 Once a cookie is "deleted" (expired), `Astro.cookies.has()` will return `false` and `Astro.cookies.get()` will return an [`AstroCookie`](#astrocookie) with a `value` of `undefined`. Options available when deleting a cookie are: `domain`, `path`, `httpOnly`, `sameSite`, and `secure`.
 
-##### `merge`
+### `merge`
 
 <p>
 
@@ -302,7 +346,7 @@ Once a cookie is "deleted" (expired), `Astro.cookies.has()` will return `false` 
 
 Merges a new `AstroCookies` instance into the current instance. Any new cookies will be added to the current instance and any cookies with the same name will overwrite existing values.
 
-##### `headers`
+### `headers`
 
 <p>
 
@@ -443,14 +487,15 @@ If true, the cookie is only set on https sites.
 
 Allows customizing how the cookie is serialized.
 
-### `Astro.redirect()`
+## `Astro.redirect()`
 
 <p>
 
 **Type:** `(path: string, status?: number) => Response`
+<Since v="1.5.0" />
 </p>
 
-Allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) as a second parameter.
+`redirect()` returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object that allows you to redirect to another page, and optionally provide an [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages) as a second parameter.
 
 A page (and not a child component) must `return` the result of `Astro.redirect()` for the redirect to occur.
 
@@ -473,7 +518,16 @@ if (!isLoggedIn(cookie)) {
 ---
 ```
 
-### `Astro.rewrite()`
+```ts
+import type { APIContext } from 'astro';
+
+export function GET({ redirect }: APIContext) {
+  return redirect('/login', 302);
+}
+```
+
+
+## `Astro.rewrite()`
 
 <p>
 
@@ -481,7 +535,7 @@ if (!isLoggedIn(cookie)) {
 <Since v="4.13.0" />
 </p>
 
-Allows you to serve content from a different URL or path without redirecting the browser to a new page. 
+`rewrite()` allows you to serve content from a different URL or path without redirecting the browser to a new page. 
 
 The method accepts either a string, a `URL`, or a `Request` for the location of the path.
 
@@ -493,12 +547,28 @@ return Astro.rewrite("/login")
 ---
 ```
 
+```ts
+import type { APIContext } from 'astro';
+
+export function GET({ rewrite }: APIContext) {
+  return rewrite('/login');
+}
+```
+
 Use a `URL` type when you need to construct the URL path for the rewrite. The following example renders a page's parent path by creating a new URL from the relative  `"../"` path:
 
 ```astro title="src/pages/blog/index.astro"
 ---
 return Astro.rewrite(new URL("../", Astro.url))
 ---
+```
+
+```ts
+import type { APIContext } from 'astro';
+
+export function GET({ rewrite }: APIContext) {
+  return rewrite(new URL("../", Astro.url));
+}
 ```
 
 Use a `Request` type for complete control of the `Request` sent to the server for the new path. The following example sends a request to render the parent page while also providing headers:
@@ -512,576 +582,6 @@ return Astro.rewrite(new Request(new URL("../", Astro.url), {
 }))
 ---
 ```
-
-### `Astro.url`
-
-<p>
-
-**Type:** `URL`<br />
-<Since v="1.0.0-rc" />
-</p>
-
-A [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object constructed from the current `Astro.request.url` URL string value. Useful for interacting with individual properties of the request URL, like pathname and origin. 
-
-Equivalent to doing `new URL(Astro.request.url)`.
-
-`Astro.url` will be `localhost` in dev mode if [site](/en/reference/configuration-reference/#site) is not configured for static sites, and for on-demand rendered routes.
-
-```astro
-<h1>The current URL is: {Astro.url}</h1>
-<h1>The current URL pathname is: {Astro.url.pathname}</h1>
-<h1>The current URL origin is: {Astro.url.origin}</h1>
-```
-
-You can also use `Astro.url` to create new URLs by passing it as an argument to [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL).
-
-```astro title="src/pages/index.astro"
----
-// Example: Construct a canonical URL using your production domain
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-// Example: Construct a URL for SEO meta tags using your current domain
-const socialImageURL = new URL('/images/preview.png', Astro.url);
----
-<link rel="canonical" href={canonicalURL} />
-<meta property="og:image" content={socialImageURL} />
-```
-
-### `Astro.clientAddress`
-
-<p>
-
-**Type:** `string`<br />
-<Since v="1.0.0-rc" />
-</p>
-
-Specifies the [IP address](https://en.wikipedia.org/wiki/IP_address) of the request. This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
-
-```astro
----
-const ip = Astro.clientAddress;
----
-
-<div>Your IP address is: <span class="address">{ ip }</span></div>
-```
-
-### `Astro.site`
-
-<p>
-
-**Type:** `URL | undefined`
-</p>
-
-`Astro.site` returns a `URL` made from `site` in your Astro config. If `site` in your Astro config isn't defined, `Astro.site` won't be defined.
-
-### `Astro.generator`
-
-<p>
-
-**Type:** `string`<br />
-<Since v="1.0.0" />
-</p>
-
-`Astro.generator` is a convenient way to add a [`<meta name="generator">`](https://html.spec.whatwg.org/multipage/semantics.html#meta-generator) tag with your current version of Astro. It follows the format `"Astro v1.x.x"`.
-
-```astro mark="Astro.generator"
-<html>
-  <head>
-    <meta name="generator" content={Astro.generator} />
-  </head>
-  <body>
-    <footer>
-      <p>Built with <a href="https://astro.build">{Astro.generator}</a></p>
-    </footer>
-  </body>
-</html>
-```
-
-### `Astro.slots`
-
-`Astro.slots` contains utility functions for modifying an Astro component's slotted children.
-
-#### `Astro.slots.has()`
-
-<p>
-
-**Type:** `(slotName: string) => boolean`
-</p>
-
-You can check whether content for a specific slot name exists with `Astro.slots.has()`. This can be useful when you want to wrap slot contents, but only want to render the wrapper elements when the slot is being used.
-
-```astro  title="src/pages/index.astro"
----
----
-<slot />
-
-{Astro.slots.has('more') && (
-  <aside>
-    <h2>More</h2>
-    <slot name="more" />
-  </aside>
-)}
-```
-
-#### `Astro.slots.render()`
-
-<p>
-
-**Type:** `(slotName: string, args?: any[]) => Promise<string>`
-</p>
-
-You can asynchronously render the contents of a slot to a string of HTML using `Astro.slots.render()`.
-
-```astro
----
-const html = await Astro.slots.render('default');
----
-<Fragment set:html={html} />
-```
-
-:::note
-This is for advanced use cases! In most circumstances, it is simpler to render slot contents with [the `<slot />` element](/en/basics/astro-components/#slots).
-:::
-
-`Astro.slots.render()` optionally accepts a second argument: an array of parameters that will be forwarded to any function children. This can be useful for custom utility components.
-
-For example, this `<Shout />` component converts its `message` prop to uppercase and passes it to the default slot:
-
-```astro title="src/components/Shout.astro" "await Astro.slots.render('default', [message])"
----
-const message = Astro.props.message.toUpperCase();
-let html = '';
-if (Astro.slots.has('default')) {
-  html = await Astro.slots.render('default', [message]);
-}
----
-<Fragment set:html={html} />
-```
-
-A callback function passed as `<Shout />`’s child will receive the all-caps `message` parameter:
-
-```astro title="src/pages/index.astro"
----
-import Shout from "../components/Shout.astro";
----
-<Shout message="slots!">
-  {(message) => <div>{message}</div>}
-</Shout>
-
-<!-- renders as <div>SLOTS!</div> -->
-```
-
-Callback functions can be passed to named slots inside a wrapping HTML element tag with a `slot` attribute. This element is only used to transfer the callback to a named slot and will not be rendered onto the page.
-
-```astro
-<Shout message="slots!">
-  <fragment slot="message">
-    {(message) => <div>{message}</div>}
-  </fragment>
-</Shout>
-```
-
-Use a standard HTML element for the wrapping tag, or any lower case tag (e.g. `<fragment>` instead of `<Fragment />`) that will not be interpreted as a component.  Do not use the HTML `<slot>` element as this will be interpreted as an Astro slot.
-
-### `Astro.self`
-
-`Astro.self` allows Astro components to be recursively called. This behaviour lets you render an Astro component from within itself by using `<Astro.self>` in the component template. This can be helpful for iterating over large data stores and nested data-structures.
-
-```astro
----
-// NestedList.astro
-const { items } = Astro.props;
----
-<ul class="nested-list">
-  {items.map((item) => (
-    <li>
-      <!-- If there is a nested data-structure we render `<Astro.self>` -->
-      <!-- and can pass props through with the recursive call -->
-      {Array.isArray(item) ? (
-        <Astro.self items={item} />
-      ) : (
-        item
-      )}
-    </li>
-  ))}
-</ul>
-```
-
-This component could then be used like this:
-
-```astro
----
-import NestedList from './NestedList.astro';
----
-<NestedList items={['A', ['B', 'C'], 'D']} />
-```
-
-And would render HTML like this:
-
-```html
-<ul class="nested-list">
-  <li>A</li>
-  <li>
-    <ul class="nested-list">
-      <li>B</li>
-      <li>C</li>
-    </ul>
-  </li>
-  <li>D</li>
-</ul>
-```
-
-
-### `Astro.locals`
-
-<p>
-
-<Since v="2.4.0" />
-</p>
-
-`Astro.locals` is an object containing any values from the [`context.locals`](#contextlocals) object from a middleware. Use this to access data returned by middleware in your `.astro` files.
-
-```astro title="src/pages/Orders.astro"
----
-const title = Astro.locals.welcomeTitle();
-const orders = Array.from(Astro.locals.orders.entries());
----
-<h1>{title}</h1>
-<ul>
-    {orders.map(order => {
-        return <li>{/* do something with each order */}</li>
-    })}
-</ul>
-```
-
-### `Astro.preferredLocale`
-
-<p>
-
-**Type:** `string | undefined`<br />
-<Since v="3.5.0" />
-</p>
-
-`Astro.preferredLocale` is a computed value that represents the preferred locale of the user. 
-
-It is computed by checking the configured locales in your `i18n.locales` array and locales supported by the users's browser via the header `Accept-Language`. This value is `undefined` if no such match exists.
-
-This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
-
-### `Astro.preferredLocaleList`
-
-<p>
-
-**Type:** `string[] | undefined`<br />
-<Since v="3.5.0" />
-</p>
-
-`Astro.preferredLocaleList` represents the array of all locales that are both requested by the browser and supported by your website. This produces a list of all compatible languages between your site and your visitor. 
-
-If none of the browser's requested languages are found in your locales array, then the value is `[]`: you do not support any of your visitor's preferred locales.
-
-If the browser does not specify any preferred languages, then this value will be [`i18n.locales`](/en/reference/configuration-reference/#i18nlocales): all of your supported locales will be considered equally preferred by a visitor with no preferences. 
-
-This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
-
-### `Astro.currentLocale`
-
-<p>
-
-**Type:** `string | undefined`<br />
-<Since v="3.5.6" />
-</p>
-
-The locale computed from the current URL, using the syntax specified in your `locales` configuration. If the URL does not contain a `/[locale]/` prefix, then the value will default to `i18n.defaultLocale`.
-
-### `Astro.getActionResult()`
-
-<p>
-**Type:** `(action: TAction) => ActionReturnType<TAction> | undefined`<br />
-<Since v="4.15.0" />
-</p>
-
-`Astro.getActionResult()` is a function that returns the result of an [Action](/en/guides/actions/) submission. This accepts an action function as an argument (e.g. `actions.logout`) and returns a `data` or `error` object when a submission is received. Otherwise, it will return `undefined`.
-
-```astro title="src/pages/index.astro"
----
-import { actions } from 'astro:actions';
-
-const result = Astro.getActionResult(actions.logout);
----
-
-<form action={actions.logout}>
-  <button type="submit">Log out</button>
-</form>
-{result?.error && <p>Failed to log out. Please try again.</p>}
-```
-
-### `Astro.callAction()`
-
-<p>
-<Since v="4.15.0" />
-</p>
-
-`Astro.callAction()` is a function used to call an Action handler directly from your Astro component. This function accepts an Action function as the first argument (e.g. `actions.logout`) and any input that action receives as the second argument. It returns the result of the action as a promise.
-
-```astro title="src/pages/index.astro"
----
-import { actions } from 'astro:actions';
-
-const { data, error } = await Astro.callAction(actions.logout, { userId: '123' });
----
-```
-
-### `Astro.routePattern`
-
-<p>
-
-**Type**: `string`<br />
-<Since v="5.0.0" />
-</p>
-
-The route pattern responsible for generating the current page or route. In file-based routing, this resembles the file path in your project used to create the route. When integrations create routes for your project, `context.routePattern` is identical to the value for `injectRoute.pattern`.
-	
-The value will start with a leading slash and look similar to the path of a page component relative to your `srcDir/pages/` folder without a file extension.
-	
-For example, the file `src/pages/en/blog/[slug].astro` will return `/en/blog/[slug]` for `context.routePattern`. Every page on your site generated by that file (e.g. `/en/blog/post-1/`, `/en/blog/post-2/`, etc.) shares the same value for `context.routePattern`. In the case of `index.*` routes, the route pattern will not include the word "index." For example, `src/pages/index.astro` will return `/`.
-	
-You can use this property to understand which route is rendering your component. This allows you to target or analyze similarly-generated page URLs together. For example, you can use it to conditionally render certain information, or collect metrics about which routes are slower.
-
-See also: [`context.routePattern`](#contextroutepattern)
-
-### `Astro.isPrerendered`
-
-<p>
-
-**Type**: `boolean`<br />
-<Since v="5.0.0" />
-</p>
-
-A boolean representing whether or not the current page is prerendered.
-
-You can use this property to run conditional logic in middleware, for example, to avoid accessing headers in prerendered pages.
-
-See also: [`context.isPrerendered`](#contextisprerendered)
-
-## Endpoint Context
-
-[Endpoint functions](/en/guides/endpoints/) receive a context object as the first parameter. It mirrors many of the `Astro` global properties.
-
-```ts title="endpoint.json.ts"
-import type { APIContext } from 'astro';
-
-export function GET(context: APIContext) {
-  // ...
-}
-```
-
-### `context.params`
-
-`context.params` is an object containing the values of dynamic route segments matched for this request.
-
-In static builds, this will be the `params` returned by `getStaticPaths()` used for prerendering [dynamic routes](/en/guides/routing/#dynamic-routes).
-
-In SSR builds, this can be any value matching the path segments in the dynamic route pattern.
-
-```ts title="src/pages/posts/[id].json.ts"
-import type { APIContext } from 'astro';
-
-export function getStaticPaths() {
-  return [
-    { params: { id: '1' } },
-    { params: { id: '2' } },
-    { params: { id: '3' } }
-  ];
-}
-
-export function GET({ params }: APIContext) {
-	return new Response(
-    JSON.stringify({ id: params.id }),
-  );
-}
-```
-
-See also: [`params`](#params)
-
-### `context.props`
-
-<p>
-
-<Since v="1.5.0" />
-</p>
-
-`context.props` is an object containing any `props` passed from `getStaticPaths()`. Because `getStaticPaths()` is not used when building for SSR (server-side rendering), `context.props` is only available in static builds.
-
-```ts title="src/pages/posts/[id].json.ts"
-import type { APIContext } from 'astro';
-
-export function getStaticPaths() {
-  return [
-    { params: { id: '1' }, props: { author: 'Blu' } },
-    { params: { id: '2' }, props: { author: 'Erika' } },
-    { params: { id: '3' }, props: { author: 'Matthew' } }
-  ];
-}
-
-export function GET({ props }: APIContext) {
-	return new Response(
-    JSON.stringify({ author: props.author }),
-  );
-}
-```
-
-See also: [Data Passing with `props`](#data-passing-with-props)
-
-### `context.request`
-
-<p>
-
-**Type:** `Request`
-</p>
-
-A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object. It can be used to get the `url`, `headers`, `method`, and even body of the request.
-
-```ts
-import type { APIContext } from 'astro';
-
-export function GET({ request }: APIContext) {
-  return new Response(`Hello ${request.url}`);
-}
-```
-
-See also: [Astro.request](#astrorequest)
-
-### `context.cookies`
-
-<p>
-
-**Type:** `AstroCookies`
-</p>
-
-`context.cookies` contains utilities for reading and manipulating cookies.
-
-See also: [Astro.cookies](#astrocookies)
-
-### `context.url`
-
-<p>
-
-**Type:** `URL`<br />
-<Since v="1.5.0" />
-</p>
-
-A [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object constructed from the current `context.request.url` URL string value.
-
-See also: [Astro.url](#astrourl)
-
-### `context.clientAddress`
-
-<p>
-
-**Type:** `string`<br />
-<Since v="1.5.0" />
-</p>
-
-Specifies the [IP address](https://en.wikipedia.org/wiki/IP_address) of the request. This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
-
-```ts
-import type { APIContext } from 'astro';
-
-export function GET({ clientAddress }: APIContext) {
-  return new Response(`Your IP address is: ${clientAddress}`);
-}
-```
-
-See also: [Astro.clientAddress](#astroclientaddress)
-
-
-### `context.site`
-
-<p>
-
-**Type:** `URL | undefined`<br />
-<Since v="1.5.0" />
-</p>
-
-`context.site` returns a `URL` made from `site` in your Astro config. If undefined, this will return a URL generated from `localhost`.
-
-See also: [Astro.site](#astrosite)
-
-### `context.generator`
-
-<p>
-
-**Type:** `string`<br />
-<Since v="1.5.0" />
-</p>
-
-`context.generator` is a convenient way to indicate the version of Astro your project is running. It follows the format `"Astro v1.x.x"`.
-
-```ts title="src/pages/site-info.json.ts"
-import type { APIContext } from 'astro';
-
-export function GET({ generator, site }: APIContext) {
-  const body = JSON.stringify({ generator, site });
-  return new Response(body);
-}
-```
-
-See also: [Astro.generator](#astrogenerator)
-
-### `context.redirect()`
-
-<p>
-
-**Type:** `(path: string, status?: number) => Response`<br />
-<Since v="1.5.0" />
-</p>
-
-`context.redirect()` returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object that allows you to redirect to another page. This function is only available when building for SSR (server-side rendering) and should not be used for static sites.
-
-```ts
-import type { APIContext } from 'astro';
-
-export function GET({ redirect }: APIContext) {
-  return redirect('/login', 302);
-}
-```
-
-See also: [`Astro.redirect()`](#astroredirect)
-
-### `context.rewrite()`
-
-<p>
-
-**Type:** `(rewritePayload: string | URL | Request) => Promise<Response>`<br />
-<Since v="4.13.0" />
-</p>
-
-Allows you to serve content from a different URL or path without redirecting the browser to a new page. 
-
-The method accepts either a string, a `URL`, or a `Request` for the location of the path.
-
-Use a string to provide an explicit path:
-
-```ts
-import type { APIContext } from 'astro';
-
-export function GET({ rewrite }: APIContext) {
-  return rewrite('/login');
-}
-```
-
-Use a `URL` type when you need to construct the URL path for the rewrite. The following example renders a page's parent path by creating a new URL from the relative  `"../"` path:
-
-```ts
-import type { APIContext } from 'astro';
-
-export function GET({ rewrite }: APIContext) {
-  return rewrite(new URL("../", Astro.url));
-}
-```
-
-Use a `Request` type for complete control of the `Request` sent to the server for the new path. The following example sends a request to render the parent page while also providing headers:
-
 ```ts
 import type { APIContext } from 'astro';
 
@@ -1094,13 +594,15 @@ export function GET({ rewrite }: APIContext) {
 }
 ```
 
-See also: [`Astro.rewrite()`](#astrorewrite)
 
-### `context.locals`
+## `Astro.locals`
 
-<p><Since v="2.4.0" /></p>
+<p>
 
-`context.locals` is an object used to store and access arbitrary information during the lifecycle of a request.
+<Since v="2.4.0" />
+</p>
+
+`locals` is an  object used to store and access arbitrary information during the lifecycle of a request. `Astro.locals` is an object containing any values from the `context.locals` object from a middleware. Use this to access data returned by middleware in your `.astro` files.
 
 Middleware functions can read and write the values of `context.locals`:
 
@@ -1125,37 +627,99 @@ export function GET({ locals }: APIContext) {
 }
 ```
 
-:::note
-The value of `locals` cannot be overridden at run time. Doing so would risk wiping out all the information stored by the user.  Astro performs checks and will throw an error if `locals` are overridden.
-:::
+Astro components can only read information from `context.locals`:
+```astro title="src/pages/Orders.astro"
+---
+const title = Astro.locals.welcomeTitle();
+const orders = Array.from(Astro.locals.orders.entries());
+---
+<h1>{title}</h1>
+<ul>
+    {orders.map(order => {
+        return <li>{/* do something with each order */}</li>
+    })}
+</ul>
+```
 
-See also: [`Astro.locals`](#astrolocals)
-
-### `context.getActionResult()`
+## `Astro.preferredLocale`
 
 <p>
 
+**Type:** `string | undefined`<br />
+<Since v="3.5.0" />
+</p>
+
+`Astro.preferredLocale` is a computed value that represents the preferred locale of the user. 
+
+It is computed by checking the configured locales in your `i18n.locales` array and locales supported by the users's browser via the header `Accept-Language`. This value is `undefined` if no such match exists.
+
+This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
+
+## `Astro.preferredLocaleList`
+
+<p>
+
+**Type:** `string[] | undefined`<br />
+<Since v="3.5.0" />
+</p>
+
+`preferredLocaleList` represents the array of all locales that are both requested by the browser and supported by your website. This produces a list of all compatible languages between your site and your visitor. 
+
+If none of the browser's requested languages are found in your locales array, then the value is `[]`: you do not support any of your visitor's preferred locales.
+
+If the browser does not specify any preferred languages, then this value will be [`i18n.locales`](/en/reference/configuration-reference/#i18nlocales): all of your supported locales will be considered equally preferred by a visitor with no preferences. 
+
+This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
+
+## `Astro.currentLocale`
+
+<p>
+
+**Type:** `string | undefined`<br />
+<Since v="3.5.6" />
+</p>
+
+The locale computed from the current URL, using the syntax specified in your `locales` configuration. If the URL does not contain a `/[locale]/` prefix, then the value will default to `i18n.defaultLocale`.
+
+## `Astro.getActionResult()`
+
+<p>
 **Type:** `(action: TAction) => ActionReturnType<TAction> | undefined`<br />
 <Since v="4.15.0" />
 </p>
 
-`context.getActionResult()` is a function that returns the result of an [Action](/en/guides/actions/) submission. This accepts an action function as an argument (e.g. `actions.logout`), and returns a `data` or `error` object when a submission is received. Otherwise, it will return `undefined`.
+`getActionResult()` is a function that returns the result of an [Action](/en/guides/actions/) submission. This accepts an action function as an argument (e.g. `actions.logout`) and returns a `data` or `error` object when a submission is received. Otherwise, it will return `undefined`.
 
+```astro title="src/pages/index.astro"
+---
+import { actions } from 'astro:actions';
 
-See also [`Astro.getActionResult()`](#astrogetactionresult)
+const result = Astro.getActionResult(actions.logout);
+---
 
-### `context.callAction()`
+<form action={actions.logout}>
+  <button type="submit">Log out</button>
+</form>
+{result?.error && <p>Failed to log out. Please try again.</p>}
+```
+
+## `Astro.callAction()`
 
 <p>
 <Since v="4.15.0" />
 </p>
 
-`context.callAction()` is a function used to call an Action handler directly from your Astro component. This function accepts an Action function as the first argument (e.g. `actions.logout`) and any input that action receives as the second argument. It returns the result of the action as a promise.
+`callAction()` is a function used to call an Action handler directly from your Astro component. This function accepts an Action function as the first argument (e.g. `actions.logout`) and any input that action receives as the second argument. It returns the result of the action as a promise.
 
+```astro title="src/pages/index.astro"
+---
+import { actions } from 'astro:actions';
 
-See also [`Astro.callAction()`](#astrocallaction)
+const { data, error } = await Astro.callAction(actions.logout, { userId: '123' });
+---
+```
 
-### `context.routePattern`
+## `Astro.routePattern`
 
 <p>
 
@@ -1171,9 +735,7 @@ For example, the file `src/pages/en/blog/[slug].astro` will return `/en/blog/[sl
 
 You can use this property to understand which route is rendering your component. This allows you to target or analyze similarly-generated page URLs together. For example, you can use it to conditionally render certain information, or collect metrics about which routes are slower.
 
-See also: [`Astro.routePattern`](#astroroutepattern)
-
-### `context.isPrerendered`
+## `Astro.isPrerendered`
 
 <p>
 
@@ -1185,7 +747,119 @@ A boolean representing whether or not the current page is prerendered.
 
 You can use this property to run conditional logic in middleware, for example, to avoid accessing headers in prerendered pages.
 
-See also: [`Astro.isPrerendered`](#astroisprerendered)
+## `Astro.glob()`
+
+:::caution[Deprecated in v5.0]
+Use [Vite's `import.meta.glob`](https://vite.dev/guide/features.html#glob-import) to query project files. 
+
+`Astro.glob('../pages/post/*.md')` can be replaced with:
+
+`Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));`
+
+See the [imports guide](/en/guides/imports/#importmetaglob) for more information and usage.
+:::
+
+`Astro.glob()` is a way to load many local files into your static site setup.
+
+```astro
+---
+// src/components/my-component.astro
+const posts = await Astro.glob('../pages/post/*.md'); // returns an array of posts that live at ./src/pages/post/*.md
+---
+
+<div>
+{posts.slice(0, 3).map((post) => (
+  <article>
+    <h2>{post.frontmatter.title}</h2>
+    <p>{post.frontmatter.description}</p>
+    <a href={post.url}>Read more</a>
+  </article>
+))}
+</div>
+```
+
+`.glob()` only takes one parameter: a relative URL glob of which local files you'd like to import. It’s asynchronous, and returns an array of the exports from matching files.
+
+`.glob()` can't take variables or strings that interpolate them, as they aren't statically analyzable. (See [the imports guide](/en/guides/imports/#supported-values) for a workaround.) This is because `Astro.glob()` is a wrapper of Vite's [`import.meta.glob()`](https://vite.dev/guide/features.html#glob-import).
+
+:::note
+You can also use `import.meta.glob()` itself in your Astro project. You may want to do this when:
+- You need this feature in a file that isn't `.astro`, like an API route. `Astro.glob()` is only available in `.astro` files, while `import.meta.glob()` is available anywhere in the project.
+- You don't want to load each file immediately. `import.meta.glob()` can return functions that import the file content, rather than returning the content itself. Note that this import includes all styles and scripts for any imported files. These will be bundled and added to the page whether or not a file is actually used, as this is decided by static analysis, not at runtime.
+- You want access to each file's path. `import.meta.glob()` returns a map of a file's path to its content, while `Astro.glob()` returns a list of content.
+- You want to pass multiple patterns; for example, you want to add a "negative pattern" that filters out certain files. `import.meta.glob()` can optionally take an array of glob strings, rather than a single string.
+
+Read more in the [Vite documentation](https://vite.dev/guide/features.html#glob-import).
+:::
+
+#### Markdown Files
+
+Markdown files loaded with `Astro.glob()` return the following `MarkdownInstance` interface:
+
+```ts
+export interface MarkdownInstance<T extends Record<string, any>> {
+  /* Any data specified in this file's YAML frontmatter */
+	frontmatter: T;
+  /* The absolute file path of this file */
+	file: string;
+  /* The rendered path of this file */
+	url: string | undefined;
+  /* Astro Component that renders the contents of this file */
+	Content: AstroComponentFactory;
+  /** (Markdown only) Raw Markdown file content, excluding layout HTML and YAML frontmatter */
+	rawContent(): string;
+  /** (Markdown only) Markdown file compiled to HTML, excluding layout HTML */
+	compiledContent(): string;
+  /* Function that returns an array of the h1...h6 elements in this file */
+	getHeadings(): Promise<{ depth: number; slug: string; text: string }[]>;
+	default: AstroComponentFactory;
+}
+```
+
+You can optionally provide a type for the `frontmatter` variable using a TypeScript generic.
+
+```astro
+---
+interface Frontmatter {
+  title: string;
+  description?: string;
+}
+const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
+---
+
+<ul>
+  {posts.map(post => <li>{post.frontmatter.title}</li>)}
+</ul>
+```
+
+#### Astro Files
+
+Astro files have the following interface:
+
+```ts
+export interface AstroInstance {
+  /* The file path of this file */
+  file: string;
+  /* The URL for this file (if it is in the pages directory) */
+	url: string | undefined;
+	default: AstroComponentFactory;
+}
+```
+
+#### Other Files
+
+Other files may have various different interfaces, but `Astro.glob()` accepts a TypeScript generic if you know exactly what an unrecognized file type contains.
+
+```ts
+---
+interface CustomDataFile {
+  default: Record<string, any>;
+}
+const data = await Astro.glob<CustomDataFile>('../data/**/*.js');
+---
+```
+
+
 
 ## `getStaticPaths()`
 
@@ -1467,14 +1141,140 @@ Get the URL of the first page (will be `undefined` if on page 1). If a value is 
 
 Get the URL of the last page (will be `undefined` if no more pages). If a value is set for [`base`](/en/reference/configuration-reference/#base), prepend the base path to the URL.
 
-## `import.meta`
+## Component syntax
 
-All ESM modules include a `import.meta` property. Astro adds `import.meta.env` through [Vite](https://vite.dev/guide/env-and-mode.html).
+### `Astro.slots`
 
-**`import.meta.env.SSR`** can be used to know when rendering on the server. Sometimes you might want different logic, like a component that should only be rendered in the client:
+`Astro.slots` contains utility functions for modifying an Astro component's slotted children.
 
-```jsx
-export default function () {
-  return import.meta.env.SSR ? <div class="spinner"></div> : <FancyComponent />;
-}
+#### `Astro.slots.has()`
+
+<p>
+
+**Type:** `(slotName: string) => boolean`
+</p>
+
+You can check whether content for a specific slot name exists with `Astro.slots.has()`. This can be useful when you want to wrap slot contents, but only want to render the wrapper elements when the slot is being used.
+
+```astro  title="src/pages/index.astro"
+---
+---
+<slot />
+
+{Astro.slots.has('more') && (
+  <aside>
+    <h2>More</h2>
+    <slot name="more" />
+  </aside>
+)}
 ```
+
+#### `Astro.slots.render()`
+
+<p>
+
+**Type:** `(slotName: string, args?: any[]) => Promise<string>`
+</p>
+
+You can asynchronously render the contents of a slot to a string of HTML using `Astro.slots.render()`.
+
+```astro
+---
+const html = await Astro.slots.render('default');
+---
+<Fragment set:html={html} />
+```
+
+:::note
+This is for advanced use cases! In most circumstances, it is simpler to render slot contents with [the `<slot />` element](/en/basics/astro-components/#slots).
+:::
+
+`Astro.slots.render()` optionally accepts a second argument: an array of parameters that will be forwarded to any function children. This can be useful for custom utility components.
+
+For example, this `<Shout />` component converts its `message` prop to uppercase and passes it to the default slot:
+
+```astro title="src/components/Shout.astro" "await Astro.slots.render('default', [message])"
+---
+const message = Astro.props.message.toUpperCase();
+let html = '';
+if (Astro.slots.has('default')) {
+  html = await Astro.slots.render('default', [message]);
+}
+---
+<Fragment set:html={html} />
+```
+
+A callback function passed as `<Shout />`’s child will receive the all-caps `message` parameter:
+
+```astro title="src/pages/index.astro"
+---
+import Shout from "../components/Shout.astro";
+---
+<Shout message="slots!">
+  {(message) => <div>{message}</div>}
+</Shout>
+
+<!-- renders as <div>SLOTS!</div> -->
+```
+
+Callback functions can be passed to named slots inside a wrapping HTML element tag with a `slot` attribute. This element is only used to transfer the callback to a named slot and will not be rendered onto the page.
+
+```astro
+<Shout message="slots!">
+  <fragment slot="message">
+    {(message) => <div>{message}</div>}
+  </fragment>
+</Shout>
+```
+
+Use a standard HTML element for the wrapping tag, or any lower case tag (e.g. `<fragment>` instead of `<Fragment />`) that will not be interpreted as a component.  Do not use the HTML `<slot>` element as this will be interpreted as an Astro slot.
+
+### `Astro.self`
+
+`Astro.self` allows Astro components to be recursively called. This behaviour lets you render an Astro component from within itself by using `<Astro.self>` in the component template. This can be helpful for iterating over large data stores and nested data-structures.
+
+```astro
+---
+// NestedList.astro
+const { items } = Astro.props;
+---
+<ul class="nested-list">
+  {items.map((item) => (
+    <li>
+      <!-- If there is a nested data-structure we render `<Astro.self>` -->
+      <!-- and can pass props through with the recursive call -->
+      {Array.isArray(item) ? (
+        <Astro.self items={item} />
+      ) : (
+        item
+      )}
+    </li>
+  ))}
+</ul>
+```
+
+This component could then be used like this:
+
+```astro
+---
+import NestedList from './NestedList.astro';
+---
+<NestedList items={['A', ['B', 'C'], 'D']} />
+```
+
+And would render HTML like this:
+
+```html
+<ul class="nested-list">
+  <li>A</li>
+  <li>
+    <ul class="nested-list">
+      <li>B</li>
+      <li>C</li>
+    </ul>
+  </li>
+  <li>D</li>
+</ul>
+```
+
+-----


### PR DESCRIPTION
#### Description (required)

WIP - experiment combining the `Astro.global` and `context` object entries since several are duplicates or only links up to the global entry anyway.

This also makes each entry more visible to see where we haven't sufficiently documented.

Notably:

Is this still the right page for:

- `getStaticPaths()` ?
- `Astro.slots` and `Astro.self` ?

Still figuring this page out!