### PR TITLE
Fix grammatical error in Contributor Manual ("is has" → "has")

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We welcome contributions of any size and contributors of any skill level. As an 
 >
 > There, you'll find all the information below, and so much more!
 
-This document is has some basic information to get you started, but we encourage you to visit our [dedicated site for contributing to Astro docs](https://contribute.docs.astro.build) for all the information you need!
+This document has some basic information to get you started, but we encourage you to visit our [dedicated site for contributing to Astro docs](https://contribute.docs.astro.build) for all the information you need!
 
 There, you will find a writing and style guide, instructions on how to make changes and open PRs, guidance for translating the docs, and even information about how to help review Astro Docs PRs. 
 


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
The sentence "This document is has some basic information to get you started..." contains a grammatical error due to the incorrect combination of "is" and "has" in this context. The word "is" is unnecessary and disrupts the sentence's structure.

The correct phrase should simply be "has", as it properly indicates possession of the information.
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

