### PR TITLE
migrate: replace deprecated output: server refrence with SSR

### DIFF
--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -21,7 +21,7 @@ See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/goo
 ### Prerequisites
 
 - A [Firebase project with a web app configured](https://firebase.google.com/docs/web/setup).
-- An Astro project with [SRR for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
+- An Astro project with an adapter [for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
 - Firebase credentials: You will need two sets of credentials to connect Astro to Firebase:
   - Web app credentials: These credentials will be used by the client side of your app. You can find them in the Firebase console under *Project settings > General*. Scroll down to the **Your apps** section and click on the **Web app** icon.
   - Project credentials: These credentials will be used by the server side of your app. You can generate them in the Firebase console under *Project settings > Service accounts > Firebase Admin SDK > Generate new private key*.

--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -21,7 +21,7 @@ See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/goo
 ### Prerequisites
 
 - A [Firebase project with a web app configured](https://firebase.google.com/docs/web/setup).
-- An Astro project with [`output: 'server'` for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
+- An Astro project with [SRR for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
 - Firebase credentials: You will need two sets of credentials to connect Astro to Firebase:
   - Web app credentials: These credentials will be used by the client side of your app. You can find them in the Firebase console under *Project settings > General*. Scroll down to the **Your apps** section and click on the **Web app** icon.
   - Project credentials: These credentials will be used by the server side of your app. You can generate them in the Firebase console under *Project settings > Service accounts > Firebase Admin SDK > Generate new private key*.


### PR DESCRIPTION
as of astro 5, the output: server is optional and not needed

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
So, the firebase and astro getting started documentation says that you need a astro project with config output: "server" which is no longer needed as of astro 5. so removing it to not cause any confusion for future readers

<!-- Please make changes in **one language** only -->
Just replaced the output:"server" refrence in the top of the document to point to "SSR" enabled project instead  

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
discord: gdm_music