### PR TITLE
i18n(fr): Update `reference/errors/*`

### DIFF
--- a/src/content/docs/fr/reference/errors/session-storage-init-error.mdx
+++ b/src/content/docs/fr/reference/errors/session-storage-init-error.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **SessionStorageInitError**: Error when initializing session storageDRIVER ? ` WITH DRIVER ${DRIVER` : ''}. ERROR ?? ''
+> Error when initializing session storage with driver `DRIVER`. `ERROR`
 
 ## Qu'est-ce qui a mal tourné ?
 Apparaît lorsque le stockage de la session n'a pas pu être initialisé.

--- a/src/content/docs/fr/reference/errors/session-storage-save-error.mdx
+++ b/src/content/docs/fr/reference/errors/session-storage-save-error.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **SessionStorageSaveError**: Error when saving session dataDRIVER ? ` WITH DRIVER ${DRIVER` : ''}. ERROR ?? ''
+> Error when saving session data with driver `DRIVER`. `ERROR`
 
 ## Qu'est-ce qui a mal tourné ?
 Apparaît lorsque les données de la session n'ont pas pu être sauvegardées.


### PR DESCRIPTION


#### Description (required)
Update `reference/errors/session-storage-init-error.mdx` and `reference/errors/session-storage-save-error.mdx` from #10680

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
