### PR TITLE
i18n(fr): update `guides/markdown-content.mdx`

### DIFF
--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -11,7 +11,7 @@ import RecipeLinks from "~/components/RecipeLinks.astro";
 import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Le [Markdown](https://daringfireball.net/projects/markdown/) est couramment utilisé pour créer des contenus à forte teneur en texte, tels que des articles de blog et de la documentation. Astro inclut une prise en charge intégrée des fichiers Markdown standard qui peuvent également inclure un [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) pour définir des propriétés personnalisées telles qu'un titre, une description et des balises.
+Le [Markdown](https://daringfireball.net/projects/markdown/) est couramment utilisé pour créer des contenus à forte teneur en texte, tels que des articles de blog et de la documentation. Astro inclut une prise en charge intégrée des fichiers Markdown qui peuvent également inclure un [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) (ou [TOML](https://toml.io)) pour définir des propriétés personnalisées telles qu'un titre, une description et des balises.
 
 Dans Astro, vous pouvez créer du contenu en utilisant [GitHub Flavored Markdown](https://github.github.com/gfm/), puis l'afficher dans des composants `.astro`. Cela combine un format d'écriture familier conçu pour le contenu avec la flexibilité de la syntaxe et de l'architecture des composants d'Astro.
 
@@ -79,7 +79,7 @@ Les propriétés exportées suivantes sont disponibles dans votre composant `.as
 
 - **`file`** - Le chemin absolu du fichier (par exemple `/home/user/projects/.../file.md`).
 - **`url`** - L'URL de la page (par exemple `/fr/guides/markdown-content`).
-- **`frontmatter`** - Contient toutes les données spécifiées dans le frontmatter YAML du fichier.
+- **`frontmatter`** - Contient toutes les données spécifiées dans le frontmatter YAML (ou TOML) du fichier.
 - **`<Content />`** - Un composant qui renvoie le contenu complet et affiché du fichier.
 - **`RawContent()`** - Une fonction qui renvoie le document Markdown brut sous forme de chaîne de caractères.
 - **`compiledContent()`** - Une fonction asynchrone qui retourne le document Markdown compilé en une chaîne HTML.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10826 to the French translation of `guides/markdown-content.mdx` (YAML/TOML).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
