### PR TITLE
i18n(fr): update adapter links in `integrations-guide/*`

### DIFF
--- a/src/content/docs/fr/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/cloudflare.mdx
@@ -4,7 +4,7 @@ title: '@astrojs/cloudflare'
 description: "Apprendre à utiliser l'adaptateur SSR @astrojs/cloudflare pour déployer votre projet Astro."
 sidebar:
   label: Cloudflare
-githubIntegrationURL: 'https://github.com/withastro/adapters/tree/main/packages/cloudflare/'
+githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
 category: adapter
 i18nReady: true
 ---

--- a/src/content/docs/fr/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/netlify.mdx
@@ -4,7 +4,7 @@ title: '@astrojs/netlify'
 description: "Apprenez à utiliser l'adaptateur SSR @astrojs/netlify pour déployer votre projet Astro."
 sidebar:
   label: Netlify
-githubIntegrationURL: 'https://github.com/withastro/adapters/tree/main/packages/netlify/'
+githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/netlify/'
 category: adapter
 i18nReady: true
 ---

--- a/src/content/docs/fr/guides/integrations-guide/node.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/node.mdx
@@ -4,7 +4,7 @@ title: '@astrojs/node'
 description: "Apprenez à utiliser l'adaptateur SSR @astrojs/node pour déployer votre projet Astro."
 sidebar:
   label: Node
-githubIntegrationURL: 'https://github.com/withastro/adapters/tree/main/packages/node/'
+githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/node/'
 category: adapter
 i18nReady: true
 ---

--- a/src/content/docs/fr/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/vercel.mdx
@@ -4,7 +4,7 @@ title: '@astrojs/vercel'
 description: "Apprenez à utiliser l'adaptateur SSR @astrojs/vercel pour déployer votre projet Astro."
 sidebar:
   label: Vercel
-githubIntegrationURL: 'https://github.com/withastro/adapters/tree/main/packages/vercel/'
+githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/vercel/'
 category: adapter
 i18nReady: true
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the `githubIntegrationURL` for Node, Netlify, Vercel and Cloudflare in the French translations (see #10898, #10900, #10901 and #10910).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
