### PR TITLE
i18n(fr): update `integrations-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/integrations-reference.mdx
+++ b/src/content/docs/fr/reference/integrations-reference.mdx
@@ -55,9 +55,10 @@ interface AstroIntegration {
     'astro:server:done'?: (options: { logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:build:start'?: (options: { logger: AstroIntegrationLogger; }) => void | Promise<void>;
     'astro:build:setup'?: (options: {
-      vite: ViteConfigWithSSR;
+      vite: vite.InlineConfig;
       pages: Map<string, PageBuildData>;
       target: 'client' | 'server';
+      updateConfig: (newConfig: vite.InlineConfig) => void;
       logger: AstroIntegrationLogger;
     }) => void | Promise<void>;
     'astro:build:generated'?: (options: { dir: URL; logger: AstroIntegrationLogger; }) => void | Promise<void>;
@@ -811,9 +812,11 @@ L'adresse, la famille et le numéro de port fournis par le [module Node.js Net](
 
 ```js
 'astro:build:setup'?: (options: {
-  vite: ViteConfigWithSSR;
+  vite: vite.InlineConfig;
   pages: Map<string, PageBuildData>;
   target: 'client' | 'server';
+  updateConfig: (newConfig: vite.InlineConfig) => void;
+  logger: AstroIntegrationLogger;
 }) => void | Promise<void>;
 
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the `astro:build:setup` hook signature in the French translation of `integrations-reference.mdx` (see #10410)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
