### PR TITLE
Fix typo in configuration example for Netlify Blob sessions

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/sessions.mdx
+++ b/src/content/docs/en/reference/experimental-flags/sessions.mdx
@@ -71,8 +71,8 @@ You can also pass any available options to the unstorage driver in a separate `s
 
 ```js title="astro.config.mjs" ins={7-11}
   {
+    adapter: netlify(),
     experimental: {
-      adapter: netlify(),
       session: {
         // The name of the unstorage driver is camelCase
         driver: "netlify-blobs",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Netlify blob example had `adapter` incorrectly nested in the `experimental`  property instead of at the root of the configuration object.

Discord: sledsworth


<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!
<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
