### PR TITLE
fix: update zed extension link

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -28,7 +28,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 ## Zed
 
-[Zed](https://zed.dev/) is an open-source code editor that added support for Astro in version 0.123.2. You can install the [Astro extension](https://github.com/zed-industries/zed/tree/main/extensions/astro) in the IDE's Extensions tab. This extension includes features like syntax highlighting, code completion, and formatting.
+[Zed](https://zed.dev/) is an open-source code editor that added support for Astro in version 0.123.2. You can install the [Astro extension](https://github.com/zed-extensions/astro) in the IDE's Extensions tab. This extension includes features like syntax highlighting, code completion, and formatting.
 
 ## JetBrains IDEs
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The link to the Astro extension in the Zed editor has changed, so I've updated it.