### PR TITLE
i18n(pt-BR): create `reference/errors/render-undefined-entry-error.mdx`

### DIFF
--- a/src/content/docs/pt-br/reference/errors/render-undefined-entry-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/render-undefined-entry-error.mdx
@@ -1,0 +1,8 @@
+---
+title: Tentativa de processar uma entrada indefinida da coleção de conteúdo.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+## O que deu errado?
+Astro tentou processar uma entrada da coleção de conteúdo que é indefinida. Isso pode acontecer se você tentar processar uma entrada que não existe.


### PR DESCRIPTION
#### Description (required)

translate content i18n pt-br/reference/errors/render-undefined-entry-error.mdx