### PR TITLE
fix: update prettier setup in `editor-setup.mdx`

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -98,11 +98,11 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
       </Fragment>
     </PackageManagerTabs>
 
-2. Create a `.prettierrc.json` config file at the root of your project and add `prettier-plugin-astro` to it.
+2. Create a `.prettierrc` configuration file (or `.prettierrc.json`, `.prettierrc.mjs`, or [other supported formats](https://prettier.io/docs/configuration)) in the root of your project and add `prettier-plugin-astro` to it.
 
     In this file, also manually specify the parser for Astro files.
 
-    ```json title=".prettierrc.json"
+    ```json title=".prettierrc"
     {
       "plugins": ["prettier-plugin-astro"],
       "overrides": [

--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -83,41 +83,40 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-      npm install --save-dev prettier prettier-plugin-astro
+      npm install --save-dev --save-exact prettier prettier-plugin-astro
       ```
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-      pnpm add -D prettier prettier-plugin-astro
+      pnpm add --save-dev --save-exact prettier prettier-plugin-astro
       ```
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      yarn add --dev prettier prettier-plugin-astro
+      yarn add --dev --exact prettier prettier-plugin-astro
       ```
       </Fragment>
     </PackageManagerTabs>
 
-2. Create a `.prettierrc.mjs` config file at the root of your project and add `prettier-plugin-astro` to it.
+2. Create a `.prettierrc.json` config file at the root of your project and add `prettier-plugin-astro` to it.
 
     In this file, also manually specify the parser for Astro files.
 
-    ```js title=".prettierrc.mjs"
-    /** @type {import("prettier").Config} */
-    export default {
-      plugins: ['prettier-plugin-astro'],
-      overrides: [
+    ```json title=".prettierrc.json"
+    {
+      "plugins": ["prettier-plugin-astro"],
+      "overrides": [
         {
-          files: '*.astro',
-          options: {
-            parser: 'astro',
-          },
-        },
-      ],
-    };
+          "files": "*.astro",
+          "options": {
+            "parser": "astro",
+          }
+        }
+      ]
+    }
     ```
 
-3. Run the command `prettier . --write` in the terminal to format your files.
+3. Run the following command in your terminal to format your files.
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -132,7 +131,7 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-      yarn prettier . --write
+      yarn exec prettier . --write
       ```
       </Fragment>
     </PackageManagerTabs>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- update the install and run CLI commands to respect the [Prettier documentation](https://prettier.io/docs/install).
- according to the [Prettier documentation](https://prettier.io/docs/configuration), the `JSON` format is the first to be documented. So I don't think it's necessary to use a different format.

if you have a different opinion on this, please let me know!
