### PR TITLE
Fix typo

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -598,7 +598,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     // Optional: delete the session after the page is rendered.
     // Feel free to implement your own persistence strategy
     await actionStore.delete(sessionId);
-    ctx.cookies.delete("action-session-id");
+    context.cookies.delete("action-session-id");
     return next();
   }
   


### PR DESCRIPTION
#### Description

Fix typo: `ctx` => `context`
`context` variable name is used throughout the example except one place, where its called `ctx`
