### PR TITLE
[migration guides] update options for content location

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -212,7 +212,7 @@ You may also wish to reuse code from Gatsby's `src/components/seo.js` to include
 
 ### Migrating Pages and Posts
 
-In Gatsby, your [pages and posts](/en/basics/astro-pages/) may exist in `src/pages/` or outside of `src` in another folder, like `content`. In Astro, **all your page content must live within `src/`**.
+In Gatsby, your [pages and posts](/en/basics/astro-pages/) may exist in `src/pages/` or outside of `src` in another folder, like `content`. In Astro, all your page content must live within `src/` unless you are using [content collections](/en/guides/content-collections/).
 
 #### React Pages
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -306,7 +306,7 @@ export default function Head() {
 
 In Next.js, your posts either live in `/pages` or `/app/routeName/page.jsx`.
 
-In Astro, **all your page content must live within `src/`**, unless you are using [content collections](/en/guides/content-collections/).
+In Astro, all your page content must live within `src/` unless you are using [content collections](/en/guides/content-collections/).
 
 #### React pages
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -225,7 +225,7 @@ You may also wish to reuse code from [your Nuxt's page's `head` property](https:
 
 ### Migrating Pages and Posts
 
-In NuxtJS, your [pages](/en/basics/astro-pages/) live in `/pages`. In Astro, **all your page's content must live within `src/** unless you are using [content collections](/en/guides/content-collections/).
+In NuxtJS, your [pages](/en/basics/astro-pages/) live in `/pages`. In Astro, all your page content must live within `src/` unless you are using [content collections](/en/guides/content-collections/).
 
 #### Vue Pages
 


### PR DESCRIPTION
This updates and unifies the three full "Migrate to Astro" guides that currently claim that content must live within `src`. This makes the sentence consistent in all three guides that this is not a restriction when using content collections.

Closes #10189