### PR TITLE
i18n(fr): update `errors/cant-use-astro-config-module-error.mdx`

### DIFF
--- a/src/content/docs/fr/reference/errors/cant-use-astro-config-module-error.mdx
+++ b/src/content/docs/fr/reference/errors/cant-use-astro-config-module-error.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **CantUseAstroConfigModuleError**: Cannot import the module "MODULE_NAME" because the experimental feature is disabled. Enable `experimental.serializeManifest` in your `astro.config.mjs` 
+> **CantUseAstroConfigModuleError**: Cannot import the module "MODULE_NAME" because the experimental feature is disabled. Enable `experimental.serializeConfig` in your `astro.config.mjs` 
 
 ## Qu'est-ce qui a mal tourné ?
 Impossible d'utiliser le module `astro:config` sans activer la fonctionnalité expérimentale.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #10926 to the French translation of `errors/cant-use-astro-config-module-error.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
