### PR TITLE
fix: correct markdown option name

### DIFF
--- a/src/content/docs/en/guides/syntax-highlighting.mdx
+++ b/src/content/docs/en/guides/syntax-highlighting.mdx
@@ -32,7 +32,7 @@ var fun = function lang(l) {
 
 Astro's Markdown code blocks are styled by Shiki by default, preconfigured with the `github-dark` theme. The compiled output will be limited to inline `style`s without any extraneous CSS classes, stylesheets, or client-side JS.
 
-You can [add a Prism stylesheet and switch to Prism's highlighting](#add-a-prism-stylesheet), or disable Astro's syntax highlighting entirely, with the [`markdown.syntaxHighlighting`](/en/reference/configuration-reference/#markdownsyntaxhighlight) configuration option.
+You can [add a Prism stylesheet and switch to Prism's highlighting](#add-a-prism-stylesheet), or disable Astro's syntax highlighting entirely, with the [`markdown.syntaxHighlight`](/en/reference/configuration-reference/#markdownsyntaxhighlight) configuration option.
 
 <ReadMore>See the full [`markdown.shikiConfig` reference](/en/reference/configuration-reference/#markdownshikiconfig) for the complete set of Markdown syntax highlighting options available when using Shiki.</ReadMore>
 
@@ -214,7 +214,7 @@ In addition to the [list of languages supported by Prism](https://prismjs.com/#s
 
 ## Add a Prism stylesheet
 
-If you opt to use Prism (either by configuring `markdown.syntaxHighlighting: 'prism'` or with the `<Prism />` component), Astro will apply Prism's CSS classes instead of Shiki's to your code. You will need to bring your own CSS stylesheet for syntax highlighting to appear.
+If you opt to use Prism (either by configuring `markdown.syntaxHighlight: 'prism'` or with the `<Prism />` component), Astro will apply Prism's CSS classes instead of Shiki's to your code. You will need to bring your own CSS stylesheet for syntax highlighting to appear.
 
 <Steps>
 1. Choose a premade stylesheet from the available [Prism Themes](https://github.com/PrismJS/prism-themes).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

The `markdown.syntaxHighlighting` option name has been corrected to the proper [`markdown.syntaxHighlight`](https://docs.astro.build/en/reference/configuration-reference/#markdown.syntaxHighlight).

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
