### PR TITLE
Replace `entry.render()` with `render(entry)` in `recipes/` & `integrations-guide`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -117,10 +117,10 @@ Then, query your collection using the [Content Collection APIs](/en/guides/conte
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntryBySlug } from 'astro:content';
+import { getEntryBySlug, render } from 'astro:content';
 
 const entry = await getEntryBySlug('docs', 'why-markdoc');
-const { Content } = await entry.render();
+const { Content } = await render(entry);
 ---
 
 <!--Access frontmatter properties with `data`-->
@@ -139,10 +139,10 @@ Variables can be passed as props via the `Content` component:
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntryBySlug } from 'astro:content';
+import { getEntryBySlug, render } from 'astro:content';
 
 const entry = await getEntryBySlug('docs', 'why-markdoc');
-const { Content } = await entry.render();
+const { Content } = await render(entry);
 ---
 
 <!--Pass the `abTest` param as a variable-->
@@ -177,10 +177,10 @@ To access frontmatter, you can pass the entry `data` property as a variable wher
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntry } from 'astro:content';
+import { getEntry, render } from 'astro:content';
 
 const entry = await getEntry('docs', 'why-markdoc');
-const { Content } = await entry.render();
+const { Content } = await render(entry);
 ---
 
 <Content frontmatter={entry.data} />

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -117,9 +117,9 @@ Then, query your collection using the [Content Collection APIs](/en/guides/conte
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntryBySlug, render } from 'astro:content';
+import { getEntry, render } from 'astro:content';
 
-const entry = await getEntryBySlug('docs', 'why-markdoc');
+const entry = await getEntry('docs', 'why-markdoc');
 const { Content } = await render(entry);
 ---
 
@@ -139,9 +139,9 @@ Variables can be passed as props via the `Content` component:
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntryBySlug, render } from 'astro:content';
+import { getEntry, render } from 'astro:content';
 
-const entry = await getEntryBySlug('docs', 'why-markdoc');
+const entry = await getEntry('docs', 'why-markdoc');
 const { Content } = await render(entry);
 ---
 

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -89,11 +89,11 @@ This recipe calculates time based on your repository’s Git history and may not
 
 4. Display Last Modified Time
 
-   If your content is stored in a [content collection](/en/guides/content-collections/), access the `remarkPluginFrontmatter` from the `entry.render()` function. Then render `lastModified` in your template wherever you would like it to appear.
+   If your content is stored in a [content collection](/en/guides/content-collections/), access the `remarkPluginFrontmatter` from the `render(entry)` function. Then render `lastModified` in your template wherever you would like it to appear.
 
    ```astro title="src/pages/posts/[slug].astro" {3-4,6,17,19-21,28}
    ---
-   import { CollectionEntry, getCollection } from 'astro:content';
+   import { getCollection, render } from 'astro:content';
    import dayjs from "dayjs";
    import utc from "dayjs/plugin/utc";
 
@@ -102,13 +102,13 @@ This recipe calculates time based on your repository’s Git history and may not
    export async function getStaticPaths() {
      const blog = await getCollection('blog');
      return blog.map(entry => ({
-       params: { slug: entry.slug },
+       params: { slug: entry.id },
        props: { entry },
      }));
    }
 
    const { entry } = Astro.props;
-   const { Content, remarkPluginFrontmatter } = await entry.render();
+   const { Content, remarkPluginFrontmatter } = await render(entry);
 
    const lastModified = dayjs(remarkPluginFrontmatter.lastModified)
      .utc()

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -72,7 +72,7 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
 
 4. Display Reading Time
 
-    If your blog posts are stored in a [content collection](/en/guides/content-collections/), access the `remarkPluginFrontmatter` from the `entry.render()` function. Then, render `minutesRead` in your template wherever you would like it to appear.
+    If your blog posts are stored in a [content collection](/en/guides/content-collections/), access the `remarkPluginFrontmatter` from the `render(entry)` function. Then, render `minutesRead` in your template wherever you would like it to appear.
 
     ```astro title="src/pages/posts/[slug].astro" "const { Content, remarkPluginFrontmatter } = await render(entry);" "<p>{remarkPluginFrontmatter.minutesRead}</p>"
     ---

--- a/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
+++ b/src/content/docs/en/recipes/tailwind-rendered-markdown.mdx
@@ -75,16 +75,16 @@ Then, add the package as a plugin in your Tailwind configuration file.
     For example, `prose-h1:font-bold` gives all `<h1>` tags the `font-bold` Tailwind class.
     :::
 
-2. Query your collection entry on the page you want to render your Markdown. Pass the `<Content />` component from `await entry.render()` to `<Prose />` as a child to wrap your Markdown content in Tailwind styles.
+2. Query your collection entry on the page you want to render your Markdown. Pass the `<Content />` component from `await render(entry)` to `<Prose />` as a child to wrap your Markdown content in Tailwind styles.
 
     ```astro title="src/pages/index.astro"
     ---
     import Prose from '../components/Prose.astro';
     import Layout from '../layouts/Layout.astro';
-    import { getEntry } from 'astro:content';
+    import { getEntry, render } from 'astro:content';
 
     const entry = await getEntry('collection', 'entry');
-    const { Content } = await entry.render();
+    const { Content } = await render(entry);
     ---
     <Layout>
       <Prose>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I notice that entries no longer have a `render()` method, so I replace `entry.render()` with `render(entry)` and update the import sentences as well in following `recipes/` & `integrations-guide`:

- `reading-time.mdx`
- `modified-time.mdx` (include `params` changed)
- `markdoc.mdx`
- `tailwind-rendered-markdown.mdx`

#### Related issues & labels (optional)

- #10521 
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
