### PR TITLE
[markdown-content] clearer distinction between imported Markdown and collections data

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -402,7 +402,7 @@ const posts = await getCollection('blog');
 ```
 #### Rendering body content 
 
-Once queried, you can render Markdown and MDX entries to HTML using the `render()` function property. Calling this function gives you access to rendered HTML content, including both a `<Content />` component and a list of all rendered headings.
+Once queried, you can render Markdown and MDX entries to HTML using the [`render()`](/en/reference/modules/astro-content/#render) function property. Calling this function gives you access to rendered HTML content, including both a `<Content />` component and a list of all rendered headings.
 
 ```astro title="src/pages/blog/post-1.astro" {5,8}
 ---

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -31,7 +31,7 @@ Local Markdown can be imported into `.astro` components using an `import` statem
 
 If you have groups of related Markdown files, consider [defining them as collections](/en/guides/content-collections/). This gives you several advantages, including the ability to store Markdown files anywhere on your filesystem or remotely.
 
-Collections use content-specfic, optimized API for [querying and rendering your Markdown content](#markdown-from-content-collections-queries) instead of file imports. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
+Collections use content-specfic, optimized APIs for [querying and rendering your Markdown content](#markdown-from-content-collections-queries) instead of file imports. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
 
 <ReadMore>See more about [when to use content collections](/en/guides/content-collections/#when-to-create-a-collection) instead of file imports.</ReadMore>
 

--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -21,11 +21,17 @@ For additional functionality, such as including components and JSX expressions i
 
 ## Organizing Markdown files
 
-Your local Markdown files can be kept anywhere within your `src/` directory. Local Markdown can be imported into `.astro` components using an `import` statement for a single file and [Vite's `import.meta.glob()`](/en/guides/imports/#importmetaglob) to query multiple files at once.
+Your local Markdown files can be kept anywhere within your `src/` directory. Markdown files located within `src/pages/` will automatically generate [Markdown pages on your site](#individual-markdown-pages).
+
+Your Markdown content and frontmatter properties are available to use in components through [local file imports](#importing-markdown) or when [queried and rendered from data fetched by a content collections helper function](#markdown-from-content-collections-queries).
+
+### File imports vs content collections queries
+
+Local Markdown can be imported into `.astro` components using an `import` statement for a single file and [Vite's `import.meta.glob()`](/en/guides/imports/#importmetaglob) to query multiple files at once. The [exported data from these Markdown files](#importing-markdown) can then be used in the `.astro` component.
 
 If you have groups of related Markdown files, consider [defining them as collections](/en/guides/content-collections/). This gives you several advantages, including the ability to store Markdown files anywhere on your filesystem or remotely.
 
-Collections also allow you to use content-specfic, optimized API for querying and rendering your content. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
+Collections use content-specfic, optimized API for [querying and rendering your Markdown content](#markdown-from-content-collections-queries) instead of file imports. Collections are intended for sets of data that share the same structure, such as blog posts or product items. When you define that shape in a schema, you additionally get validation, type safety, and Intellisense in your editor.
 
 <ReadMore>See more about [when to use content collections](/en/guides/content-collections/#when-to-create-a-collection) instead of file imports.</ReadMore>
 
@@ -59,11 +65,13 @@ const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
 ### Available Properties
 
-#### Querying collections
+#### Markdown from content collections queries
 
-When fetching data from your collections via helper functions, your Markdown's frontmatter properties are available on a `data` object (e.g. `post.data.title`). Additionally, `body` contains the raw, uncompiled body content as a string.
+When fetching data from your collections with the helper functions `getCollection()` or `getEntry()`, your Markdown's frontmatter properties are available on a `data` object (e.g. `post.data.title`). Additionally, `body` contains the raw, uncompiled body content as a string.
 
-<ReadMore>See the full [CollectionEntry type](/en/reference/modules/astro-content/#collectionentry).</ReadMore>
+The [`render()`](/en/reference/modules/astro-content/#render) function returns your Markdown body content, a generated list of headings, as well as a modified frontmatter object after any remark or rehype plugins have been applied.
+
+<ReadMore>Read more about [using content returned by a collections query](/en/guides/content-collections/#using-content-in-astro-templates).</ReadMore>
 
 #### Importing Markdown
 
@@ -146,7 +154,7 @@ Astro generates heading `id`s based on `github-slugger`. You can find more examp
 
 ### Heading IDs and plugins
 
-Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files and provides a `getHeadings()` utility for retrieving these IDs in [Markdown exported properties](#available-properties).
+Astro injects an `id` attribute into all heading elements (`<h1>` to `<h6>`) in Markdown and MDX files. You can retrieve this data from the `getHeadings()` utility available as a [Markdown exported property](#available-properties) from an imported file, or from the `render()` function when [using Markdown returned from a content collections query](#markdown-from-content-collections-queries).
 
 You can customize these heading IDs by adding a rehype plugin that injects `id` attributes (e.g. `rehype-slug`). Your custom IDs, instead of Astro's defaults, will be reflected in the HTML output and the items returned by `getHeadings()`.
 


### PR DESCRIPTION
Addresses an issue where it was difficult to find information about accessing headings data from Markdown content collections entries.

The page was written before collections, and therefore emphasized exported Markdown properties even though this information is only appropriate when importing Markdown files. More relevant information is available on the Contents Collections guide page, and in reference, but someone may first look at the Markdown guide even when their Markdown files are part of a collection.

This does not duplicate content found elsewhere, but attempts to:
- empahsize in multiple places that you may be working with Markdown that came from either a file import or a content collection (there's a difference!)
- adds more contextual links throughout, notably adds a link to the `render()` reference on the Content Collections guide page which contains helpful information in understanding how headings are accessed differently in Content Collections

Closes #10361