### PR TITLE
Change "Firebase Hosting" to "Google Firebase"

### DIFF
--- a/src/components/DeployGuidesNav.astro
+++ b/src/components/DeployGuidesNav.astro
@@ -30,7 +30,7 @@ const services: Service[] = [
 	{ title: 'Clever Cloud', slug: 'clever-cloud', supports: ['ssr', 'static'] },
 	{ title: 'Azion', slug: 'azion', supports: ['ssr', 'static'] },
 	{ title: 'Google Cloud', slug: 'google-cloud', supports: ['ssr', 'static'] },
-	{ title: 'Firebase Hosting', slug: 'google-firebase', supports: ['ssr', 'static'] },
+	{ title: 'Google Firebase', slug: 'google-firebase', supports: ['ssr', 'static'] },
 	{ title: 'Heroku', slug: 'heroku', supports: ['static'] },
 	{ title: 'Microsoft Azure', slug: 'microsoft-azure', supports: ['static'] },
 	{ title: 'Buddy', slug: 'buddy', supports: ['static'] },


### PR DESCRIPTION
#### Description (required)

This matches the name in the left nav of deployment providers. Also, Firebase has multiple hosting products now - [Hosting](https://firebase.google.com/docs/hosting) and [App Hosting](https://firebase.google.com/docs/app-hosting), so this paves the way for a potential future App Hosting guide (I work on Firebase).

Preview link: https://deploy-preview-10949--astro-docs-2.netlify.app/en/guides/deploy/

#### Related issues & labels (optional)

- Suggested label: deployment