### PR TITLE
fix: close gate actions middleware code block

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -684,6 +684,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   context.cookies.set('user-session', /* session token */);
   return next();
 });
+```
 
 ## Call actions from Astro components and server endpoints
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
This adds the missing backticks to close the `src/middleware.ts` code block example in the [gate actions middleware documentation](https://5-0-0-beta.docs.astro.build/en/guides/actions/#gate-actions-from-middleware).

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `5.0.0-beta`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
