### PR TITLE
i18n(fr): update links in `integrations-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/integrations-reference.mdx
+++ b/src/content/docs/fr/reference/integrations-reference.mdx
@@ -1146,7 +1146,7 @@ export default {
 **Type :** [`URL`](https://developer.mozilla.org/fr/docs/Web/API/URL)
 </p>
 
-Un chemin URL vers le répertoire de sortie de la construction. Notez que si vous avez besoin d'une chaîne de chemin absolu valide, vous devez utiliser l'utilitaire intégré [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl) de Node.
+Un chemin URL vers le répertoire de sortie de la construction. Notez que si vous avez besoin d'une chaîne de chemin absolu valide, vous devez utiliser l'utilitaire intégré [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl-options) de Node.
 
 ```js
 import { fileURLToPath } from 'node:url';
@@ -1187,7 +1187,7 @@ export default {
 **Type :** [`URL`](https://developer.mozilla.org/fr/docs/Web/API/URL)
 </p>
 
-Un chemin URL vers le répertoire de sortie de la compilation. Notez que si vous avez besoin d'un chemin absolu valide, vous devriez utiliser l'utilitaire intégré de Node [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl).
+Un chemin URL vers le répertoire de sortie de la compilation. Notez que si vous avez besoin d'un chemin absolu valide, vous devriez utiliser l'utilitaire intégré de Node [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl-options).
 
 ```js
 import { writeFile } from 'node:fs/promises';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes some anchors (Node links) in the French translation of `integrations-reference.mdx` (see #10924).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
