### PR TITLE
[i18nIgnore] remove `await` from `import.meta.glob()`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -131,7 +131,7 @@ Or you can use that exported `title` in your page using `import` and `import.met
 
 ```astro title="src/pages/index.astro"
 ---
-const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
+const matches = import.meta.glob('./posts/*.mdx', { eager: true });
 const posts = Object.values(matches);
 ---
 

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -45,7 +45,7 @@ Here is my _great_ post!
 ```astro title="src/pages/my-posts.astro"
 ---
 import * as greatPost from '../posts/great-post.md';
-const posts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>

--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -339,7 +339,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // Get all `src/pages/posts/` entries
-const allPosts = await Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 
 // Fetch remote data
 const response = await fetch('https://randomuser.me/api/');

--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -339,7 +339,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // Get all `src/pages/posts/` entries
-const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 
 // Fetch remote data
 const response = await fetch('https://randomuser.me/api/');

--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -368,7 +368,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // Get all `src/pages/posts/` entries
-const allPosts = await Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 ---
 
 export const pageQuery = graphql`

--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -368,7 +368,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // Get all `src/pages/posts/` entries
-const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 ---
 
 export const pageQuery = graphql`

--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -397,7 +397,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // Get all `src/pages/posts/` entries
-const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
 
 const response = await fetch('https://randomuser.me/api/');
 const data = await response.json();

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -532,7 +532,7 @@ In the following example, we will implement nested pagination to build the URLs 
 // src/pages/[tag]/[page].astro
 export async function getStaticPaths({ paginate }) {
   const allTags = ['red', 'blue', 'green'];
-  const allPosts = Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+  const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
   // For every tag, return a paginate() result.
   // Make sure that you pass `{params: {tag}}` to `paginate()`
   // so that Astro knows which tag grouping the result is for.

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -836,7 +836,7 @@ Use [Vite's `import.meta.glob`](https://vite.dev/guide/features.html#glob-import
 
 `Astro.glob('../pages/post/*.md')` can be replaced with:
 
-`Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));`
+`Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));`
 
 See the [imports guide](/en/guides/imports/#importmetaglob) for more information and usage.
 :::

--- a/src/content/docs/en/tutorial/5-astro-api/1.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/1.mdx
@@ -29,7 +29,7 @@ Now that you have a few blog posts to link to, it's time to configure the Blog p
     ```astro title="src/pages/blog.astro" ins={3}
     ---
     import BaseLayout from '../layouts/BaseLayout.astro'
-    const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     <BaseLayout pageTitle={pageTitle}>
@@ -141,7 +141,7 @@ Try on your own to make all the necessary changes to your Astro project so that 
     ---
     import BaseLayout from '../layouts/BaseLayout.astro';
     import BlogPost from '../components/BlogPost.astro';
-    const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     ```
@@ -161,7 +161,7 @@ Try on your own to make all the necessary changes to your Astro project so that 
     ---
     import BaseLayout from '../layouts/BaseLayout.astro';
     import BlogPost from '../components/BlogPost.astro';
-    const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog"
     ---
     <BaseLayout pageTitle={pageTitle}>
@@ -186,7 +186,7 @@ If your Astro component contains the following line of code:
 
 ```astro
 ---
-const myPosts = Object.values(await import.meta.glob('./posts/*.md', { eager:  true }));
+const myPosts = Object.values(import.meta.glob('./posts/*.md', { eager:  true }));
 ---
 ```
 

--- a/src/content/docs/en/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/2.mdx
@@ -70,7 +70,7 @@ You can create entire sets of pages dynamically using `.astro` files that export
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+      const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -183,7 +183,7 @@ Even if it looks challenging, you can try following along with the steps to buil
    import BaseLayout from '../../layouts/BaseLayout.astro';
 
    export async function getStaticPaths() {
-     const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+     const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
      const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
    }
@@ -249,7 +249,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+  const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
   
   const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/en/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/3.mdx
@@ -114,7 +114,7 @@ Fortunately, you already know a way to grab the data from all your Markdown file
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
     const pageTitle = "Tag Index";
     ---
     ```
@@ -125,7 +125,7 @@ Fortunately, you already know a way to grab the data from all your Markdown file
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
     const tags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
     const pageTitle = "Tag Index";
     ---
@@ -209,7 +209,7 @@ Here is what your new page should look like:
 ```astro title="src/pages/tags/index.astro"
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---

--- a/src/content/docs/en/tutorial/6-islands/4.mdx
+++ b/src/content/docs/en/tutorial/6-islands/4.mdx
@@ -207,7 +207,7 @@ Upgrade to the latest version of Astro, and upgrade all integrations to their la
     import BlogPost from "../components/BlogPost.astro";
 
     const pageTitle = "My Astro Learning Blog";
-    const allPosts = Object.values(await import.meta.glob("../pages/posts/*.md", { eager: true }));
+    const allPosts = Object.values(import.meta.glob("../pages/posts/*.md", { eager: true }));
     const allPosts = await getCollection("blog");
     ---
     ```

--- a/src/content/docs/fr/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/mdx.mdx
@@ -110,7 +110,7 @@ Ou vous pouvez utiliser ce `title` exporté dans votre page en utilisant les ins
 
 ```astro title="src/pages/index.astro"
 ---
-const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
+const matches = import.meta.glob('./posts/*.mdx', { eager: true });
 const posts = Object.values(matches);
 ---
 

--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -43,7 +43,7 @@ Voici mon _incroyable_ billet !
 ```astro title="src/pages/my-posts.astro"
 ---
 import * as greatPost from '../posts/great-post.md';
-const posts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>

--- a/src/content/docs/fr/guides/routing.mdx
+++ b/src/content/docs/fr/guides/routing.mdx
@@ -532,7 +532,7 @@ Dans l'exemple suivant, nous allons implémenter la pagination imbriquée pour c
 // src/pages/[tag]/[page].astro
 export function getStaticPaths({paginate}) {
   const allTags = ['red', 'blue', 'green'];
-  const allPosts = Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+  const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
   // Pour chaque tag, retourne un résultat paginate().
   // Assurez-vous de passer `{params: {tag}}` à la fonction `paginate()`
   // afin qu'Astro sache à quel groupe de tags le résultat est destiné.

--- a/src/content/docs/ko/guides/imports.mdx
+++ b/src/content/docs/ko/guides/imports.mdx
@@ -251,7 +251,7 @@ Vite의 `import.meta.glob()` 함수는 정적 문자열 리터럴만 지원합�
 const { postSlug } = Astro.props;
 const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
 
-const posts = await Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
+const posts = Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
 const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
 ---
 

--- a/src/content/docs/ko/guides/imports.mdx
+++ b/src/content/docs/ko/guides/imports.mdx
@@ -205,7 +205,7 @@ import logoUrl from '@assets/logo.png?url';
 ```astro title="src/components/my-component.astro" {3,4}
 ---
 // `./src/pages/post/`에서 `.md`로 끝나는 모든 파일을 가져옵니다.
-const matches = await import.meta.glob('../pages/post/*.md', { eager: true }); 
+const matches = import.meta.glob('../pages/post/*.md', { eager: true }); 
 const posts = Object.values(matches);
 ---
 
@@ -228,7 +228,7 @@ const posts = Object.values(matches);
 ```astro title="src/pages/component-library.astro" {8}
 ---
 // `./src/components/`에서 `.astro`로 끝나는 모든 파일을 가져옵니다.
-const components = Object.values(await import.meta.glob('../components/*.astro', { eager: true }));
+const components = Object.values(import.meta.glob('../components/*.astro', { eager: true }));
 ---
 <!-- 모든 컴포넌트 표시 -->{
   components.map((component) => (
@@ -251,7 +251,7 @@ Vite의 `import.meta.glob()` 함수는 정적 문자열 리터럴만 지원합�
 const { postSlug } = Astro.props;
 const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
 
-const posts = await Object.values(await import.meta.glob("../pages/blog/*.md", { eager: true }));
+const posts = await Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
 const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
 ---
 

--- a/src/content/docs/ko/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/ko/guides/integrations-guide/mdx.mdx
@@ -131,7 +131,7 @@ export const title = 'My first MDX post'
 
 ```astro title="src/pages/index.astro"
 ---
-const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
+const matches = import.meta.glob('./posts/*.mdx', { eager: true });
 const posts = Object.values(matches);
 ---
 

--- a/src/content/docs/ko/guides/markdown-content.mdx
+++ b/src/content/docs/ko/guides/markdown-content.mdx
@@ -45,7 +45,7 @@ Here is my _great_ post!
 ```astro title="src/pages/my-posts.astro"
 ---
 import * as greatPost from '../posts/great-post.md';
-const posts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>

--- a/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
@@ -338,7 +338,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // 모든 `src/pages/posts/` 항목을 가져오기
-const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 
 // 원격 데이터 가져오기
 const response = await fetch('https://randomuser.me/api/');

--- a/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
@@ -338,7 +338,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // 모든 `src/pages/posts/` 항목을 가져오기
-const allPosts = await Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 
 // 원격 데이터 가져오기
 const response = await fetch('https://randomuser.me/api/');

--- a/src/content/docs/ko/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-gatsby.mdx
@@ -369,7 +369,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // 모든 `src/pages/posts/` 항목을 가져오기
-const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 ---
 
 export const pageQuery = graphql`

--- a/src/content/docs/ko/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-gatsby.mdx
@@ -369,7 +369,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // 모든 `src/pages/posts/` 항목을 가져오기
-const allPosts = await Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+const allPosts = await Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 ---
 
 export const pageQuery = graphql`

--- a/src/content/docs/ko/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-nextjs.mdx
@@ -398,7 +398,7 @@ import { getCollection } from 'astro:content';
 const allBlogPosts = await getCollection('blog');
 
 // 모든 `src/pages/posts/` 항목을 가져오기
-const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
 
 const response = await fetch('https://randomuser.me/api/');
 const data = await response.json();

--- a/src/content/docs/ko/guides/routing.mdx
+++ b/src/content/docs/ko/guides/routing.mdx
@@ -534,7 +534,7 @@ const { page } = Astro.props;
 // src/pages/[tag]/[page].astro
 export async function getStaticPaths({ paginate }) {
   const allTags = ['red', 'blue', 'green'];
-  const allPosts = Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));
+  const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
   // 모든 태그에 대해 paginate() 결과를 반환합니다.
   // `{params: {tag}}`를 `paginate()`에 전달했는지 확인합니다.
   // Astro가 결과가 어떤 태그 그룹에 대한 것인지 알 수 있도록 합니다.

--- a/src/content/docs/ko/reference/api-reference.mdx
+++ b/src/content/docs/ko/reference/api-reference.mdx
@@ -831,7 +831,7 @@ true인 경우 쿠키는 https 사이트에만 설정됩니다.
 
 `Astro.glob('../pages/post/*.md')`를 다음과 같이 변환할 수 있습니다.
 
-`Object.values(await import.meta.glob('../pages/post/*.md', { eager: true }));`
+`Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));`
 
 더 많은 정보와 사용법은 [가져오기 가이드](/ko/guides/imports/#importmetaglob)를 참조하세요.
 :::

--- a/src/content/docs/ko/tutorial/5-astro-api/1.mdx
+++ b/src/content/docs/ko/tutorial/5-astro-api/1.mdx
@@ -29,7 +29,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title="src/pages/blog.astro" ins={3}
     ---
     import BaseLayout from '../layouts/BaseLayout.astro'
-    const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     <BaseLayout pageTitle={pageTitle}>
@@ -140,7 +140,7 @@ import { Steps } from '@astrojs/starlight/components';
     ---
     import BaseLayout from '../layouts/BaseLayout.astro';
     import BlogPost from '../components/BlogPost.astro';
-    const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     ```
@@ -160,7 +160,7 @@ import { Steps } from '@astrojs/starlight/components';
     ---
     import BaseLayout from '../layouts/BaseLayout.astro';
     import BlogPost from '../components/BlogPost.astro';
-    const allPosts = Object.values(await import.meta.glob('../pages/posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../pages/posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog"
     ---
     <BaseLayout pageTitle={pageTitle}>
@@ -183,7 +183,7 @@ Astro 컴포넌트에 다음 코드 줄이 포함되어 있을때
 
 ```astro
 ---
-const myPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
+const myPosts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
 ---
 ```
 

--- a/src/content/docs/ko/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/ko/tutorial/5-astro-api/2.mdx
@@ -70,7 +70,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+      const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -182,7 +182,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+      const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
       const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
     }
@@ -249,7 +249,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+  const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
   
   const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/ko/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/ko/tutorial/5-astro-api/3.mdx
@@ -115,7 +115,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
     const pageTitle = "Tag Index";
     ---
     ```
@@ -126,7 +126,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
     const tags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
     const pageTitle = "Tag Index";
     ---
@@ -210,7 +210,7 @@ import { Steps } from '@astrojs/starlight/components';
 ```astro title="src/pages/tags/index.astro"
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---

--- a/src/content/docs/ko/tutorial/6-islands/4.mdx
+++ b/src/content/docs/ko/tutorial/6-islands/4.mdx
@@ -208,7 +208,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BlogPost from "../components/BlogPost.astro";
 
     const pageTitle = "My Astro Learning Blog";
-    const allPosts = Object.values(await import.meta.glob("../pages/posts/*.md", { eager: true }));
+    const allPosts = Object.values(import.meta.glob("../pages/posts/*.md", { eager: true }));
     const allPosts = await getCollection("blog");
     ---
     ```

--- a/src/content/docs/zh-cn/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/mdx.mdx
@@ -109,7 +109,7 @@ export const title = '我的第一篇 MDX 博客'
 
 ```astro title="src/pages/index.astro"
 ---
-const matches = await import.meta.glob('./posts/*.mdx', { eager: true });
+const matches = import.meta.glob('./posts/*.mdx', { eager: true });
 const posts = Object.values(matches);
 ---
 

--- a/src/content/docs/zh-cn/guides/markdown-content.mdx
+++ b/src/content/docs/zh-cn/guides/markdown-content.mdx
@@ -44,7 +44,7 @@ author: 'Ben'
 ```astro title="src/pages/my-posts.astro"
 ---
 import * as greatPost from '../posts/great-post.md';
-const posts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>


### PR DESCRIPTION
Changes all occurrences in all languages of `await import.meta.glob('*', { eager: true });` to remove `await` as it is not needed.