### PR TITLE
i18(es): fix typo in `es.ts`

### DIFF
--- a/src/content/nav/es.ts
+++ b/src/content/nav/es.ts
@@ -2,7 +2,7 @@ import { navDictionary } from '../../util/navDictionary';
 
 export default navDictionary({
 	start: 'Inicio',
-	'start.welcome': '!Bienvenidos, Mundo!',
+	'start.welcome': '¡Bienvenidos, Mundo!',
 	'start.newProject': 'Comienza un nuevo proyecto',
 	'start.config': 'Configuración',
 	'start.migrate': 'Migrar a Astro',


### PR DESCRIPTION
**Description (required)**

- Upgrade `es.ts` to fix a typo on the ¡ sign

Related issues & labels (optional)

- Suggested label: `i18n`