### PR TITLE
Fix link to public types in upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -416,7 +416,7 @@ Astro v5.0 refactors this file to remove outdated and internal types. This refac
 
 Remove any types that now cause errors in your project as you no longer have access to them. These are mostly APIs that have previously been deprecated and removed, but may also include types that are now internal.
 
-<ReadMore>See the [public types exposed for use](https://github.com/withastro/astro/tree/next/packages/astro/src/types/public).</ReadMore>
+<ReadMore>See the [public types exposed for use](https://github.com/withastro/astro/tree/main/packages/astro/src/types/public).</ReadMore>
 
 ### Experimental Flags
 


### PR DESCRIPTION
Updates the link to public-facing types to point to `main` branch (instead of `next`)