### PR TITLE
fix: outputs and type in `astro-i18n`

### DIFF
--- a/src/content/docs/en/reference/modules/astro-i18n.mdx
+++ b/src/content/docs/en/reference/modules/astro-i18n.mdx
@@ -60,7 +60,7 @@ getRelativeLocaleUrl("fr");
 // returns /fr
 
 getRelativeLocaleUrl("fr", "");
-// returns /fr
+// returns /fr/
 
 getRelativeLocaleUrl("fr", "getting-started");
 // returns /fr/getting-started
@@ -82,7 +82,7 @@ getRelativeLocaleUrl("fr_CA", "getting-started", {
 
 <p>
 
-**Type:** `(locale: string, path: string, options?: GetLocaleOptions) => string`
+**Type:** `(locale: string, path?: string, options?: GetLocaleOptions) => string`
 </p>
 
 Use this function to retrieve an absolute path for a locale when [`site`] has a value. If [`site`] isn't configured, the function returns a relative URL. If the locale doesn't exist, Astro throws an error.
@@ -98,7 +98,7 @@ getAbsoluteLocaleUrl("fr");
 // returns https://example.com/fr
 
 getAbsoluteLocaleUrl("fr", ""); 
-// returns https://example.com/fr
+// returns https://example.com/fr/
 
 getAbsoluteLocaleUrl("fr", "getting-started"); 
 // returns https://example.com/fr/getting-started


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Fixes the output displayed as comment for `getRelativeLocaleUrl("fr")` and `getAbsoluteLocaleUrl("fr")` (missing slash)
* Fixes the type for `getAbsoluteLocaleUrl()` (path is optional)

#### Related issues & labels (optional)

- Closes #10743
- Related https://github.com/withastro/astro/issues/13032
- Suggested label: `code snippet update` (and not sure which label matches the type update... `typo/link/grammar - quick fix!` I guess) ... Feel free to correct the labels 😄 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
