### PR TITLE
Docs: imports: Update to `import.meta.glob()`

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -346,7 +346,7 @@ Additionally, glob patterns must begin with one of the following:
 
 ### `import.meta.glob()` vs `getCollection()`
 
-[Content collections](/en/guides/content-collections/) provide a [`getCollection()` API](/en/reference/modules/astro-content/#getcollection) for loading multiple files instead of `Astro.glob()`. If your content files (e.g. Markdown, MDX, Markdoc) are located in collections within the `src/content/` directory, use `getCollection()` to [query a collection](/en/guides/content-collections/#querying-collections) and return content entries.
+[Content collections](/en/guides/content-collections/) provide a [`getCollection()` API](/en/reference/modules/astro-content/#getcollection) for loading multiple files instead of `import.meta.glob()`. If your content files (e.g. Markdown, MDX, Markdoc) are located in collections within the `src/content/` directory, use `getCollection()` to [query a collection](/en/guides/content-collections/#querying-collections) and return content entries.
 
 ## WASM
 


### PR DESCRIPTION
Updating a pre Astro 5 reference 

https://docs.astro.build/en/guides/upgrade-to/v5/#deprecated-astroglob
