### PR TITLE
Additional import.meta.glob fixes

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -287,12 +287,13 @@ You can optionally provide a type for the `frontmatter` variable using a TypeScr
 
 ```astro
 ---
+import type { MarkdownInstance } from 'astro';
 interface Frontmatter {
     title: string;
     description?: string;
 }
 
-const posts = import.meta.glob<MarkdownInstance<Frontmatter>>('./posts/**/*.md');
+const posts = Object.values(import.meta.glob<MarkdownInstance<Frontmatter>>('./posts/**/*.md', { eager: true }));
 ---
 
 <ul>
@@ -323,7 +324,7 @@ Other files may have various different interfaces, but `import.meta.glob()` acce
 interface CustomDataFile {
   default: Record<string, any>;
 }
-const data = await import.meta.glob<CustomDataFile>('../data/**/*.js');
+const data = import.meta.glob<CustomDataFile>('../data/**/*.js');
 ---
 ```
 


### PR DESCRIPTION
Fixes 2 more instances of `import.meta.glob`