### PR TITLE
fix: update `astro-components.mdx`

### DIFF
--- a/src/content/docs/en/basics/astro-components.mdx
+++ b/src/content/docs/en/basics/astro-components.mdx
@@ -3,7 +3,6 @@ title: Components
 description: An introduction to Astro components.
 i18nReady: true
 ---
-
 import ReadMore from '~/components/ReadMore.astro';
 
 **Astro components** are the basic building blocks of any Astro project. They are HTML-only templating components with no client-side runtime and use the `.astro` file extension.
@@ -45,7 +44,6 @@ You can use the component script to write any JavaScript code that you need to r
 - fetching content from an API or database
 - creating variables that you will reference in your template
 
-
 ```astro title="src/components/MyComponent.astro"
 ---
 import SomeAstroComponent from '../components/SomeAstroComponent.astro';
@@ -54,6 +52,7 @@ import someData from '../data/pokemon.json';
 
 // Access passed-in component props, like `<X title="Hello, World" />`
 const { title } = Astro.props;
+
 // Fetch external data, even from a private API or database
 const data = await fetch('SOME_SECRET_API_URL/users').then(r => r.json());
 ---
@@ -108,7 +107,7 @@ const { title } = Astro.props;
 </ul>
 
 <!-- Use a template directive to build class names from multiple strings or even objects! -->
-<p class:list={["add", "dynamic", {classNames: true}]} />
+<p class:list={["add", "dynamic", { classNames: true }]} />
 ```
 
 ## Component-based design
@@ -125,7 +124,6 @@ import Button from './Button.astro';
   <Button title="Button 3" />
 </div>
 ```
-
 
 ## Component Props
 
@@ -221,8 +219,6 @@ import Wrapper from '../components/Wrapper.astro';
 
 This pattern is the basis of an [Astro layout component](/en/basics/layouts/): an entire page of HTML content can be “wrapped” with `<SomeLayoutComponent></SomeLayoutComponent>` tags and sent to the component to render inside of common page elements defined there.
 
-
-
 ### Named Slots
 
 An Astro component can also have named slots. This allows you to pass only HTML elements with the corresponding slot name into a slot's location.
@@ -240,17 +236,19 @@ const { title } = Astro.props;
 ---
 <div id="content-wrapper">
   <Header />
-  <slot name="after-header" />  <!--  children with the `slot="after-header"` attribute will go here -->
+  <!--  children with the `slot="after-header"` attribute will go here -->
+  <slot name="after-header" />
   <Logo />
   <h1>{title}</h1>
-  <slot />  <!--  children without a `slot`, or with `slot="default"` attribute will go here -->
+  <!--  children without a `slot`, or with `slot="default"` attribute will go here -->
+  <slot />
   <Footer />
-  <slot name="after-footer" />  <!--  children with the `slot="after-footer"` attribute will go here -->
+  <!--  children with the `slot="after-footer"` attribute will go here -->
+  <slot name="after-footer" />
 </div>
 ```
 
 To inject HTML content into a particular slot, use the `slot` attribute on any child element to specify the name of the slot. All other child elements of the component will be injected into the default (unnamed) `<slot />`.
-
 
 ```astro /slot=".*?"/
 ---
@@ -273,7 +271,7 @@ To pass multiple HTML elements into a component's `<slot/>` placeholder without 
 
 ```astro title="src/components/CustomTable.astro" "<slot name="header"/>" "<slot name="body"/>"
 ---
-// Create a custom table with named slot placeholders for head and body content
+// Create a custom table with named slot placeholders for header and body content
 ---
 <table class="bg-white">
   <thead class="sticky top-0 bg-white"><slot name="header" /></thead>
@@ -306,13 +304,12 @@ Note that named slots must be an immediate child of the component. You cannot pa
 Named slots can also be passed to [UI framework components](/en/guides/framework-components/)!
 :::
 
-
 :::note
-It is not possible to dynamically generate an Astro slot name, such as within a map function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
+It is not possible to dynamically generate an Astro slot name, such as within a [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function. If this feature is needed within UI framework components, it might be best to generate these dynamic slots within the framework itself.
 :::
 
-
 ### Fallback Content for Slots
+
 Slots can also render **fallback content**. When there are no matching children passed to a slot, a `<slot />` element will render its own placeholder children.
 
 ```astro {14}
@@ -335,7 +332,7 @@ const { title } = Astro.props;
 </div>
 ```
 
-Fallback content will only be displayed when there are no matching elements with the slot="name" attribute being passed in to a named slot.
+Fallback content will only be displayed when there are no matching elements with the `slot="name"` attribute being passed in to a named slot.
 
 Astro will pass an empty slot when a slot element exists but has no content to pass. Fallback content cannot be used as a default when an empty slot is passed. Fallback content is only displayed when no slot element can be found.
 
@@ -372,10 +369,10 @@ import BaseLayout from './BaseLayout.astro';
 ```
 
 :::note
-Named slots can be transferred to another component using both the `name` and `slot` attributes on a `<slot />` tag
+Named slots can be transferred to another component using both the `name` and `slot` attributes on a `<slot />` tag.
 :::
 
-Now, the default and `head` slots passed to `HomeLayout` will be transferred to the `BaseLayout` parent
+Now, the default and `head` slots passed to `HomeLayout` will be transferred to the `BaseLayout` parent.
 
 ```astro
 // src/pages/index.astro
@@ -393,6 +390,7 @@ import HomeLayout from '../layouts/HomeLayout.astro';
 Astro supports importing and using `.html` files as components or placing these files within the `src/pages/` subdirectory as pages. You may want to use HTML components if you're reusing code from an existing site built without a framework, or if you want to ensure that your component has no dynamic features.
 
 HTML components must contain only valid HTML, and therefore lack key Astro component features:
+
 - They don't support frontmatter, server-side imports, or dynamic expressions.
 - Any `<script>` tags are left unbundled, treated as if they had `is:inline`. 
 - They can only [reference assets that are in the `public/` folder](/en/basics/project-structure/#public).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- update `astro-components.mdx`
- Remove unnecessary whitespace
- Adding whitespace to JavaScript objects
- Adding a link to the `map` function
- Change the position of codeblock comments for readability
- Adding inline codeblocks for readability
- Fixed typos and added missing `.`

For readability, I've changed the comment position in the codeblock to the following, if you have any comments on this, please let me know.

##### Before

![be](https://github.com/user-attachments/assets/9e11b6f7-469b-437c-8d98-1d4d2e90b74c)

##### After

![af](https://github.com/user-attachments/assets/71c5e068-7c0e-43a9-b995-93f31c782acf)

