### PR TITLE
feat(link): update link in `guides/deploy/aws` because it now links to same page [i18nIgnore]

### DIFF
--- a/src/content/docs/en/guides/deploy/aws.mdx
+++ b/src/content/docs/en/guides/deploy/aws.mdx
@@ -150,7 +150,7 @@ To connect S3 with Cloudfront, create a CloudFront distribution with the followi
 This configuration will serve your site using the Cloudfront CDN network. You can find your CloudFront distribution URL in the bucket's **Distributions > Domain name**.
 
 :::note
-When connecting CloudFront to an S3 static website endpoint, you rely on S3 bucket policies for access control. See [S3 static website hosting](/en/guides/deploy/aws/#s3-static-website-hosting) section for more information about bucket policies.
+When connecting CloudFront to an S3 static website endpoint, you rely on S3 bucket policies for access control. See [S3 static website hosting](#s3-static-website-hosting) section for more information about bucket policies.
 :::
 
 ## Continuous deployment with GitHub Actions


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The link `/en/guides/deploy/aws/#s3-static-website-hosting` can be shortened to just `#s3-static-website-hosting` because the heading is on the same page.<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: link?<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
