### PR TITLE
Removed redundant nullish coalescing operator

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -104,10 +104,11 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
       :global(.dark) .moon { fill: white; }
     </style>
 
-    <script is:inline>
+    <script>
       const theme = (() => {
-        if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-          return localStorage.getItem('theme');
+        const localStorageTheme = localStorage?.getItem("theme") ?? '';
+        if (['dark', 'light'].includes(localStorageTheme)) {
+          return localStorageTheme;
         }
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
           return 'dark';

--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -107,7 +107,7 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
     <script is:inline>
       const theme = (() => {
         if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-          return localStorage.getItem('theme') ?? "light";
+          return localStorage.getItem('theme');
         }
         if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
           return 'dark';

--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -104,7 +104,7 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
       :global(.dark) .moon { fill: white; }
     </style>
 
-    <script>
+    <script is:inline>
       const theme = (() => {
         const localStorageTheme = localStorage?.getItem("theme") ?? '';
         if (['dark', 'light'].includes(localStorageTheme)) {


### PR DESCRIPTION
#### Description (required)

This PR removes the redundant nullish coalescing operator (??) from the code that retrieves the theme from localStorage. The nullish coalescing operator is unnecessary in this context because the existence of the theme in localStorage is already checked.

#### Related issues & labels (optional)

- Suggested label: enhancement
