### PR TITLE
docs(content-collections): remove stale anti-use-case

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -587,6 +587,5 @@ Collections provide excellent structure, safety, and organization when you have 
 Collections **may not be your solution** if:
 
 - You have only one or a small number of different pages. Consider [making individual page components](/en/basics/astro-pages/) such as `src/pages/about.astro` with your content directly instead.
-- Your data is not stored in a supported format, such as TOML. Use other methods of [importing files](/en/guides/imports/#import-statements) or [fetching data](/en/guides/data-fetching/) instead.
 - You are displaying files that are not processed by Astro, such as PDFs. Place these static assets in the [`public/` directory](/en/basics/project-structure/#public) of your project instead.
 - You are using APIs that need to be updated in real time. Content collections are only updated at build time, so if you need live data you should consider [on-demand rendering](/en/guides/on-demand-rendering/).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

With the advent of custom loaders in Astro v5, the "non-standard" data anti-use-case is invalid (yay!). This should be removed from documentation to prevent confusion :)

Discord Username: rayhanadev

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
