### PR TITLE
Add missing code fence

### DIFF
--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -183,6 +183,7 @@ A function that can be returned from [`getStaticPaths()`](#getstaticpaths) to di
 The following example fetches and passes 150 items to the `paginate` function, and creates static, prerendered pages at build time that will display 10 items per page:
 
 ```astro title="src/pages/pokemon/[page].astro"
+---
 export async function getStaticPaths({ paginate }) {
   // Load your data with fetch(), getCollection(), etc.
   const response = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=150`);
@@ -194,6 +195,7 @@ export async function getStaticPaths({ paginate }) {
 }
 
 const { page } = Astro.props;
+---
 ```
 
 `paginate()` has the following arguments:


### PR DESCRIPTION
#### Description (required)

This PR fixes a code block which was missing the code fence, resulting in broken code highlights on the docs (see https://docs.astro.build/en/reference/routing-reference/#paginate)