### PR TITLE
i18n(pt-BR): create `reference/errors/missing-middleware-for-internationalization.mdx`

### DIFF
--- a/src/content/docs/pt-br/reference/errors/missing-middleware-for-internationalization.mdx
+++ b/src/content/docs/pt-br/reference/errors/missing-middleware-for-internationalization.mdx
@@ -1,0 +1,10 @@
+---
+title: Roteamento manual de internacionalização habilitado sem possuir um middleware.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **MissingMiddlewareForInternationalization**: A definição `i18n.routing: 'manual'` na sua configuração exige que você forneça o seu próprio arquivo i18n `middleware`.
+
+## O que deu errado?
+Astro lança um erro se o usuário habilita roteamento manual, mas não possui um arquivo _middleware_.


### PR DESCRIPTION
#### Description (required)

translate content i18n pt-br/reference/errors/missing-middleware-for-internationalization.mdx
