### PR TITLE
Add need for adapter to server islands guide

### DIFF
--- a/src/content/docs/en/guides/on-demand-rendering.mdx
+++ b/src/content/docs/en/guides/on-demand-rendering.mdx
@@ -21,7 +21,7 @@ On-demand rendering on the server at request time is also known as **server-side
 
 To render any page on demand, you need to add an **adapter**. Each adapter allows Astro to output a script that runs your project on a specific **runtime**: the environment that runs code on the server to generate pages when they are requested (e.g. Netlify, Cloudflare).
 
-You may also wish to add an adapter even if your site is entirely static and you are not rendering any pages on demand. For example, the [Netlify adapter](/en/guides/integrations-guide/netlify/) enables Netlify's Image CDN, and the [Vercel adapter](/en/guides/integrations-guide/vercel/) enables services such as web analytics.
+You may also wish to add an adapter even if your site is entirely static and you are not rendering any pages on demand. For example, the [Netlify adapter](/en/guides/integrations-guide/netlify/) enables Netlify's Image CDN, and [server islands](/en/guides/server-islands/) require an adapter to use `server:defer` on a component.
 
 <IntegrationsNav category="adapter"/>
 

--- a/src/content/docs/en/guides/on-demand-rendering.mdx
+++ b/src/content/docs/en/guides/on-demand-rendering.mdx
@@ -21,7 +21,7 @@ On-demand rendering on the server at request time is also known as **server-side
 
 To render any page on demand, you need to add an **adapter**. Each adapter allows Astro to output a script that runs your project on a specific **runtime**: the environment that runs code on the server to generate pages when they are requested (e.g. Netlify, Cloudflare).
 
-You may also wish to add an adapter even if your site is entirely static and you are not rendering any pages on demand. For example, the [Netlify adapter](/en/guides/integrations-guide/netlify/) enables Netlify's Image CDN, and [server islands](/en/guides/server-islands/) require an adapter to use `server:defer` on a component.
+You may also wish to add an adapter even if your site is entirely static and you are not rendering any pages on demand. For example, the [Netlify adapter](/en/guides/integrations-guide/netlify/) enables Netlify's Image CDN, and [server islands](/en/guides/server-islands/) require an adapter installed to use `server:defer` on a component.
 
 <IntegrationsNav category="adapter"/>
 

--- a/src/content/docs/en/guides/server-islands.mdx
+++ b/src/content/docs/en/guides/server-islands.mdx
@@ -14,7 +14,7 @@ A server island is a normal server-rendered [Astro component](/en/basics/astro-c
 
 Your page will be rendered immediately with any specified [fallback content as a placeholder](#server-island-fallback-content). Then, the component's own contents are fetched on the client and displayed when available.
 
-Add the [`server:defer` directive](/en/reference/directives-reference/#server-directives) to any component on your page to turn it into its own island:
+With [an adapter installed](/en/guides/on-demand-rendering/#server-adapters) to perform the delayed rendering, add the [`server:defer` directive](/en/reference/directives-reference/#server-directives) to any component on your page to turn it into its own island:
 
 ```astro title="src/pages/index.astro" "server:defer"
 ---
@@ -23,7 +23,7 @@ import Avatar from '../components/Avatar.astro';
 <Avatar server:defer />
 ```
 
-These components can do [anything you normally would in an on-demand rendered page](/en/guides/on-demand-rendering/#on-demand-rendering-features), such as fetch content, and access cookies:
+These components can do [anything you normally would in an on-demand rendered page](/en/guides/on-demand-rendering/#on-demand-rendering-features) using an adapter, such as fetch content, and access cookies:
 
 ```astro title="src/components/Avatar.astro"
 ---


### PR DESCRIPTION
#### Description (required)

This PR adds explicit mention that server islands require an adapter installed (in three places).