### PR TITLE
docs: Add information about dynamic static split server islands

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -157,6 +157,12 @@ export default {
 }
 ```
 
+This hook gives you the opportunity to add private config options that are exposed only to integrations.
+There are certain options that are not directly exposed to users, but are allowed to be written from integrations.
+
+For example, the astro config [`serverIslandDynamicBase`](https://github.com/withastro/astro/blob/30d720f519f991720ee0b7c328a4bf4bbf31760d/packages/astro/src/types/public/config.ts#L1979-L1986)
+option is not exposed to users, but can be written from integrations to allow an integration to change the base URL of the exported server islands.
+
 #### `addRenderer` option
 
 **Type:** `(renderer:` [`AstroRenderer`](https://github.com/withastro/astro/blob/fdd607c5755034edf262e7b275732519328a33b2/packages/astro/src/%40types/astro.ts#L872-L883) `) => void;`

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -157,6 +157,8 @@ export default {
 }
 ```
 
+<p><Since v="5.1" /></p>
+
 This hook gives you the opportunity to add private config options that are exposed only to integrations.
 There are certain options that are not directly exposed to users, but are allowed to be written from integrations.
 

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -159,11 +159,41 @@ export default {
 
 <p><Since v="5.1" /></p>
 
+##### Private Config Options
+
 This hook gives you the opportunity to add private config options that are exposed only to integrations.
 There are certain options that are not directly exposed to users, but are allowed to be written from integrations.
 
-For example, the astro config [`serverIslandDynamicBase`](https://github.com/withastro/astro/blob/30d720f519f991720ee0b7c328a4bf4bbf31760d/packages/astro/src/types/public/config.ts#L1979-L1986)
-option is not exposed to users, but can be written from integrations to allow an integration to change the base URL of the exported server islands.
+##### `serverIslandDynamicBase`
+
+**Type:** `string`
+
+The base URL of the exported server islands. This option is not exposed to users,
+but can be written from integrations to allow an integration to change the base URL of the exported server islands.
+
+Example usage:
+
+```js
+export default {
+  hooks: {
+    'astro:config:setup': ({ updateConfig }) => {
+      updateConfig({
+        serverIslandDynamicBase: 'https://my-server-islands.com'
+      })
+    }
+  }
+}
+```
+
+Would result in the following client HTML output:
+
+```html
+<script>
+  //...
+  let response = await fetch('https://my-server-islands.com/_server-islands/...')
+</script>
+```
+
 
 #### `addRenderer` option
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

This PR is the documentation follow-on to [this PR](https://github.com/withastro/astro/pull/12320) which adds the ability to serve the server islands from a separate domain.

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.1`. See astro PR [12560](https://github.com/withastro/astro/pull/12560).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs?

jake_roberts
<!-- https://astro.build/chat -->


