### PR TITLE
Add dockerhub URL to registry examples in Google Cloud Deploy Guide

### DIFF
--- a/src/content/docs/en/guides/deploy/google-cloud.mdx
+++ b/src/content/docs/en/guides/deploy/google-cloud.mdx
@@ -65,7 +65,7 @@ docker push HOSTNAME/PROJECT-ID/IMAGE:TAG
 Change the following values in the commands above to match your project:
 
 - `SOURCE_IMAGE`: the local image name or image ID.
-- `HOSTNAME`: the registry host (`gcr.io`, `eu.gcr.io`, `asia.gcr.io`, `us.gcr.io`).
+- `HOSTNAME`: the registry host (`gcr.io`, `eu.gcr.io`, `asia.gcr.io`, `us.gcr.io`, `docker.io`).
 - `PROJECT`: your Google Cloud project ID.
 - `TARGET-IMAGE`: the name for the image when it's stored in the registry.
 - `TAG` is the version associated with the image.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since Docker Hub is mentioned in the text above, I think it would make sense to include the Registry URL in the examples below...<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
