### PR TITLE
i18n(pt-BR): create `reference/errors/content-loader-invalid-data-error.mdx`

### DIFF
--- a/src/content/docs/pt-br/reference/errors/content-loader-invalid-data-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/content-loader-invalid-data-error.mdx
@@ -1,0 +1,13 @@
+---
+title: Falta um ID na entrada de conteúdo
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Exemplo de mensagem de erro:**<br/>
+The loader for **blog** returned invalid data.<br/>
+Object is missing required property "id".
+
+## O que deu errado?
+O carregador retornou dados inválidos com uma coleção de conteúdo.
+Carregadores alinhados devem retornar um array de objetos comm campos de ID únicos ou um objeto plano com IDs como chaves e entradas como valores.


### PR DESCRIPTION
#### Description (required)

translate content i18n pt-br/reference/errors/content-loader-invalid-data-error.mdx
