### PR TITLE
fix: remove unnecessary `\` in code example

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -105,7 +105,7 @@ import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
 const blog = defineCollection({
-  loader: glob({ pattern: "**\/*.{md,mdx}", base: "./src/blog" }),
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/blog" }),
   schema: z.object({
     title: z.string(),
     description: z.string(),


### PR DESCRIPTION
#### Description

This PR removes an unnecessary backslash `\` character from a code example for the new content collection system.

This should be the last code example that used this character.

Discord user: anaxite