### PR TITLE
i18n(pt-BR): create `reference/errors/no-adapter-installed-server-islands.mdx`

### DIFF
--- a/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
+++ b/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
@@ -1,13 +1,13 @@
 ---
-title: Server Islands não podem ser usadas sem um adaptador.
+title: Ilhas no Servidor não podem ser usadas sem um adaptador.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **NoAdapterInstalledServerIslands**: _Server islands_ não podem ser usadas sem um adaptador. Por favor instale e configure o adaptador de servidor apropriado para sua distribuição final.
+> **NoAdapterInstalledServerIslands**: Ilhas no servidor não podem ser usadas sem um adaptador. Por favor instale e configure o adaptador de servidor apropriado para sua distribuição final.
 
 ## O que deu errado?
-Para usar _server islands_, as mesmas restrições de processamento no lado do servidor existem, então um adaptador é necessário.
+Para usar ilhas no servidor, as mesmas restrições de processamento no lado do servidor existem, então um adaptador é necessário.
 
 **Veja também:**
 -  [Processamento Sob Demanda](/pt-br/guides/on-demand-rendering/)

--- a/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
+++ b/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
@@ -10,4 +10,4 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 Para usar ilhas no servidor, as mesmas restrições de processamento no lado do servidor existem, então um adaptador é necessário.
 
 **Veja também:**
--  [Processamento Sob Demanda](/pt-br/guides/on-demand-rendering/)
+-  [Renderização Sob Demanda](/pt-br/guides/on-demand-rendering/)

--- a/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
+++ b/src/content/docs/pt-br/reference/errors/no-adapter-installed-server-islands.mdx
@@ -1,0 +1,13 @@
+---
+title: Server Islands não podem ser usadas sem um adaptador.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **NoAdapterInstalledServerIslands**: _Server islands_ não podem ser usadas sem um adaptador. Por favor instale e configure o adaptador de servidor apropriado para sua distribuição final.
+
+## O que deu errado?
+Para usar _server islands_, as mesmas restrições de processamento no lado do servidor existem, então um adaptador é necessário.
+
+**Veja também:**
+-  [Processamento Sob Demanda](/pt-br/guides/on-demand-rendering/)


### PR DESCRIPTION
#### Description (required)

translate content i18n pt-br/reference/errors/no-adapter-installed-server-islands.mdx