### PR TITLE
fix: remove unnecessary `await` before `import.meta.glob`

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -206,7 +206,7 @@ These aliases are also integrated automatically into [VS Code](https://code.visu
 ```astro title="src/components/my-component.astro" {3,4}
 ---
 // imports all files that end with `.md` in `./src/pages/post/`
-const matches = await import.meta.glob('../pages/post/*.md', { eager: true }); 
+const matches = import.meta.glob('../pages/post/*.md', { eager: true }); 
 const posts = Object.values(matches);
 ---
 <!-- Renders an <article> for the first 5 blog posts -->
@@ -226,7 +226,7 @@ Astro components imported using `import.meta.glob` are of type [`AstroInstance`]
 ```astro title="src/pages/component-library.astro" {8}
 ---
 // imports all files that end with `.astro` in `./src/components/`
-const components = Object.values(await import.meta.glob('../components/*.astro', { eager: true }));
+const components = Object.values(import.meta.glob('../components/*.astro', { eager: true }));
 ---
 <!-- Display all of our components -->
 {components.map((component) => (
@@ -248,7 +248,7 @@ A common workaround is to instead import a larger set of files that includes all
 const { postSlug } = Astro.props;
 const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
 
-const posts = await Object.values(await import.meta.glob("../pages/blog/*.md", { eager: true }));
+const posts = Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
 const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
 ---
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When used with `{ eager: true }`, [`import.meta.glob` no longer returns a promise](https://github.com/vitejs/vite/blob/ef7a6a35e6827b92445e5a0c2c0022616efc80dd/packages/vite/types/importGlob.d.ts#L66-L74) and thus no longer needs `await`.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
