### PR TITLE
Clean up v5 sidebar implementation

### DIFF
--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -83,7 +83,7 @@ const isCurrent = (sidebar: SidebarEntry[]): boolean =>
 	<MobileMenuFooter {...Astro.props} />
 </div>
 
-<div class="sl-hidden md:sl-block">
+<div class="desktop-footer sl-hidden md:sl-block">
 	<Sponsors />
 </div>
 
@@ -94,6 +94,11 @@ const isCurrent = (sidebar: SidebarEntry[]): boolean =>
 		vertical-align: super;
 		font-size: 0.75em;
 		font-weight: 700;
+	}
+
+	/** Align sponsors at sidebar bottom when there is room. */
+	.desktop-footer {
+		margin-top: auto;
 	}
 
 	/** Always show the scrollbar gutter. */

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -1,6 +1,5 @@
 ---
 import { Icon } from '@astrojs/starlight/components';
-import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
 import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
 import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
 import type { Props } from '@astrojs/starlight/props';
@@ -13,6 +12,7 @@ import Sponsors from '../LeftSidebar/Sponsors.astro';
 import TabbedContent from '../tabs/TabbedContent.astro';
 import TabListItem from '../tabs/TabListItem.astro';
 import TabPanel from '../tabs/TabPanel.astro';
+import MobileMenuFooter from './MobileMenuFooter.astro';
 
 const { sidebar, slug } = Astro.props;
 

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -1,6 +1,8 @@
 ---
 import { Icon } from '@astrojs/starlight/components';
-import Default from '@astrojs/starlight/components/Sidebar.astro';
+import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
 import type { Props } from '@astrojs/starlight/props';
 import type { SidebarEntry } from 'node_modules/@astrojs/starlight/utils/navigation';
 import { stripLeadingAndTrailingSlashes } from 'node_modules/@astrojs/starlight/utils/path';
@@ -56,24 +58,30 @@ const isCurrent = (sidebar: SidebarEntry[]): boolean =>
 		.some((entry) => entry === true);
 ---
 
-<TabbedContent class="tabbed-sidebar">
-	<Fragment slot="tab-list">
+<SidebarPersister {...Astro.props}>
+	<TabbedContent class="tabbed-sidebar">
+		<Fragment slot="tab-list">
+			{
+				sidebar.map(({ label, entries }, index) => (
+					<TabListItem id={makeId(label)} initial={isCurrent(entries)} class="tab-item">
+						<Icon class="icon" name={getIcon(index)} /> {label}
+					</TabListItem>
+				))
+			}
+		</Fragment>
 		{
-			sidebar.map(({ label, entries }, index) => (
-				<TabListItem id={makeId(label)} initial={isCurrent(entries)} class="tab-item">
-					<Icon class="icon" name={getIcon(index)} /> {label}
-				</TabListItem>
+			sidebar.map(({ label, entries }) => (
+				<TabPanel id={makeId(label)} initial={isCurrent(entries)}>
+					<SidebarSublist sublist={entries} />
+				</TabPanel>
 			))
 		}
-	</Fragment>
-	{
-		sidebar.map(({ label, entries }) => (
-			<TabPanel id={makeId(label)} initial={isCurrent(entries)}>
-				<Default {...Astro.props} sidebar={entries} />
-			</TabPanel>
-		))
-	}
-</TabbedContent>
+	</TabbedContent>
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter {...Astro.props} />
+</div>
 
 <div class="sl-hidden md:sl-block">
 	<Sponsors />

--- a/src/components/tabs/TabPanel.astro
+++ b/src/components/tabs/TabPanel.astro
@@ -32,15 +32,7 @@ const { id, initial } = Astro.props;
 
 	@keyframes tab-panel-appear {
 		from {
-			position: absolute;
-			width: 1px;
-			height: 1px;
-			padding: 0;
-			margin: -1px;
-			overflow: hidden;
-			clip: rect(0, 0, 0, 0);
-			white-space: nowrap;
-			border-width: 0;
+			display: none;
 		}
 	}
 </style>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This is a follow-up to #9890 and cleans up some repeated markup to improve performance. The initial prototype included several repeated scripts and extra unnecessary DOM that these changes clear up.

WebPageTest before/after comparison: https://www.webpagetest.org/video/compare.php?tests=241202_BiDcYR_BZH,241202_BiDcVQ_BZN

https://github.com/user-attachments/assets/6796ea8c-48c9-4f09-a9fc-6d0c24248634

