### PR TITLE
i18n(fr): update `errors/get-static-paths-removed-rsshelper.mdx`

### DIFF
--- a/src/content/docs/fr/reference/errors/get-static-paths-removed-rsshelper.mdx
+++ b/src/content/docs/fr/reference/errors/get-static-paths-removed-rsshelper.mdx
@@ -1,5 +1,5 @@
 ---
-title: L'aide RSS et StaticPaths ne sont plus disponible.
+title: L'assistant RSS getStaticPaths n'est plus disponible.
 i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The French translation of `errors/get-static-paths-removed-rsshelper.mdx` was marked as outdated because of #9240 but the links are already up to date... Instead I fixed the `title` which was wrongly translated.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
