### PR TITLE
Add content collection custom IDs section

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -79,15 +79,15 @@ export const collections = { blog, dogs };
 
 ### Defining the collection `loader`
 
-The Content Layer API allows you to fetch your content (whether stored locally in your project or remotely) and uses a `loader` property to retrieve your data. 
+The Content Layer API allows you to fetch your content (whether stored locally in your project or remotely) and uses a `loader` property to retrieve your data. A loader returns an array or object of entries each containing an `id` property that will provide a URL slug as well as an identifier to allow you to [query entries](#querying-collections). 
 
 #### Built-in loaders
 
-Astro provides two built-in loader functions (`glob()` and `file()`) for fetching your local content, as well as access to the API to construct your own loader and fetch remote data.
+Astro provides two built-in loader functions (`glob()` and `file()`) for fetching your local content, as well as access to the API to construct your own loader and fetch remote data. 
 
-The `glob()` loader creates entries from directories of Markdown, MDX, Markdoc, or JSON files from anywhere on the filesystem. It accepts a `pattern` of entry files to match, and a `base` file path of where your files are located. Use this when you have one file per entry.
+The `glob()` loader creates entries from directories of Markdown, MDX, Markdoc, or JSON files from anywhere on the filesystem. It accepts a `pattern` of entry files to match, and a `base` file path of where your files are located. Each entry's `id` will be automatically generated from its file name. Use this loader when you have one file per entry.
 
-The `file()` loader creates multiple entries from a single local file. It accepts a `base` file path to your file and optionally a [`parser` function](#parser-function) for data files it cannot parse automatically. Use this when your data file can be parsed as an array of objects.
+The `file()` loader creates multiple entries from a single local file. Each entry in the file must have a unique `id` key property. It accepts a `base` file path to your file and optionally a [`parser` function](#parser-function) for data files it cannot parse automatically. Use this loader when your data file can be parsed as an array of objects.
 
 ```ts  title="src/content.config.ts" {5,9}
 import { defineCollection, z } from 'astro:content';

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -337,6 +337,31 @@ relatedPosts:
 ---
 ```
 
+### Defining custom IDs
+
+When using the `glob()` loader with Markdown, MDX, Markdoc, or JSON files, every content entry [`id`](/en/reference/modules/astro-content/#id) is automatically generated in an URL-friendly format based on the content filename.
+The `id` is used to query the entry directly from your collection.
+It is also useful when creating new pages and URLs from your content.
+
+You can override an entry’s generated `id` by adding your own `slug` property to the file frontmatter or data object for JSON files.
+This is similar to the “permalink” feature of other web frameworks.
+
+```md {3}
+---
+title: My Blog Post
+slug: my-custom-id/supports/slashes
+---
+Your blog post content here.
+```
+
+```json {3}
+{
+  "title": "Blog Category",
+  "slug": "my-custom-id/supports/slashes",
+  "description": "Your category description here."
+}
+```
+
 ## Querying Collections
 
 Astro provides helper functions to query a collection and return one (or more) content entries.

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -339,14 +339,11 @@ relatedPosts:
 
 ### Defining custom IDs
 
-When using the `glob()` loader with Markdown, MDX, Markdoc, or JSON files, every content entry [`id`](/en/reference/modules/astro-content/#id) is automatically generated in an URL-friendly format based on the content filename.
-The `id` is used to query the entry directly from your collection.
-It is also useful when creating new pages and URLs from your content.
+When using the `glob()` loader with Markdown, MDX, Markdoc, or JSON files, every content entry [`id`](/en/reference/modules/astro-content/#id) is automatically generated in an URL-friendly format based on the content filename. The `id` is used to query the entry directly from your collection. It is also useful when creating new pages and URLs from your content.
 
-You can override an entry’s generated `id` by adding your own `slug` property to the file frontmatter or data object for JSON files.
-This is similar to the “permalink” feature of other web frameworks.
+You can override an entry’s generated `id` by adding your own `slug` property to the file frontmatter or data object for JSON files. This is similar to the “permalink” feature of other web frameworks.
 
-```md {3}
+```md title="src/blog/1.md" {3}
 ---
 title: My Blog Post
 slug: my-custom-id/supports/slashes
@@ -354,9 +351,9 @@ slug: my-custom-id/supports/slashes
 Your blog post content here.
 ```
 
-```json {3}
+```json title="src/categories/1.json" {3}
 {
-  "title": "Blog Category",
+  "title": "My Category",
   "slug": "my-custom-id/supports/slashes",
   "description": "Your category description here."
 }

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -83,7 +83,7 @@ The Content Layer API allows you to fetch your content (whether stored locally i
 
 #### Built-in loaders
 
-Astro provides two built-in loader functions (`glob()` and `file()`) for fetching your local content, as well as access to the API to construct your own loader and fetch remote data. 
+Astro provides two built-in loader functions (`glob()` and `file()`) for fetching your local content, as well as access to the API to construct your own loader and fetch remote data.
 
 The `glob()` loader creates entries from directories of Markdown, MDX, Markdoc, or JSON files from anywhere on the filesystem. It accepts a `pattern` of entry files to match, and a `base` file path of where your files are located. Each entry's `id` will be automatically generated from its file name. Use this loader when you have one file per entry.
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -79,7 +79,7 @@ export const collections = { blog, dogs };
 
 ### Defining the collection `loader`
 
-The Content Layer API allows you to fetch your content (whether stored locally in your project or remotely) and uses a `loader` property to retrieve your data. A loader returns an array or object of entries each containing an `id` property that will provide a URL slug as well as an identifier to allow you to [query entries](#querying-collections). 
+The Content Layer API allows you to fetch your content (whether stored locally in your project or remotely) and uses a `loader` property to retrieve your data. 
 
 #### Built-in loaders
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed on Discord, this PR adds back an equivalent of the [“Defining custom slugs”](https://docs.astro.build/en/guides/content-collections/#defining-custom-slugs) section in the current version of the docs for the content collections page in the v5 docs.

The content is based on the current version but updated to match the new changes related to the Content Layer API.

A few notes:

- It works with JSON files too.
- The sentence about `slug` being a special, reserved property name not allowed in `schema` is removed, as it is not true anymore.
- Not sure about the capitalization of IDs in the title.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: 5.0.0-beta 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->