### PR TITLE
fix: remove experimental and update comments in `cli-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -149,7 +149,7 @@ You will often use these `astro` commands, or the scripts that run them, without
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
+  # run the dev server on port 8080 using the `dev` script in `package.json`
   npm run dev -- --port 8080
 
   # build your site with verbose logs using the `build` script in `package.json`
@@ -158,7 +158,7 @@ You will often use these `astro` commands, or the scripts that run them, without
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
+  # run the dev server on port 8080 using the `dev` script in `package.json`
   pnpm dev --port 8080
 
   # build your site with verbose logs using the `build` script in `package.json`
@@ -167,7 +167,7 @@ You will often use these `astro` commands, or the scripts that run them, without
   </Fragment>
   <Fragment slot="yarn">
   ```shell
-  # run the dev server on port 8080 using the `start` script in `package.json`
+  # run the dev server on port 8080 using the `dev` script in `package.json`
   yarn dev --port 8080
 
   # build your site with verbose logs using the `build` script in `package.json`
@@ -259,7 +259,7 @@ Running `astro dev`, `astro build` or `astro check` will run the `sync` command 
 Generates TypeScript types for all Astro modules. This sets up a [`.astro/types.d.ts` file](/en/guides/typescript/#setup) for type inferencing, and defines modules for features that rely on generated types:
 - The `astro:content` module for the [Content Collections API](/en/guides/content-collections/).
 - The `astro:db` module for [Astro DB](/en/guides/astro-db/).
-- The `astro:env` module for [experimental Astro Env](/en/guides/environment-variables/).
+- The `astro:env` module for [Astro Env](/en/guides/environment-variables/).
 - The `astro:actions` module for [Astro Actions](/en/guides/actions/)
 
 ## `astro add`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds two changes to `cli-reference.mdx`:
* the comment above each command was still using "`start` script" instead of `dev` so I updated the comments
* Astro Env was still marked as experimental in the `astro sync` section so I removed that mention

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
