### PR TITLE
Replace the Astro.glob API deprecated in the tutorial

### DIFF
--- a/src/content/docs/es/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/es/tutorial/5-astro-api/2.mdx
@@ -69,7 +69,7 @@ Puedes crear conjuntos completos de páginas de forma dinámica utilizando archi
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = await Astro.glob('../posts/*.md');
+      const allPosts = await import.meta.glob('../posts/*.md');
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -182,7 +182,7 @@ Aunque parezca un reto, puedes intentar seguir los pasos para construir esta fun
    import BaseLayout from '../../layouts/BaseLayout.astro';
 
    export async function getStaticPaths() {
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     
     const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
    ```
@@ -246,7 +246,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob('../posts/*.md');
+  const allPosts = await import.meta.glob('../posts/*.md');
   
   const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/es/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/es/tutorial/5-astro-api/3.mdx
@@ -115,7 +115,7 @@ Afortunadamente, ya conoces una forma de obtener los datos de todos tus archivos
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const pageTitle = "Índice de etiquetas";
     ---
     ```
@@ -126,7 +126,7 @@ Afortunadamente, ya conoces una forma de obtener los datos de todos tus archivos
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     const pageTitle = "Índice de etiquetas";
     ---
@@ -210,7 +210,7 @@ Este es el aspecto que debería tener tu nueva página:
 ```astro title="src/pages/tags/index.astro"
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = await Astro.glob('../posts/*.md');
+const allPosts = await import.meta.glob('../posts/*.md');
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Índice de etiquetas";
 ---

--- a/src/content/docs/ja/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/ja/tutorial/5-astro-api/2.mdx
@@ -70,7 +70,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = await Astro.glob('../posts/*.md');
+      const allPosts = await import.meta.glob('../posts/*.md');
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -183,7 +183,7 @@ import { Steps } from '@astrojs/starlight/components';
    import BaseLayout from '../../layouts/BaseLayout.astro';
  
    export async function getStaticPaths() {
-     const allPosts = await Astro.glob('../posts/*.md');
+     const allPosts = await import.meta.glob('../posts/*.md');
  
      const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
    ```
@@ -249,7 +249,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob('../posts/*.md');
+  const allPosts = await import.meta.glob('../posts/*.md');
 
   const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/ja/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/ja/tutorial/5-astro-api/3.mdx
@@ -114,7 +114,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const pageTitle = "タグインデックス";
     ---
     ```
@@ -125,7 +125,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     const pageTitle = "タグインデックス";
     ---
@@ -209,7 +209,7 @@ import { Steps } from '@astrojs/starlight/components';
 ```astro title="src/pages/tags/index.astro"
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = await Astro.glob('../posts/*.md');
+const allPosts = await import.meta.glob('../posts/*.md');
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---

--- a/src/content/docs/pt-br/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/pt-br/tutorial/5-astro-api/2.mdx
@@ -70,7 +70,7 @@ Você pode criar conjuntos inteiros de páginas dinamicamente utilizando arquivo
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = await Astro.glob('../posts/*.md');
+      const allPosts = await import.meta.glob('../posts/*.md');
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -183,7 +183,7 @@ Mesmo que isso pareça desafiador, você pode tentar seguir as etapas adiante pa
    import BaseLayout from '../../layouts/BaseLayout.astro';
 
    export async function getStaticPaths() {
-     const allPosts = await Astro.glob('../posts/*.md');
+     const allPosts = await import.meta.glob('../posts/*.md');
 
      const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
    }
@@ -249,7 +249,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob('../posts/*.md');
+  const allPosts = await import.meta.glob('../posts/*.md');
   
   const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/pt-br/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/pt-br/tutorial/5-astro-api/3.mdx
@@ -114,7 +114,7 @@ Felizmente, você já sabe uma forma de conseguir os dados de todos os seus arqu
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const pageTitle = "Índice de Tags";
     ---
     ```
@@ -125,7 +125,7 @@ Felizmente, você já sabe uma forma de conseguir os dados de todos os seus arqu
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     const pageTitle = "Índice de Tags";
     ---
@@ -209,7 +209,7 @@ Aqui está como sua nova página deve se parecer:
 ```astro title="src/pages/tags/index.astro"
 --- 
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = await Astro.glob('../posts/*.md');
+const allPosts = await import.meta.glob('../posts/*.md');
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Índice de Tags";
 ---

--- a/src/content/docs/ru/tutorial/5-astro-api/2.mdx
+++ b/src/content/docs/ru/tutorial/5-astro-api/2.mdx
@@ -70,7 +70,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-      const allPosts = await Astro.glob('../posts/*.md');
+      const allPosts = await import.meta.glob('../posts/*.md');
 
       return [
         {params: {tag: "astro"}, props: {posts: allPosts}},
@@ -183,7 +183,7 @@ import { Steps } from '@astrojs/starlight/components';
     import BaseLayout from '../../layouts/BaseLayout.astro';
 
     export async function getStaticPaths() {
-     const allPosts = await Astro.glob('../posts/*.md');
+     const allPosts = await import.meta.glob('../posts/*.md');
 
      const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     }
@@ -249,7 +249,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPost from '../../components/BlogPost.astro'
 
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob('../posts/*.md');
+  const allPosts = await import.meta.glob('../posts/*.md');
 
   const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 

--- a/src/content/docs/ru/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/ru/tutorial/5-astro-api/3.mdx
@@ -114,7 +114,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={3}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const pageTitle = "Индекс тегов";
     ---
     ```
@@ -125,7 +125,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     const pageTitle = "Индекс тегов";
     ---
@@ -209,7 +209,7 @@ import { Steps } from '@astrojs/starlight/components';
 ```astro title="src/pages/tags/index.astro"
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-const allPosts = await Astro.glob('../posts/*.md');
+const allPosts = await import.meta.glob('../posts/*.md');
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---

--- a/src/content/docs/zh-cn/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/zh-cn/tutorial/5-astro-api/3.mdx
@@ -125,7 +125,7 @@ import { Steps } from '@astrojs/starlight/components';
     ```astro title = "src/pages/tags/index.astro" ins={4}
     ---
     import BaseLayout from '../../layouts/BaseLayout.astro';
-    const allPosts = await Astro.glob('../posts/*.md');
+    const allPosts = await import.meta.glob('../posts/*.md');
     const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
     const pageTitle = "Tag Index";
     ---


### PR DESCRIPTION
#### Description (required)

There are many places in the tutorial that use the deprecated Astro.glob instead of import.meta.glob.

Astro Discord:  jumpjump_02073
