### PR TITLE
Add note about ids having to be strings to content collection docs

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -223,7 +223,7 @@ Schemas enforce consistent frontmatter or entry data within a collection through
 
 Schemas also power Astro's automatic TypeScript typings for your content. When you define a schema for your collection, Astro will automatically generate and apply a TypeScript interface to it. The result is full TypeScript support when you query your collection, including property autocompletion and type-checking.
 
-Every frontmatter or data property of your collection entries must be defined using a Zod data type:
+Every frontmatter or data property of your collection entries must be defined using a Zod data type. When defining your schema, make sure that if you provide an `id` property, it is a string:
 
 ```ts title="src/content.config.ts" {6-11,15-19}
 import { defineCollection, z } from 'astro:content';


### PR DESCRIPTION
#### Description (required)

This PR adds a sentence to clarify that the IDs of content collections always have to be strings. This is undocumented behavior and lead to confusion, see [Custom content loader: `entry missing id` when using an id from the source data](https://discord.com/channels/830184174198718474/1319456296176582727) on the Astro Discord server.

#### Related issues & labels (optional)

- Related to [this PR on the main repo](https://github.com/withastro/astro/pull/12892)
