### PR TITLE
i18n(fr): update `guides/cms/drupal.mdx`

### DIFF
--- a/src/content/docs/fr/guides/cms/drupal.mdx
+++ b/src/content/docs/fr/guides/cms/drupal.mdx
@@ -492,7 +492,7 @@ Cet exemple utilise le mode statique par défaut d'Astro et crée [un fichier de
     Dans notre exemple, l'objet `props` transmet trois propriétés à la page :
     - `title` : une chaîne de caractères, représentant le titre de votre message.
     - `body` : une chaîne de caractères, représentant le contenu de votre entrée.
-    - `created` : un horodatage, basé sur la date de création de votre fichier.
+    - `date` : un horodatage, basé sur la date de création de votre fichier.
 
 3. Utilisez les `props` de la page pour afficher votre article de blog.
 
@@ -526,7 +526,7 @@ Cet exemple utilise le mode statique par défaut d'Astro et crée [un fichier de
         });
     }
 
-    const {title, created, body} = Astro.props;
+    const {title, date, body} = Astro.props;
     ---
     <html lang="fr">
       <head>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10756 to the French translation of `guides/cms/drupal.mdx` (replace some `created` vars with `date`).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
