### PR TITLE
Simplify link imports in `guides/imports.mdx`

### DIFF
--- a/src/content/docs/de/guides/imports.mdx
+++ b/src/content/docs/de/guides/imports.mdx
@@ -1,11 +1,8 @@
 ---
-title: Importe Referenz
-description: Erfahre, wie du verschiedene Dateitypen in Astro importieren kannst.
+title: Importe
+description: Erfahre, wie du verschiedene Dateitypen in Astro importierst.
 i18nReady: true
 ---
-
-import RecipeLinks from "~/components/RecipeLinks.astro";
-import ReadMore from '~/components/ReadMore.astro';
 
 Astro unterstützt die meisten statischen Elemente, ohne dass eine Konfiguration erforderlich ist. Du kannst die Anweisung `import` an beliebiger Stelle in deinem Projekt-JavaScript verwenden (einschließlich Astro-Frontmatter) und Astro wird eine optimierte Kopie dieses statischen Elements in deinem endgültigen Build einfügen. `@import` wird auch innerhalb von CSS & `<style>` Tags unterstützt.
 
@@ -19,25 +16,16 @@ Die folgenden Dateitypen werden von Astro standardmäßig unterstützt:
 - TypeScript (`.ts`, `.tsx`)
 - NPM-Pakete
 - JSON (`.json`)
+- JSX (`.jsx`, `.tsx`)
 - CSS (`.css`)
 - CSS-Module (`.module.css`)
 - Bilder & Assets (`.svg`, `.jpg`, `.png`, etc.)
 
-Darüber hinaus kannst du Astro erweitern, um Unterstützung für verschiedene [UI-Frameworks](/de/guides/framework-components/) wie React, Svelte und Vue-Komponenten hinzuzufügen. Du kannst auch die [Astro MDX-Integration](/de/guides/integrations-guide/mdx/) oder die [Astro Markdoc-Integration](/de/guides/integrations-guide/markdoc/) installieren und `.mdx` oder `.mdoc` Dateien in deinem Projekt verwenden.
+Darüber hinaus kannst du Astro erweitern, um Unterstützung für verschiedene [UI-Frameworks](/de/guides/framework-components/) wie React, Svelte und Vue-Komponenten hinzuzufügen. Du kannst auch die [Astro MDX Integration](/de/guides/integrations-guide/mdx/) installieren und `.mdx` Dateien in deinem Projekt verwenden.
 
 ### Dateien in `public/`
 
-Du kannst jedes statische Asset in das Verzeichnis [`public/`](/de/basics/project-structure/#public) deines Projekts legen und Astro kopiert es direkt und unverändert in deinen endgültigen Build. `public/`-Dateien werden von Astro nicht gebaut oder gebündelt, was bedeutet, dass jede Art von Datei unterstützt wird. 
-
-Du kannst eine `public/`-Datei über einen URL-Pfad direkt in deinem HTML-Vorlagen referenzieren.
-
-```astro
-// Link zu /public/reports/annual/2024.pdf
-Lade den <a href="/reports/annual/2024.pdf">Jahresbericht 2024 als PDF herunter</a>.
-
-// Um /public/assets/cats/ginger.jpg anzuzeigen
-<img src="/assets/cats/ginger.jpg" alt="Eine orangefarbene Katze, die auf einem Bett schläft.">
-```
+Du kannst jedes statische Asset in das Verzeichnis [`public/`](/de/basics/project-structure/#public) deines Projekts legen und Astro kopiert es direkt und unverändert in deinen endgültigen Build. `public/`-Dateien werden von Astro nicht gebaut oder gebündelt, was bedeutet, dass jede Art von Datei unterstützt wird. Du kannst eine `public/`-Datei über einen URL-Pfad direkt in deinem HTML-Vorlagen referenzieren.
 
 ## Import-Anweisungen
 
@@ -51,13 +39,6 @@ import { getUser } from './user.js';
 
 JavaScript kann mit der normalen ESM-Syntax `import` und `export` importiert werden.
 
-:::note[JSX-Dateien importieren]
-
-Ein geeignetes [UI-Framework](/de/guides/framework-components/) ([React](/de/guides/integrations-guide/react/), [Preact](/de/guides/integrations-guide/preact/), oder [Solid](/de/guides/integrations-guide/solid-js/)) ist erforderlich, um JSX/TSX-Dateien zu rendern.
-Verwende gegebenenfalls die Erweiterungen `.jsx`/`.tsx`, da Astro JSX in `.js`/`.ts`-Dateien nicht unterstützt.
-
-:::
-
 ### TypeScript
 
 ```js
@@ -65,7 +46,7 @@ import { getUser } from './user';
 import type { UserType } from './user';
 ```
 
-Astro bietet eine integrierte Unterstützung für [TypeScript](https://www.typescriptlang.org/). Du kannst `.ts`- und `.tsx`-Dateien direkt in dein Astro-Projekt importieren und sogar TypeScript-Code direkt in dein [Astro-Komponentenskript](/de/basics/astro-components/#das-komponentenskript) und alle [Skript-Tags](/de/guides/client-side-scripts/) schreiben.
+Astro bietet eine integrierte Unterstützung für [TypeScript](https://www.typescriptlang.org/). Du kannst "ts"- und "tsx"-Dateien direkt in dein Astro-Projekt importieren und sogar TypeScript-Code direkt in dein [Astro-Komponentenskript](/de/basics/astro-components/#das-komponentenskript) und alle [hoisted script tags](/de/guides/client-side-scripts/) schreiben.
 
 **Astro führt selbst keine Typüberprüfung durch.** Die Typüberprüfung sollte außerhalb von Astro erfolgen, entweder durch deine IDE oder durch ein separates Skript. Für die Typüberprüfung von Astro-Dateien steht der Befehl [`astro check`](/de/reference/cli-reference/#astro-check) zur Verfügung.
 
@@ -79,7 +60,21 @@ import MyComponent from "./MyComponent"; // MyComponent.tsx
 
 :::
 
-<ReadMore>Lies mehr über [TypeScript-Unterstützung in Astro](/de/guides/typescript/).</ReadMore>
+📚 Lies mehr über [TypeScript-Unterstützung in Astro](/de/guides/typescript/).
+
+### JSX / TSX
+
+```js
+import { MyComponent } from './MyComponent.jsx';
+```
+
+Astro bietet integrierte Unterstützung für JSX-Dateien (*.jsx und *.tsx) in deinem Projekt. Die JSX-Syntax wird automatisch in JavaScript umgewandelt.
+
+Auch wenn Astro JSX-Syntax versteht, musst du eine Framework-Integration einbinden, um Frameworks wie React, Preact und Solid korrekt zu rendern. In unserem Leitfaden [Integrationen nutzen](/de/guides/integrations-guide/) erfährst du mehr.
+
+:::note
+**Astro unterstützt JSX nicht in `.js`/`.ts`-Dateien.** JSX wird nur innerhalb von Dateien verarbeitet, die mit den Dateierweiterungen `.jsx` und `.tsx` enden.
+:::
 
 ### NPM-Pakete
 
@@ -90,8 +85,7 @@ Wenn du ein NPM-Paket installierst hast, kannst du es in Astro importieren.
 import { Icon } from 'astro-icon';
 ---
 ```
-
-Wenn ein Paket in einem älteren Format veröffentlicht wurde, wird Astro versuchen, das Paket in ESM zu konvertieren, damit die `import`-Anweisungen funktionieren. In einigen Fällen musst du deine [`vite` config](/de/reference/configuration-reference/#vite) anpassen, damit es funktioniert.
+Wenn ein Paket in einem älteren Format veröffentlicht wurde, wird Astro versuchen, das Paket in ESM zu konvertieren, damit die "import"-Anweisungen funktionieren. In einigen Fällen muss du deine [`vite` config](/de/reference/configuration-reference/#vite) anpassen, damit es funktioniert.
 
 :::caution
 Einige Pakete sind auf eine Browser-Umgebung angewiesen. Astro-Komponenten laufen auf dem Server, daher kann der Import dieser Pakete im Frontmatter zu [Fehlern führen](/de/guides/troubleshooting/#document-or-window-is-not-defined).
@@ -115,12 +109,10 @@ import './style.css';
 
 Astro unterstützt den Import von CSS-Dateien direkt in deine Anwendung. Importierte Styles werden nicht exportiert, aber wenn du einen importierst, werden diese Styles automatisch in die Seite eingefügt. Dies funktioniert standardmäßig für alle CSS-Dateien und kann Compile-to-CSS-Sprachen wie Sass und Less über Plugins unterstützen.
 
-<ReadMore>Lies mehr über fortgeschrittene Anwendungsfälle für den CSS-Import, wie z.B. eine direkte URL-Referenz für eine CSS-Datei oder den Import von CSS als String im [Styling-Leitfaden](/de/guides/styling/#advanced).</ReadMore>
-
 ### CSS-Module
 
 ```jsx
-// 1. Konvertiert die Klassennamen aus './style.module.css' in eindeutige Werte, welche für diesen Bereich verfügbar sind (scoped).
+// 1. Konvertiert die Klassennamen aus './style.module.css' in eindeutige Werte (scoped).
 // 2. Gibt ein Objekt zurück, das die ursprünglichen Klassennamen auf ihren endgültigen, zugewiesenen Wert abbildet.
 import styles from './style.module.css';
 
@@ -128,7 +120,7 @@ import styles from './style.module.css';
 return <div className={styles.error}>Deine Fehlermeldung</div>;
 ```
 
-Astro unterstützt CSS-Module unter Verwendung der Namenskonvention `[name].module.css`. Wie bei jeder CSS-Datei wird beim Importieren einer solchen Datei das CSS automatisch auf die Seite angewendet. CSS-Module exportieren jedoch ein spezielles Standardobjekt `styles`, das deine ursprünglichen Klassennamen auf eindeutige Bezeichner abbildet.
+Astro unterstützt CSS-Module unter Verwendung der Namenskonvention `[name].module.css`. Wie bei jeder CSS-Datei wird beim Importieren einer solchen Datei das CSS automatisch auf die Seite angewendet. CSS-Module exportieren jedoch ein spezielles Standardobjekt "styles", das deine ursprünglichen Klassennamen auf eindeutige Bezeichner abbildet.
 
 CSS-Module helfen dir dabei, das Scoping und die Isolierung von Komponenten auf dem Frontend mit eindeutig generierten Klassennamen für deine Stylesheets durchzusetzen.
 
@@ -140,37 +132,37 @@ import svgReference from './image.svg'; // svgReference === '/src/image.svg'
 import txtReference from './words.txt'; // txtReference === '/src/words.txt'
 
 // This example uses JSX, but you can use import references with any framework.
-<img src={imgReference.src} alt="Bildbeschreibung" />;
+<img src={imgReference} alt="image description" />;
 ```
 
-Alle anderen, oben nicht explizit erwähnten Assets können über ESM `import` importiert werden und geben einen URL-Verweis auf das fertige Asset zurück. Dies kann nützlich sein, um Nicht-JS-Assets per URL zu referenzieren, z.B. um ein Bildelement mit einem `src`-Attribut zu erstellen, das auf dieses Bild zeigt.
+Alle anderen, oben nicht explizit erwähnten Assets können über ESM `import` importiert werden und geben einen URL-Verweis auf das fertige Asset zurück. Dies kann nützlich sein, um Nicht-JS-Assets per URL zu referenzieren, z.B. um ein Bildelement mit einem "src"-Attribut zu erstellen, das auf dieses Bild zeigt.
 
 Es kann auch nützlich sein, Bilder in den Ordner `public/` zu legen, wie auf der [Projektstruktur-Seite](/de/basics/project-structure/#public) erklärt.
-
-<ReadMore>Lies mehr über das Anhängen von Vite-Importparametern (z.B. `?url`, `?raw`) in [Vite's Leitfaden für den Umgang mit statischen Assets](https://vite.dev/guide/assets.html).</ReadMore>
 
 :::note
 Das Hinzufügen von **Alt-Text** zu `<img>`-Tags wird aus Gründen der Zugänglichkeit empfohlen! Vergiss nicht, deinen Bildelementen das Attribut `alt="eine hilfreiche Beschreibung"` hinzuzufügen. Du kannst das Attribut einfach leer lassen, wenn das Bild rein dekorativ ist.
 :::
 
-## Aliase
+## Import-Aliasnamen
 
 Ein **Aliasname** (kurz **Alias**) ist eine Möglichkeit, um Abkürzungen für Importpfade zu erstellen.
 
 Aliasnamen können dabei helfen, die Entwicklungserfahrung in Codebasen mit vielen Verzeichnissen oder relativen Importpfaden zu verbessern.
 
-```astro title="src/pages/about/company.astro" del="../../components" del="../../assets"
+```astro
 ---
+// mein-projekt/src/pages/ueber-uns/firma.astro
+
 import Button from '../../components/controls/Button.astro';
 import logoUrl from '../../assets/logo.png?url';
 ---
 ```
 
-In diesem Beispiel müsste man bei der Entwicklung die Baumbeziehung zwischen `src/pages/about/company.astro`, `src/components/controls/Button.astro` und `src/assets/logo.png` berücksichtigen, um die richtigen relativen Importpfade definieren zu können. Und falls die Datei `company.astro` jemals verschoben werden sollte, müssten diese Importpfade ebenfalls aktualisiert werden.
+In diesem Beispiel müsste man bei der Entwicklung die Baumbeziehung zwischen `src/pages/ueber-uns/firma.astro`, `src/components/controls/Button.astro` und `src/assets/logo.png` berücksichtigen, um die richtigen relativen Importpfade definieren zu können. Und falls die Datei `firma.astro` jemals verschoben werden sollte, müssten diese Importpfade ebenfalls aktualisiert werden.
 
-Du kannst Import-Aliase in `tsconfig.json` hinzufügen
+Um diese Situation zu verbessern, kannst du Import-Aliasnamen entweder in der Datei `tsconfig.json` oder `jsconfig.json` hinzufügen.
 
-```json title="tsconfig.json" ins={5-6}
+```json
 {
   "compilerOptions": {
     "baseUrl": ".",
@@ -182,38 +174,35 @@ Du kannst Import-Aliase in `tsconfig.json` hinzufügen
 }
 ```
 
-:::note
-Stelle sicher, dass `compilerOptions.baseUrl` gesetzt ist, damit die Pfade mit Aliasnamen aufgelöst werden können.
-:::
+Mit dieser zentralen Änderung kannst du die Importpfade nun überall in deinem Projekt benutzen:
 
-Der Entwicklungsserver wird nach dieser Konfigurationsänderung automatisch neu gestartet. Du kannst jetzt die Aliase überall in deinem Projekt importieren:
-
-```astro title="src/pages/about/company.astro" ins="@components" ins="@assets"
+```astro
 ---
-import Button from '@components/controls/Button.astro';
-import logoUrl from '@assets/logo.png?url';
+// mein-projekt/src/pages/ueber-uns/firma.astro
+
+import Button from '@components/Button.astro';
+import logoUrl from '@assets/logo.png';
 ---
 ```
 
 Die von dir definierten Aliasnamen werden auch automatisch in [VS Code](https://code.visualstudio.com/docs/languages/jsconfig) und andere Editoren integriert.
 
-## `import.meta.glob()`
+## `Astro.glob()`
 
-Mit [Vite's `import.meta.glob()`](https://vite.dev/guide/features.html#glob-import) kannst du viele Dateien auf einmal importieren, indem du Glob-Muster verwendest, um passende Dateipfade zu finden.
+Mit [`Astro.glob()`](/de/reference/api-reference/#astroglob) kannst du viele Dateien auf einmal importieren.
 
-Die Funktion `import.meta.glob()` nimmt als Parameter ein relatives [Glob-Muster](/de/guides/imports/#glob-patterns), das den lokalen Dateien entspricht, die du importieren möchtest. Sie gibt ein Array mit den Exporten jeder passenden Datei zurück. Um alle übereinstimmenden Module im Voraus zu laden, gibst du als zweites Argument `{ eager: true }` an:
+`Astro.glob()` erlaubt nur einen Parameter: ein relatives [Glob-Pattern](/de/guides/imports/#glob-patterns), das zu den lokalen Dateien passt, die du importieren möchtest. Es ist asynchron und gibt ein Array mit den Exporten jeder passenden Datei zurück.
 
-```astro title="src/components/my-component.astro" {3,4}
+```astro title="src/components/my-component.astro"
 ---
-// importiert alle Dateien, die mit `.md` in `./src/pages/post/` enden
-const matches = import.meta.glob('../pages/post/*.md', { eager: true }); 
-const posts = Object.values(matches);
+// importiert alle Dateien, die mit `.md` enden in `./src/pages/post/`
+const posts = await Astro.glob('../pages/post/*.md'); 
 ---
-<!-- Erzeugt einen <Artikel> für die ersten 5 Blogbeiträge -->
+<!-- Rendert einen <Artikel> für die ersten 5 Blogbeiträge -->
 <div>
 {posts.slice(0, 4).map((post) => (
   <article>
-    <h2>{post.frontmatter.title}</h2>
+    <h1>{post.frontmatter.title}</h1>
     <p>{post.frontmatter.description}</p>
     <a href={post.url}>Read more</a>
   </article>
@@ -221,14 +210,14 @@ const posts = Object.values(matches);
 </div>
 ```
 
-Astro-Komponenten, die mit `import.meta.glob` importiert werden, sind vom Typ [`AstroInstance`](#astro-dateien). Du kannst jede Komponenteninstanz mit ihrer Eigenschaft `default` darstellen:
+Astro-Komponenten, die mit `Astro.glob` importiert werden, sind vom Typ [`AstroInstance`](/de/reference/api-reference/#astro-dateien). Du kannst jede Komponenteninstanz mit ihrer Eigenschaft `default` darstellen:
 
 ```astro title="src/pages/component-library.astro" {8}
 ---
-// importiert alle Dateien, die mit `.astro` in `./src/components/` enden
-const components = Object.values(import.meta.glob('../components/*.astro', { eager: true }));
+// importiert alle Dateien, die mit `.astro` enden in `./src/components/`
+const components = await Astro.glob('../components/*.astro');
 ---
-<!-- Alle unsere Komponenten anzeigen -->
+<!-- Alle Komponenten anzeigen -->
 {components.map((component) => (
   <div>
     <component.default size={24} />
@@ -236,118 +225,22 @@ const components = Object.values(import.meta.glob('../components/*.astro', { eag
 ))}
 ```
 
-### Unterstützte Werte
+### Glob Patterns
 
-Die Funktion `import.meta.glob()` von Vite unterstützt nur statische String-Literale. Sie unterstützt keine dynamischen Variablen und keine String-Interpolation.
+Ein Glob-Pattern ist ein Dateipfad, der spezielle Platzhalterzeichen unterstützt. Es wird verwendet, um auf mehrere Dateien in deinem Projekt gleichzeitig zu verweisen.
 
-Eine gängige Lösung ist es, stattdessen eine größere Menge an Dateien zu importieren, die alle benötigten Dateien enthält, und diese dann zu filtern:
+Das Glob-Pattern `./pages/**/*.{md,mdx}` beginnt beispielsweise im Unterverzeichnis `pages`, durchsucht alle Unterverzeichnisse (`/**`) und erfasst jeden Dateinamen (`/*`), der entweder auf `.md` oder `.mdx` (`.{md,mdx}`) endet.
 
-```astro {6-7}
----
-// src/components/featured.astro
-const { postSlug } = Astro.props;
-const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
+#### Glob-Patterns in Astro
 
-const posts = Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
-const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
----
+Um mit `Astro.glob()` verwendet zu werden, muss das Glob-Pattern ein String-Literal sein und darf keine Variablen enthalten. Siehe [die Anleitung zur Fehlerbehebung](/de/guides/troubleshooting/#astroglob---no-matches-found) für eine andere Lösung.
 
-<p>
-  Schau dir meinen Lieblingspost, <a href={myFeaturedPost.url}>{myFeaturedPost.frontmatter.title}</a>, an!
-</p>
-```
-
-### Importtyp Hilfsmittel
-
-#### Markdown-Dateien
-
-Markdown-Dateien, die mit `import.meta.glob()` geladen werden, geben die folgende `MarkdownInstance`-Schnittstelle zurück.
-
-```ts
-export interface MarkdownInstance<T extends Record<string, any>> {
-  /* Alle im YAML-Frontmatter dieser Datei angegebenen Daten */
-	frontmatter: T;
-  /* Der absolute Dateipfad für diese Datei */
-	file: string;
-  /* Der gerenderte Pfad zu dieser Datei */
-	url: string | undefined;
-  /* Astro-Komponente, die den Inhalt dieser Datei wiedergibt */
-	Content: AstroComponentFactory;
-  /** (nur Markdown) Roher Inhalt der Markdown-Datei, ohne Layout-HTML und YAML-Frontmatter */
-	rawContent(): string;
-  /** (nur Markdown) Markdown-Datei, die zu HTML kompiliert wurde, ohne Layout-HTML */
-	compiledContent(): string;
-  /* Funktion, die ein Array mit den h1...h6-Elementen in dieser Datei zurückgibt */
-	getHeadings(): Promise<{ depth: number; slug: string; text: string }[]>;
-	default: AstroComponentFactory;
-}
-```
-
-Du kannst optional einen Typ für die Variable `frontmatter` angeben, indem du eine TypeScript-Generik verwendest.
-
-```astro
----
-import type { MarkdownInstance } from 'astro';
-interface Frontmatter {
-    title: string;
-    description?: string;
-}
-
-const posts = Object.values(import.meta.glob<MarkdownInstance<Frontmatter>>('./posts/**/*.md', { eager: true }));
----
-
-<ul>
-  {posts.map(post => <li>{post.frontmatter.title}</li>)}
-</ul>
-```
-
-#### Astro-Dateien
-
-Astro-Dateien haben die folgende Schnittstelle:
-
-```ts
-export interface AstroInstance {
-  /* Der Dateipfad für diese Datei */
-  file: string;
-  /* Die URL für diese Datei (wenn sie sich im Seitenverzeichnis befindet) */
-	url: string | undefined;
-	default: AstroComponentFactory;
-}
-```
-
-#### Andere Dateien
-
-Andere Dateien können verschiedene Schnittstellen haben, aber `import.meta.glob()` akzeptiert eine TypeScript-Generik, wenn du genau weißt, was ein nicht erkannter Dateityp enthält.
-
-```ts
----
-interface CustomDataFile {
-  default: Record<string, any>;
-}
-const data = import.meta.glob<CustomDataFile>('../data/**/*.js');
----
-```
-
-### Glob-Muster
-
-Ein Glob-Muster ist ein Dateipfad, der spezielle Platzhalterzeichen unterstützt. Es wird verwendet, um mehrere Dateien in deinem Projekt gleichzeitig zu referenzieren.
-
-Das globale Muster `./pages/**/*.{md,mdx}` beginnt zum Beispiel im Unterverzeichnis `pages`, durchsucht alle Unterverzeichnisse (`/**`) und passt auf jeden Dateinamen (`/*`), der entweder auf `.md` oder `.mdx` (`.{md,mdx}`) endet.
-
-#### Glob-Muster in Astro
-
-Um mit `import.meta.glob()` verwendet zu werden, muss das Glob-Muster ein String-Literal sein und darf keine Variablen enthalten.
-
-Außerdem müssen die Glob-Muster mit einem der folgenden Zeichen beginnen:
+Außerdem müssen Glob-Pattern mit einem der folgenden Zeichen beginnen:
 - `./` (um im aktuellen Verzeichnis zu beginnen)
 - `../` (um im übergeordneten Verzeichnis zu beginnen)
 - `/` (um im Stammverzeichnis des Projekts zu beginnen)
-
-[Lies mehr über die Syntax des glob-Musters] (https://github.com/mrmlnc/fast-glob#pattern-syntax).
-
-### `import.meta.glob()` vs `getCollection()`
-
-[Inhaltssammlungen](/de/guides/content-collections/) bieten eine [`getCollection()` API](/de/reference/modules/astro-content/#getcollection) zum Laden mehrerer Dateien anstelle von `import.meta.glob()`. Wenn deine Inhaltsdateien (z.B. Markdown, MDX, Markdoc) in Sammlungen innerhalb des Verzeichnisses `src/content/` liegen, verwende `getCollection()`, um [eine Sammlung abzufragen](/de/guides/content-collections/#querying-collections) und Inhaltseinträge zurückzugeben.
+ 
+[Lies mehr über die Syntax des Glob-Pattern](https://github.com/mrmlnc/fast-glob#pattern-syntax).
 
 ## WASM
 
@@ -358,9 +251,10 @@ const wasm = await WebAssembly.instantiateStreaming(fetch('/example.wasm'));
 
 Astro unterstützt das Laden von WASM-Dateien direkt in deine Anwendung unter Verwendung der [`WebAssembly`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly) API des Browsers.
 
+
 ## Node Builtins
 
-Wir empfehlen Astro-Benutzern, Node.js-Builtins (`fs`, `path`, etc.) zu vermeiden, wann immer es möglich ist. Astro ist mit mehreren Laufzeiten kompatibel, die [Adapter](/de/guides/on-demand-rendering/) verwenden. Dazu gehören [Deno](https://github.com/denoland/deno-astro-adapter) und [Cloudflare Workers](/de/guides/integrations-guide/cloudflare/), die keine Node-Builtins wie `fs` unterstützen.
+Wir empfehlen Astro-Benutzern, Node.js-Builtins (`fs`, `path`, etc.) wann immer möglich zu vermeiden. Astro soll in Zukunft mit mehreren JavaScript-Laufzeiten kompatibel sein. Dazu gehören [Deno](https://deno.land/) und [Cloudflare Workers](https://workers.cloudflare.com/), die keine Node-Builtins wie `fs` unterstützen.
 
 Unser Ziel ist es, Astro-Alternativen zu gängigen Node.js-Builtins anzubieten. Allerdings gibt es davon bisher keine. Wenn du also _wirklich_ diese eingebauten Module verwenden musst, halten wir dich nicht auf. Astro unterstützt Node.js-Builtins, die das neuere `node:`-Präfix von Node verwenden. Wenn du z.B. eine Datei lesen willst, kannst du das folgendermaßen tun:
 
@@ -379,10 +273,39 @@ const data = JSON.parse(json);
 
 ## Erweiterung der Unterstützung von Dateitypen
 
-Mit **Vite** und kompatiblen **Rollup**-Plugins kannst du Dateitypen importieren, die von Astro nicht nativ unterstützt werden. Wo du die benötigten Plugins findest erfährst du im Abschnitt [„Plugins finden“](https://vite.dev/guide/using-plugins.html#finding-plugins) der Vite-Dokumentation.
+Mit **Vite** und kompatiblen **Rollup**-Plugins kannst du Dateitypen importieren, die von Astro nicht nativ unterstützt werden. Wo du die benötigten Plugins findest erfährst du im Abschnitt [Finding Plugins](https://vite.dev/guide/using-plugins.html#finding-plugins) der Vite-Dokumentation.
 
-:::note[Pluginkonfiguration]
+
+ :::note[plugin configuration]
 In der Dokumentation deines Plugins findest du Informationen zu den Konfigurationsoptionen und zur korrekten Installation.
 :::
 
-<RecipeLinks slugs={["de/recipes/add-yaml-support"]} />
+### Beispiel: YAML-Unterstützung
+
+Das Datenformat YAML (`.yml`) wird von Astro nicht von Haus aus unterstützt, aber du kannst es mit einem kompatiblen Rollup-Plugin wie [`@rollup/plugin-yaml`](https://www.npmjs.com/package/@rollup/plugin-yaml) hinzufügen:
+
+1. Installiere `@rollup/plugin-yaml`:
+
+    ```bash
+    npm install @rollup/plugin-yaml --save-dev
+    ```
+
+2. Importiere das Plugin in deine "astro.config.mjs" und füge es zum Array "Vite plugins" hinzu:
+
+    ```js title="astro.config.mjs" ins={2,5-7}
+    import { defineConfig } from 'astro/config';
+    import yaml from '@rollup/plugin-yaml';
+
+    export default defineConfig({
+      vite: {
+        plugins: [yaml()]
+      }
+    });
+    ```
+
+
+3. Zuletzt kannst du YAML-Daten mit einer Import-Anweisung importieren:
+
+    ```js
+    import yml from './data.yml';
+    ```

--- a/src/content/docs/de/guides/imports.mdx
+++ b/src/content/docs/de/guides/imports.mdx
@@ -1,8 +1,11 @@
 ---
-title: Importe
-description: Erfahre, wie du verschiedene Dateitypen in Astro importierst.
+title: Importe Referenz
+description: Erfahre, wie du verschiedene Dateitypen in Astro importieren kannst.
 i18nReady: true
 ---
+
+import RecipeLinks from "~/components/RecipeLinks.astro";
+import ReadMore from '~/components/ReadMore.astro';
 
 Astro unterstützt die meisten statischen Elemente, ohne dass eine Konfiguration erforderlich ist. Du kannst die Anweisung `import` an beliebiger Stelle in deinem Projekt-JavaScript verwenden (einschließlich Astro-Frontmatter) und Astro wird eine optimierte Kopie dieses statischen Elements in deinem endgültigen Build einfügen. `@import` wird auch innerhalb von CSS & `<style>` Tags unterstützt.
 
@@ -16,16 +19,25 @@ Die folgenden Dateitypen werden von Astro standardmäßig unterstützt:
 - TypeScript (`.ts`, `.tsx`)
 - NPM-Pakete
 - JSON (`.json`)
-- JSX (`.jsx`, `.tsx`)
 - CSS (`.css`)
 - CSS-Module (`.module.css`)
 - Bilder & Assets (`.svg`, `.jpg`, `.png`, etc.)
 
-Darüber hinaus kannst du Astro erweitern, um Unterstützung für verschiedene [UI-Frameworks](/de/guides/framework-components/) wie React, Svelte und Vue-Komponenten hinzuzufügen. Du kannst auch die [Astro MDX Integration](/de/guides/integrations-guide/mdx/) installieren und `.mdx` Dateien in deinem Projekt verwenden.
+Darüber hinaus kannst du Astro erweitern, um Unterstützung für verschiedene [UI-Frameworks](/de/guides/framework-components/) wie React, Svelte und Vue-Komponenten hinzuzufügen. Du kannst auch die [Astro MDX-Integration](/de/guides/integrations-guide/mdx/) oder die [Astro Markdoc-Integration](/de/guides/integrations-guide/markdoc/) installieren und `.mdx` oder `.mdoc` Dateien in deinem Projekt verwenden.
 
 ### Dateien in `public/`
 
-Du kannst jedes statische Asset in das Verzeichnis [`public/`](/de/basics/project-structure/#public) deines Projekts legen und Astro kopiert es direkt und unverändert in deinen endgültigen Build. `public/`-Dateien werden von Astro nicht gebaut oder gebündelt, was bedeutet, dass jede Art von Datei unterstützt wird. Du kannst eine `public/`-Datei über einen URL-Pfad direkt in deinem HTML-Vorlagen referenzieren.
+Du kannst jedes statische Asset in das Verzeichnis [`public/`](/de/basics/project-structure/#public) deines Projekts legen und Astro kopiert es direkt und unverändert in deinen endgültigen Build. `public/`-Dateien werden von Astro nicht gebaut oder gebündelt, was bedeutet, dass jede Art von Datei unterstützt wird. 
+
+Du kannst eine `public/`-Datei über einen URL-Pfad direkt in deinem HTML-Vorlagen referenzieren.
+
+```astro
+// Link zu /public/reports/annual/2024.pdf
+Lade den <a href="/reports/annual/2024.pdf">Jahresbericht 2024 als PDF herunter</a>.
+
+// Um /public/assets/cats/ginger.jpg anzuzeigen
+<img src="/assets/cats/ginger.jpg" alt="Eine orangefarbene Katze, die auf einem Bett schläft.">
+```
 
 ## Import-Anweisungen
 
@@ -39,6 +51,13 @@ import { getUser } from './user.js';
 
 JavaScript kann mit der normalen ESM-Syntax `import` und `export` importiert werden.
 
+:::note[JSX-Dateien importieren]
+
+Ein geeignetes [UI-Framework](/de/guides/framework-components/) ([React](/de/guides/integrations-guide/react/), [Preact](/de/guides/integrations-guide/preact/), oder [Solid](/de/guides/integrations-guide/solid-js/)) ist erforderlich, um JSX/TSX-Dateien zu rendern.
+Verwende gegebenenfalls die Erweiterungen `.jsx`/`.tsx`, da Astro JSX in `.js`/`.ts`-Dateien nicht unterstützt.
+
+:::
+
 ### TypeScript
 
 ```js
@@ -46,7 +65,7 @@ import { getUser } from './user';
 import type { UserType } from './user';
 ```
 
-Astro bietet eine integrierte Unterstützung für [TypeScript](https://www.typescriptlang.org/). Du kannst "ts"- und "tsx"-Dateien direkt in dein Astro-Projekt importieren und sogar TypeScript-Code direkt in dein [Astro-Komponentenskript](/de/basics/astro-components/#das-komponentenskript) und alle [hoisted script tags](/de/guides/client-side-scripts/) schreiben.
+Astro bietet eine integrierte Unterstützung für [TypeScript](https://www.typescriptlang.org/). Du kannst `.ts`- und `.tsx`-Dateien direkt in dein Astro-Projekt importieren und sogar TypeScript-Code direkt in dein [Astro-Komponentenskript](/de/basics/astro-components/#das-komponentenskript) und alle [Skript-Tags](/de/guides/client-side-scripts/) schreiben.
 
 **Astro führt selbst keine Typüberprüfung durch.** Die Typüberprüfung sollte außerhalb von Astro erfolgen, entweder durch deine IDE oder durch ein separates Skript. Für die Typüberprüfung von Astro-Dateien steht der Befehl [`astro check`](/de/reference/cli-reference/#astro-check) zur Verfügung.
 
@@ -60,21 +79,7 @@ import MyComponent from "./MyComponent"; // MyComponent.tsx
 
 :::
 
-📚 Lies mehr über [TypeScript-Unterstützung in Astro](/de/guides/typescript/).
-
-### JSX / TSX
-
-```js
-import { MyComponent } from './MyComponent.jsx';
-```
-
-Astro bietet integrierte Unterstützung für JSX-Dateien (*.jsx und *.tsx) in deinem Projekt. Die JSX-Syntax wird automatisch in JavaScript umgewandelt.
-
-Auch wenn Astro JSX-Syntax versteht, musst du eine Framework-Integration einbinden, um Frameworks wie React, Preact und Solid korrekt zu rendern. In unserem Leitfaden [Integrationen nutzen](/de/guides/integrations-guide/) erfährst du mehr.
-
-:::note
-**Astro unterstützt JSX nicht in `.js`/`.ts`-Dateien.** JSX wird nur innerhalb von Dateien verarbeitet, die mit den Dateierweiterungen `.jsx` und `.tsx` enden.
-:::
+<ReadMore>Lies mehr über [TypeScript-Unterstützung in Astro](/de/guides/typescript/).</ReadMore>
 
 ### NPM-Pakete
 
@@ -85,7 +90,8 @@ Wenn du ein NPM-Paket installierst hast, kannst du es in Astro importieren.
 import { Icon } from 'astro-icon';
 ---
 ```
-Wenn ein Paket in einem älteren Format veröffentlicht wurde, wird Astro versuchen, das Paket in ESM zu konvertieren, damit die "import"-Anweisungen funktionieren. In einigen Fällen muss du deine [`vite` config](/de/reference/configuration-reference/#vite) anpassen, damit es funktioniert.
+
+Wenn ein Paket in einem älteren Format veröffentlicht wurde, wird Astro versuchen, das Paket in ESM zu konvertieren, damit die `import`-Anweisungen funktionieren. In einigen Fällen musst du deine [`vite` config](/de/reference/configuration-reference/#vite) anpassen, damit es funktioniert.
 
 :::caution
 Einige Pakete sind auf eine Browser-Umgebung angewiesen. Astro-Komponenten laufen auf dem Server, daher kann der Import dieser Pakete im Frontmatter zu [Fehlern führen](/de/guides/troubleshooting/#document-or-window-is-not-defined).
@@ -109,10 +115,12 @@ import './style.css';
 
 Astro unterstützt den Import von CSS-Dateien direkt in deine Anwendung. Importierte Styles werden nicht exportiert, aber wenn du einen importierst, werden diese Styles automatisch in die Seite eingefügt. Dies funktioniert standardmäßig für alle CSS-Dateien und kann Compile-to-CSS-Sprachen wie Sass und Less über Plugins unterstützen.
 
+<ReadMore>Lies mehr über fortgeschrittene Anwendungsfälle für den CSS-Import, wie z.B. eine direkte URL-Referenz für eine CSS-Datei oder den Import von CSS als String im [Styling-Leitfaden](/de/guides/styling/#advanced).</ReadMore>
+
 ### CSS-Module
 
 ```jsx
-// 1. Konvertiert die Klassennamen aus './style.module.css' in eindeutige Werte (scoped).
+// 1. Konvertiert die Klassennamen aus './style.module.css' in eindeutige Werte, welche für diesen Bereich verfügbar sind (scoped).
 // 2. Gibt ein Objekt zurück, das die ursprünglichen Klassennamen auf ihren endgültigen, zugewiesenen Wert abbildet.
 import styles from './style.module.css';
 
@@ -120,7 +128,7 @@ import styles from './style.module.css';
 return <div className={styles.error}>Deine Fehlermeldung</div>;
 ```
 
-Astro unterstützt CSS-Module unter Verwendung der Namenskonvention `[name].module.css`. Wie bei jeder CSS-Datei wird beim Importieren einer solchen Datei das CSS automatisch auf die Seite angewendet. CSS-Module exportieren jedoch ein spezielles Standardobjekt "styles", das deine ursprünglichen Klassennamen auf eindeutige Bezeichner abbildet.
+Astro unterstützt CSS-Module unter Verwendung der Namenskonvention `[name].module.css`. Wie bei jeder CSS-Datei wird beim Importieren einer solchen Datei das CSS automatisch auf die Seite angewendet. CSS-Module exportieren jedoch ein spezielles Standardobjekt `styles`, das deine ursprünglichen Klassennamen auf eindeutige Bezeichner abbildet.
 
 CSS-Module helfen dir dabei, das Scoping und die Isolierung von Komponenten auf dem Frontend mit eindeutig generierten Klassennamen für deine Stylesheets durchzusetzen.
 
@@ -132,37 +140,37 @@ import svgReference from './image.svg'; // svgReference === '/src/image.svg'
 import txtReference from './words.txt'; // txtReference === '/src/words.txt'
 
 // This example uses JSX, but you can use import references with any framework.
-<img src={imgReference} alt="image description" />;
+<img src={imgReference.src} alt="Bildbeschreibung" />;
 ```
 
-Alle anderen, oben nicht explizit erwähnten Assets können über ESM `import` importiert werden und geben einen URL-Verweis auf das fertige Asset zurück. Dies kann nützlich sein, um Nicht-JS-Assets per URL zu referenzieren, z.B. um ein Bildelement mit einem "src"-Attribut zu erstellen, das auf dieses Bild zeigt.
+Alle anderen, oben nicht explizit erwähnten Assets können über ESM `import` importiert werden und geben einen URL-Verweis auf das fertige Asset zurück. Dies kann nützlich sein, um Nicht-JS-Assets per URL zu referenzieren, z.B. um ein Bildelement mit einem `src`-Attribut zu erstellen, das auf dieses Bild zeigt.
 
 Es kann auch nützlich sein, Bilder in den Ordner `public/` zu legen, wie auf der [Projektstruktur-Seite](/de/basics/project-structure/#public) erklärt.
+
+<ReadMore>Lies mehr über das Anhängen von Vite-Importparametern (z.B. `?url`, `?raw`) in [Vite's Leitfaden für den Umgang mit statischen Assets](https://vite.dev/guide/assets.html).</ReadMore>
 
 :::note
 Das Hinzufügen von **Alt-Text** zu `<img>`-Tags wird aus Gründen der Zugänglichkeit empfohlen! Vergiss nicht, deinen Bildelementen das Attribut `alt="eine hilfreiche Beschreibung"` hinzuzufügen. Du kannst das Attribut einfach leer lassen, wenn das Bild rein dekorativ ist.
 :::
 
-## Import-Aliasnamen
+## Aliase
 
 Ein **Aliasname** (kurz **Alias**) ist eine Möglichkeit, um Abkürzungen für Importpfade zu erstellen.
 
 Aliasnamen können dabei helfen, die Entwicklungserfahrung in Codebasen mit vielen Verzeichnissen oder relativen Importpfaden zu verbessern.
 
-```astro
+```astro title="src/pages/about/company.astro" del="../../components" del="../../assets"
 ---
-// mein-projekt/src/pages/ueber-uns/firma.astro
-
 import Button from '../../components/controls/Button.astro';
 import logoUrl from '../../assets/logo.png?url';
 ---
 ```
 
-In diesem Beispiel müsste man bei der Entwicklung die Baumbeziehung zwischen `src/pages/ueber-uns/firma.astro`, `src/components/controls/Button.astro` und `src/assets/logo.png` berücksichtigen, um die richtigen relativen Importpfade definieren zu können. Und falls die Datei `firma.astro` jemals verschoben werden sollte, müssten diese Importpfade ebenfalls aktualisiert werden.
+In diesem Beispiel müsste man bei der Entwicklung die Baumbeziehung zwischen `src/pages/about/company.astro`, `src/components/controls/Button.astro` und `src/assets/logo.png` berücksichtigen, um die richtigen relativen Importpfade definieren zu können. Und falls die Datei `company.astro` jemals verschoben werden sollte, müssten diese Importpfade ebenfalls aktualisiert werden.
 
-Um diese Situation zu verbessern, kannst du Import-Aliasnamen entweder in der Datei `tsconfig.json` oder `jsconfig.json` hinzufügen.
+Du kannst Import-Aliase in `tsconfig.json` hinzufügen
 
-```json
+```json title="tsconfig.json" ins={5-6}
 {
   "compilerOptions": {
     "baseUrl": ".",
@@ -174,35 +182,38 @@ Um diese Situation zu verbessern, kannst du Import-Aliasnamen entweder in der Da
 }
 ```
 
-Mit dieser zentralen Änderung kannst du die Importpfade nun überall in deinem Projekt benutzen:
+:::note
+Stelle sicher, dass `compilerOptions.baseUrl` gesetzt ist, damit die Pfade mit Aliasnamen aufgelöst werden können.
+:::
 
-```astro
+Der Entwicklungsserver wird nach dieser Konfigurationsänderung automatisch neu gestartet. Du kannst jetzt die Aliase überall in deinem Projekt importieren:
+
+```astro title="src/pages/about/company.astro" ins="@components" ins="@assets"
 ---
-// mein-projekt/src/pages/ueber-uns/firma.astro
-
-import Button from '@components/Button.astro';
-import logoUrl from '@assets/logo.png';
+import Button from '@components/controls/Button.astro';
+import logoUrl from '@assets/logo.png?url';
 ---
 ```
 
 Die von dir definierten Aliasnamen werden auch automatisch in [VS Code](https://code.visualstudio.com/docs/languages/jsconfig) und andere Editoren integriert.
 
-## `Astro.glob()`
+## `import.meta.glob()`
 
-Mit [`Astro.glob()`](/de/reference/api-reference/#astroglob) kannst du viele Dateien auf einmal importieren.
+Mit [Vite's `import.meta.glob()`](https://vite.dev/guide/features.html#glob-import) kannst du viele Dateien auf einmal importieren, indem du Glob-Muster verwendest, um passende Dateipfade zu finden.
 
-`Astro.glob()` erlaubt nur einen Parameter: ein relatives [Glob-Pattern](/de/guides/imports/#glob-patterns), das zu den lokalen Dateien passt, die du importieren möchtest. Es ist asynchron und gibt ein Array mit den Exporten jeder passenden Datei zurück.
+Die Funktion `import.meta.glob()` nimmt als Parameter ein relatives [Glob-Muster](/de/guides/imports/#glob-patterns), das den lokalen Dateien entspricht, die du importieren möchtest. Sie gibt ein Array mit den Exporten jeder passenden Datei zurück. Um alle übereinstimmenden Module im Voraus zu laden, gibst du als zweites Argument `{ eager: true }` an:
 
-```astro title="src/components/my-component.astro"
+```astro title="src/components/my-component.astro" {3,4}
 ---
-// importiert alle Dateien, die mit `.md` enden in `./src/pages/post/`
-const posts = await Astro.glob('../pages/post/*.md'); 
+// importiert alle Dateien, die mit `.md` in `./src/pages/post/` enden
+const matches = import.meta.glob('../pages/post/*.md', { eager: true }); 
+const posts = Object.values(matches);
 ---
-<!-- Rendert einen <Artikel> für die ersten 5 Blogbeiträge -->
+<!-- Erzeugt einen <Artikel> für die ersten 5 Blogbeiträge -->
 <div>
 {posts.slice(0, 4).map((post) => (
   <article>
-    <h1>{post.frontmatter.title}</h1>
+    <h2>{post.frontmatter.title}</h2>
     <p>{post.frontmatter.description}</p>
     <a href={post.url}>Read more</a>
   </article>
@@ -210,14 +221,14 @@ const posts = await Astro.glob('../pages/post/*.md');
 </div>
 ```
 
-Astro-Komponenten, die mit `Astro.glob` importiert werden, sind vom Typ [`AstroInstance`](/de/reference/api-reference/#astro-dateien). Du kannst jede Komponenteninstanz mit ihrer Eigenschaft `default` darstellen:
+Astro-Komponenten, die mit `import.meta.glob` importiert werden, sind vom Typ [`AstroInstance`](#astro-dateien). Du kannst jede Komponenteninstanz mit ihrer Eigenschaft `default` darstellen:
 
 ```astro title="src/pages/component-library.astro" {8}
 ---
-// importiert alle Dateien, die mit `.astro` enden in `./src/components/`
-const components = await Astro.glob('../components/*.astro');
+// importiert alle Dateien, die mit `.astro` in `./src/components/` enden
+const components = Object.values(import.meta.glob('../components/*.astro', { eager: true }));
 ---
-<!-- Alle Komponenten anzeigen -->
+<!-- Alle unsere Komponenten anzeigen -->
 {components.map((component) => (
   <div>
     <component.default size={24} />
@@ -225,22 +236,118 @@ const components = await Astro.glob('../components/*.astro');
 ))}
 ```
 
-### Glob Patterns
+### Unterstützte Werte
 
-Ein Glob-Pattern ist ein Dateipfad, der spezielle Platzhalterzeichen unterstützt. Es wird verwendet, um auf mehrere Dateien in deinem Projekt gleichzeitig zu verweisen.
+Die Funktion `import.meta.glob()` von Vite unterstützt nur statische String-Literale. Sie unterstützt keine dynamischen Variablen und keine String-Interpolation.
 
-Das Glob-Pattern `./pages/**/*.{md,mdx}` beginnt beispielsweise im Unterverzeichnis `pages`, durchsucht alle Unterverzeichnisse (`/**`) und erfasst jeden Dateinamen (`/*`), der entweder auf `.md` oder `.mdx` (`.{md,mdx}`) endet.
+Eine gängige Lösung ist es, stattdessen eine größere Menge an Dateien zu importieren, die alle benötigten Dateien enthält, und diese dann zu filtern:
 
-#### Glob-Patterns in Astro
+```astro {6-7}
+---
+// src/components/featured.astro
+const { postSlug } = Astro.props;
+const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
 
-Um mit `Astro.glob()` verwendet zu werden, muss das Glob-Pattern ein String-Literal sein und darf keine Variablen enthalten. Siehe [die Anleitung zur Fehlerbehebung](/de/guides/troubleshooting/#astroglob---no-matches-found) für eine andere Lösung.
+const posts = Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
+const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
+---
 
-Außerdem müssen Glob-Pattern mit einem der folgenden Zeichen beginnen:
+<p>
+  Schau dir meinen Lieblingspost, <a href={myFeaturedPost.url}>{myFeaturedPost.frontmatter.title}</a>, an!
+</p>
+```
+
+### Importtyp Hilfsmittel
+
+#### Markdown-Dateien
+
+Markdown-Dateien, die mit `import.meta.glob()` geladen werden, geben die folgende `MarkdownInstance`-Schnittstelle zurück.
+
+```ts
+export interface MarkdownInstance<T extends Record<string, any>> {
+  /* Alle im YAML-Frontmatter dieser Datei angegebenen Daten */
+	frontmatter: T;
+  /* Der absolute Dateipfad für diese Datei */
+	file: string;
+  /* Der gerenderte Pfad zu dieser Datei */
+	url: string | undefined;
+  /* Astro-Komponente, die den Inhalt dieser Datei wiedergibt */
+	Content: AstroComponentFactory;
+  /** (nur Markdown) Roher Inhalt der Markdown-Datei, ohne Layout-HTML und YAML-Frontmatter */
+	rawContent(): string;
+  /** (nur Markdown) Markdown-Datei, die zu HTML kompiliert wurde, ohne Layout-HTML */
+	compiledContent(): string;
+  /* Funktion, die ein Array mit den h1...h6-Elementen in dieser Datei zurückgibt */
+	getHeadings(): Promise<{ depth: number; slug: string; text: string }[]>;
+	default: AstroComponentFactory;
+}
+```
+
+Du kannst optional einen Typ für die Variable `frontmatter` angeben, indem du eine TypeScript-Generik verwendest.
+
+```astro
+---
+import type { MarkdownInstance } from 'astro';
+interface Frontmatter {
+    title: string;
+    description?: string;
+}
+
+const posts = Object.values(import.meta.glob<MarkdownInstance<Frontmatter>>('./posts/**/*.md', { eager: true }));
+---
+
+<ul>
+  {posts.map(post => <li>{post.frontmatter.title}</li>)}
+</ul>
+```
+
+#### Astro-Dateien
+
+Astro-Dateien haben die folgende Schnittstelle:
+
+```ts
+export interface AstroInstance {
+  /* Der Dateipfad für diese Datei */
+  file: string;
+  /* Die URL für diese Datei (wenn sie sich im Seitenverzeichnis befindet) */
+	url: string | undefined;
+	default: AstroComponentFactory;
+}
+```
+
+#### Andere Dateien
+
+Andere Dateien können verschiedene Schnittstellen haben, aber `import.meta.glob()` akzeptiert eine TypeScript-Generik, wenn du genau weißt, was ein nicht erkannter Dateityp enthält.
+
+```ts
+---
+interface CustomDataFile {
+  default: Record<string, any>;
+}
+const data = import.meta.glob<CustomDataFile>('../data/**/*.js');
+---
+```
+
+### Glob-Muster
+
+Ein Glob-Muster ist ein Dateipfad, der spezielle Platzhalterzeichen unterstützt. Es wird verwendet, um mehrere Dateien in deinem Projekt gleichzeitig zu referenzieren.
+
+Das globale Muster `./pages/**/*.{md,mdx}` beginnt zum Beispiel im Unterverzeichnis `pages`, durchsucht alle Unterverzeichnisse (`/**`) und passt auf jeden Dateinamen (`/*`), der entweder auf `.md` oder `.mdx` (`.{md,mdx}`) endet.
+
+#### Glob-Muster in Astro
+
+Um mit `import.meta.glob()` verwendet zu werden, muss das Glob-Muster ein String-Literal sein und darf keine Variablen enthalten.
+
+Außerdem müssen die Glob-Muster mit einem der folgenden Zeichen beginnen:
 - `./` (um im aktuellen Verzeichnis zu beginnen)
 - `../` (um im übergeordneten Verzeichnis zu beginnen)
 - `/` (um im Stammverzeichnis des Projekts zu beginnen)
- 
-[Lies mehr über die Syntax des Glob-Pattern](https://github.com/mrmlnc/fast-glob#pattern-syntax).
+
+[Lies mehr über die Syntax des glob-Musters] (https://github.com/mrmlnc/fast-glob#pattern-syntax).
+
+### `import.meta.glob()` vs `getCollection()`
+
+[Inhaltssammlungen](/de/guides/content-collections/) bieten eine [`getCollection()` API](/de/reference/modules/astro-content/#getcollection) zum Laden mehrerer Dateien anstelle von `import.meta.glob()`. Wenn deine Inhaltsdateien (z.B. Markdown, MDX, Markdoc) in Sammlungen innerhalb des Verzeichnisses `src/content/` liegen, verwende `getCollection()`, um [eine Sammlung abzufragen](/de/guides/content-collections/#querying-collections) und Inhaltseinträge zurückzugeben.
 
 ## WASM
 
@@ -251,10 +358,9 @@ const wasm = await WebAssembly.instantiateStreaming(fetch('/example.wasm'));
 
 Astro unterstützt das Laden von WASM-Dateien direkt in deine Anwendung unter Verwendung der [`WebAssembly`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly) API des Browsers.
 
-
 ## Node Builtins
 
-Wir empfehlen Astro-Benutzern, Node.js-Builtins (`fs`, `path`, etc.) wann immer möglich zu vermeiden. Astro soll in Zukunft mit mehreren JavaScript-Laufzeiten kompatibel sein. Dazu gehören [Deno](https://deno.land/) und [Cloudflare Workers](https://workers.cloudflare.com/), die keine Node-Builtins wie `fs` unterstützen.
+Wir empfehlen Astro-Benutzern, Node.js-Builtins (`fs`, `path`, etc.) zu vermeiden, wann immer es möglich ist. Astro ist mit mehreren Laufzeiten kompatibel, die [Adapter](/de/guides/on-demand-rendering/) verwenden. Dazu gehören [Deno](https://github.com/denoland/deno-astro-adapter) und [Cloudflare Workers](/de/guides/integrations-guide/cloudflare/), die keine Node-Builtins wie `fs` unterstützen.
 
 Unser Ziel ist es, Astro-Alternativen zu gängigen Node.js-Builtins anzubieten. Allerdings gibt es davon bisher keine. Wenn du also _wirklich_ diese eingebauten Module verwenden musst, halten wir dich nicht auf. Astro unterstützt Node.js-Builtins, die das neuere `node:`-Präfix von Node verwenden. Wenn du z.B. eine Datei lesen willst, kannst du das folgendermaßen tun:
 
@@ -273,39 +379,10 @@ const data = JSON.parse(json);
 
 ## Erweiterung der Unterstützung von Dateitypen
 
-Mit **Vite** und kompatiblen **Rollup**-Plugins kannst du Dateitypen importieren, die von Astro nicht nativ unterstützt werden. Wo du die benötigten Plugins findest erfährst du im Abschnitt [Finding Plugins](https://vite.dev/guide/using-plugins.html#finding-plugins) der Vite-Dokumentation.
+Mit **Vite** und kompatiblen **Rollup**-Plugins kannst du Dateitypen importieren, die von Astro nicht nativ unterstützt werden. Wo du die benötigten Plugins findest erfährst du im Abschnitt [„Plugins finden“](https://vite.dev/guide/using-plugins.html#finding-plugins) der Vite-Dokumentation.
 
-
- :::note[plugin configuration]
+:::note[Pluginkonfiguration]
 In der Dokumentation deines Plugins findest du Informationen zu den Konfigurationsoptionen und zur korrekten Installation.
 :::
 
-### Beispiel: YAML-Unterstützung
-
-Das Datenformat YAML (`.yml`) wird von Astro nicht von Haus aus unterstützt, aber du kannst es mit einem kompatiblen Rollup-Plugin wie [`@rollup/plugin-yaml`](https://www.npmjs.com/package/@rollup/plugin-yaml) hinzufügen:
-
-1. Installiere `@rollup/plugin-yaml`:
-
-    ```bash
-    npm install @rollup/plugin-yaml --save-dev
-    ```
-
-2. Importiere das Plugin in deine "astro.config.mjs" und füge es zum Array "Vite plugins" hinzu:
-
-    ```js title="astro.config.mjs" ins={2,5-7}
-    import { defineConfig } from 'astro/config';
-    import yaml from '@rollup/plugin-yaml';
-
-    export default defineConfig({
-      vite: {
-        plugins: [yaml()]
-      }
-    });
-    ```
-
-
-3. Zuletzt kannst du YAML-Daten mit einer Import-Anweisung importieren:
-
-    ```js
-    import yml from './data.yml';
-    ```
+<RecipeLinks slugs={["de/recipes/add-yaml-support"]} />

--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -201,7 +201,7 @@ These aliases are also integrated automatically into [VS Code](https://code.visu
 
 [Vite's `import.meta.glob()`](https://vite.dev/guide/features.html#glob-import) is a way to import many files at once using glob patterns to find matching file paths.
 
-`import.meta.glob()` takes a relative [glob pattern](/en/guides/imports/#glob-patterns) matching the local files you'd like to import as a parameter. It returns an array of each matching file's exports. To load all matched modules up front, pass `{ eager: true }` as the second argument:
+`import.meta.glob()` takes a relative [glob pattern](#glob-patterns) matching the local files you'd like to import as a parameter. It returns an array of each matching file's exports. To load all matched modules up front, pass `{ eager: true }` as the second argument:
 
 ```astro title="src/components/my-component.astro" {3,4}
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
