### PR TITLE
update some SSR wording

### DIFF
--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -21,7 +21,7 @@ See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/goo
 ### Prerequisites
 
 - A [Firebase project with a web app configured](https://firebase.google.com/docs/web/setup).
-- An Astro project with [server-side rendering (SSR)](/en/guides/on-demand-rendering/) enabled.
+- An Astro project with [`output: 'server'` for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
 - Firebase credentials: You will need two sets of credentials to connect Astro to Firebase:
   - Web app credentials: These credentials will be used by the client side of your app. You can find them in the Firebase console under *Project settings > General*. Scroll down to the **Your apps** section and click on the **Web app** icon.
   - Project credentials: These credentials will be used by the server side of your app. You can generate them in the Firebase console under *Project settings > Service accounts > Firebase Admin SDK > Generate new private key*.

--- a/src/content/docs/en/guides/backend/supabase.mdx
+++ b/src/content/docs/en/guides/backend/supabase.mdx
@@ -17,7 +17,7 @@ import { FileTree } from '@astrojs/starlight/components';
 ### Prerequisites
 
 - A Supabase project. If you don't have one, you can sign up for free at [supabase.com](https://supabase.com/) and create a new project.
-- An Astro project with [server-side rendering (SSR)](/en/guides/on-demand-rendering/) enabled.
+- An Astro project with [`output: 'server'` for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
 - Supabase credentials for your project. You can find these in the **Settings > API** tab of your Supabase project.
   - `SUPABASE_URL`: The URL of your Supabase project.
   - `SUPABASE_ANON_KEY`: The anonymous key for your Supabase project.

--- a/src/content/docs/en/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/en/guides/cms/kontent-ai.mdx
@@ -443,9 +443,9 @@ const blogPost: BlogPost = Astro.props.blogPost
 
 Navigate to your Astro preview (http://localhost:4321/blog/astro-is-amazing/ by default) to see the rendered blog post.
 
-#### Server-side rendering
+#### On-demand rendering
 
-If you've opted into SSR mode, you will use dynamic routes to fetch the page data from Kontent.ai.
+If your routes are [rendered on demand](/en/guides/on-demand-rendering/), you will use dynamic routes to fetch the page data from Kontent.ai.
 
 Create a new file `[slug].astro` in `/src/pages/blog/` and add the following code. The data fetching is very similar to previous use cases but adds an `equalsFilter` that lets us find the right blog post based on the used URL:
 

--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -450,7 +450,7 @@ This file will generate a page for each story, with the slug and content fetched
 When adding folders inside of Storyblok, include them in the slug when interacting with the Storyblok API. For example, in the GET request above we can use **cdn/stories/blog**, with a blog folder inside rather than using them at the root.
 :::
 
-#### On-deand rendering
+#### On-demand rendering
 
 If you are [rendering your routes on demand with an adapter](/en/guides/on-demand-rendering/), you will use dynamic routes to fetch the page data from Storyblok.
 

--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -395,7 +395,7 @@ const content = data.story.content;
 </html>
 ```
 
-To generate pages for all of your blog posts, create a `.astro` page that will create dynamic routes. This approach varies depending on whether you're using **static site generation** (the default) or **server-side rendering**.
+To generate pages for all of your blog posts, create a `.astro` page that will create dynamic routes. This approach varies depending on whether your routes are prerendered (the default in Astro) or [rendered on demand](/en/guides/on-demand-rendering/).
 
 #### Static site generation
 
@@ -450,9 +450,9 @@ This file will generate a page for each story, with the slug and content fetched
 When adding folders inside of Storyblok, include them in the slug when interacting with the Storyblok API. For example, in the GET request above we can use **cdn/stories/blog**, with a blog folder inside rather than using them at the root.
 :::
 
-#### Server-side rendering
+#### On-deand rendering
 
-If you’ve [opted into SSR mode](/en/guides/on-demand-rendering/), you will use dynamic routes to fetch the page data from Storyblok.
+If you are [rendering your routes on demand with an adapter](/en/guides/on-demand-rendering/), you will use dynamic routes to fetch the page data from Storyblok.
 
 Create a new directory `src/pages/blog/` and add a new file called `[...slug].astro` with the following code:
 

--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -318,9 +318,9 @@ const article = Astro.props;
 Make sure to choose the right rendering for your content. For markdown check out our [markdown guide](/en/guides/markdown-content/). If you are rendering html refer to [this guide](/en/reference/directives-reference/#sethtml) for safety.
 :::
 
-#### Server-side rendering
+#### On-demand rendering
 
-If you've [opted into on-demand rendering](/en/guides/on-demand-rendering/), [generate your dynamic routes](/en/guides/routing/#server-ssr-mode) using the following code:
+If you've [opted into on-demand rendering with an adapter](/en/guides/on-demand-rendering/), [generate your dynamic routes](/en/guides/routing/#server-ssr-mode) using the following code:
 
 Create the `src/pages/blog/[slug].astro` file:
 

--- a/src/content/docs/en/guides/deploy/index.mdx
+++ b/src/content/docs/en/guides/deploy/index.mdx
@@ -111,10 +111,10 @@ Run the command `npm run build` to build your Astro site.
 
 By default, the build output will be placed at `dist/`. This location can be changed using the [`outDir` configuration option](/en/reference/configuration-reference/#outdir).
 
-## Adding an Adapter for SSR
+## Adding an Adapter for on-demand rendering
 
 :::note
-Before deploying your Astro site with [SSR (server-side rendering)](/en/guides/on-demand-rendering/) enabled, make sure you have:
+Before deploying your Astro site with [on-demand rendering](/en/guides/on-demand-rendering/) enabled, make sure you have:
 
 - Installed the [appropriate adapter](/en/guides/on-demand-rendering/) to your project dependencies (either manually, or using the adapter's `astro add` command, e.g. `npx astro add netlify`).
 - [Added the adapter](/en/reference/configuration-reference/#integrations) to your `astro.config.mjs` file's import and default export when installing manually. (The `astro add` command will take care of this step for you!)

--- a/src/content/docs/en/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/en/guides/integrations-guide/lit.mdx
@@ -8,7 +8,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 :::caution[Deprecated]
-This Astro integration to enable server-side rendering and client-side hydration for your [Lit](https://lit.dev/) custom elements was deprecated in Astro 5.0.
+This Astro integration to enable on-demand rendering and client-side hydration for your [Lit](https://lit.dev/) custom elements was deprecated in Astro 5.0.
 :::
 
 You can continue to use Lit for client components by adding a client-side script tag. For example:

--- a/src/content/docs/en/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/en/guides/integrations-guide/preact.mdx
@@ -12,7 +12,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import Since from '~/components/Since.astro';
 
-This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [Preact](https://preactjs.com/) components.
+This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [Preact](https://preactjs.com/) components.
 
 ## Why Preact?
 

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [React](https://react.dev/) components.
+This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [React](https://react.dev/) components.
 
 ## Installation
 

--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Since from '~/components/Since.astro';
 
-This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [SolidJS](https://www.solidjs.com/) components.
+This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [SolidJS](https://www.solidjs.com/) components.
 
 ## Installation
 

--- a/src/content/docs/en/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/en/guides/integrations-guide/svelte.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Since from '~/components/Since.astro';
 
-This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [Svelte](https://svelte.dev/) 5 components. For Svelte 3 and 4 support, install `@astrojs/svelte@5` instead.
+This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [Svelte](https://svelte.dev/) 5 components. For Svelte 3 and 4 support, install `@astrojs/svelte@5` instead.
 
 ## Installation
 

--- a/src/content/docs/en/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vue.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Since from '~/components/Since.astro';
 
-This **[Astro integration][astro-integration]** enables server-side rendering and client-side hydration for your [Vue 3](https://vuejs.org/) components.
+This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [Vue 3](https://vuejs.org/) components.
 
 ## Installation
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -145,7 +145,7 @@ import App from '../cra-project/App.jsx';
 :::note[Client directives]
 Your app needs a [client directive](/en/reference/directives-reference/#client-directives) for interactivity. Astro will render your React app as static HTML until you opt-in to client-side JavaScript.
 
-Use `client:load` to ensure your app loads immediately from the server, or `client:only="react"` to skip server-side rendering and run your app entirely client-side.
+Use `client:load` to ensure your app loads immediately from the server, or `client:only="react"` to skip rendering on the server and run your app entirely client-side.
 :::
 
 See our guide for [configuring Astro](/en/guides/configuring-astro/) for more details and available options.

--- a/src/content/docs/en/guides/migrate-to-astro/index.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/index.mdx
@@ -36,7 +36,7 @@ Depending on your existing project, you may be able to use your existing:
 
 [Many existing sites can be built with Astro](/en/concepts/why-astro/). Astro is ideally suited for your existing content-based sites like blogs, landing pages, marketing sites and portfolios. Astro integrates with several popular headless CMSs, and allows you to connect eCommerce shop carts.
 
-Astro allows you to choose between a statically-generated site and [server-side rendering (SSR)](/en/guides/on-demand-rendering/), making it a great replacement for SSGs or for sites that need to fetch some page data on the fly.
+Astro allows you have a fully statically-generated website, a dynamic app with routes rendered on demand, or a combination of both with [complete control over your project rendering](/en/guides/on-demand-rendering/), making it a great replacement for SSGs or for sites that need to fetch some page data on the fly.
 
 ## How will my project design change?
 

--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -90,7 +90,7 @@ bunx --bun astro preview
 
 ## Add SSR with Bun
 
-Since Bun features [Node.js API compatibility](https://bun.sh/docs/runtime/nodejs-apis), you can use any Astro adapter for [server-side rendering](/en/guides/on-demand-rendering/) to your Astro project:
+Since Bun features [Node.js API compatibility](https://bun.sh/docs/runtime/nodejs-apis), you can use any Astro adapter for [on-demand rendering](/en/guides/on-demand-rendering/) with your Astro project:
 
 ```bash
 bunx astro add vercel

--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -8,11 +8,11 @@ import Since from '~/components/Since.astro';
 import { FileTree } from '@astrojs/starlight/components';
 
 
-Astro is designed to make it easy to deploy to any cloud provider for SSR (server-side rendering). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/). See the [SSR guide](/en/guides/on-demand-rendering/) to learn how to use an existing adapter.
+Astro is designed to make it easy to deploy to any cloud provider for on-demand rendering, also known as server-side rendering (SSR). This ability is provided by __adapters__, which are [integrations](/en/reference/integrations-reference/). See the [on-demand rendering guide](/en/guides/on-demand-rendering/) to learn how to use an existing adapter.
 
 ## What is an adapter?
 
-An adapter is a special kind of [integration](/en/reference/integrations-reference/) that provides an entrypoint for server-side rendering. An adapter does two things:
+An adapter is a special kind of [integration](/en/reference/integrations-reference/) that provides an entrypoint for server rendering at request time. An adapter does two things:
 
 - Implements host-specific APIs for handling requests.
 - Configures the build according to host conventions.
@@ -85,7 +85,7 @@ export type AstroAdapterFeatureMap = {
    */
   hybridOutput?: AdapterSupport;
   /**
-   * The adapter is able to serve SSR pages
+   * The adapter is able to serve pages rendered on demand
    */
   serverOutput?: AdapterSupport;
   /**
@@ -106,7 +106,7 @@ export type AstroAdapterFeatureMap = {
 The properties are:
 
 * __name__: A unique name for your adapter, used for logging.
-* __serverEntrypoint__: The entrypoint for server-side rendering.
+* __serverEntrypoint__: The entrypoint for on-demand server rendering.
 * __exports__: An array of named exports when used in conjunction with `createExports` (explained below).
 * __adapterFeatures__: An object that enables specific features that must be supported by the adapter. 
   These features will change the built output, and the adapter must implement the proper logic to handle the different output. 
@@ -403,7 +403,7 @@ A set of features that changes the output of the emitted files. When an adapter 
 **Type:** `boolean`
 </p>
 
-Defines whether any SSR middleware code will be bundled when built.
+Defines whether any on-demand rendering middleware code will be bundled when built.
 
 When enabled, this prevents middleware code from being bundled and imported by all pages during the build:
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -182,7 +182,7 @@ Runs Astro's development server. This is a local HTTP server that doesn't bundle
 
 ## `astro build`
 
-Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If [SSR is enabled](/en/guides/on-demand-rendering/), this will generate the necessary server files to serve your site.
+Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If any routes are [rendered on demand](/en/guides/on-demand-rendering/), this will generate the necessary server files to serve your site.
 
 ### Flags
 
@@ -200,7 +200,7 @@ Starts a local server to serve the contents of your static directory (`dist/` by
 
 This command allows you to preview your site locally [after building](#astro-build) to catch any errors in your build output before deploying it. It is not designed to be run in production. For help with production hosting, check out our guide on [Deploying an Astro Website](/en/guides/deploy/).
 
-Since Astro 1.5.0, `astro preview` also works for SSR builds if you use an adapter that supports it. Currently, only the [Node adapter](/en/guides/integrations-guide/node/) supports `astro preview`.
+Since Astro 1.5.0, the [Node adapter](/en/guides/integrations-guide/node/) supports `astro preview` for builds generated with on-demand rendering.
 
 Can be combined with the [common flags](#common-flags) documented below.
 

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -10,7 +10,7 @@ import Since from '~/components/Since.astro';
 
 Astro provides two types of image services: Local and External.
 
-- **Local services** handle image transformations directly at build for static sites, or at runtime both in development mode and SSR. These are often wrappers around libraries like Sharp, ImageMagick, or Squoosh. In dev mode and in SSR, local services use an API endpoint to do the transformation.
+- **Local services** handle image transformations directly at build for static sites, or at runtime both in development mode and for on-demand rendering. These are often wrappers around libraries like Sharp, ImageMagick, or Squoosh. In dev mode and in production routes rendered on demand, local services use an API endpoint to do the transformation.
 - **External services** point to URLs and can add support for services such as Cloudinary, Vercel, or any [RIAPI](https://github.com/riapi/riapi)-compliant server.
 
 ## Building using the Image Services API
@@ -19,7 +19,7 @@ Service definitions take the shape of an exported default object with various re
 
 External services provide a `getURL()` that points to the `src` of the output `<img>` tag.
 
-Local services provide a `transform()` method to perform transformations on your image, and  `getURL()` and `parseURL()` methods to use an endpoint for dev mode and SSR.
+Local services provide a `transform()` method to perform transformations on your image, and  `getURL()` and `parseURL()` methods to use an endpoint for dev mode and when rendered on demand.
 
 Both types of services can provide `getHTMLAttributes()` to determine the other attributes of the output `<img>` and `validateOptions()` to validate and augment the passed options.
 
@@ -124,7 +124,7 @@ export default service;
 
 At build time for static sites and pre-rendered routes, both `<Image />` and `getImage(options)` call the `transform()` function. They pass options either through component attributes or an `options` argument, respectively. The transformed images will be built to a `dist/_astro` folder. Their file names will contain a hash of the properties passed to `propertiesToHash`. This property is optional and will default to `['src', 'width', 'height', 'format', 'quality']`. If your custom image service has more options that change the generated images, add these to the array.
 
-In dev mode and SSR mode, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
+In dev mode and when using an adapter to render on demand, Astro doesn't know ahead of time which images need to be optimized. Astro uses a GET endpoint (by default, `/_image`) to process the images at runtime. `<Image />` and `getImage()` pass their options to `getURL()`, which will return the endpoint URL. Then, the endpoint calls `parseURL()` and passes the resulting properties to `transform()`.
 
 #### getConfiguredImageService & imageConfig
 
@@ -163,7 +163,7 @@ export const GET: APIRoute = async ({ request }) => {
 
 `getURL(options: ImageTransform, imageConfig: AstroConfig['image']): string`
 
-For local services, this hook returns the URL of the endpoint that generates your image (in SSR and dev mode). It is unused during build. The local endpoint that `getURL()` points to may call both `parseURL()` and `transform()`.
+For local services, this hook returns the URL of the endpoint that generates your image (for on-demand rendering and in dev mode). It is unused during build. The local endpoint that `getURL()` points to may call both `parseURL()` and `transform()`.
 
 For external services, this hook returns the final URL of the image.
 
@@ -191,7 +191,7 @@ export type ImageTransform = {
 
 `parseURL(url: URL, imageConfig: AstroConfig['image']): { src: string, [key: string]: any}`
 
-This hook parses the generated URLs by `getURL()` back into an object with the different properties to be used by `transform` (in SSR and dev mode). It is unused during build.
+This hook parses the generated URLs by `getURL()` back into an object with the different properties to be used by `transform` (for on-demand rendering and in dev mode). It is unused during build.
 
 ### `transform()`
 
@@ -201,7 +201,7 @@ This hook parses the generated URLs by `getURL()` back into an object with the d
 
 This hook transforms and returns the image and is called during the build to create the final asset files.
 
-You must return a `format` to ensure that the proper MIME type is served to users in SSR and development mode.
+You must return a `format` to ensure that the proper MIME type is served to users for on-demand rendering and development mode.
 
 ### `getHTMLAttributes()`
 


### PR DESCRIPTION
#### Description (required)

This updates a handful of wording (e.g. SSR mode) in English pages. No links are changed as they had already been edited to make link checker pass. This just chooses some places to use our more common wording.

Notably:

- does not update the config ref/error messages that are generated at source.
- does not update the API reference page since that's open in another PR and any adjustments can be made there before merging to avoid conflicts