### PR TITLE
Update drupal.mdx

### DIFF
--- a/src/content/docs/en/guides/cms/drupal.mdx
+++ b/src/content/docs/en/guides/cms/drupal.mdx
@@ -492,7 +492,7 @@ This example uses Astro's default static mode, and creates [a dynamic routing pa
     In our example, the `props` object passes three properties to the page:
     - `title`: a string, representing the title of your post.
     - `body`: a string, representing the content of your entry.
-    - `created`: a timestamp, based on your file creation date.
+    - `date`: a timestamp, based on your file creation date.
 
 3. Use the page `props` to display your blog post.
 
@@ -526,7 +526,7 @@ This example uses Astro's default static mode, and creates [a dynamic routing pa
         });
     }
 
-    const {title, created, body} = Astro.props;
+    const {title, date, body} = Astro.props;
     ---
     <html lang="en">
       <head>


### PR DESCRIPTION
changing incorrect "created" prop to correct "date" prop name in Drupal integration instruction.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
