### PR TITLE
Add caution note about browser API issues in mobile - device debuggin…

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -432,6 +432,10 @@ Sets which network IP addresses the dev server and preview server should listen 
 Do not use the `--host` flag to expose the dev server and preview server in a production environment. The servers are designed for local use while developing your site only.
 :::
 
+:::caution
+When debugging on mobile devices using an IP address instead of `localhost`, some browser APIs that require a secure context may not work as expected. These can include `navigator.clipboard`, the `MediaRecorder` API for recording audio and video, and the Web Authentication API (`WebAuthn`). This is because browsers typically enforce the use of a secure context (e.g., HTTPS) for privacy - sensitive features. To ensure proper functionality, consider setting up a local HTTPS environment or using Chrome's insecure origin allowance settings.
+:::
+
 ### `--verbose`
 
 Enables verbose logging, which is helpful when debugging an issue.


### PR DESCRIPTION
with IP addresses in Astro docs

In the context of mobile - device debugging with Astro, when using an IP address instead of localhost to access the development page, certain browser APIs that require a secure context (such as navigator.clipboard, MediaRecorder, and WebAuthn) may not function as expected. This is due to browsers' security policies that enforce the use of secure contexts (e.g., HTTPS) for privacy - sensitive features. To assist developers in avoiding such issues, this PR adds a caution note to the relevant documentation section, providing clear information about the problem and suggesting possible solutions like setting up a local HTTPS environment or using Chrome's insecure - origin allowance settings.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
Hi, maintainers of the Astro documentation : 
I'm proposing to add a caution note in the Astro documentation regarding browser API issues that occur during mobile - device debugging when using an IP address instead of localhost.
When developers are debugging on mobile devices using an IP address, they may encounter situations where some browser APIs requiring a secure context, such as navigator.clipboard, MediaRecorder, and WebAuthn, don't work as expected. This is because browsers enforce strict security policies that mandate a secure context (usually HTTPS) for privacy - sensitive features.
Currently, the documentation lacks information about this potential problem, which can lead to confusion and wasted time for developers. By adding this caution note, we can help developers quickly understand the root cause of these issues and provide them with possible solutions, such as setting up a local HTTPS environment or using Chrome's insecure - origin allowance settings. This will enhance the developer experience and save their time when using Astro for mobile - device debugging.
