### PR TITLE
fix: type annotation for `render()` in `astro:content`

### DIFF
--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -197,7 +197,7 @@ const enterpriseRelatedPosts = await getEntries(enterprisePost.data.relatedPosts
 
 <p>
 
-**Type:** `() => Promise<RenderedEntry>`
+**Type:** `(entry: CollectionEntry) => Promise<RenderedEntry>`
 <Since v="5.0.0" />
 </p>
 


### PR DESCRIPTION
#### Description

The `render()` function was previously annotated as `() => Promise<RenderedEntry>`, which is incorrect—it should take an `entry` parameter.  

This PR updates the type annotation to reflect the correct function signature:  
`(entry: CollectionEntry) => Promise<RenderedEntry>`.  

#### Related issues

- Closes #11123 


<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
