### PR TITLE
i18n(fr): update `guides/testing.mdx`

### DIFF
--- a/src/content/docs/fr/guides/testing.mdx
+++ b/src/content/docs/fr/guides/testing.mdx
@@ -108,10 +108,10 @@ Vous pouvez également installer Playwright dans votre projet Astro à l'aide du
     ```html title="src/pages/index.astro"
     ---
     ---
-    <html lang="en">
+    <html lang="fr">
       <head>
         <title>Astro est génial !</title>
-        <meta name="description" content="Tirez du contenu de n'importe où et diffusez-le rapidement grâce à l'architecture d'îles de nouvelle génération d'Astro." />
+        <meta name="description" content="Tirez du contenu de n'importe où et diffusez-le rapidement grâce à l'architecture en îles de nouvelle génération d'Astro." />
       </head>
       <body></body>
     </html>
@@ -243,11 +243,11 @@ export default defineConfig({
     ---
     <html lang="fr">
       <head>
-        <title>Astro is awesome!</title>
+        <title>Astro est génial !</title>
         <meta name="description" content="Tirez du contenu de n'importe où et diffusez-le rapidement grâce à l'architecture en îlots de nouvelle génération d'Astro." />
       </head>
       <body>
-      <h1>Bonjour au monde de la part d'Astro</h1>
+      <h1>Bonjour au monde depuis Astro</h1>
       </body>
     </html>
     ```
@@ -258,8 +258,8 @@ export default defineConfig({
     it('titles are correct', () => {
       const page = cy.visit('http://localhost:4321');
 
-      page.get('title').should('have.text', 'Astro is awesome!')
-      page.get('h1').should('have.text', 'Hello world from Astro');
+      page.get('title').should('have.text', 'Astro est génial !')
+      page.get('h1').should('have.text', 'Bonjour au monde depuis Astro');
     });
     ```
 
@@ -354,7 +354,7 @@ Vous pouvez installer NightwatchJS dans votre projet Astro en utilisant le gesti
     ---
     <html lang="fr">
       <head>
-        <title>Astro est formidable !</title>
+        <title>Astro est génial !</title>
         <meta name="description" content="Tirez du contenu de n'importe où et diffusez-le rapidement grâce à l'architecture en îlots de nouvelle génération d'Astro." />
       </head>
       <body></body>
@@ -368,7 +368,7 @@ Vous pouvez installer NightwatchJS dans votre projet Astro en utilisant le gesti
 		    before(browser => browser.navigateTo('http://localhost:4321/'));
 		
 		    it("check that the title is correct", function (browser) {
-		        browser.assert.titleEquals('Astro is awesome!')
+		        browser.assert.titleEquals('Astro est génial !')
 		    });
 		
 		    after(browser => browser.end());


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The French translation of `guides/testing.mdx` was marked as outdated due to #9240 but the changes are not applicable (`island` > `islands`) so instead I updated the code snippets to make them consistent:
* a page to test was translated but the expectation was not translated
* a page to test and an expectation was both translated but in a different way...

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
