### PR TITLE
[from-gatsby] use LinkCard for community resources

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx
@@ -8,7 +8,7 @@ stub: false
 framework: Gatsby
 i18nReady: true
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
 import AstroJSXTabs from '~/components/tabs/AstroJSXTabs.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
@@ -567,21 +567,26 @@ This page layout shows one header when visiting the home page, and a different h
 
 ## Community Resources
 
-- Blog Post: [Migrating from Gatsby to Astro](https://loige.co/migrating-from-gatsby-to-astro/)
+<CardGrid>
+<LinkCard title="Migrating from Gatsby to Astro" href="https://loige.co/migrating-from-gatsby-to-astro/" 
+description="How and why I migrated this blog from Gatsby to Astro and what I learned in the process." />
+<LinkCard title="Migrating to Astro was EZ" href="https://joelhooks.com/migrating-to-astro-was-ez" 
+description="This is about the process of migrating from Gatsby to Astro, and why I chose Astro." 
+ />
+<LinkCard title="My Switch from Gatsby to Astro" href="https://www.joshfinnie.com/blog/my-switch-from-gatsby-to-astro/" 
+description="The switch to Astro is definitely worth a blog post! It’s revolutionizing the static web development scene for the better."/>
+<LinkCard title="Why I moved to Astro from Gatsby" href="https://dev.to/askrodney/why-i-moved-to-astro-from-gatsby-3fck" 
+description="Taking a quick look at what made me want to switch and why Astro was a good fit." />
+<LinkCard title="Another Migration: From Gatsby to Astro" href="https://logarithmicspirals.com/blog/migrating-from-gatsby-to-astro/" 
+description="Learn about how I transitioned my personal website from Gatsby to Astro as I share insights and experiences from the migration process."/>
+<LinkCard title="Migrating my website from Gatsby to Astro" href="https://dev.to/flashblaze/migrating-my-website-from-gatsby-to-astro-2ej5" 
+description="Astro has entered the chat." />
+<LinkCard title="Why and how I moved my blog away from Gatsby and React to Astro Js and Preact" href="https://www.helmerdavila.com/blog/en/why-and-how-i-moved-my-blog-away-from-gatsby-and-react-to-astro-js-and-preact" 
+description="All is about simplicity and power at the same time." />
 
-- Blog Post: [Migrating to Astro was EZ](https://joelhooks.com/migrating-to-astro-was-ez).
-
-- Blog Post: [My Switch from Gatsby to Astro](https://www.joshfinnie.com/blog/my-switch-from-gatsby-to-astro/).
-
-- Blog Post: [Why I moved to Astro from Gatsby](https://dev.to/askrodney/why-i-moved-to-astro-from-gatsby-3fck).
-
-- Blog Post: [Migrating my website from Gatsby to Astro](https://dev.to/flashblaze/migrating-my-website-from-gatsby-to-astro-2ej5).
-
-- Blog Post: [Another Migration: From Gatsby to Astro](https://logarithmicspirals.com/blog/migrating-from-gatsby-to-astro/).
-
-- Blog Post: [Why and how I moved my blog away from Gatsby and React to Astro and Preact](https://www.helmerdavila.com/blog/en/why-and-how-i-moved-my-blog-away-from-gatsby-and-react-to-astro-js-and-preact)
-
-- Blog Post: [How I rewrote my HUGE 100gb+ Gatsby site in Astro and learned to love it in the process](https://dunedinsound.com/blog/how_i_rewrote_my_huge_gatsby_site_in_astro_and_learned_to_love_it_in_the_process/)
+<LinkCard title="How I rewrote my HUGE Gatsby site in Astro and learned to love it in the process" href="https://dunedinsound.com/blog/how_i_rewrote_my_huge_gatsby_site_in_astro_and_learned_to_love_it_in_the_process/" 
+description="Everything is faster. Happier. More productive."/>
+</CardGrid>
 
 :::note[Have a resource to share?]
 If you found (or made!) a helpful video or blog post about converting a Gatsby site to Astro, [edit this page](https://github.com/withastro/docs/edit/main/src/content/docs/en/guides/migrate-to-astro/from-gatsby.mdx) and add it here!


### PR DESCRIPTION
This PR changes the bulleted list of community resources to `<LinkCard>` components in a `<CardGrid>` for the Migrate from Gatsby page.

If we like this, then we can accept PRs to update the other Migrate to Astro pages!

Note:
- Titles are the blog post / article titles
- Descriptions are the subtitle / description of the article if available. If not, I chose the earliest sentence(s) that seemed like a standalone subtitle/tagline/intro. So, we have some flexibility here (e.g. being more strategic about length).

Before:
![image](https://github.com/user-attachments/assets/667f6cd2-6b87-42aa-b9d4-8a4b5c07ff59)

After:
![Screenshot 2025-01-23 18 55 47](https://github.com/user-attachments/assets/93b6bafe-ddd7-49a4-b71a-4887c1ee1383)
