### PR TITLE
[I18nIgnore] fix(tutorial): remove a useless `await` in unit 5

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/1.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/1.mdx
@@ -48,7 +48,7 @@ Now that you have a few blog posts to link to, it's time to configure the Blog p
     ```astro title="src/pages/blog.astro" del={9,10,11} ins={13}
     ---
     import BaseLayout from '../layouts/BaseLayout.astro'
-    const allPosts = await Object.values(import.meta.glob('./posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     <BaseLayout pageTitle={pageTitle}>

--- a/src/content/docs/ko/tutorial/5-astro-api/1.mdx
+++ b/src/content/docs/ko/tutorial/5-astro-api/1.mdx
@@ -47,7 +47,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title="src/pages/blog.astro" del={9,10,11} ins={13}
     ---
     import BaseLayout from '../layouts/BaseLayout.astro'
-    const allPosts = await Object.values(import.meta.glob('./posts/*.md', { eager: true }));
+    const allPosts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
     const pageTitle = "My Astro Learning Blog";
     ---
     <BaseLayout pageTitle={pageTitle}>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We have a remaining `await` in front of `Object.values` which is useless and makes the code snippets inconsistent across the tutorial, so I removed it.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Related: #10332
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
