### PR TITLE
[project-structure] remove `src/content` and mention images

### DIFF
--- a/src/content/docs/en/basics/project-structure.mdx
+++ b/src/content/docs/en/basics/project-structure.mdx
@@ -13,7 +13,7 @@ Here's how an Astro project is organized, and some files you will find in your n
 
 Astro leverages an opinionated folder layout for your project. Every Astro project root should include the following directories and files:
 
-- `src/*` - Your project source code (components, pages, styles, etc.)
+- `src/*` - Your project source code (components, pages, styles, images, etc.)
 - `public/*` - Your non-code, unprocessed assets (fonts, icons, etc.)
 - `package.json` - A project manifest.
 - `astro.config.mjs` - An Astro configuration file. (recommended)
@@ -27,17 +27,19 @@ A common Astro project directory might look like this:
 - public/
   - robots.txt
   - favicon.svg
-  - social-image.png
+  - my-cv.pdf
 - src/
+    - blog/
+      - post1.md
+      - post2.md
+      - post3.md
   - components/
     - Header.astro
     - Button.jsx
-  - content/
-      - config.ts
-      - posts/
-        - post1.md
-        - post2.md
-        - post3.md
+  - images/
+    - image1.jpg
+    - image2.jpg
+    - image3.jpg
   - layouts/
     - PostLayout.astro
   - pages/
@@ -48,6 +50,7 @@ A common Astro project directory might look like this:
     - rss.xml.js
   - styles/
     - global.css
+  - content.config.ts
 - astro.config.mjs
 - package.json
 - tsconfig.json
@@ -63,13 +66,14 @@ The `src/` folder is where most of your project source code lives. This includes
 - [UI framework components (React, etc.)](/en/guides/framework-components/)
 - [Styles (CSS, Sass)](/en/guides/styling/)
 - [Markdown](/en/guides/markdown-content/)
+- [Images to be optimized and processed by Astro](/en/guides/images/)
 
 Astro processes, optimizes, and bundles your `src/` files to create the final website that is shipped to the browser.  Unlike the static `public/` directory, your `src/` files are built and handled for you by Astro.
 
 Some files (like Astro components) are not even sent to the browser as written but are instead rendered to static HTML. Other files (like CSS) are sent to the browser but may be optimized or bundled with other CSS files for performance.
 
 :::tip
-While this guide describes some popular conventions used in the Astro community, the only directories reserved by Astro are `src/pages/` and `src/content/`. You are free to rename and reorganize any other directories in a way that works best for you.
+While this guide describes some popular conventions used in the Astro community, the only directory reserved by Astro is `src/pages/`. You are free to rename and reorganize any other directories in a way that works best for you.
 :::
 
 ### `src/pages`
@@ -86,10 +90,6 @@ Pages routes are created for your site by adding [supported file types](/en/basi
 
 This is a common convention in Astro projects, but it is not required. Feel free to organize your components however you like!
 
-### `src/content`
-
-The `src/content/` directory is reserved to store [content collections](/en/guides/content-collections/) and a configuration file. No other files are allowed inside this folder.
-
 ### `src/layouts`
 
 [Layouts](/en/basics/layouts/) are Astro components that define the UI structure shared by one or more [pages](/en/basics/astro-pages/).
@@ -104,7 +104,7 @@ It is a common convention to store your CSS or Sass files in a `src/styles` dire
 
 The `public/` directory is for files and assets in your project that do not need to be processed during Astro's build process. The files in this folder will be copied into the build folder untouched, and then your site will be built.
 
-This behavior makes `public/` ideal for common assets like images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`.
+This behavior makes `public/` ideal for common assets that do not require any processing, like some images and fonts, or special files such as `robots.txt` and `manifest.webmanifest`.
 
 You can place CSS and JavaScript in your `public/` directory, but be aware that those files will not be bundled or optimized in your final build.
 


### PR DESCRIPTION
#### Description (required)

This PR updates `project-structure.mdx` because it still had some outdated information re: content collections.

Additionally, it more clearly mentions putting images in the `src/` file, since the wording had not changed from when most images *were* kept in `public/`