### PR TITLE
i18n(fr): update `guides/styling.mdx`

### DIFF
--- a/src/content/docs/fr/guides/styling.mdx
+++ b/src/content/docs/fr/guides/styling.mdx
@@ -1,6 +1,6 @@
 ---
-title: Styles & CSS
-description: Apprenez à styliser des composants dans Astro avec des styles délimités, des CSS externes et des outils tels que Sass et PostCSS.
+title: Styles et CSS
+description: Apprenez à mettre en forme des composants dans Astro avec des styles à portée limitée, des CSS externes et des outils tels que Sass et PostCSS.
 i18nReady: true
 
 ---
@@ -9,11 +9,11 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import ReadMore from '~/components/ReadMore.astro'
 
 
-Astro a été conçu pour faciliter le stylisme et l'écriture de CSS. Écrivez votre propre CSS directement dans un composant Astro ou importez votre bibliothèque CSS préférée comme [Tailwind][tailwind]. Les langages de style avancés comme [Sass][sass] et [Less][less] sont également pris en charge.
+Astro a été conçu pour rendre la mise en forme et l'écriture CSS un jeu d'enfant. Écrivez votre propre CSS directement dans un composant Astro ou importez votre bibliothèque CSS préférée comme [Tailwind][tailwind]. Les langages avancés de mise en forme comme [Sass][sass] et [Less][less] sont également pris en charge.
 
 ##  Styliser avec Astro
 
-Le style d'un composant Astro est aussi simple que l'ajout d'une balise `<style>` à votre composant ou à votre modèle de page. Lorsque vous placez une balise `<style>` à l'intérieur d'un composant Astro, Astro détecte le CSS et gère vos styles pour vous, automatiquement.
+La mise en forme d'un composant Astro est aussi simple que l'ajout d'une balise `<style>` à votre composant ou à votre modèle de page. Lorsque vous placez une balise `<style>` à l'intérieur d'un composant Astro, Astro détecte le CSS et gère vos styles pour vous, automatiquement.
 
 ```astro title="src/components/MyComponent.astro"
 <style>
@@ -21,9 +21,9 @@ Le style d'un composant Astro est aussi simple que l'ajout d'une balise `<style>
 </style>
 ```
 
-### Styles scopés
+### Styles à portée limitée
 
-Les règles CSS Astro `<style>` sont automatiquement **scopées par défaut**. Les styles scopés sont compilés en coulisses pour ne s'appliquer qu'au HTML écrit à l'intérieur de ce même composant. Le CSS que vous écrivez à l'intérieur d'un composant Astro est automatiquement encapsulé à l'intérieur de ce composant.
+Les règles CSS définies dans la balise `<style>` d'Astro disposent automatiquement d'une **portée limitée par défaut** (« scoped » en anglais). Les styles à portée limitée sont compilés en arrière-plan pour s'appliquer uniquement au code HTML écrit à l'intérieur de ce même composant. Le CSS que vous écrivez à l'intérieur d'un composant Astro est automatiquement encapsulé à l'intérieur de ce composant.
 
 Ce CSS:
 ```astro title="src/pages/index.astro"
@@ -38,7 +38,7 @@ Ce CSS:
 </style>
 ```
 
-Voici ce que cela donne :
+Est compilé comme ceci :
 ```astro
 <style>
   h1[data-astro-cid-hhnqfkh6] {
@@ -52,25 +52,25 @@ Voici ce que cela donne :
 ```
 
 
-Les styles délimités ne fuient pas et n'ont pas d'impact sur le reste de votre site. Dans Astro, il est possible d'utiliser des sélecteurs peu spécifiques comme `h1 {}` ou `p {}` car ils seront compilés avec des scopes dans la sortie finale.
+Les styles à portée limitée ne fuient pas et n'auront pas d'impact sur le reste de votre site. Dans Astro, il est possible d'utiliser des sélecteurs peu spécifiques comme `h1 {}` ou `p {}` car ils seront compilés avec une portée limitée dans la sortie finale.
 
-Les styles délimités ne s'appliquent pas non plus aux autres composants Astro contenus dans votre modèle. Si vous devez styliser un composant enfant, pensez à envelopper ce composant dans un `<div>` (ou un autre élément) que vous pourrez ensuite styliser.
+Les styles à portée limitée ne s'appliquent pas non plus aux autres composants Astro contenus dans votre modèle. Si vous devez mettre en forme un composant enfant, pensez à envelopper ce composant dans un `<div>` (ou un autre élément) que vous pourrez ensuite mettre en forme.
 
-La spécificité des styles délimités est préservée, ce qui leur permet de fonctionner de manière cohérente avec d'autres fichiers CSS ou bibliothèques CSS tout en préservant les limites exclusives qui empêchent les styles de s'appliquer en dehors du composant.
+La spécificité des styles à portée limitée est préservée, ce qui leur permet de fonctionner de manière cohérente avec d'autres fichiers CSS ou bibliothèques CSS tout en préservant les limites exclusives qui empêchent les styles de s'appliquer en dehors du composant.
 
 ### Styles globaux
 
-Bien que nous recommandions des styles délimités pour la plupart des composants, il se peut que vous trouviez une raison valable d'écrire des feuilles de style CSS globales et non délimitées. Vous pouvez refuser le marquage CSS automatique avec l'attribut `<style is:global>`.
+Bien que nous recommandions des styles à portée limitée pour la plupart des composants, il se peut que vous trouviez une raison valable d'écrire du CSS global et sans portée limitée. Vous pouvez désactiver la portée CSS automatique avec l'attribut `<style is:global>`.
 
 ```astro title="src/components/GlobalStyles.astro" "is:global"
 <style is:global>
-  /* Non codé, livré tel quel au navigateur.
+  /* Sans portée limitée, livré tel quel au navigateur.
      S'applique à toutes les balises <h1> de votre site. */
   h1 { color: red; }
 </style>
 ```
 
-Vous pouvez également mélanger des règles CSS globales et étendues dans la même balise `<style>` en utilisant le sélecteur `:global()`. Cela devient un modèle puissant pour appliquer des styles CSS aux enfants de votre composant.
+Vous pouvez également mélanger des règles CSS globales et à portée limitée dans la même balise `<style>` en utilisant le sélecteur `:global()`. Cela devient un modèle puissant pour appliquer des styles CSS aux enfants de votre composant.
 
 ```astro title="src/components/MixedStyles.astro" ":global(h1)"
 <style>
@@ -81,13 +81,13 @@ Vous pouvez également mélanger des règles CSS globales et étendues dans la m
     color: blue;
   }
 </style>
-<h1>Title</h1>
+<h1>Titre</h1>
 <article><slot /></article>
 ```
 
-C'est un excellent moyen de styliser des éléments tels que des articles de blog ou des documents dont le contenu est géré par un CMS et qui se trouvent en dehors d'Astro. Mais attention : les composants dont l'apparence diffère selon qu'ils ont ou non un certain composant parent peuvent devenir difficiles à dépanner.
+C'est un excellent moyen de mettre en forme des éléments tels que des articles de blog ou des documents dont le contenu est géré par un CMS et qui se trouvent en dehors d'Astro. Mais attention : les composants dont l'apparence diffère selon qu'ils ont ou non un certain composant parent peuvent devenir difficiles à dépanner.
 
-Les styles restreints doivent être utilisés aussi souvent que possible. Les styles globaux ne doivent être utilisés qu'en cas de besoin.
+Les styles à portée limitée doivent être utilisés aussi souvent que possible. Les styles globaux ne doivent être utilisés qu'en cas de besoin.
 
 ### Combiner des classes avec `class:list`
 
@@ -107,13 +107,13 @@ const { isRed } = Astro.props;
 </style>
 ```
 
-<ReadMore>Consultez notre page [directives reference](/fr/reference/directives-reference/#classlist) pour en savoir plus sur `class:list`.</ReadMore>
+<ReadMore>Consultez notre page de [référence des directives](/fr/reference/directives-reference/#classlist) pour en savoir plus sur `class:list`.</ReadMore>
 
 ### Variables CSS
 
 <p><Since v="0.21.0" /></p>
 
-Le `<style>` Astro peut faire référence à n'importe quelle variable CSS disponible sur la page. Vous pouvez également passer des variables CSS directement à partir de la page d'accueil de votre composant en utilisant la directive `define:vars`.
+La balise `<style>` d'Astro peut référencer n'importe quelle variable CSS disponible sur la page. Vous pouvez également passer des variables CSS directement à partir du frontmatter de votre composant en utilisant la directive `define:vars`.
 
 ```astro title="src/components/DefineVars.astro" /define:vars={{.*}}/ /var\\(.*\\)/
 ---
@@ -129,16 +129,16 @@ const backgroundColor = "rgb(24 121 78)";
 <h1>Bonjour</h1>
 ```
 
-<ReadMore>Consultez notre page [directives reference](/fr/reference/directives-reference/#definevars) pour en savoir plus sur `define:vars`.</ReadMore>
+<ReadMore>Consultez notre page de [référence des directives](/fr/reference/directives-reference/#definevars) pour en savoir plus sur `define:vars`.</ReadMore>
 
 
-### Transmettre une `classe` à un composant enfant
+### Transmettre une classe à un composant enfant
 
 Dans Astro, les attributs HTML comme `class` ne sont pas automatiquement transmis aux composants enfants.
 
 Au lieu de cela, il faut accepter un attribut `class` dans le composant enfant et l'appliquer à l'élément racine. Lors de la déstructuration, vous devez le renommer, car `class` est un [mot réservé](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Lexical_grammar#mots-clés) en JavaScript.
 
-En utilisant la stratégie de style par défaut, vous devez également passer l'attribut `data-astro-cid-*`. Vous pouvez le faire en passant le reste des props au composant. Si vous avez changé `scopedStyleStrategy` en `'class'` ou `'where'`, la propriété `...rest` n'est pas nécessaire.
+En utilisant la stratégie de style à portée limitée par défaut, vous devez également passer l'attribut `data-astro-cid-*`. Vous pouvez le faire en passant le reste des props au composant. Si vous avez changé `scopedStyleStrategy` en `'class'` ou `'where'`, la propriété `...rest` n'est pas nécessaire.
 
 ```astro title="src/components/MyComponent.astro" {2,4}
 ---
@@ -158,16 +158,16 @@ import MyComponent from "../components/MyComponent.astro"
     color: red;
   }
 </style>
-<MyComponent class="red">Ce sera rouge!</MyComponent>
+<MyComponent class="red">Ce sera rouge !</MyComponent>
 ```
 
-:::noteStyles en cascade à partir des composants parents]
+:::note[Styles à portée limitée à partir des composants parents]
 Parce que l'attribut `data-astro-cid-*` inclut l'enfant dans la portée de son parent, il est possible que les styles passent en cascade du parent à l'enfant. Pour éviter que cela n'ait des effets secondaires inattendus, assurez-vous d'utiliser des noms de classe uniques dans le composant enfant.
 :::
 
 ### Styles en ligne
 
-Vous pouvez styler les éléments HTML en ligne en utilisant l'attribut `style`. Il peut s'agir d'une chaîne CSS ou d'un objet de propriétés CSS :
+Vous pouvez mettre en forme les éléments HTML en ligne en utilisant l'attribut `style`. Il peut s'agir d'une chaîne CSS ou d'un objet de propriétés CSS :
 
 ```astro title="src/pages/index.astro"
 // Ils sont équivalents:
@@ -179,12 +179,12 @@ Vous pouvez styler les éléments HTML en ligne en utilisant l'attribut `style`.
 
 Il y a deux façons de résoudre les feuilles de style globales externes : une importation ESM pour les fichiers situés dans la source de votre projet, et un lien URL absolu pour les fichiers dans votre répertoire `public/`, ou hébergés en dehors de votre projet.
 
-<ReadMore>En savoir plus sur l'utilisation des [assets statique](/fr/guides/imports/) situés dans `public/` ou `src/`.</ReadMore>
+<ReadMore>En savoir plus sur l'utilisation des [ressources statiques](/fr/guides/imports/) situés dans `public/` ou `src/`.</ReadMore>
 
 ### Importer une feuille de style locale
 
 :::caution[Utilisation d'un paquet npm ?]
-Vous pouvez avoir besoin de mettre à jour votre `astro.config` lorsque vous importez des paquets npm. Voir la section ["importer des feuilles de style depuis un paquet npm"](#importer-une-feuille-de-style-à-partir-dun-paquet-npm) ci-dessous.
+Vous pouvez avoir besoin de mettre à jour votre `astro.config` lorsque vous importez des paquets npm. Voir la section [« importer des feuilles de style depuis un paquet npm »](#importer-une-feuille-de-style-à-partir-dun-paquet-npm) ci-dessous.
 :::
 
 Vous pouvez importer des feuilles de style dans le frontmatter de vos composants Astro en utilisant la syntaxe d'importation ESM. Les importations CSS fonctionnent comme [toute autre importation ESM dans un composant Astro](/fr/basics/astro-components/#le-script-du-composant), qui doit être référencé comme **relatif au composant** et doit être écrit en **haut** du script de votre composant, avec toutes les autres importations.
@@ -223,7 +223,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   vite: {
     ssr: {
-      noExternal: ['package-name'],
+      noExternal: ['nom-du-paquet'],
     }
   }
 })
@@ -244,22 +244,22 @@ import 'package-name/normalize';
 <html><!-- Votre page ici --></html>
 ```
 
-### Charger une feuille de style statique via les balises "link
+### Charger une feuille de style statique via les balises "link"
 
 Vous pouvez également utiliser l'élément `<link>` pour charger une feuille de style sur la page. Il doit s'agir d'un chemin d'URL absolu vers un fichier CSS situé dans votre répertoire `/public`, ou d'une URL vers un site web externe. Les valeurs href `<link>` relatives ne sont pas supportées.
 
 ```astro title="src/pages/index.astro" {3,5}
 <head>
-  <!-- Local: /public/styles/global.css -->
+  <!-- Local : /public/styles/global.css -->
   <link rel="stylesheet" href="/styles/global.css" />
   <!-- Externe -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.24.1/themes/prism-tomorrow.css" />
 </head>
 ```
 
-Comme cette approche utilise le répertoire `public/`, elle ne tient pas compte du traitement CSS normal, du regroupement et des optimisations fournis par Astro. Si vous avez besoin de ces transformations, utilisez la méthode [Import a Stylesheet](#importer-une-feuille-de-style-locale) ci-dessus.
+Comme cette approche utilise le répertoire `public/`, elle ne tient pas compte du traitement CSS normal, du regroupement et des optimisations fournis par Astro. Si vous avez besoin de ces transformations, utilisez la méthode [Importer une feuille de style](#importer-une-feuille-de-style-locale) ci-dessus.
 
-## Ordre en cascade
+## Ordre de cascade
 
 Les composants Astro doivent parfois évaluer plusieurs sources de CSS. Par exemple, votre composant peut importer une feuille de style CSS, inclure sa propre balise `<style>`, *et* être rendu à l'intérieur d'une mise en page qui importe du CSS.
 
@@ -281,7 +281,7 @@ Si une règle est plus _spécifique_ qu'une autre, sa valeur sera prioritaire, q
 </div>
 ```
 
-Si deux règles ont la même spécificité, l'ordre d'apparition est évalué et la valeur de la dernière règle est prioritaire :
+Si deux règles ont la même spécificité, l'_ordre d'apparition_ est évalué et la valeur de la dernière règle est prioritaire :
 ```astro title="src/components/MyComponent.astro"
 <style>
   h1 { color: purple }
@@ -298,11 +298,11 @@ Les règles CSS Astro sont évaluées dans cet ordre d'apparition :
 
 - **balises `<link>` dans l'en-tête** (priorité la plus faible)
 - **styles importés**
-- **styles copiés** (priorité la plus élevée)
+- **styles à portée limitée** (priorité la plus élevée)
 
-### Styles encadrés
+### Styles à portée limitée
 
-L'utilisation de [scoped styles](#styles-scopés) n'augmente pas la _spécificité_ de votre CSS, mais ils viendront toujours en dernier dans l'_ordre d'apparition_. Ils auront donc la priorité sur les autres styles de même spécificité. Par exemple, si vous importez une feuille de style qui entre en conflit avec un style scopé, c'est la valeur du style scopé qui s'appliquera :
+L'utilisation de [styles à portée limitée](#styles-à-portée-limitée) n'augmente pas la _spécificité_ de votre CSS, mais ils viendront toujours en dernier dans l'_ordre d'apparition_. Ils auront donc la priorité sur les autres styles de même spécificité. Par exemple, si vous importez une feuille de style qui entre en conflit avec un style à portée limitée, c'est la valeur du style à portée limitée qui s'appliquera :
 
 ```css title="src/components/make-it-purple.css"
 h1 {
@@ -323,7 +323,7 @@ import "./make-it-purple.css"
 </div>
 ```
 
-Si vous rendez le style importé _plus spécifique_, il aura une plus grande priorité que le style délimité :
+Si vous rendez le style importé _plus spécifique_, il aura une priorité plus élevée que le style à portée limitée :
 
 ```css title="src/components/make-it-purple.css"
 div > h1 {
@@ -373,14 +373,14 @@ import "./make-it-purple.css"
 </div>
 ```
 
-Alors que les balises `<style>` sont cadrées et ne s'appliquent qu'au composant qui les déclare, le CSS _importé_ peut "fuir". L'importation d'un composant applique toutes les feuilles de style CSS qu'il importe, même si le composant n'est jamais utilisé :
+Alors que les balises `<style>` sont à portée limitée et ne s'appliquent qu'au composant qui les déclare, le CSS _importé_ peut « fuir ». L'importation d'un composant applique toutes les feuilles de style CSS qu'il importe, même si le composant n'est jamais utilisé :
 
-```astro title="src/components/MyComponent.astro"
+```astro title="src/components/PurpleComponent.astro"
 ---
 import "./make-it-purple.css"
 ---
 <div>
-  <h1>I import purple CSS.</h1>
+  <h1>J'importe du CSS violet.</h1>
 </div>
 ```
 ```astro title="src/components/MyComponent.astro"
@@ -402,8 +402,8 @@ import PurpleComponent from "./PurpleComponent.astro";
 Un modèle courant dans Astro consiste à importer des feuilles de style CSS globales à l'intérieur d'un [Layout](/fr/basics/layouts/). Veillez à importer le composant Layout avant les autres importations afin qu'il ait la priorité la plus faible.
 :::
 
-### Link Tags
-Les feuilles de style chargées via [les balises de lien](#charger-une-feuille-de-style-statique-via-les-balises-link) sont évaluées dans l'ordre, avant tout autre style dans un fichier Astro. Par conséquent, ces styles ont une priorité inférieure à celle des feuilles de style importées et des styles délimités :
+### Balises de lien
+Les feuilles de style chargées via [les balises de lien](#charger-une-feuille-de-style-statique-via-les-balises-link) sont évaluées dans l'ordre, avant tout autre style dans un fichier Astro. Par conséquent, ces styles ont une priorité inférieure à celle des feuilles de style importées et des styles à portée limitée :
 
 ```astro title="src/pages/index.astro"
 ---
@@ -509,9 +509,9 @@ export default defineConfig({
 
 Vous pouvez également utiliser tous les préprocesseurs CSS ci-dessus dans les frameworks JS ! Veillez à suivre les modèles recommandés par chaque framework :
 
-- **React** / **Preact**: `importer les styles depuis './styles.module.scss';`
-- **Vue**: `<style lang="scss">`
-- **Svelte**: `<style lang="scss">`
+- **React** / **Preact** : `importer les styles depuis './styles.module.scss';`
+- **Vue** : `<style lang="scss">`
+- **Svelte** : `<style lang="scss">`
 
 ## PostCSS
 
@@ -527,7 +527,7 @@ module.exports = {
 ```
 
 
-## Frameworks et librairies
+## Frameworks et bibliothèques
 
 ### 📘 React / Preact
 
@@ -547,13 +547,13 @@ Vue dans Astro supporte les mêmes méthodes que `vue-loader` :
 
 ### 📕 Svelte
 
-Svelte dans Astro fonctionne aussi exactement comme prévu : [Svelte Styling Docs][svelte-style].
+Svelte dans Astro fonctionne aussi exactement comme prévu : [Documentation sur la mise en forme avec Svelte][svelte-style].
 
 ## Style Markdown
 
 Toutes les méthodes de style Astro sont disponibles pour un [composant de mise en page Markdown](/fr/basics/layouts/#mises-en-page-markdown), mais des méthodes différentes auront des effets de style différents sur votre page.
 
-Vous pouvez appliquer des styles globaux à votre contenu Markdown en ajoutant des [feuilles de style importées](#styles-externes) à la mise en page qui englobe le contenu de votre page. Il est également possible d'appliquer un style à votre document Markdown avec des balises [`<style is:global>`](#styles-globaux) dans le composant de mise en page.  Notez que tous les styles ajoutés sont soumis à [l'ordre de cascade d'Astro](#ordre-en-cascade), et vous devriez vérifier votre page rendue avec soin pour vous assurer que vos styles sont appliqués comme prévu.
+Vous pouvez appliquer des styles globaux à votre contenu Markdown en ajoutant des [feuilles de style importées](#styles-externes) à la mise en page qui englobe le contenu de votre page. Il est également possible d'appliquer un style à votre document Markdown avec des balises [`<style is:global>`](#styles-globaux) dans le composant de mise en page.  Notez que tous les styles ajoutés sont soumis à [l'ordre de cascade d'Astro](#ordre-de-cascade), et vous devriez vérifier votre page rendue avec soin pour vous assurer que vos styles sont appliqués comme prévu.
 
 Vous pouvez également ajouter des [intégrations CSS](#intégrations-css), notamment [Tailwind](/fr/guides/integrations-guide/tailwind/). Si vous utilisez Tailwind, le [plugin de typographie](https://tailwindcss.com/docs/typography-plugin) peut être utile pour styliser Markdown.
 
@@ -565,7 +565,7 @@ Lorsque Astro construit votre site pour un déploiement en production, il minifi
 
 Cependant, lorsque plusieurs pages partagent des styles, certains morceaux partagés peuvent devenir très petits. S'ils étaient tous envoyés séparément, cela entraînerait de nombreuses requêtes de feuilles de style et affecterait les performances du site. C'est pourquoi, par défaut, Astro ne liera que les éléments de votre HTML dont la taille est supérieure à 4kB en tant que balises `<link rel="stylesheet">`, tout en intégrant les éléments plus petits dans `<style type="text/css">`. Cette approche permet de trouver un équilibre entre le nombre de requêtes supplémentaires et le volume de CSS qui peut être mis en cache entre les pages.
 
-Vous pouvez configurer la taille à partir de laquelle les feuilles de style seront liées en externe (en octets) en utilisant l'option `assetsInlineLimit` de construction vite. Notez que cette option affecte également l'inlining des scripts et des images.
+Vous pouvez configurer la taille à partir de laquelle les feuilles de style seront liées en externe (en octets) en utilisant l'option `assetsInlineLimit` de construction vite. Notez que cette option affecte également l'intégration en ligne des scripts et des images.
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -579,7 +579,7 @@ export default defineConfig({
 });
 ```
 
-If you would rather all project styles remain external, you can configure the `inlineStylesheets` build option.
+Si vous préférez que tous les styles de projet restent externes, vous pouvez configurer l'option de construction `inlineStylesheets`.
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -591,7 +591,7 @@ export default defineConfig({
 });
 ```
 
-Si vous préférez que tous les styles du projet restent externes, vous pouvez configurer l'option de construction `inlineStylesheets`.
+Vous pouvez également définir cette option sur `'always'`, ce qui intégrera en ligne toutes les feuilles de style.
 
 ## Avancé
 
@@ -599,7 +599,7 @@ Si vous préférez que tous les styles du projet restent externes, vous pouvez c
 Soyez prudent lorsque vous contournez le regroupement CSS intégré d'Astro ! Les styles ne seront pas automatiquement inclus dans la sortie construite, et il est de votre responsabilité de vous assurer que le fichier référencé est correctement inclus dans la sortie finale de la page.
 :::
 
-### Importations CSS `?raw`
+### Importations CSS avec `?raw`
 
 Pour les cas d'utilisation avancés, les feuilles de style CSS peuvent être lues directement à partir du disque sans être regroupées ou optimisées par Astro. Cela peut s'avérer utile lorsque vous avez besoin d'un contrôle total sur un extrait de CSS et que vous devez contourner la gestion CSS automatique d'Astro.
 
@@ -614,7 +614,7 @@ import rawStylesCSS from '../styles/main.css?raw';
 ```
 
 Voir la [documentation de Vite](https://vite.dev/guide/assets.html#importing-asset-as-string) pour plus d'informations.
-### Importations CSS `?url`
+### Importations CSS avec `?url`
 
 Pour les cas d'utilisation avancés, vous pouvez importer une référence URL directe pour un fichier CSS dans le répertoire `src/` de votre projet. Cela peut être utile lorsque vous avez besoin d'un contrôle total sur la façon dont un fichier CSS est chargé sur la page. Cependant, cela empêchera l'optimisation de ce fichier CSS avec le reste de votre page CSS.
 

--- a/src/content/docs/fr/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v3.mdx
@@ -483,7 +483,7 @@ Astro v3.0 introduit une nouvelle valeur par défaut : `"attribut"`. Par défau
 
 #### Que devrais-je faire ?
 
-Pour conserver la [portée de style](/fr/guides/styling/#styles-scopés) actuelle de votre projetmettez à jour le fichier de configuration avec la valeur par défaut précédente :
+Pour conserver la [portée de style](/fr/guides/styling/#styles-à-portée-limitée) actuelle de votre projet, mettez à jour le fichier de configuration avec la valeur par défaut précédente :
 
 ```js title="astro.config.mjs" ins={4}
 import { defineConfig } from "astro/config";


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The file was marked as outdated due to #9240 but I added more changes:
* update the title to match the one updated in #9240
* fix a malformed aside (`:::noteStyles`)
* fix some typo and untranslated strings
* fix some mismatches between the English version and the translation (e.g. code snippet file path)
* make the translation of `scoped styles` consistent (we previously had `limités`, `délimités`, `scopés`, `étendues`, `codés`, etc. on the same page! I think the most accurate translation is `portée limitée` and this matches the one [used on Starlight docs](https://starlight.astro.build/fr/reference/overrides/#markdowncontent))
* improve the translation of `styling` to make it consistent with [Starlight docs](https://starlight.astro.build/fr/guides/css-and-tailwind/): `mise en forme` is the most accurate and widely used translation when referring to CSS so I replaced some occurrences of `stylisme` and `styliser`... but I haven't updated a heading to avoid breaking links in a lot of pages.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
