### PR TITLE
fix: update a link in `guides/environment-variables.mdx`

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -85,7 +85,7 @@ PUBLIC_POKEAPI="https://pokeapi.co/api/v2"
 
 You can also add `.production`, `.development` or a custom mode name to the filename itself (e.g `env.testing`, `.env.staging`). This allows you to use different sets of environment variables at different times.
 
-The `astro dev` and `astro build` commands default to `"development"` and `"production"` modes, respectively. You can run these commands with the [`--mode` flag](//en/reference/cli-reference/#--mode-string) to pass a different value for `mode` and load the matching `.env` file.
+The `astro dev` and `astro build` commands default to `"development"` and `"production"` modes, respectively. You can run these commands with the [`--mode` flag](/en/reference/cli-reference/#--mode-string) to pass a different value for `mode` and load the matching `.env` file.
 
 This allows you to run the dev server or build your site connecting to different APIs:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes a link in `guides/environment-variables.mdx` by replacing a double slash with a single slash: `//en` > `/en`

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
