### PR TITLE
Hotfix for #10148: fix indentation in `^?` comments

### DIFF
--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -292,9 +292,9 @@ type Params = InferGetStaticParamsType<typeof getStaticPaths>;
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 const { id } = Astro.params as Params;
-//               		 ^? { id: string; }
+//                   ^? { id: string; }
 const { title } = Astro.props;
-//                			^? { draft: boolean; title: string; }
+//                      ^? { draft: boolean; title: string; }
 ---
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Quick fix for misaligned `// ^?` typescript comments in the code example I updated in #10148.

| Before | After |
|--------|--------|
| <img width="549" alt="Screenshot 2024-12-04 at 7 47 07 PM" src="https://github.com/user-attachments/assets/743b2b43-b1e5-4070-b493-73cfbf66c895"> | <img width="552" alt="Screenshot 2024-12-04 at 7 47 47 PM" src="https://github.com/user-attachments/assets/4ac5dc25-3a90-4f3a-9c00-e3e9d5a64984"> | 




<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Follow-up to #10148
- Suggested label: **code snippet update**<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
