### PR TITLE
i18n(es): Update vercel.mdx

### DIFF
--- a/src/content/docs/es/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/es/guides/integrations-guide/vercel.mdx
@@ -79,20 +79,6 @@ export default defineConfig({
 });
 ```
 
-### Objetivos
-
-Puedes desplegar en diferentes objetivos:
-
-* `serverless`: SSR dentro de una [función Node.js](https://vercel.com/docs/concepts/functions/serverless-functions).
-* `static`: genera un sitio estático siguiendo los formatos de salida, redirecciones, etc. de Vercel.
-
-Puedes cambiar el destino modificando la importación:
-
-```js "serverless" "static"
-import vercel from '@astrojs/vercel/serverless';
-import vercel from '@astrojs/vercel/static';
-```
-
 ## Uso
 
 <ReadMore>[Lee la guía completa para despliegue aquí.](/es/guides/deploy/vercel/)</ReadMore>
@@ -368,27 +354,6 @@ export default defineConfig({
   output: "server",
   adapter: vercel({
     skewProtection: true
-  }),
-});
-```
-
-### Configuración de agrupación de funciones
-
-El adaptador de Vercel combina todas tus rutas en una única función por defecto.
-
-También tienes la opción de dividir las compilaciones en una función separada para cada ruta usando la opción `functionPerRoute`. Esto reduce el tamaño de cada función, lo que significa que es menos probable que excedas el límite de tamaño para una función individual. Además, el código se inicia más rápido.
-
-Verifica que tu plan de Vercel incluya un número adecuado de funciones antes de habilitar `functionPerRoute`. Por ejemplo, el nivel gratuito de Vercel limita cada despliegue a no más de 12 funciones. Si tu plan de Vercel es insuficiente para el número de rutas en tu proyecto, recibirás un mensaje de error durante el despliegue.
-
-```js title="astro.config.mjs" ins={8}
-import { defineConfig } from 'astro/config';
-import vercel from '@astrojs/vercel/serverless';
-
-export default defineConfig({
-  // ...
-  output: 'server',
-  adapter: vercel({
-    functionPerRoute: true,
   }),
 });
 ```


### PR DESCRIPTION
Removed `configuración-de-agrupación-de-funciones` and `objetivos` because in the English version they do not exist.