### PR TITLE
Change `HTMLAttributes` insertions into marks

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -177,7 +177,7 @@ Astro provides the `HTMLAttributes` type to check that your markup is using vali
 
 For example, if you were building a `<Link>` component, you could do the following to mirror the default HTML attributes for `<a>` tags in your component’s prop types.
 
-```astro title="src/components/Link.astro" ins="HTMLAttributes" ins="HTMLAttributes<'a'>"
+```astro title="src/components/Link.astro" "HTMLAttributes" "HTMLAttributes<'a'>"
 ---
 import type { HTMLAttributes } from 'astro/types';
 // use a `type`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
The reason for this change is that the insertions were being used solely to highlight `HTMLAttributes`'s usage, with nothing being inserted from a previous example.

Mark accomplishes this goal without any unnecessary semantics.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: [improve documentation](https://github.com/withastro/docs/labels/improve%20documentation)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
