### PR TITLE
i18n(fr): update `content-collections` & `markdown-content` guides

### DIFF
--- a/src/content/docs/fr/guides/content-collections.mdx
+++ b/src/content/docs/fr/guides/content-collections.mdx
@@ -402,7 +402,7 @@ const posts = await getCollection('blog');
 ```
 #### Restitution du contenu
 
-Une fois la requête effectuée, vous pouvez restituer les entrées Markdown et MDX en HTML à l'aide de la propriété de fonction `render()`. L'appel de cette fonction vous donne accès au contenu HTML restitué, y compris à la fois un composant `<Content />` et une liste de tous les titres restitués.
+Une fois la requête effectuée, vous pouvez restituer les entrées Markdown et MDX en HTML à l'aide de la propriété de fonction [`render()`](/fr/reference/modules/astro-content/#render). L'appel de cette fonction vous donne accès au contenu HTML restitué, y compris à la fois un composant `<Content />` et une liste de tous les titres restitués.
 
 ```astro title="src/pages/blog/post-1.astro" {5,8}
 ---

--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -21,11 +21,17 @@ Pour des fonctionnalités supplémentaires, telles que l'inclusion de composants
 
 ## Organiser les fichiers Markdown
 
-Vos fichiers Markdown locaux peuvent être conservés n'importe où dans votre répertoire `src/`. Ils peuvent être importés dans les composants `.astro` en utilisant une instruction `import` pour un seul fichier et [`import.meta.glob()` de Vite](/fr/guides/imports/#importmetaglob) pour interroger plusieurs fichiers à la fois.
+Vos fichiers Markdown locaux peuvent être conservés n'importe où dans votre répertoire `src/`. Les fichiers Markdown situés dans `src/pages/` généreront automatiquement [des pages Markdown sur votre site](#pages-markdown-individuelles).
+
+Votre contenu Markdown et vos propriétés frontmatter peuvent être utilisés dans les composants via des [importations de fichiers locaux](#importation-de-markdown) ou lorsqu'ils sont [interrogés et rendus à partir de données récupérées par une fonction d'assistance de collections de contenu](#markdown-à-partir-des-requêtes-de-collections-de-contenu).
+
+### Importations de fichiers vs requêtes de collections de contenu
+
+Vos fichiers Markdown locaux peuvent être importés dans les composants `.astro` en utilisant une instruction `import` pour un seul fichier et [`import.meta.glob()` de Vite](/fr/guides/imports/#importmetaglob) pour interroger plusieurs fichiers à la fois. Les [données exportées à partir de ces fichiers Markdown](#importation-de-markdown) peuvent ensuite être utilisées dans le composant `.astro`.
 
 Si vous avez des groupes de fichiers Markdown apparentés, envisagez de les [définir comme des collections](/fr/guides/content-collections/). Cela présente plusieurs avantages, notamment la possibilité de stocker les fichiers Markdown n'importe où sur votre système de fichiers ou à distance.
 
-Les collections vous permettent également d'utiliser une API optimisée et spécifique au contenu pour interroger et afficher votre contenu. Les collections sont destinées aux ensembles de données qui partagent la même structure, tels que les articles de blog ou les pages de produits. Lorsque vous définissez cette forme dans un schéma, vous bénéficiez en outre de la validation, de la sécurité des types et de l'Intellisense dans votre éditeur.
+Les collections utilisent des API optimisées et spécifiques au contenu pour [interroger et restituer votre contenu Markdown](#markdown-à-partir-des-requêtes-de-collections-de-contenu) au lieu d'importer des fichiers. Les collections sont destinées aux ensembles de données qui partagent la même structure, tels que les articles de blog ou les pages de produits. Lorsque vous définissez cette forme dans un schéma, vous bénéficiez en outre de la validation, de la sécurité des types et de l'Intellisense dans votre éditeur.
 
 <ReadMore>En savoir plus sur [quand utiliser les collections de contenu](/fr/guides/content-collections/#quand-créer-une-collection) au lieu des importations de fichiers.</ReadMore>
 
@@ -59,11 +65,13 @@ const posts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
 
 ### Propriétés disponibles
 
-#### Interroger les collections
+#### Markdown à partir des requêtes de collections de contenu
 
-Lorsque vous récupérez des données de vos collections via des fonctions d'aide, les propriétés de votre document Markdown sont disponibles dans un objet `data` (par exemple `post.data.title`). De plus, `body` contient le contenu brut, non compilé, sous forme de chaîne de caractères.
+Lorsque vous récupérez des données de vos collections avec les fonctions d'aide `getCollection()` ou `getEntry()`, les propriétés du frontmatter de votre Markdown sont disponibles dans un objet `data` (par exemple `post.data.title`). De plus, `body` contient le contenu brut, non compilé, sous forme de chaîne de caractères.
 
-<ReadMore>Voir le [Type des entrées de collection](/fr/reference/modules/astro-content/#collectionentry) complet.</ReadMore>
+La fonction [`render()`](/fr/reference/modules/astro-content/#render) renvoie le contenu du corps de votre Markdown, une liste de titres générée, ainsi qu'un objet frontmatter modifié après l'application de tout plugin Remark ou Rehype.
+
+<ReadMore>En savoir plus sur [l'utilisation du contenu renvoyé par une requête de collection](/fr/guides/content-collections/#utilisation-du-contenu-dans-les-modèles-astro).</ReadMore>
 
 #### Importation de Markdown
 
@@ -146,7 +154,7 @@ Astro génère des `id`s d'en-tête basés sur `github-slugger`. Vous pouvez tro
 
 ### ID des titres et plugins
 
-Astro injecte un attribut `id` dans tous les éléments d'en-tête (`<h1>` à `<h6>`) dans les fichiers Markdown et MDX et fournit un utilitaire `getHeadings()` pour récupérer ces ID dans les [propriétés exportées Markdown](#propriétés-disponibles).
+Astro injecte un attribut `id` dans tous les éléments d'en-tête (`<h1>` à `<h6>`) dans les fichiers Markdown et MDX. Vous pouvez récupérer ces données à partir de l'utilitaire `getHeadings()` disponible en tant que [propriété exportée Markdown](#propriétés-disponibles) à partir d'un fichier importé, ou à partir de la fonction `render()` lorsque [vous utilisez du Markdown renvoyé à partir d'une requête de collections de contenu](#markdown-à-partir-des-requêtes-de-collections-de-contenu).
 
 Vous pouvez personnaliser ces ID en ajoutant un plugin rehype qui injecte les attributs `id` (par exemple `rehype-slug`). Vos ID personnalisés, au lieu des valeurs par défaut d'Astro, seront reflétés dans la sortie HTML et les éléments retournés par `getHeadings()`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations of `guides/content-collections.mdx` and `guides/markdown-content.mdx` with changes from #10594

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
