### PR TITLE
i18n(pt-BR): create `reference/errors/adapter-support-output-mismatch.mdx`

### DIFF
--- a/src/content/docs/pt-br/reference/errors/adapter-support-output-mismatch.mdx
+++ b/src/content/docs/pt-br/reference/errors/adapter-support-output-mismatch.mdx
@@ -1,0 +1,15 @@
+---
+title: Adaptador não suporta a saída do servidor.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **AdapterSupportOutputMismatch**: O adaptador `ADAPTER_NAME` está configurado para processar um website estático, mas o projeto contém páginas processadas pelo servidor. Por favor instale e configure o adaptador de servidor apropriado para sua distribuição final.
+
+## O que deu errado?
+O adaptador configurado atualmente não suporta processamento no lado do servidor, o que é exigido pela configuração atual do projeto.
+
+Dependendo do seu adaptador, pode existir um _entrypoint_ diferente para usar processamento no lado do servidor. Por exemplo, o adaptador `@astrojs/vercel` possui um _entrypoint_ `@astrojs/vercel/static` para processamento estático, e um _entrypoint_ `@astrojs/vercel/serverless` para processamento no lado do servidor. 
+
+**Veja também:**
+-  [Processamento no Lado do Servidor](/pt-br/guides/on-demand-rendering/)


### PR DESCRIPTION
#### Description (required)

i18n pt-br translate content /reference/errors/adapter-support-output-mismatch.mdx
