### PR TITLE
i18n(fr): update `guides/syntax-highlighting.mdx`

### DIFF
--- a/src/content/docs/fr/guides/syntax-highlighting.mdx
+++ b/src/content/docs/fr/guides/syntax-highlighting.mdx
@@ -111,9 +111,12 @@ export default defineConfig({
 
 ### Personnaliser les thèmes Shiki
 
-Vous pouvez suivre [la propre documentation des thèmes de Shiki](https://shiki.style/themes) pour plus d'options de personnalisation des thèmes, les bascules entre les modes clair et sombre ou l'application de styles via des variables CSS.
+Vous pouvez suivre [la propre documentation des thèmes de Shiki](https://shiki.style/themes) pour plus d'options de personnalisation des thèmes, les [bascules entre les modes clair et sombre](https://shiki.style/guide/dual-themes) ou l'application de styles via des [variables CSS](https://shiki.style/guide/theme-colors#css-variables-theme).
 
-Les blocs de code Astro sont stylisés à l'aide de la classe `.astro-code`, vous devrez donc remplacer la classe `.shiki` dans les exemples par `.astro-code`.
+Vous devrez ajuster les exemples de la documentation de Shiki pour votre projet Astro en effectuant les substitutions suivantes :
+
+- Les blocs de code sont mis en forme à l'aide de la classe `.astro-code` au lieu de `.shiki`
+- Lors de l'utilisation du thème `css-variables`, les propriétés personnalisées sont préfixées par `--astro-code-` au lieu de `--shiki-`
 
 ## Composants pour les blocs de code
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11134 to the French translation of `guides/syntax-highlighting.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
