### PR TITLE
fix: remove useless escape characters in `pattern`

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -304,7 +304,7 @@ A common example is a blog post that references reusable author profiles stored 
 import { defineCollection, reference, z } from 'astro:content';
 
 const blog = defineCollection({
-  loader: glob({ pattern: '**\/[^_]*.md', base: "./src/data/blog" }),
+  loader: glob({ pattern: '**/[^_]*.md', base: "./src/data/blog" }),
   schema: z.object({
     title: z.string(),
     // Reference a single author from the `authors` collection by `id`
@@ -315,7 +315,7 @@ const blog = defineCollection({
 });
 
 const authors = defineCollection({
-  loader: glob({ pattern: '**\/[^_]*.json', base: "./src/data/authors" }),
+  loader: glob({ pattern: '**/[^_]*.json', base: "./src/data/authors" }),
   schema: z.object({
     name: z.string(),
     portfolio: z.string().url(),

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -129,7 +129,7 @@ See the instructions below for updating an existing content collection (`type: '
     const blog = defineCollection({
       // For content layer you no longer define a `type`
       type: 'content',
-      loader: glob({ pattern: '**\/[^_]*.md', base: "./src/data/blog" }),
+      loader: glob({ pattern: '**/[^_]*.md', base: "./src/data/blog" }),
       schema: z.object({
         title: z.string(),
         description: z.string(),

--- a/src/content/docs/en/tutorial/6-islands/4.mdx
+++ b/src/content/docs/en/tutorial/6-islands/4.mdx
@@ -118,7 +118,7 @@ Upgrade to the latest version of Astro, and upgrade all integrations to their la
     import { z, defineCollection } from "astro:content";
     // Define a `loader` and `schema` for each collection
     const blog = defineCollection({
-        loader: glob({ pattern: '**\/[^_]*.md', base: "./src/blog" }),
+        loader: glob({ pattern: '**/[^_]*.md', base: "./src/blog" }),
         schema: z.object({
           title: z.string(),
           pubDate: z.date(),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

To avoid confusion whether the editor automatically removes the character or ESlint displays a warning, I removed the useless escape character in the loader `pattern`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Related:
  * #10152
  * https://discord.com/channels/830184174198718474/853350631389265940/1314275896038785227
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
