### PR TITLE
Update add-content-collections.mdx

### DIFF
--- a/src/content/docs/en/tutorials/add-content-collections.mdx
+++ b/src/content/docs/en/tutorials/add-content-collections.mdx
@@ -348,31 +348,10 @@ The steps below show you how to extend the final product of the Build a Blog tut
       </Box>
 </Steps>
 
-### Update any frontmatter values to match your schema
-
-<Steps>
-14. If necessary, update any frontmatter values throughout your project, such as in your layout, that do not match your collections schema. 
-
-    In the blog tutorial example, `pubDate` was a string. Now, according to the schema that defines types for the post frontmatter, `pubDate` will be a `Date`
-    object.
-    
-    To render the date in the blog post layout, convert it to a string:
-
-    ```astro title="src/layouts/MarkdownPostLayout.astro" ins="toString()"
-    ...
-    <BaseLayout pageTitle={frontmatter.title}>
-      <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
-      <p><em>{frontmatter.description}</em></p>
-      <p>Written by: {frontmatter.author}</p>
-      <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
-    ...
-    ```
-</Steps>
-
 ### Update RSS function
 
 <Steps>
-15. Lastly, the tutorial blog project includes an RSS feed. This function must also use `getCollection()` to return information from your blog posts. You will then generate the RSS items using the `data` object returned.
+14. Lastly, the tutorial blog project includes an RSS feed. This function must also use `getCollection()` to return information from your blog posts. You will then generate the RSS items using the `data` object returned.
 
     ```js title="src/pages/rss.xml.js" del={2,11} ins={3,6,12-17}
     import rss from '@astrojs/rss';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
This Pull Request removes a section of duplicate content identified in the documentation.
I noticed that the `pubDate` was already parsed as a string in a previous tutorial section, so there is no need to parse it again. Here is the relevant section: https://docs.astro.build/en/tutorial/4-layouts/3/#nest-your-two-layouts

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs? Yes

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
