### PR TITLE
Remove duplicated `prop` in `routing-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -299,7 +299,7 @@ Get the URL of the current page (useful for canonical URLs). If a value is set f
 **Type:** `string | undefined`
 </p>
 
-Get the URL of the previous page (will be `undefined` if on the first page). If a value is set for [`base`](/en/reference/configuration-reference/#base), the URL starts with that value.
+Get the URL of the previous page (will be `undefined` if on page 1). If a value is set for [`base`](/en/reference/configuration-reference/#base), prepend the base path to the URL.
 
 ##### `page.url.next`
 
@@ -308,24 +308,7 @@ Get the URL of the previous page (will be `undefined` if on the first page). If 
 **Type:** `string | undefined`
 </p>
 
-Get the URL of the next page (will be `undefined` if on the last page). If a value is set for [`base`](/en/reference/configuration-reference/#base), the URL starts with that value.
-
-##### `page.url.first`
-
-<p>
-  **Type:** `string`
-</p>
-
-Get the URL of the first page (will be `undefined` if on the first page). If a value is set for [`base`](/en/reference/configuration-reference/#base), the URL starts with that value.
-
-##### `page.url.last`
-
-<p>
-  **Type:** `string`
-</p>
-
-Get the URL of the last page  (will be `undefined` if on the last page). If a value is set for [`base`](/en/reference/configuration-reference/#base), the URL starts with that value.
-
+Get the URL of the next page (will be `undefined` if no more pages). If a value is set for [`base`](/en/reference/configuration-reference/#base), prepend the base path to the URL.
 
 ##### `page.url.first`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When I translate `routing-reference.mdx`, I notice something duplicated and inconsistent in their descriptions, comparing to [v4](https://v4.docs.astro.build/en/reference/api-reference/#pageurlprev).

so I make changes in `routing-reference.mdx`:
- Remove duplicated `prop`: `page.url.first` & `page.url.last`.
- Make descriptions consistent.

#### Related issues & labels (optional)

- Suggested label: consistency/formatting

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
