### PR TITLE
fix: remove useless escape character in `content-collections.mdx`

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -94,7 +94,7 @@ import { defineCollection, z } from 'astro:content';
 import { glob, file } from 'astro/loaders'; // Not available with legacy API
 
 const blog = defineCollection({
-  loader: glob({ pattern: "**\/*.md", base: "./src/data/blog" }),
+  loader: glob({ pattern: "**/*.md", base: "./src/data/blog" }),
   schema: /* ... */ 
 });
 const dogs = defineCollection({
@@ -230,7 +230,7 @@ import { defineCollection, z } from 'astro:content';
 import { glob, file } from 'astro/loaders'; // Not available with legacy API
 
 const blog = defineCollection({
-  loader: glob({ pattern: "**\/*.md", base: "./src/data/blog" }),
+  loader: glob({ pattern: "**/*.md", base: "./src/data/blog" }),
   schema: z.object({
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Same as #10209 but with a different pattern:
I haven't noticed this pattern in the previous PR because I was looking for an exact matching... but I checked `"**\/*.md"` and `"**/*.md"` are both valid.
So, to avoid confusion whether the editor automatically removes the character or ESlint displays a warning, I removed the useless escape character in some loader patterns in `content-collections.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
