### PR TITLE
i18n(fr): fix a heading in `integrations-guide/markdoc.mdx`

### DIFF
--- a/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
@@ -536,7 +536,7 @@ Les étapes suivantes permettent de créer une balise image Markdoc personnalis�
     ```
 </Steps>
 
-### Configuration de Markdoc
+## Configuration avancée de Markdoc
 
 Le fichier `markdoc.config.mjs|ts` accepte [toutes les options de configuration de Markdoc](https://markdoc.dev/docs/config), y compris [les tags](https://markdoc.dev/docs/tags) et [les fonctions](https://markdoc.dev/docs/functions).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes a heading in the French translation of `integrations-guide/markdoc.mdx`. It seems we have an inconsistency in wording and level compared to the English version.

The heading was added in #7744 ... we had a title but level 3 instead of level 2 and we missed the `advanced` part.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
