### PR TITLE
Cleanup docgen workflows post-v5 release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,12 +19,6 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen
             PR_TITLE: 'ci: update reference docs'
-            # Custom options for running with Astro v5 beta code
-          - SOURCE_BRANCH: next
-            TARGET_BRANCH: 5.0.0-beta
-            LABEL: 5.0.0-beta,ci
-            PR_BRANCH: ci/docgen-beta
-            PR_TITLE: '[BETA] ci: update reference docs'
     steps:
       - name: Check out code using Git
         uses: actions/checkout@v4
@@ -66,12 +60,6 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen-errors
             PR_TITLE: 'ci: update error reference docs'
-            # Custom options for running with Astro v5 beta code
-          - SOURCE_BRANCH: next
-            TARGET_BRANCH: 5.0.0-beta
-            LABEL: 5.0.0-beta,ci
-            PR_BRANCH: ci/docgen-errors-beta
-            PR_TITLE: '[BETA] ci: update error reference docs'
     steps:
       - name: Check out code using Git
         uses: actions/checkout@v4

--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -6,7 +6,7 @@ import jsdoc from 'jsdoc-api';
 import fetch from 'node-fetch';
 
 // Fill this in to test a response locally, with fetching.
-const STUB = ``; // fs.readFileSync('/PATH/TO/MONOREPO/astro/packages/astro/src/@types/astro.ts', {encoding: 'utf-8'});
+const STUB = ``; // fs.readFileSync('/PATH/TO/MONOREPO/astro/packages/astro/src/types/public/config.ts', {encoding: 'utf-8'});
 
 const HEADER = `---
 # NOTE: This file is auto-generated from 'scripts/docgen.mjs'
@@ -46,7 +46,7 @@ export async function run() {
 	const sourceBranch = process.env.SOURCE_BRANCH || 'main';
 	const sourceRepo = process.env.SOURCE_REPO || 'withastro/astro';
 
-	let task = 'Fetch `@types/astro.ts` from ' + sourceRepo + '#' + sourceBranch;
+	let task = 'Fetch `src/types/public/config.ts` from ' + sourceRepo + '#' + sourceBranch;
 	console.time(task);
 
 	const inputBuffer =


### PR DESCRIPTION
This PR removes the v5-beta workflows from our docgen CI scripts. These were running nightly to update our beta docs during the prerelease period, but are no longer needed (and fail because our v5 branches no longer exist).

I also updated a line logged in the config reference generation script that hadn’t been updated to match the new file location which we changed as part of v5.