### PR TITLE
Use a simpler label for fonts guide in the sidebar

### DIFF
--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -1,5 +1,7 @@
 ---
 title: Using custom fonts
+sidebar:
+  label: Fonts
 description: >-
   Looking to add some custom typefaces to an Astro website? Use Google Fonts
   with Fontsource or add a font of your choice.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- This PR updates the sidebar label for the fonts guide from “Using custom fonts” to “Fonts”
- Reasoning: I struggled to quickly find the page even though I was fairly certain it was in the “Build your UI” group. I suspect this is because the keyword is “fonts” but this is somewhat buried behind “using custom” which are not very specific. Given the context of other guides being labelled similarly as “Styles”, “Components”, etc., “Fonts” feels in keeping and helps make it more scannable.

| Before | After |
|--------|--------|
| <img width="294" alt="build your UI sidebar group with using custom fonts item" src="https://github.com/user-attachments/assets/f71e3f6f-0505-4fa8-aff4-d174bbc9bdd6" /> | <img width="296" alt="build your UI sidebar group with fonts item" src="https://github.com/user-attachments/assets/12d71cfb-9168-453a-93f6-84af71a4e015" /> | 