### PR TITLE
[nightly.yml] update PR title for ci config reference docs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
             TARGET_BRANCH: main
             LABEL: ci
             PR_BRANCH: ci/docgen
-            PR_TITLE: 'ci: update reference docs'
+            PR_TITLE: 'ci: update configuration reference docs'
     steps:
       - name: Check out code using Git
         uses: actions/checkout@v4


### PR DESCRIPTION

#### Description (required)

This PR updates the nightly auto-generated ci PR title for configuration reference docs to include the word "configuration."

We used to only have one action to pull in "reference" docs, but since we added the "error reference" docs separately, now we have "reference" and "error reference". 

I'm requesting that we instead use "configuration reference" and "error reference" so that I have an easier time telling them apart. 😅 
