### PR TITLE
fix: update two code snippets in the tutorial

### DIFF
--- a/src/content/docs/en/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/3.mdx
@@ -210,7 +210,7 @@ Here is what your new page should look like:
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
-const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
+const tags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---
 <BaseLayout pageTitle={pageTitle}>

--- a/src/content/docs/en/tutorial/6-islands/2.mdx
+++ b/src/content/docs/en/tutorial/6-islands/2.mdx
@@ -95,7 +95,7 @@ To add interactivity to an Astro component, you can use a `<script>` tag. This s
 <Steps>
 1. Add the following `<script>` tag in `src/components/ThemeIcon.astro` after your `<style>` tag:
 
-    ```astro title="src/components/ThemeIcon.astro" ins={9-37}
+    ```astro title="src/components/ThemeIcon.astro" ins={9-38}
     <style>
       .sun { fill: black; }
       .moon { fill: transparent; }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I followed the tutorial again to check the consistency between the tutorial and the `blog-tutorial-demo` repository (see https://github.com/withastro/blog-tutorial-demo/pull/39 and https://github.com/withastro/blog-tutorial-demo/pull/40). Almost everything looks good here, I only updated two things:

* Adds a missing `any` in the code check-in of unit 5-3 to prevent a Typescript error (if someone tries to replace his code) and to match what we had before.
* Fixes the line highlighting in unit 6-2 (I forgot to check that in #10719)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
