### PR TITLE
fix: update `dev-toolbar.mdx`

### DIFF
--- a/src/content/docs/en/guides/dev-toolbar.mdx
+++ b/src/content/docs/en/guides/dev-toolbar.mdx
@@ -9,7 +9,7 @@ While the dev server is running, Astro includes a dev toolbar at the bottom of e
 
 This toolbar includes a number of useful tools for debugging and inspecting your site during development and can be [extended with more dev toolbar apps](#extending-the-dev-toolbar) found in the integrations directory. You can even [build your own toolbar apps](/en/recipes/making-toolbar-apps/) using the [Dev Toolbar API](/en/reference/dev-toolbar-app-reference/)!
 
-This toolbar is enabled by default and appears when you hover over the bottom of the page. It is a dev tool only and will not appear on your published site.
+This toolbar is enabled by default and appears when you hover over the bottom of the page. It is a development tool only and will not appear on your published site.
 
 ## Built-in apps
 

--- a/src/content/docs/en/guides/dev-toolbar.mdx
+++ b/src/content/docs/en/guides/dev-toolbar.mdx
@@ -1,15 +1,15 @@
 ---
 title: Dev toolbar
-description: A guide to using the developer toolbar in Astro
+description: A guide to using the dev toolbar in Astro
 i18nReady: true
 ---
 import RecipeLinks from "~/components/RecipeLinks.astro";
 
-While the dev server is running, Astro includes a development toolbar at the bottom of every page in your local browser preview.
+While the dev server is running, Astro includes a dev toolbar at the bottom of every page in your local browser preview.
 
 This toolbar includes a number of useful tools for debugging and inspecting your site during development and can be [extended with more dev toolbar apps](#extending-the-dev-toolbar) found in the integrations directory. You can even [build your own toolbar apps](/en/recipes/making-toolbar-apps/) using the [Dev Toolbar API](/en/reference/dev-toolbar-app-reference/)!
 
-This toolbar is enabled by default and appears when you hover over the bottom of the page. It is a development tool only and will not appear on your published site.
+This toolbar is enabled by default and appears when you hover over the bottom of the page. It is a dev tool only and will not appear on your published site.
 
 ## Built-in apps
 
@@ -35,7 +35,7 @@ The dev toolbar aims to provide a quick and easy way to catch common issues duri
 
 ### Settings
 
-The Settings app allows you to configure options for the development toolbar, such as verbose logging, disabling notifications, and adjusting its placement on your screen.
+The Settings app allows you to configure options for the dev toolbar, such as verbose logging, disabling notifications, and adjusting its placement on your screen.
 
 ## Extending the dev toolbar
 
@@ -63,7 +63,7 @@ export default defineConfig({
 })
 ```
 
-To enable the dev toolbar again, remove these lines from your configuration, or set `enabled:true`.
+To enable the dev toolbar again, remove these lines from your configuration, or set `enabled: true`.
 
 ### Per-user
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- The terms `development toolbar`, `developer toolbar`, and `dev toolbar`, which all mean the same thing, have been unified into `dev toolbar`, which is the most commonly used term in this document.
- Added missing spaces. Changed `enabled:true` to `enabled: true`
