### PR TITLE
fix: make tutorial consistent with `blog-tutorial-demo` (Typescript errors)

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -107,7 +107,7 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
     <script is:inline>
       const theme = (() => {
         if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-          return localStorage.getItem('theme');
+          return localStorage.getItem('theme') ?? "light";
         }
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
           return 'dark';
@@ -131,7 +131,7 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
         localStorage.setItem("theme", isDark ? "dark" : "light");
       }
 
-      document.getElementById("themeToggle").addEventListener("click", handleToggleClick);
+      document.getElementById("themeToggle")?.addEventListener("click", handleToggleClick);
     </script>
     ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes two more Typescript errors in the unit 6 of the tutorial. (see https://github.com/withastro/blog-tutorial-demo/pull/33)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
