### PR TITLE
typo in `reference/experimental-flags/session.mdx` [i18nIgnore]

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/sessions.mdx
+++ b/src/content/docs/en/reference/experimental-flags/sessions.mdx
@@ -31,7 +31,7 @@ const cart = await Astro.session.get('cart');
 
 Sessions rely on a [configurable session `driver`](#enabling-experimental-sessions) to store data on the `session` object. A [session cookie](#cookies) stores an identifying session ID.
 
-The [`session` object](#sessions-api) allow you to interact with the stored user state (e.g. add items to a shopping cart) and the session ID (e.g. delete the session ID cookie when logging out).
+The [`session` object](#sessions-api) allows you to interact with the stored user state (e.g. add items to a shopping cart) and the session ID (e.g. delete the session ID cookie when logging out).
 
 ## Enabling experimental sessions
 


### PR DESCRIPTION
#### Description (required)

I think I found a missing `s` after a third person: `session object`

> I'm writing [i18nIgnore] into the title, alto it would work with just `typo` because I think new translators have an easier job figuring out what changes were made to outdated translations if the more specific key word is included...

