### PR TITLE
Add reference to the official example on the payload repo

### DIFF
--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -217,7 +217,8 @@ export async function getStaticPaths() {
 
 To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow the instructions for your preferred hosting provider.
 
-## Community Resources 
+## Community Resources
+
 - Check out the [official Astro integration](https://github.com/payloadcms/payload/tree/main/examples/astro) on the Payload CMS repository
 - Try this [Payload CMS & Astro Template](https://github.com/Lambdo-Labs/payloadcms-astro-template).
 - Check out [Astroad](https://github.com/mooxl/astroad) for easy development and VPS deployment with Docker.

--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -218,6 +218,6 @@ export async function getStaticPaths() {
 To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow the instructions for your preferred hosting provider.
 
 ## Community Resources 
-
+- Check out the [official Astro integration](https://github.com/payloadcms/payload/tree/main/examples/astro) on the Payload CMS repository
 - Try this [Payload CMS & Astro Template](https://github.com/Lambdo-Labs/payloadcms-astro-template).
 - Check out [Astroad](https://github.com/mooxl/astroad) for easy development and VPS deployment with Docker.

--- a/src/content/docs/en/guides/cms/payload.mdx
+++ b/src/content/docs/en/guides/cms/payload.mdx
@@ -219,6 +219,6 @@ To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow 
 
 ## Community Resources
 
-- Check out the [official Astro integration](https://github.com/payloadcms/payload/tree/main/examples/astro) on the Payload CMS repository
+- Check out the [official Astro Payload CMS integration](https://github.com/payloadcms/payload/tree/main/examples/astro).
 - Try this [Payload CMS & Astro Template](https://github.com/Lambdo-Labs/payloadcms-astro-template).
 - Check out [Astroad](https://github.com/mooxl/astroad) for easy development and VPS deployment with Docker.


### PR DESCRIPTION
#### Description
I added the link to the new and official PayloadCMS Astro integration example, that can be found on the PayloadCMS repository.


#### First-time contributor to Astro Docs?
Yes

#### Discord username
`albertogiunta`
