### PR TITLE
i18n(fr): update `routing-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/routing-reference.mdx
+++ b/src/content/docs/fr/reference/routing-reference.mdx
@@ -299,7 +299,7 @@ Obtenir l'URL de la page actuelle (utile pour les URL canoniques). Si une valeur
 **Type :** `string | undefined`
 </p>
 
-Obtenir l'URL de la page précédente (sera `undefined` si elle se trouve sur la première page). Si une valeur est définie pour [`base`](/fr/reference/configuration-reference/#base), l'URL commence par cette valeur.
+Obtenir l'URL de la page précédente (sera `undefined` si elle se trouve sur la page 1). Si une valeur est définie pour [`base`](/fr/reference/configuration-reference/#base), ajoute le chemin de base à l'URL.
 
 ##### `page.url.next`
 
@@ -309,23 +309,6 @@ Obtenir l'URL de la page précédente (sera `undefined` si elle se trouve sur la
 </p>
 
 Obtenir l'URL de la page suivante (sera `undefined` si elle se trouve sur la dernière page). Si une valeur est définie pour [`base`](/fr/reference/configuration-reference/#base), l'URL commence par cette valeur.
-
-##### `page.url.first`
-
-<p>
-  **Type :** `string`
-</p>
-
-Obtenir l'URL de la première page (sera `undefined` si elle se trouve sur la première page). Si une valeur est définie pour [`base`](/fr/reference/configuration-reference/#base), l'URL commence par cette valeur.
-
-##### `page.url.last`
-
-<p>
-  **Type :** `string`
-</p>
-
-Obtenir l'URL de la dernière page (sera `undefined` si elle se trouve sur la dernière page). Si une valeur est définie pour [`base`](/fr/reference/configuration-reference/#base), l'URL commence par cette valeur.
-
 
 ##### `page.url.first`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10746 to the French translation of `routing-reference.mdx`:
* Slightly rewords the description of `page.url.prev`
* Removes duplicate properties (`page.url.first` and `page.url.last`)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
