### PR TITLE
Add the fact that the return value of getEntry is always nullable to upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -186,7 +186,8 @@ This backwards compatibility implementation is able to emulate most of the featu
   - The special `layout` field is not supported in Markdown collection entries. This property is intended only for standalone page files located in `src/pages/` and not likely to be in your collection entries. However, if you were using this property, you must now create dynamic routes that include your page styling.
   - Sort order of generated collections is non-deterministic and platform-dependent. This means that if you are calling `getCollection()`, the order in which entries are returned may be different than before. If you need a specific order, you must sort the collection entries yourself.
   - `image().refine()` is not supported. If you need to validate the properties of an image you will need to do this at runtime in your page or component.
-  - the `key` argument of `getEntry(collection, key)` is typed as `string`, rather than having types for every entry.
+  - The `key` argument of `getEntry(collection, key)` is typed as `string`, rather than having types for every entry.
+  - Previously when calling `getEntry(collection, key)` with a static string as the key, the return type was not nullable. The type now includes `undefined` so you must check if the entry is defined before using the result or you will have type errors.
 
 ##### Enabling the `legacy.collections` flag
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

One of the side effectys of the way we generate types with the content layer is that the return type for `getEntry` always includes `undefined`. This can cause type errors if you pass a static string key and assume the result is always defined. This PR adds this to the upgrade guide.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
