### PR TITLE
[content-collections] quick fixes

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -23,7 +23,7 @@ Projects may continue using the legacy Content Collections API introduced in Ast
 
 You can define a **collection** from a set of data that is structurally similar. This can be a directory of blog posts, a JSON file of product items, or any data that represents multiple items of the same shape.
 
-Collections stored locally in your project or on your filesystem can have entries of Markdown, MDX, Markdoc, or JSON files:
+Collections stored locally in your project or on your filesystem can have entries of Markdown, MDX, Markdoc, YAML, or JSON files:
 
 <FileTree>
 - src/
@@ -85,7 +85,7 @@ The Content Layer API allows you to fetch your content (whether stored locally i
 
 Astro provides two built-in loader functions (`glob()` and `file()`) for fetching your local content, as well as access to the API to construct your own loader and fetch remote data.
 
-The `glob()` loader creates entries from directories of Markdown, MDX, Markdoc, or JSON files from anywhere on the filesystem. It accepts a `pattern` of entry files to match, and a `base` file path of where your files are located. Each entry's `id` will be automatically generated from its file name. Use this loader when you have one file per entry.
+The `glob()` loader creates entries from directories of Markdown, MDX, Markdoc, or JSON files from anywhere on the filesystem. It accepts a `pattern` of entry files to match using glob patterns supported by [micromatch](https://github.com/micromatch/micromatch#matching-featuresh), and a base file path of where your files are located. Each entry's `id` will be automatically generated from its file name. Use this loader when you have one file per entry.
 
 The `file()` loader creates multiple entries from a single local file. Each entry in the file must have a unique `id` key property. It accepts a `base` file path to your file and optionally a [`parser` function](#parser-function) for data files it cannot parse automatically. Use this loader when your data file can be parsed as an array of objects.
 


### PR DESCRIPTION
This is the "quick fix" to at least get some minimal helpful/correct info into content collections but does not entirely solve 10147 (not linking so it won't close)

- Adds that collections can be YAML
- notes that we use `micromatch` for matching in `pattern`