### PR TITLE
[i18nIgnore] Fix typo in `content-collections.mdx`

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -165,7 +165,7 @@ The `parser` argument also allows you to load a single collection from a nested 
 {"dogs": [{}], "cats": [{}]}
 ```
 
-You can seperate these collections by passing a custom `parser` to the `file()` loader for each collection:
+You can separate these collections by passing a custom `parser` to the `file()` loader for each collection:
 
 ```typescript title="src/content.config.ts"
 const dogs = defineCollection({


### PR DESCRIPTION
#### Description (required)

Fix english typo in `src/content/docs/en/guides/content-collections.mdx`