### PR TITLE
More links to tutorials for beginners in docs

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/3.mdx
+++ b/src/content/docs/en/tutorial/6-islands/3.mdx
@@ -71,7 +71,12 @@ Congratulations on completing the Astro blog tutorial! Share your achievement wi
 
 ## Next Steps
 
-You can enhance this project's final code with one of our tutorial extensions, or start your next Astro project!
+There are many more tutorials out there: 
+   1. Free YouTube videos: [1](https://youtu.be/e-hTm5VmofI?si=UHCR_OwX4YZXIKqf), [2](https://youtu.be/XoIHKO6AkoM?si=yMEREmelpz9Q6U3O) 
+   2. Paid online courses: [1](https://www.udemy.com/course/astrojs-101-build-blazing-fast-frontends/), [2](https://learnastro.dev/), [3](https://astrocourse.dev/), [4](https://www.udemy.com/course/astro-the-complete-guide/), [5](https://www.udemy.com/course/astrojs-101-build-blazing-fast-frontends/)
+
+Or you can enhance this project's final code with one of our tutorial extensions, or start your next Astro project!
+
 <CardGrid>
   <LinkCard
     title="Start a new Astro Project"


### PR DESCRIPTION
Added other tutorials for beginners. It includes links to paid offerings. But I am in no way affiliated with any of these and genuinely believe that they do add value for readers.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

I need to educate our employees in the company with Astro. We were a WordPress shop so far. So I have been searching for offerings with videos for them to onboard themselves. This is good content that all other newbies in the Astro community could benefit from. That's why I suggest to add it to the official docs.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: docs, tutorials, videos

Username in Astro Discord: martinseibert (legacy: mseibert#0410) 
