### PR TITLE
[v5 upgrade] include MDX in collections instructions

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -121,7 +121,7 @@ See the instructions below for updating an existing content collection (`type: '
 
 1. **Move the content config file**. This file no longer lives within the `src/content/` folder. This file should now exist at `src/content.config.ts`.
 
-2. **Edit the collection definition**. Your updated collection requires a `loader` which indicates both a folder for the location of your collection (`base`) and a `pattern` defining the collection enty filenames and extensions to match. (You may need to update the example below accordingly.) The option to select a collection `type` is no longer available.
+2. **Edit the collection definition**. Your updated collection requires a `loader` which indicates both a folder for the location of your collection (`base`) and a `pattern` defining the collection entry filenames and extensions to match. (You may need to update the example below accordingly. You can use [globster.xyz](https://globster.xyz/) to check your glob pattern.) The option to select a collection `type` is no longer available.
 
     ```ts ins={3,8} del={7}
     // src/content.config.ts
@@ -131,7 +131,7 @@ See the instructions below for updating an existing content collection (`type: '
     const blog = defineCollection({
       // For content layer you no longer define a `type`
       type: 'content',
-      loader: glob({ pattern: '**/[^_]*.(md|mdx)', base: "./src/data/blog" }),
+      loader: glob({ pattern: '**/[^_]*.{md|mdx}', base: "./src/data/blog" }),
       schema: z.object({
         title: z.string(),
         description: z.string(),

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -121,7 +121,7 @@ See the instructions below for updating an existing content collection (`type: '
 
 1. **Move the content config file**. This file no longer lives within the `src/content/` folder. This file should now exist at `src/content.config.ts`.
 
-2. **Edit the collection definition**. Your updated collection requires a `loader`, and the option to select a collection `type` is no longer available.
+2. **Edit the collection definition**. Your updated collection requires a `loader` which indicates both a folder for the location of your collection (`base`) and a `pattern` defining the collection enty filenames and extensions to match. (You may need to update the example below accordingly.) The option to select a collection `type` is no longer available.
 
     ```ts ins={3,8} del={7}
     // src/content.config.ts
@@ -131,7 +131,7 @@ See the instructions below for updating an existing content collection (`type: '
     const blog = defineCollection({
       // For content layer you no longer define a `type`
       type: 'content',
-      loader: glob({ pattern: '**/[^_]*.md', base: "./src/data/blog" }),
+      loader: glob({ pattern: '**/[^_]*.(md|mdx)', base: "./src/data/blog" }),
       schema: z.object({
         title: z.string(),
         description: z.string(),

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -131,7 +131,7 @@ See the instructions below for updating an existing content collection (`type: '
     const blog = defineCollection({
       // For content layer you no longer define a `type`
       type: 'content',
-      loader: glob({ pattern: '**/[^_]*.{md|mdx}', base: "./src/data/blog" }),
+      loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: "./src/data/blog" }),
       schema: z.object({
         title: z.string(),
         description: z.string(),


### PR DESCRIPTION
Adds more detail to Step 2 of content collections upgrade to include:

- an updated pattern that would cover people with MDX collection entries
- more explicit text defining `pattern` and `base`, with a warning to update the examples given if necessary