### PR TITLE
fix(v5): broken link and missing type annotations in tutorial

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/1.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/1.mdx
@@ -167,7 +167,7 @@ Try on your own to make all the necessary changes to your Astro project so that 
     <BaseLayout pageTitle={pageTitle}>
       <p>This is where I will post about my journey learning Astro.</p>
       <ul>
-        {allPosts.map((post) => <BlogPost url={post.url} title={post.frontmatter.title} />)}
+        {allPosts.map((post: any) => <BlogPost url={post.url} title={post.frontmatter.title} />)}
       </ul>
     </BaseLayout>
     ```

--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -251,10 +251,10 @@ import BlogPost from '../../components/BlogPost.astro';
 export async function getStaticPaths() {
   const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
   
-  const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
+  const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
 
   return uniqueTags.map((tag) => {
-    const filteredPosts = allPosts.filter((post) => post.frontmatter.tags.includes(tag));
+    const filteredPosts = allPosts.filter((post: any) => post.frontmatter.tags.includes(tag));
     return {
       params: { tag },
       props: { posts: filteredPosts },
@@ -268,7 +268,7 @@ const { posts } = Astro.props;
 <BaseLayout pageTitle={tag}>
   <p>Posts tagged with {tag}</p>
   <ul>
-    {posts.map((post) => <BlogPost url={post.url} title={post.frontmatter.title}/>)}
+    {posts.map((post: any) => <BlogPost url={post.url} title={post.frontmatter.title}/>)}
   </ul>
 </BaseLayout>
 ```

--- a/src/content/docs/en/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/3.mdx
@@ -361,7 +361,7 @@ const { frontmatter } = Astro.props;
   <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} /> 
 
   <div class="tags">
-    {frontmatter.tags.map((tag) => (
+    {frontmatter.tags.map((tag: string) => (
       <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
     ))}
   </div>

--- a/src/content/docs/en/tutorial/6-islands/4.mdx
+++ b/src/content/docs/en/tutorial/6-islands/4.mdx
@@ -346,4 +346,4 @@ The tutorial blog project includes an RSS feed. This function must also use `get
     }
     ```
 
-For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-layer) of the tutorial repo.
+For the full example of the blog tutorial using content collections, see the [Content Collections branch](https://github.com/withastro/blog-tutorial-demo/tree/content-collections) of the tutorial repo.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
I know we're not supposed to send PRs right now, but since I noticed some errors while I did the tutorial again (see https://github.com/withastro/blog-tutorial-demo/pull/33), I thought I'd make the necessary updates!

#### Description (required)

Updates the tutorial to:
* Add missing type annotations in the Unit 5 (final code snippet, code check-ins...)
* Fix a broken link in Unit 6

I haven't addressed `ThemeIcon.astro` because I don't know if it's necessary or not:
* when I follow the tutorial I don't see any error
* when I open `blog-tutorial-demo` I see Typescript errors...

#### Related issues & labels (optional)

- Suggested label: 5.0.0-beta, code snippet update, typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

Sorry for the wrong automatic labels... I forgot to use the `5.0.0` branch as base... 😅 