### PR TITLE
i18n(fr): add `content-loader-returns-invalid-id.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -118,6 +118,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**GetEntryDeprecationError**](/fr/reference/errors/get-entry-deprecation-error/)<br/>Utilisation non valide des fonctions `getDataEntryById` ou `getEntryBySlug`.
 - [**InvalidContentEntryFrontmatterError**](/fr/reference/errors/invalid-content-entry-frontmatter-error/)<br/>Le frontmatter du contenu ne correspond pas au schéma.
 - [**InvalidContentEntryDataError**](/fr/reference/errors/invalid-content-entry-data-error/)<br/>Les données d'entrée de contenu ne correspondent pas au schéma.
+- [**ContentLoaderReturnsInvalidId**](/fr/reference/errors/content-loader-returns-invalid-id/)<br/>Le chargeur de contenu a renvoyé une entrée avec un `id` non valide.
 - [**ContentEntryDataError**](/fr/reference/errors/content-entry-data-error/)<br/>Les données d'entrée de contenu ne correspondent pas au schéma.
 - [**ContentLoaderInvalidDataError**](/fr/reference/errors/content-loader-invalid-data-error/)<br/>L'entrée de contenu ne contient pas d'ID
 - [**InvalidContentEntrySlugError**](/fr/reference/errors/invalid-content-entry-slug-error/)<br/>Le Slug du contenu n'est pas valide.

--- a/src/content/docs/fr/reference/errors/content-loader-returns-invalid-id.mdx
+++ b/src/content/docs/fr/reference/errors/content-loader-returns-invalid-id.mdx
@@ -1,0 +1,17 @@
+---
+title: Le chargeur de contenu a renvoyé une entrée avec un id non valide.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Example error message:**<br/>
+The content loader for the collection **blog** returned an entry with an invalid `id`:<br/>
+&#123;<br/>
+  "id": 1,<br/>
+  "title": "Hello, World!"<br/>
+&#125;
+
+## Qu'est-ce qui a mal tourné ?
+Un chargeur de contenu a renvoyé un `id` non valide.
+Assurez-vous que l'`id` de l'entrée est une chaîne de caractères.
+Consultez la [documentation des collections de contenu](/fr/guides/content-collections/) pour plus d'informations.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10770:
* Translates `content-loader-returns-invalid-id.mdx` in French
* Updates `error-reference.mdx` to add the new error

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
