### PR TITLE
Add missing `data` property in middleware docs

### DIFF
--- a/src/content/docs/en/guides/middleware.mdx
+++ b/src/content/docs/en/guides/middleware.mdx
@@ -78,6 +78,7 @@ Then you can use this information inside any `.astro` file with `Astro.locals`.
 ---
 const title = Astro.locals.welcomeTitle();
 const orders = Array.from(Astro.locals.orders.entries());
+const data = Astro.locals;
 ---
 <h1>{title}</h1>
 <p>This {data.property} is from middleware.</p>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The sample code references `data.property`. However, the `data` variable is not defined in the front matter.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
