### PR TITLE
fix: indent & line highlighting in `guides/internationalization.mdx`

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -40,7 +40,7 @@ export default defineConfig({
 
 Organize your content folders with localized content by language. Create individual `/[locale]/` folders anywhere within `src/pages/` and Astro's [file-based routing](/en/guides/routing/) will create your pages at corresponding URL paths.
 
-Your folder names must match the items in `locales` exactly. Include a localized folder for your `defaultLocale` only if you configure `prefixDefaultLocale: true` to show a localized URL path for your default language (e.g. /en/about/).
+Your folder names must match the items in `locales` exactly. Include a localized folder for your `defaultLocale` only if you configure `prefixDefaultLocale: true` to show a localized URL path for your default language (e.g. `/en/about/`).
 
 <FileTree>
 - src
@@ -255,7 +255,7 @@ This routing option allows you to customize your domains on a per-language basis
 
 Add `i18n.domains` to map any of your supported `locales` to custom URLs:
 
-```js title="astro.config.mjs" {3-7} ins={14-21}
+```js title="astro.config.mjs" {3-7} ins={14-19}
 import { defineConfig } from "astro/config"
 export default defineConfig({
   site: "https://example.com",
@@ -334,7 +334,7 @@ export default defineConfig({
     locales: ["es", "en", "fr"],
     locales: ["es", "en", {
       path: "french", // no slashes included
-        codes: ["fr", "fr-BR", "fr-CA"]
+      codes: ["fr", "fr-BR", "fr-CA"]
     }],
     defaultLocale: "en",
     routing: {

--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -255,7 +255,7 @@ This routing option allows you to customize your domains on a per-language basis
 
 Add `i18n.domains` to map any of your supported `locales` to custom URLs:
 
-```js title="astro.config.mjs" {3-7} ins={14-19}
+```js title="astro.config.mjs" {3-7} ins={14-17}
 import { defineConfig } from "astro/config"
 export default defineConfig({
   site: "https://example.com",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes a few nitpicks in `guides/internationalization.mdx`:
* in the `domains` section, the highlighting for inserted lines should be restricted to the `domains` property
* in the code snippet of `Custom locale paths`, the indent for `codes` was wrong
* in the `Create localized folders` section, missing backticks for a route (all other routes on the page are wrapped with backticks)

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
