### PR TITLE
i18n(fr): update `errors/env-unsupported-get-secret.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -81,7 +81,6 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**i18nNoLocaleFoundInPath**](/fr/reference/errors/i18n-no-locale-found-in-path/)<br/>Le chemin d'accès ne contient aucune locale
 - [**RouteNotFound**](/fr/reference/errors/route-not-found/)<br/>Route non trouvée.
 - [**EnvInvalidVariables**](/fr/reference/errors/env-invalid-variables/)<br/>Variables d'environnement non valides
-- [**EnvUnsupportedGetSecret**](/fr/reference/errors/env-unsupported-get-secret/)<br/>astro:env getSecret non supportée
 - [**ServerOnlyModule**](/fr/reference/errors/server-only-module/)<br/>Le module n'est disponible que côté serveur
 - [**RewriteWithBodyUsed**](/fr/reference/errors/rewrite-with-body-used/)<br/>Impossible d'utiliser Astro.rewrite après que le corps de la requête a été lu
 - [**UnknownFilesystemError**](/fr/reference/errors/unknown-filesystem-error/)<br/>Une erreur inconnue s'est produite lors de la lecture ou de l'écriture de fichiers sur le disque.

--- a/src/content/docs/fr/reference/errors/env-unsupported-get-secret.mdx
+++ b/src/content/docs/fr/reference/errors/env-unsupported-get-secret.mdx
@@ -4,9 +4,11 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
+:::caution[Obsolète]
+Cette erreur provient d'une ancienne version d'Astro et n'est plus utilisée. Si vous ne parvenez pas à mettre à niveau votre projet vers une version plus récente, vous pouvez consulter [des instantanés non maintenus d'anciennes documentations](/fr/upgrade-astro/#anciennes-documentations-non-maintenues) pour obtenir de l'aide.
+:::
+
 > **EnvUnsupportedGetSecret**: `astro:env/server` exported function `getSecret` is not supported by your adapter.
 
 ## Qu'est-ce qui a mal tourné ?
 La fonction exportée `astro:env/serveur` `getSecret()` n'est pas supportée par votre adaptateur.
-
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a deprecation notice in the French translation of `reference/errors/env-unsupported-get-secret.mdx` and removes the link in `error-reference.mdx` (see #10071)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
