### PR TITLE
Fix link to TypeScript guide

### DIFF
--- a/src/content/docs/en/develop-and-build.mdx
+++ b/src/content/docs/en/develop-and-build.mdx
@@ -109,7 +109,7 @@ Explore the guides below to customize your development experience.
   <LinkCard
     title="TypeScript Configuration"
     description="Configure options for type-checking, IntelliSense, and more."
-    href="/en/guides/dev-toolbar/"
+    href="/en/guides/typescript/"
   />
 </CardGrid>
 


### PR DESCRIPTION
#### Description (required)

I found that the link to the [TypeScript guide](https://docs.astro.build/en/guides/typescript/) in the [Configure your dev environment](https://docs.astro.build/en/develop-and-build/#configure-your-dev-environment) section of the Develop and Build page was wrong, so I fixed it.

Discord username: `heldinz`

#### Related issues & labels (optional)

- Suggested label: `typo/link/grammar - quick fix!`
