### PR TITLE
i18n(fr): fix inline code in `guides/syntax-highlighting.mdx`

### DIFF
--- a/src/content/docs/fr/guides/syntax-highlighting.mdx
+++ b/src/content/docs/fr/guides/syntax-highlighting.mdx
@@ -32,7 +32,7 @@ var fun = function lang(l) {
 
 Les blocs de code Markdown d'Astro sont stylisés par Shiki par défaut, préconfigurés avec le thème `github-dark`. La sortie compilée sera limitée aux styles en ligne sans classes CSS, feuilles de style ou JS côté client superflus.
 
-Vous pouvez [ajouter une feuille de style Prism et passer à la mise en évidence de Prism](#ajouter-une-feuille-de-style-prism), ou désactivez complètement la coloration syntaxique d'Astro, avec l'option de configuration [`markdown.syntaxHighlighting`](/fr/reference/configuration-reference/#markdownsyntaxhighlight).
+Vous pouvez [ajouter une feuille de style Prism et passer à la mise en évidence de Prism](#ajouter-une-feuille-de-style-prism), ou désactivez complètement la coloration syntaxique d'Astro, avec l'option de configuration [`markdown.syntaxHighlight`](/fr/reference/configuration-reference/#markdownsyntaxhighlight).
 
 <ReadMore>Consultez la [référence `markdown.shikiConfig` complète](/fr/reference/configuration-reference/#markdownshikiconfig) pour avoir un aperçu complet des options de coloration syntaxique Markdown disponibles lors de l'utilisation de Shiki.</ReadMore>
 
@@ -214,7 +214,7 @@ En plus de la [liste des langages pris en charge par Prism](https://prismjs.com/
 
 ## Ajouter une feuille de style Prism
 
-Si vous choisissez d'utiliser Prism (soit en configurant `markdown.syntaxHighlighting: 'prism'` ou avec le composant `<Prism />`), Astro appliquera les classes CSS de Prism à votre code au lieu de celles de Shiki. Vous devrez apporter votre propre feuille de style CSS pour que la coloration syntaxique apparaisse.
+Si vous choisissez d'utiliser Prism (soit en configurant `markdown.syntaxHighlight: 'prism'` ou avec le composant `<Prism />`), Astro appliquera les classes CSS de Prism à votre code au lieu de celles de Shiki. Vous devrez apporter votre propre feuille de style CSS pour que la coloration syntaxique apparaisse.
 
 <Steps>
 1. Choisissez une feuille de style prédéfinie parmi les [Thèmes Prism](https://github.com/PrismJS/prism-themes) disponibles.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes two inline codes in the French translation of `guides/syntax-highlighting.mdx` (`syntaxHighlighting` should be `syntaxHighlight`, see #10419)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
