### PR TITLE
i18n(zh-cn): Update `invalid-content-entry-frontmatter-error.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/invalid-content-entry-frontmatter-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-content-entry-frontmatter-error.mdx
@@ -11,11 +11,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 
 ## 哪里发生了错误？
 
-在 `src/content/` 目录下的 Markdown 或 MDX 条目与其集合模式不匹配。
+Markdown 或 MDX 条目与其集合模式不匹配。
 确保所有必需的字段都存在，并且所有字段都是正确的类型。
-请检查 `src/content/config.*` 文件中的集合模式。
-更多信息，请参阅[内容集合](/zh-cn/guides/content-collections/)
-
-
-
-
+请检查 `src/content.config.*` 文件中的集合模式。
+更多信息，请参阅 [内容集合](/zh-cn/guides/content-collections/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update `invalid-content-entry-frontmatter-error.mdx`

#### Related issues & labels (optional)

- #9240
- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
