### PR TITLE
fix: malformed code snippet in `integrations-guide/mdx.mdx`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -96,7 +96,7 @@ It also adds extra features to standard MDX, including support for Markdown-styl
 
 `.mdx` files must be written in [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) rather than Astro’s HTML-like syntax.
 
-### Using MDX wth content collections
+### Using MDX with content collections
 
 To include MDX files in a content collection, make sure that your [collection loader](/en/guides/content-collections/#defining-the-collection-loader) is configured to load content from `.mdx` files:
 

--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -111,6 +111,7 @@ const blog = defineCollection({
     description: z.string(),
     pubDate: z.coerce.date(),
   })
+});
 
 export const collections = { blog };
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* The code snippet in the `Using MDX with content collections` section had an unclosed function, so I fixed it
* There was a typo in the section heading `wth` > `with`

I don't know if other languages ​​than Korean are already up to date on this file, so I didn't included the changes on the Korean version.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo, code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
