### PR TITLE
Fix abbrevation duplication of GC project [i18nIgnore]

### DIFF
--- a/src/content/docs/en/guides/deploy/google-cloud.mdx
+++ b/src/content/docs/en/guides/deploy/google-cloud.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 ### Cloud Storage (static only)
 
 <Steps>
-1. [Create a new GCP project](https://console.cloud.google.com/projectcreate), or select one you already have.
+1. [Create a new GC project](https://console.cloud.google.com/projectcreate), or select one you already have.
 
 2. Create a new bucket under [Cloud Storage](https://cloud.google.com/storage).
 
@@ -35,7 +35,7 @@ Cloud Run is a serverless platform that allows you to run a container without ha
 #### Prepare the Service
 
 <Steps>
-1. [Create a new GCP project](https://console.cloud.google.com/projectcreate), or select one you already have.
+1. [Create a new GC project](https://console.cloud.google.com/projectcreate), or select one you already have.
 
 2. Make sure the [Cloud Run API](https://console.cloud.google.com/apis/library/run.googleapis.com) is enabled.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I'm not sure if the P in `GCP` stands for project. If yes, then the word project is a duplicate, because if you don't use abbrevations it reads like: `Google Cloud Project project`<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: ~duplication 🤣~<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
