### PR TITLE
Add prefix to tab panels IDs to avoid clashes

### DIFF
--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -45,7 +45,8 @@ function assertGroups(sidebar: SidebarEntry[]): asserts sidebar is Group[] {
 assertGroups(sidebar);
 
 /** Convert a group label to an `id` we can use to identify tab panels. */
-const makeId = (label: string) => label.toLowerCase().replaceAll(/\s+/g, '-');
+// The id is prefixed to avoid clashing with existing heading IDs on the page.
+const makeId = (label: string) => '__tab-' + label.toLowerCase().replaceAll(/\s+/g, '-');
 
 /** Get the icon for a group. Update the icon names in the array to change the icons associated with a group. */
 const getIcon = (index: number) =>


### PR DESCRIPTION
#### Description (required)

This PR fixes the occasion on which a tab panel ID conflicts with a page heading ID, so you cannot click to navigate to that specific heading from links.

For example, it currently occurs on the [`integrations` heading of Configuration Reference](https://docs.astro.build/en/reference/configuration-reference/#integrations), since we have a tab of the same name "Integrations" that gets the id `integrations`.

