### PR TITLE
Use `PackageManagerTabs` for CLI commands in `guides/environment-variables`

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -89,16 +89,44 @@ The `astro dev` and `astro build` commands default to `"development"` and `"prod
 
 This allows you to run the dev server or build your site connecting to different APIs:
 
-```bash
-# Run the dev server connected to a "staging" API
-astro dev --mode staging
+<PackageManagerTabs>
+ <Fragment slot="npm">
+    ```shell
+    # Run the dev server connected to a "staging" API
+    npm run astro dev -- --mode staging
 
-# Build a site that connects to a "production" API with additional debug information
-astro build --devOutput
+    # Build a site that connects to a "production" API with additional debug information
+    npm run astro build -- --devOutput
 
-# Build a site that connects to a "testing" API
-astro build --mode testing
-```
+    # Build a site that connects to a "testing" API
+    npm run astro build -- --mode testing
+    ```
+ </Fragment>
+ <Fragment slot="pnpm">
+    ```shell
+    # Run the dev server connected to a "staging" API
+    pnpm astro dev --mode staging
+
+    # Build a site that connects to a "production" API with additional debug information
+    pnpm astro build --devOutput
+
+    # Build a site that connects to a "testing" API
+    pnpm astro build --mode testing
+    ```
+ </Fragment>
+  <Fragment slot="yarn">
+    ```shell
+    # Run the dev server connected to a "staging" API
+    yarn astro dev --mode staging
+
+    # Build a site that connects to a "production" API with additional debug information
+    yarn astro build --devOutput
+
+    # Build a site that connects to a "testing" API
+    yarn astro build --mode testing
+    ```
+ </Fragment>
+</PackageManagerTabs>
 
 For more on `.env` files, [see the Vite documentation](https://vite.dev/guide/env-and-mode.html#env-files).
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the [`.env files` section](https://docs.astro.build/en/guides/environment-variables/#env-files) in `guides/environment-variables` to use the `PackageManagerTabs` component.

`npm` requires an extra `--` before any flag so the previous format was confusing for `npm` users.

#### Related issues & labels (optional)

- Closes #10935
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
