### PR TITLE
i18n(zh-cn): Update `cant-use-astro-config-module-error.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/errors/cant-use-astro-config-module-error.mdx
+++ b/src/content/docs/zh-cn/reference/errors/cant-use-astro-config-module-error.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> **CantUseAstroConfigModuleError**: 无法导入模块 "MODULE_NAME"，因为实验性功能已禁用。在你的 `astro.config.mjs` 中启用 `experimental.serializeManifest`
+> **CantUseAstroConfigModuleError**: 无法导入模块 "MODULE_NAME"，因为实验性功能已禁用。在你的 `astro.config.mjs` 中启用 `experimental.serializeConfig`
 
 ## 哪里出了问题？
 如果不启用实验性功能，则无法使用模块 `astro:config`。


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Update `cant-use-astro-config-module-error.mdx`

#### Related issues & labels (optional)

- #10926
- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
