### PR TITLE
Fix fallback language remark plugin

### DIFF
--- a/plugins/remark-fallback-lang.ts
+++ b/plugins/remark-fallback-lang.ts
@@ -30,8 +30,8 @@ export function remarkFallbackLang(): Plugin<[], Root> {
 			if (linkSourceFileName) return;
 
 			link.children.push({
-				type: 'html',
-				value: `&nbsp;(EN)`,
+				type: 'text',
+				value: `\u00A0(EN)`,
 			});
 		});
 	};


### PR DESCRIPTION
#### Description (required)

This PR fixes the `remarkFallbackLang` remark plugin used to marks links to fallback language pages.

Repro:

1. Visit https://docs.astro.build/de/guides/cms/#kann-ich-astro-ohne-cms-nutzen
1. The `Inhalte zu erstellen` link should be marked and displayed as `Inhalte zu erstellen (EN)` as it's linking to a fallback language page in English.
   The `Integration` link in the previous section is correctly not marked as it's linking to a page in German.

This plugin broke with Astro `4.0.0-beta.0` due to to all the updates to the unified, remark and rehype dependencies in https://github.com/withastro/astro/pull/9138. It looks like the issue is located either in `hast-util-raw` or the `parse5` tokenizer (used internally) and it requires a raw node to either include an element or a whitespace (e.g. `&nbsp; (EN)` or `<span>&nbsp;(EN)</span>` instead of `&nbsp;(EN)` would work).

This PR workaround the issue by switching to a text node using the non-breaking space unicode character `U+00A0` instead of the HTML entity `&nbsp;` and I'll open later a proper issue on the related repo.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->