### PR TITLE
Update authentication.mdx - remove Lucia

### DIFF
--- a/src/content/docs/en/guides/authentication.mdx
+++ b/src/content/docs/en/guides/authentication.mdx
@@ -11,7 +11,7 @@ import ReadMore from '~/components/ReadMore.astro'
 
 Authentication and authorization are two security processes that manage access to your website or app. Authentication verifies a visitor's identity, while authorization grants access to protected areas and resources.
 
-Authentication allows you to customize areas of your site for logged-in individuals and provides the greatest protection for personal or private information. Authentication libraries (e.g. [Lucia Auth](https://lucia-auth.com/), [Auth.js](https://authjs.dev/), [Clerk](https://clerk.com)) provide utilities for multiple authentication methods such as email sign-in and OAuth providers.
+Authentication allows you to customize areas of your site for logged-in individuals and provides the greatest protection for personal or private information. Authentication libraries (e.g. [Auth.js](https://authjs.dev/), [Clerk](https://clerk.com)) provide utilities for multiple authentication methods such as email sign-in and OAuth providers.
 
 :::tip
 There is no official authentication solution for Astro, but you can find [community "auth" integrations](https://astro.build/integrations/?search=auth) in the integrations directory.


### PR DESCRIPTION
#### Description (required)
As per Lucia's home page, they are no longer building an auth library and the existing library is being deprecated.

This change removes Lucia from the suggested list of auth providers and is a documentation change only.