### PR TITLE
fix: remove `image().refine` from a code snippet in `guides/images.mdx`

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -348,7 +348,7 @@ coverAlt: "A photograph of a sunset behind a mountain range."
 This is a blog post
 ```
 
-The `image` helper for the content collections schema lets you validate the image metadata using Zod.
+The `image` helper for the content collections schema lets you validate and import the image.
 
 ```ts title="src/content.config.ts"
 import { defineCollection, z } from "astro:content";
@@ -356,9 +356,7 @@ import { defineCollection, z } from "astro:content";
 const blogCollection = defineCollection({
 	schema: ({ image }) => z.object({
 		title: z.string(),
-		cover: image().refine((img) => img.width >= 1080, {
-			message: "Cover image must be at least 1080 pixels wide!",
-		}),
+		cover: image(),
 		coverAlt: z.string(),
 	}),
 });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since v5, we cannot use `refine()` with the `image()` helper, so I updated an outdated example in `guides/images.mdx`.

I also slightly reworded the sentence above the code snippet because I believe this is no longer validated with Zod. But happy to revert or to reword if I'm wrong.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #10151
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
