### PR TITLE
i18n(fr): update the remaining `guides/upgrade-to/*`

### DIFF
--- a/src/content/docs/fr/guides/upgrade-to/v1.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v1.mdx
@@ -1,6 +1,8 @@
 ---
 title: Guide de mise à niveau héritée v0.x
 description: Guide archivé documentant les modifications entre les versions antérieures à la v1 d'Astro
+sidebar:
+  label: v1.0
 i18nReady: false
 ---
 import { Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/fr/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v2.mdx
@@ -1,6 +1,8 @@
 ---
 title: Mise à jour vers Astro v2
 description: Comment mettre à jour votre projet vers la dernière version d'Astro.
+sidebar:
+  label: v2.0
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
@@ -353,7 +355,7 @@ Astro v2.0 supprime complètement cette option. La présence d'`Astro.fetchConte
 
 #### Que devrais-je faire ?
 
-Utilisez [`Astro.glob()`](/fr/guides/imports/#astroglob) pour récupérer les fichiers Markdown ou mettez à jour votre code pour utiliser la fonctionnalité [Collections de contenu](/fr/guides/content-collections/).
+Utilisez `Astro.glob()` pour récupérer les fichiers Markdown ou mettez à jour votre code pour utiliser la fonctionnalité [Collections de contenu](/fr/guides/content-collections/).
 
 ```astro
 ---

--- a/src/content/docs/fr/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v4.mdx
@@ -1,6 +1,8 @@
 ---
 title: Mise à jour vers Astro v4
 description: Comment mettre à jour votre projet vers la dernière version d'Astro (v4.0).
+sidebar:
+  label: v4.0
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
@@ -61,13 +63,13 @@ export default defineConfig({
   experimental: {
     devOverlay: true,
     i18n: {
-      defaultLocale: "en",
       locales: ["en", "fr", "pt-br", "es"],
+      defaultLocale: "en",
     }
   },
   i18n: {
-    defaultLocale: "en",
     locales: ["en", "fr", "pt-br", "es"],
+    defaultLocale: "en",
   },
 })
 ```
@@ -304,7 +306,7 @@ Astro v4.0 supprime complètement cette option.
 
 Si vous utilisez la configuration obsolète `markdown.drafts`, vous devez maintenant la supprimer car elle n'existe plus.
 
-Pour continuer à marquer certaines pages de votre projet comme brouillons, [migrer vers les collections de contenu](/fr/guides/content-collections/#migration-basée-sur-le-routage-des-fichiers) et [filtrer manuellement les pages](/fr/guides/content-collections/#filtrer-les-requêtes-sur-les-collections) contenant la propriété `draft: true` dans le frontmatter.
+Pour continuer à marquer certaines pages de votre projet comme brouillons, [migrer vers les collections de contenu](/fr/guides/content-collections/) et filtrer manuellement les pages contenant la propriété `draft: true` dans le frontmatter.
 
 ### Supprimé : `getHeaders()`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #9240 to the French translations of:
* `guides/upgrade-to/v1.mdx` (except a link to `api-reference.mdx`)
* `guides/upgrade-to/v2.mdx`
* `guides/upgrade-to/v4.mdx` (except a link to `api-reference.mdx`)

> [!NOTE]
> The links to `api-reference.mdx`  will be updated at the same time as `api-reference.mdx` to avoid broken links

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
