### PR TITLE
Fix incorrect reference in `mdx.mdx` file

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -113,7 +113,7 @@ Or you can use that exported `title` in your page using `import` and `import.met
 ```astro title="src/pages/index.astro"
 ---
 const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
-const posts = Object.values(posts);
+const posts = Object.values(matches);
 ---
 
 {posts.map(post => <p>{post.title}</p>)}


### PR DESCRIPTION
#### Description (required)


Changes `posts` with `matches` in `mdx.mdx` file

#### Related issues & labels (optional)

- Closes #9985 

