### PR TITLE
i18n(zh-cn): Update `invalid-content-entry-slug-error.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/invalid-content-entry-slug-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/invalid-content-entry-slug-error.mdx
@@ -8,9 +8,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 
 ## 哪里发生了错误？
 
-`src/content/` 中的条目具有无效的 `slug`。此字段作为保留字段，用于生成条目的 slug，并且在存在时必须是一个字符串。
+集合条目具有无效的 `slug`。此字段作为保留字段，用于生成条目的 slug，并且在存在时必须是一个字符串。
 
 **请参阅:**
 -  [保留的条目 `slug`](/zh-cn/guides/content-collections/)
-
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update `invalid-content-entry-slug-error.mdx`

#### Related issues & labels (optional)

- #9240
- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
