### PR TITLE
Fix path typo on content collection reference page

### DIFF
--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -34,9 +34,9 @@ import {
 <Since v="2.0.0" />
 </p>
 
-`defineCollection()` is a utility to configure a collection in a `src/content.config.*` file.
+`defineCollection()` is a utility to configure a collection in a `src/content/config.*` file.
 
-```ts title="src/content.config.ts"
+```ts title="src/content/config.ts"
 import { z, defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 
@@ -268,7 +268,7 @@ A string containing the raw, uncompiled body of the Markdown or MDX document.
 
 <p><Since v="3.1.0" /></p>
 
-A string union of all collection names defined in your `src/content.config.*` file. This type can be useful when defining a generic function that accepts any collection name.
+A string union of all collection names defined in your `src/content/config.*` file. This type can be useful when defining a generic function that accepts any collection name.
 
 ```ts
 import { type CollectionKey, getCollection } from 'astro:content';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Fixing typo on content collection reference page
`src/content.config.ts` to `src/content/config.ts`
<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
