### PR TITLE
i18n(fr): update `guides/routing.mdx`

### DIFF
--- a/src/content/docs/fr/guides/routing.mdx
+++ b/src/content/docs/fr/guides/routing.mdx
@@ -12,7 +12,7 @@ Astro utilise **le routage basé sur les fichiers** pour générer vos URLs de c
 
 ## Naviguer entre les pages
 
-Astro utilise des éléments HTML standard [`<a>`](https://developer.mozilla.org/fr-FR/docs/Web/HTML/Element/a) pour naviguer entre les itinéraires. Il n'y a pas de composant `<Link>` spécifique au cadre de travail.
+Astro utilise des éléments HTML standard [`<a>`](https://developer.mozilla.org/fr-FR/docs/Web/HTML/Element/a) pour naviguer entre les routes. Il n'y a pas de composant `<Link>` spécifique au framework.
 
 ```astro title="src/pages/index.astro"
 <p>En savoir plus <a href="/about/">about</a> Astro !</p>
@@ -23,10 +23,10 @@ Astro utilise des éléments HTML standard [`<a>`](https://developer.mozilla.org
 
 ## Routes Statiques
 
-Les composants Astro (`.astro`) et les fichiers Markdown (`.md`) dans le répertoire `src/pages` **deviendront automatiquement des pages de votre site web**. La route de chaque page correspond à son chemin et à son nom de fichier dans le répertoire `src/pages`.
+Les composants de page `.astro` ainsi que les fichiers Markdown et MDX (`.md`, `.mdx`) dans le répertoire `src/pages` **deviennent automatiquement des pages de votre site web**. La route de chaque page correspond à son chemin et à son nom de fichier dans le répertoire `src/pages`.
 
 ```diff
-# Exemple: Routes Statiques
+# Exemple : Routes Statiques
 src/pages/index.astro        -> mysite.com/
 src/pages/about.astro        -> mysite.com/about
 src/pages/about/index.astro  -> mysite.com/about
@@ -87,8 +87,21 @@ Cela va générer `/en-v1/info` et `/fr-v2/info`.
 
 Les paramètres peuvent être inclus dans des parties séparées du chemin, ainsi nous pourrions utiliser `src/pages/[lang]/[version]/info.astro` avec le même `getStaticPaths` pour générer `/en/v1/info` et `/fr/v2/info`.
 
-<ReadMore>En savoir plus sur [`getStaticPaths()`](/fr/reference/api-reference/#getstaticpaths).</ReadMore>
+#### Décodage de `params`
 
+Les `params` fournis à la fonction `getStaticPaths()` ne sont pas décodés. Utilisez la fonction [`decodeURI`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) lorsque vous avez besoin de décoder les valeurs des paramètres.
+
+```astro title="src/pages/[slug].astro"
+--- 
+export function getStaticPaths() {
+  return [
+    { params: { slug: decodeURI("%5Bpage%5D") } }, // est décodé en "[page]"
+  ]
+}
+---
+```
+
+<ReadMore>En apprendre plus sur [`getStaticPaths()`](/fr/reference/routing-reference/#getstaticpaths).</ReadMore>
 
 <RecipeLinks slugs={["fr/recipes/i18n"]} />
 
@@ -131,7 +144,7 @@ Dans cet exemple, une requête pour `/withastro/astro/tree/main/docs/public/favi
 
 #### Exemple : Pages dynamiques à plusieurs niveaux
 
-Ici, nous utilisons un paramètre REST (`[...slug]`) et la fonctionnalité [`props`](/fr/reference/api-reference/#transfert-de-données-avec-props) de `getStaticPaths()` pour générer des pages pour des slugs de différentes profondeurs.
+Ici, nous utilisons un paramètre REST (`[...slug]`) et la fonctionnalité [`props`](/fr/reference/routing-reference/#data-passing-with-props) de `getStaticPaths()` pour générer des pages pour des slugs de différentes profondeurs.
 
 ```astro title="src/pages/[...slug].astro"
 ---
@@ -385,7 +398,7 @@ Astro a besoin de savoir quelle route doit être utilisée pour construire la pa
 - Les routes basées sur des fichiers ont priorité sur les redirections.
 - Si aucune des règles ci-dessus ne décide de l'ordre, les routes sont triées par ordre alphabétique en fonction des paramètres régionaux par défaut de votre installation Node.
 
-Dans l'exemple ci-dessus, voici quelques exemples de la manière dont les règles feront correspondre une URL demandée à la route utilisée pour construire le code HTML ::
+Dans l'exemple ci-dessus, voici quelques exemples de la manière dont les règles feront correspondre une URL demandée à la route utilisée pour construire le code HTML :
 
 - `pages/post/create.astro` - Ne construira que des `/post/create`.
 - `pages/post/[pid].ts` - Construira `/post/abc`, `/post/xyz`, etc. Mais pas `/post/create`.
@@ -398,7 +411,7 @@ Dans l'exemple ci-dessus, voici quelques exemples de la manière dont les règle
 Les routes internes ont la priorité sur les routes définies par l'utilisateur ou par l'intégration, car elles sont nécessaires au déroulement des fonctionnalités d'Astro. Les routes réservées d'Astro sont les suivantes :
 
 - `_astro/` : Fournit toutes les ressources statiques au client, y compris les documents CSS, les scripts client intégrés, les images optimisées et toutes les ressources Vite.
-- `_server_islands/` : Sert les composants dynamiques différés dans une [Île de serveur](/fr/reference/configuration-reference/#experimentalserverislands);
+- `_server_islands/` : Sert les composants dynamiques différés dans une [Île de serveur](/fr/guides/server-islands/).
 - `_actions/` : Sert toutes les [actions](/fr/guides/actions/) définies.
 
 ## Pagination
@@ -497,7 +510,7 @@ const { page } = Astro.props;
 {page.url.last ? <a href={page.url.last}>Fin</a> : null}
 ```
 
-<ReadMore>En savoir plus sur [la propriété `page` de pagination](/fr/reference/api-reference/#la-propriété-page-de-pagination).</ReadMore>
+<ReadMore>En savoir plus sur [la propriété `page` de pagination](/fr/reference/routing-reference/#the-pagination-page-prop).</ReadMore>
 
 ### Pagination Imbriquée
 
@@ -519,7 +532,7 @@ Dans l'exemple suivant, nous allons implémenter la pagination imbriquée pour c
 // src/pages/[tag]/[page].astro
 export function getStaticPaths({paginate}) {
   const allTags = ['red', 'blue', 'green'];
-  const allPosts = await Astro.glob('../../posts/*.md');
+  const allPosts = Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
   // Pour chaque tag, retourne un résultat paginate().
   // Assurez-vous de passer `{params: {tag}}` à la fonction `paginate()`
   // afin qu'Astro sache à quel groupe de tags le résultat est destiné.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/routing.mdx` with:
* changes from #9240
* a small reword in `Naviguer entre les pages`
* some changes that seem to have been forgotten dating back to I don't know which PR... in `Routes Statiques`

> [!NOTE]
> Once again, the links to `api-reference.mdx` have not been updated. We'll do that at the same time than updating `api-reference.mdx`

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
