### PR TITLE
feat(assets): document remote utilities

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -277,9 +277,10 @@ import {
 
 ### `isRemoteAllowed()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(src: string, { domains, remotePatterns }: {domains: string[], remotePatterns: RemotePattern[] }): boolean`
+<p>
+**Type:** `(src: string, { domains, remotePatterns }: {domains: string[], remotePatterns: RemotePattern[] }): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Determines whether a given remote resource, identified by its source URL, is allowed based on specified domains and remote patterns.
 
@@ -301,9 +302,10 @@ console.log(`Is the remote image allowed? ${isAllowed}`);
 
 ### `matchHostname()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(url: URL, hostname?: string, allowWildcard = false): boolean`
+<p>
+**Type:** `(url: URL, hostname?: string, allowWildcard = false): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
 
@@ -326,9 +328,10 @@ console.log(`Does the hostname match with wildcard? ${isMatchWithWildcard}`); //
 
 ### `matchPathname()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(url: URL, pathname?: string, allowWildcard = false): boolean`
+<p>
+**Type:** `(url: URL, pathname?: string, allowWildcard = false): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
 
@@ -352,9 +355,10 @@ console.log(`Does the pathname match with wildcard? ${isMatchWithWildcard}`); //
 
 ### `matchPattern()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(url: URL, remotePattern: RemotePattern): boolean`
+<p>
+**Type:** `(url: URL, remotePattern: RemotePattern): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Evaluates whether a given URL matches the specified remote pattern based on protocol, hostname, port, and pathname.
 
@@ -379,9 +383,10 @@ console.log(`Does the URL match the remote pattern? ${isPatternMatched}`); // Ou
 
 ### `matchPort()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(url: URL, port?: string): boolean`
+<p>
+**Type:** `(url: URL, port?: string): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
 
@@ -409,9 +414,10 @@ console.log(`Does the port match (no port specified)? ${isPortMatch3}`); // Outp
 
 ### `matchProtocol()`
 
-<p><Since v="4.0.0" /></p>
-
-**Type**: `(url: URL, protocol?: string): boolean`
+<p>
+**Type:** `(url: URL, protocol?: string): boolean`<br />
+<Since v="4.0.0" />
+</p>
 
 Compares the protocol of the provided URL with a specified protocol.
 

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -277,57 +277,162 @@ import {
 
 ### `isRemoteAllowed()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(src: string, { domains, remotePatterns }: {domains: string[], remotePatterns: RemotePattern[] }): boolean`
+
 Determines whether a given remote resource, identified by its source URL, is allowed based on specified domains and remote patterns.
 
+
 ```ts
-function isRemoteAllowed(
-	src: string,
-	{
-		domains,
-		remotePatterns,
-	}: {
-		domains: string[];
-		remotePatterns: RemotePattern[];
-	},
-): boolean
+import {isRemoteAllowed} from 'astro/assets/utils';
+
+const testImageURL = 'https://example.com/images/test.jpg';
+const domains = ['example.com', 'anotherdomain.com'];
+const remotePatterns = [
+  { protocol: 'https', hostname: 'images.example.com', pathname: '/**' }, // Allow any path under this hostname
+];
+
+const url = new URL(testImageURL);
+const isAllowed = isRemoteAllowed(url.href, { domains, remotePatterns });
+
+console.log(`Is the remote image allowed? ${isAllowed}`);
 ```
 
 ### `matchHostname()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(url: URL, hostname?: string, allowWildcard = false): boolean`
+
 Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
 
 ```ts
-function matchHostname(url: URL, hostname?: string, allowWildcard = false): boolean
+import {matchHostname} from 'astro/assets/utils';
+
+const testURL = new URL('https://sub.example.com/path/to/resource');
+
+// Example usage of matchHostname
+const hostnameToMatch = 'example.com';
+
+// Match without wildcard
+const isMatchWithoutWildcard = matchHostname(testURL, hostnameToMatch);
+console.log(`Does the hostname match without wildcard? ${isMatchWithoutWildcard}`); // Output: false
+
+// Match with wildcard
+const isMatchWithWildcard = matchHostname(testURL, hostnameToMatch, true);
+console.log(`Does the hostname match with wildcard? ${isMatchWithWildcard}`); // Output: true
 ```
 
 ### `matchPathname()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(url: URL, pathname?: string, allowWildcard = false): boolean`
+
 Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
 
 ```ts
-function matchPathname(url: URL, pathname?: string, allowWildcard = false): boolean
+import {matchPathname} from 'astro/assets/utils';
+
+const testURL = new URL('https://example.com/images/photo.jpg');
+
+// Example pathname to match
+const pathnameToMatch = '/images/photo.jpg';
+
+// Match without wildcard
+const isMatchWithoutWildcard = matchPathname(testURL, pathnameToMatch);
+console.log(`Does the pathname match without wildcard? ${isMatchWithoutWildcard}`); // Output: true
+
+// Match with wildcard
+const wildcardPathname = '/images/*';
+const isMatchWithWildcard = matchPathname(testURL, wildcardPathname, true);
+console.log(`Does the pathname match with wildcard? ${isMatchWithWildcard}`); // Output: true
 ```
 
 ### `matchPattern()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(url: URL, remotePattern: RemotePattern): boolean`
+
 Evaluates whether a given URL matches the specified remote pattern based on protocol, hostname, port, and pathname.
 
 ```ts
-function matchPattern(url: URL, remotePattern: RemotePattern): boolean
+import {matchPattern} from 'astro/assets/utils';
+
+const testURL = new URL('https://images.example.com/photos/test.jpg');
+
+// Define a remote pattern to match the URL
+const remotePattern = {
+  protocol: 'https',
+  hostname: 'images.example.com',
+  pathname: '/photos/**', // Wildcard to allow all files under /photos/
+  port: '', // Optional: Match any port or leave empty for default
+};
+
+// Check if the URL matches the remote pattern
+const isPatternMatched = matchPattern(testURL, remotePattern);
+
+console.log(`Does the URL match the remote pattern? ${isPatternMatched}`); // Output: true
 ```
 
 ### `matchPort()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(url: URL, port?: string): boolean`
+
 Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
 
 ```ts
-function matchPort(url: URL, port?: string): boolean
+import {matchPort} from 'astro/assets/utils';
+
+const testURL1 = new URL('https://example.com:8080/resource');
+const testURL2 = new URL('https://example.com/resource');
+
+// Example usage of matchPort
+const portToMatch = '8080';
+
+// Match a URL with a port specified
+const isPortMatch1 = matchPort(testURL1, portToMatch);
+console.log(`Does the port match? ${isPortMatch1}`); // Output: true
+
+// Match a URL without a port specified (default port will be assumed)
+const isPortMatch2 = matchPort(testURL2, portToMatch);
+console.log(`Does the port match? ${isPortMatch2}`); // Output: false
+
+// Check a URL without explicitly providing a port (defaults to true if port is undefined)
+const isPortMatch3 = matchPort(testURL1);
+console.log(`Does the port match (no port specified)? ${isPortMatch3}`); // Output: true
 ```
 
 ### `matchProtocol()`
 
+<p><Since v="4.0.0" /></p>
+
+**Type**: `(url: URL, protocol?: string): boolean`
+
 Compares the protocol of the provided URL with a specified protocol.
 
 ```ts
-function matchProtocol(url: URL, protocol?: string): boolean
+import {matchProtocol} from 'astro/assets/utils';
+
+const testURL1 = new URL('https://example.com/resource');
+const testURL2 = new URL('http://example.com/resource');
+
+// Example usage of matchProtocol
+const protocolToMatch = 'https';
+
+// Match a URL with correct protocol
+const isProtocolMatch1 = matchProtocol(testURL1, protocolToMatch);
+console.log(`Does the protocol match for testURL1? ${isProtocolMatch1}`); // Output: true
+
+// Match a URL with incorrect protocol
+const isProtocolMatch2 = matchProtocol(testURL2, protocolToMatch);
+console.log(`Does the protocol match for testURL2? ${isProtocolMatch2}`); // Output: false
+
+// Match a URL without explicitly providing a protocol (defaults to true if protocol is undefined)
+const isProtocolMatch3 = matchProtocol(testURL1);
+console.log(`Does the protocol match (no protocol specified)? ${isProtocolMatch3}`); // Output: true
 ```

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -265,10 +265,14 @@ export default defineConfig({
 Astro exposes a number of helper functions that can be used to develop a custom image service. These utilities can be imported from `astro/assets/utils`:
 
 ```ts
-import { matchProtocol } from "astro/assets/utils";
-
-matchProtocol(new URL("https://example.com"), "https"); // returns true
-
+import { 
+    isRemoteAllowed,
+    matchHostname,
+    matchPathname,
+    matchPattern,
+    matchPort,
+    matchProtocol
+} from "astro/assets/utils";
 ```
 
 ### `isRemoteAllowed()`

--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -259,3 +259,71 @@ export default defineConfig({
   },
 });
 ```
+
+## Utilities
+
+Astro exposes a number of helper functions that can be used to develop a custom image service. These utilities can be imported from `astro/assets/utils`:
+
+```ts
+import { matchProtocol } from "astro/assets/utils";
+
+matchProtocol(new URL("https://example.com"), "https"); // returns true
+
+```
+
+### `isRemoteAllowed()`
+
+Determines whether a given remote resource, identified by its source URL, is allowed based on specified domains and remote patterns.
+
+```ts
+function isRemoteAllowed(
+	src: string,
+	{
+		domains,
+		remotePatterns,
+	}: {
+		domains: string[];
+		remotePatterns: RemotePattern[];
+	},
+): boolean
+```
+
+### `matchHostname()`
+
+Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
+
+```ts
+function matchHostname(url: URL, hostname?: string, allowWildcard = false): boolean
+```
+
+### `matchPathname()`
+
+Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
+
+```ts
+function matchPathname(url: URL, pathname?: string, allowWildcard = false): boolean
+```
+
+### `matchPattern()`
+
+Evaluates whether a given URL matches the specified remote pattern based on protocol, hostname, port, and pathname.
+
+```ts
+function matchPattern(url: URL, remotePattern: RemotePattern): boolean
+```
+
+### `matchPort()`
+
+Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
+
+```ts
+function matchPort(url: URL, port?: string): boolean
+```
+
+### `matchProtocol()`
+
+Compares the protocol of the provided URL with a specified protocol.
+
+```ts
+function matchProtocol(url: URL, protocol?: string): boolean
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This is a follow-up PR of the code PR https://github.com/withastro/astro/pull/13355

I added the new remote pattern utilities at the end of the page. I used the description that we have in the code as a starting point, and of course we can change them.

Questions:
- Do we want to provide an example?
- I used a code block to show the signature of the functions, instead of simple code words like we do for the hooks function. I felt that having more colour would help. Happy to change it and make this consistent.


As a tangent, Astro exposes **more functions** from the specifier `astro/assets/utils` that we don't document. However, I believe that **not all functions** are meant to be exposed to userland. I want to check with the team first, and then we can do follow-up PRs to add the missing functions.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->
