### PR TITLE
docs: fix new experimental serialized config option name

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/serialized-configuration.mdx
+++ b/src/content/docs/en/reference/experimental-flags/serialized-configuration.mdx
@@ -19,13 +19,13 @@ This feature allows access to the `astro:config` virtual module which exposes a 
 
 For a complete overview, and to give feedback on this experimental API, see the [Serialized Manifest RFC](https://github.com/withastro/roadmap/blob/feat/serialised-config/proposals/0051-serialized-manifest.md).
 
-To enable this virtual module, add the `experimental.serializeManifest` feature flag to your Astro config:
+To enable this virtual module, add the `experimental.serializeConfig` feature flag to your Astro config:
 
 ```js title="astro.config.mjs" ins={3-5}
 import {defineConfig} from "astro/config"
 export default defineConfig({
   experimental: {
-    serializeManifest: true
+    serializeConfig: true
   }
 })
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the new experimental serialized configuration from `serializeManifest` to `serializeConfig`. The [docs](https://docs.astro.build/en/reference/experimental-flags/serialized-configuration/) says it's `serializeManifest`, but the [blog](https://astro.build/blog/astro-520/#experimental-astroconfig) and actual [source](https://github.com/withastro/astro/blob/3b10b97a4fecd1dfd959b160a07b5b8427fe40a7/packages/astro/src/manifest/virtual-module.ts#L38) is using `serializeConfig`.
