### PR TITLE
fix: Reorder the number of instruction list in `1-setup/2.mdx`

### DIFF
--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -66,11 +66,11 @@ When the install wizard is complete, you no longer need this terminal. You can n
 ## Open your project in VS Code
 
 <Steps>
-8. Open VS Code. You will be prompted to open a folder. Choose the folder that you created during the setup wizard.
+6. Open VS Code. You will be prompted to open a folder. Choose the folder that you created during the setup wizard.
 
-9. If this is your first time opening an Astro project, you should see a notification asking if you would like to install recommended extensions. Click to see the recommended extensions, and choose the [Astro language support extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode). This will provide syntax highlighting and autocompletions for your Astro code.
+7. If this is your first time opening an Astro project, you should see a notification asking if you would like to install recommended extensions. Click to see the recommended extensions, and choose the [Astro language support extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode). This will provide syntax highlighting and autocompletions for your Astro code.
 
-10. Make sure the terminal is visible and that you can see the command prompt, such as:
+8. Make sure the terminal is visible and that you can see the command prompt, such as:
 
     ```sh
     user@machine:~/tutorial$
@@ -92,7 +92,7 @@ In order to preview your project files _as a website_ while you work, you will n
 ### Start the dev server
 
 <Steps>
-11. Run the command to start the Astro dev server by typing into VS Code's terminal:
+9. Run the command to start the Astro dev server by typing into VS Code's terminal:
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -120,7 +120,7 @@ In order to preview your project files _as a website_ while you work, you will n
 Your project files contain all the code necessary to display an Astro website, but the browser is responsible for displaying your code as web pages.
 
 <Steps>
-12. Click on the `localhost` link in your terminal window to see a live preview of your new Astro website! 
+10. Click on the `localhost` link in your terminal window to see a live preview of your new Astro website! 
 
     (Astro uses `http://localhost:4321` by default if port `4321` is available.)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Reorder the number of instruction list in `1-setup/2.mdx`

#### Related issues & labels (optional)

- Suggested label: `typo/link/grammar - quick fix!`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
