### PR TITLE
fix: add wait to code sample

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -702,7 +702,7 @@ import { actions } from 'astro:actions';
 
 const searchQuery = Astro.url.searchParams.get('search');
 if (searchQuery) {
-  const { data, error } = Astro.callAction(actions.findProduct, { query: searchQuery });
+  const { data, error } = await Astro.callAction(actions.findProduct, { query: searchQuery });
   // handle result
 }
 ---


### PR DESCRIPTION
#### Description

When calling an action from a server endpoint, an `await` is required or `data` and `error` will be `undefined`.
