### PR TITLE
i18n(fr): update `guides/deploy/cloudflare.mdx`

### DIFF
--- a/src/content/docs/fr/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/fr/guides/deploy/cloudflare.mdx
@@ -31,7 +31,7 @@ Pour commencer, vous aurez besoin :
 
 2. Poussez votre code dans votre dépôt Git (GitHub, GitLab).
 
-3. Connectez-vous au tableau de bord de Cloudflare et sélectionnez votre compte dans **Comptes** > **Workers et Pages** > **Vue d’ensemble**.
+3. Connectez-vous au tableau de bord de Cloudflare et sélectionnez votre compte dans **Comptes** > **Compute (Workers)** > **Workers et Pages** > **Vue d’ensemble**.
 
 4. Sélectionnez **Créer**, naviguez dans l'onglet **Pages** et cliquez sur **Se connecter à Git**.
 

--- a/src/content/docs/fr/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/fr/guides/deploy/cloudflare.mdx
@@ -31,7 +31,7 @@ Pour commencer, vous aurez besoin :
 
 2. Poussez votre code dans votre dépôt Git (GitHub, GitLab).
 
-3. Connectez-vous au tableau de bord de Cloudflare et sélectionnez votre compte dans **Comptes** > **Compute (Workers)** > **Workers et Pages** > **Vue d’ensemble**.
+3. Connectez-vous au tableau de bord de Cloudflare et sélectionnez votre compte dans **Comptes** > **Capacité de calcul (Workers)** > **Workers et Pages** > **Vue d’ensemble**.
 
 4. Sélectionnez **Créer**, naviguez dans l'onglet **Pages** et cliquez sur **Se connecter à Git**.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10762 to the French translation of `guides/deploy/cloudflare.mdx`

> [!NOTE]
> I left the new label in English because I don't have a Cloudflare account so I don't know what is the translation. I tried to look for a screenshot of the dashboard translated in French... but no luck. And I guess the original version is not worse than a wrong translation... I mean `Calculer (Workers)` seems weird... but I don't use Cloudflare. So feel free to check if you have access to Cloudflare!

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
