### PR TITLE
Add `--typescript` flag removal to v5 upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -1164,9 +1164,9 @@ export default {
 
 <SourcePR number="12083" title="create-astro updates"/>
 
-The experience of creating a new Astro project using the `create astro` CLI command has been reworked.
-As Astro is TypeScript-only, the TypeScript question and its associated `--typescript` flag were often misleading and have been removed.
-The "Strict" preset is now the default, but it can still be changed manually in `tsconfig.json`.
+In Astro v4.x, it was possible to choose between Astro's three TypeScript settings when creating a new project using `create astro`, either by answering a question or by passing an associated `--typescript` flag with the desired TypeScript setting. 
+
+Astro 5.0 updates the `create astro` CLI command to remove the TypeScript question and its associated `--typescript` flag. The "strict" preset is now the default for all new projects created with the command line and it is no longer possible to customize this at that time. However, the TypeScript template can still be changed manually in `tsconfig.json`.
 
 #### What should I do?
 

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -1160,6 +1160,41 @@ export default {
 
 <ReadMore>Read more about [developing a dev toolbar app for Astro using the Dev Toolbar API](/en/reference/dev-toolbar-app-reference/).</ReadMore>
 
+### Removed: `create-astro` TypeScript question
+
+<SourcePR number="12083" title="create-astro updates"/>
+
+The experience of creating a new Astro project using the `create astro` CLI command has been reworked.
+As Astro is TypeScript-only, the TypeScript question and its associated `--typescript` flag were often misleading and have been removed.
+The "Strict" preset is now the default, but it can still be changed manually in `tsconfig.json`.
+
+#### What should I do?
+
+If you were using the `--typescript` flag with `create-astro`, remove it from your command.
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```diff lang=shell
+  -npm create astro@latest -- --template <example-name> --typescript strict
+  +npm create astro@latest -- --template <example-name>
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```diff lang=shell
+  -pnpm create astro@latest --template <example-name> --typescript strict
+  +pnpm create astro@latest --template <example-name>
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```diff lang=shell
+  -yarn create astro --template <example-name> --typescript strict
+  +yarn create astro --template <example-name>
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+<ReadMore>See [all the available `create astro` command flags](https://github.com/withastro/astro/blob/main/packages/create-astro/README.md)</ReadMore>
+
 ## Community Resources
 
 Know a good resource for Astro v5.0? [Edit this page](https://github.com/withastro/docs/edit/main/src/content/docs/en/guides/upgrade-to/v5.mdx) and add a link below!

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -1160,7 +1160,7 @@ export default {
 
 <ReadMore>Read more about [developing a dev toolbar app for Astro using the Dev Toolbar API](/en/reference/dev-toolbar-app-reference/).</ReadMore>
 
-### Removed: `create-astro` TypeScript question
+### Removed: configuring Typescript during `create-astro`
 
 <SourcePR number="12083" title="create-astro updates"/>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed on Discord, this PR adds a new section to the breaking changes of the v5 upgrade guide to document the removal of the `--typescript` flag from `create-astro`.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: 5.0

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->