### PR TITLE
fix(content-collections): improve `reference()` docs and minor fixes

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -295,7 +295,7 @@ All [Zod schema methods](https://zod.dev/?id=schema-methods) (e.g. `.parse()`, `
 
 Collection entries can also "reference" other related entries. 
 
-With the `reference()` function from the Collections API, you can define a property in a collection schema as an entry from another collection. For example, you can require that every `space-shuttle` entry includes a `pilot` property which uses the `pilot` collection's own schema for type checking, autocomplete, and validation.
+With the [`reference()` function](/en/reference/modules/astro-content/#reference) from the Collections API, you can define a property in a collection schema as an entry from another collection. For example, you can require that every `space-shuttle` entry includes a `pilot` property which uses the `pilot` collection's own schema for type checking, autocomplete, and validation.
 
 A common example is a blog post that references reusable author profiles stored as JSON, or related post URLs stored in the same collection:
 
@@ -335,6 +335,8 @@ relatedPosts:
 - my-year-in-review # references `src/data/blog/my-year-in-review.md`
 ---
 ```
+
+These references will be transformed into objects containing a `collection` key and an `id` key, allowing you to easily [query them in your templates](/en/guides/content-collections/#accessing-referenced-data).
 
 ### Defining custom IDs
 
@@ -472,7 +474,7 @@ const englishDocsEntries = await getCollection('docs', ({ id }) => {
 
 ### Accessing referenced data
 
-Any [references defined in your schema](/en/guides/content-collections/#defining-collection-references) must be queried separately after first querying your collection entry. You can use the `getEntry()` function to return a single referenced item, or `getEntries()` to retrieve multiple referenced entries from the returned `data` object. 
+Any [references defined in your schema](/en/guides/content-collections/#defining-collection-references) must be queried separately after first querying your collection entry. Since the [`reference()` function](/en/reference/modules/astro-content/#reference) transforms a reference to an object with `collection` and `id` as keys, you can use the `getEntry()` function to return a single referenced item, or `getEntries()` to retrieve multiple referenced entries from the returned `data` object.
 
 ```astro title="src/pages/blog/welcome.astro"
 ---
@@ -480,9 +482,10 @@ import { getEntry, getEntries } from 'astro:content';
 
 const blogPost = await getEntry('blog', 'welcome');
 
-// Resolve a singular reference
+// Resolve a singular reference (e.g. `{collection: "authors", id: "ben-holmes"}`)
 const author = await getEntry(blogPost.data.author);
 // Resolve an array of references
+// (e.g. `[{collection: "blog", id: "about-me"}, {collection: "blog", id: "my-year-in-review"}]`)
 const relatedPosts = await getEntries(blogPost.data.relatedPosts);
 ---
 

--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -301,6 +301,7 @@ A common example is a blog post that references reusable author profiles stored 
 
 ```ts title="src/content.config.ts"
 import { defineCollection, reference, z } from 'astro:content';
+import { glob } from 'astro/loaders';
 
 const blog = defineCollection({
   loader: glob({ pattern: '**/[^_]*.md', base: "./src/data/blog" }),

--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -24,6 +24,7 @@ import {
   getEntry,
   getEntries,
   reference,
+  render
  } from 'astro:content';
 ```
 ### `defineCollection()`
@@ -184,7 +185,7 @@ See the `Content Collections` guide for examples of [querying collection entries
 
 ```astro
 ---
-import { getEntries } from 'astro:content';
+import { getEntries, getEntry } from 'astro:content';
 
 const enterprisePost = await getEntry('blog', 'enterprise');
 
@@ -294,7 +295,7 @@ This includes the following property:
 - `image` - The `image()` schema helper that allows you [to use local images in Content Collections](/en/guides/images/#images-in-content-collections)
 
 ```ts
-import type { SchemaContext } from 'astro:content';
+import { defineCollection, z, type SchemaContext } from "astro:content";
 
 export const imageSchema = ({ image }: SchemaContext) =>
     z.object({

--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -87,7 +87,7 @@ A `loader` is either an object or a function that allows you to load data from a
 <Since v="2.5.0" />
 </p>
 
-The `reference()` function is used in the content config to define a relationship, or "reference," from one collection to another. This accepts a collection name and validates the entry identifier(s) specified in your content frontmatter or data file.
+The `reference()` function is used in the content config to define a relationship, or "reference," from one collection to another. This accepts a collection name and validates the entry identifier(s) specified in your content frontmatter or data file before transforming the reference into an object containing the collection name and the reference id.
 
 This example defines references from a blog author to the `authors` collection and an array of related posts to the same `blog` collection:
 

--- a/src/content/docs/en/reference/modules/astro-content.mdx
+++ b/src/content/docs/en/reference/modules/astro-content.mdx
@@ -276,13 +276,15 @@ A string containing the raw, uncompiled body of the Markdown or MDX document.
 
 <p><Since v="3.1.0" /></p>
 
-A string union of all collection names defined in your `src/content.config.*` file. This type can be useful when defining a generic function that accepts any collection name.
+A string union of all collection names defined in your `src/content.config.*` file. This type can be useful when defining a generic function wrapping the built-in `getCollection()`.
 
 ```ts
 import { type CollectionKey, getCollection } from 'astro:content';
 
-async function getCollection(collection: CollectionKey) {
-  return getCollection(collection);
+async function queryCollection(collection: CollectionKey) {
+  return getCollection(collection, ({ data }) => {
+    return data.draft !== true;
+  });
 }
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates both `guides/content-collections` and `reference/modules/astro-content`:
* add explanations regarding the `reference()` output (#10774)
* add missing imports in code snippets
* update the `CollectionKey` example with I believe a more useful example (the previous example was basically the same thing as the built-in `getCollection` function... and using the same name so it could be a recursive function)

#### Related issues & labels (optional)

- Closes #10774
- Suggested label: improve or update documentation

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
