### PR TITLE
fix(tutorial): prevent character encoding issue in unit 4

### DIFF
--- a/src/content/docs/en/tutorial/4-layouts/2.mdx
+++ b/src/content/docs/en/tutorial/4-layouts/2.mdx
@@ -34,6 +34,7 @@ When you include the `layout` frontmatter property in an `.md` file, all of your
     ---
     const { frontmatter } = Astro.props;
     ---
+    <meta charset="utf-8" />
     <h1>{frontmatter.title}</h1>
     <p>Written by {frontmatter.author}</p>
     <slot />
@@ -78,10 +79,11 @@ Published on: 2022-07-01
 Welcome to my _new blog_ about learning Astro! Here, I will share my learning journey as I build a new website.
 ```
 
-```astro title="src/layouts/MarkdownPostLayout.astro" ins={5}
+```astro title="src/layouts/MarkdownPostLayout.astro" ins={6}
 ---
 const { frontmatter } = Astro.props;
 ---
+<meta charset="utf-8" />
 <h1>{frontmatter.title}</h1>
 <p>Published on: {frontmatter.pubDate.toString().slice(0,10)}</p>
 <p>Written by {frontmatter.author}</p>
@@ -96,6 +98,7 @@ Here is an example of a refactored layout that leaves only individual blog post 
 ---
 const { frontmatter } = Astro.props;
 ---
+<meta charset="utf-8" />
 <h1>{frontmatter.title}</h1>
 <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
 <p><em>{frontmatter.description}</em></p>

--- a/src/content/docs/en/tutorial/4-layouts/3.mdx
+++ b/src/content/docs/en/tutorial/4-layouts/3.mdx
@@ -29,12 +29,13 @@ You already have a `BaseLayout.astro` for defining the overall layout of your pa
 <Steps>
 1. In `src/layouts/MarkdownPostLayout.astro`, import `BaseLayout.astro` and use it to wrap the entire template content. Don't forget to pass the `pageTitle` prop:
 
-    ```astro title="src/layouts/MarkdownPostLayout.astro" ins={2,5,12}
+    ```astro title="src/layouts/MarkdownPostLayout.astro" ins={2,5,13}
     ---
     import BaseLayout from './BaseLayout.astro';
     const { frontmatter } = Astro.props;
     ---
     <BaseLayout pageTitle={frontmatter.title}>
+      <meta charset="utf-8" />
       <h1>{frontmatter.title}</h1>
       <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
       <p><em>{frontmatter.description}</em></p>
@@ -44,13 +45,31 @@ You already have a `BaseLayout.astro` for defining the overall layout of your pa
     </BaseLayout>
     ```
 
-2. Check your browser preview at `http://localhost:4321/posts/post-1`. Now you should see content rendered by:
+2. In `src/layouts/MarkdownPostLayout.astro`, you can now remove the `meta` tag as it is already included in your `BaseLayout`:
+
+    ```astro title="src/layouts/MarkdownPostLayout.astro" del={6}
+    ---
+    import BaseLayout from './BaseLayout.astro';
+    const { frontmatter } = Astro.props;
+    ---
+    <BaseLayout pageTitle={frontmatter.title}>
+      <meta charset="utf-8" />
+      <h1>{frontmatter.title}</h1>
+      <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
+      <p><em>{frontmatter.description}</em></p>
+      <p>Written by: {frontmatter.author}</p>
+      <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+      <slot />
+    </BaseLayout>
+    ```
+
+3. Check your browser preview at `http://localhost:4321/posts/post-1`. Now you should see content rendered by:
 
     - Your **main page layout**, including your styles, navigation links, and social footer.
     - Your **blog post layout**, including frontmatter properties like the description, date, title, and image.
     - Your **individual blog post Markdown content**, including just the text written in this post.
 
-3. Notice that your page title is now displayed twice, once by each layout.
+4. Notice that your page title is now displayed twice, once by each layout.
 
     Remove the line that displays your page title from `MarkdownPostLayout.astro`:
 
@@ -65,7 +84,7 @@ You already have a `BaseLayout.astro` for defining the overall layout of your pa
     </BaseLayout>
     ```
 
-4. Check your browser preview again at `http://localhost:4321/posts/post-1` and verify that this line is no longer displayed and that your title is only displayed once. Make any other adjustments necessary to ensure that you do not have any duplicated content.
+5. Check your browser preview again at `http://localhost:4321/posts/post-1` and verify that this line is no longer displayed and that your title is only displayed once. Make any other adjustments necessary to ensure that you do not have any duplicated content.
 </Steps>
 
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since the change introduced by https://github.com/withastro/astro/pull/12231 in Astro 5, `<meta charset="utf-8" />` is no longer automatically added for Markdown files that use the `layout` frontmatter property. So users was facing a character encoding issue in unit 4 while checking the rendering of `MarkdownPostLayout` before nesting it in `BaseLayout`.

|Before|After|
|---|---|
|![tutorial-before](https://github.com/user-attachments/assets/b056c7de-7b7d-4d4c-b196-0469860fc09d)|![tutorial-after](https://github.com/user-attachments/assets/eee67e8f-443b-476e-9081-8665de4959bc)|

This PR:
* adds `<meta charset="utf-8" />` in [unit 4-2](https://docs.astro.build/en/tutorial/4-layouts/2/)
* adds a new step in [unit 4-3](https://docs.astro.build/en/tutorial/4-layouts/3/) to remove the `<meta charset="utf-8" />` (I thought maybe it was easier for beginners to understand rather than removing it in step 1)

#### Related issues & labels (optional)

- Closes #10977
- Suggested label: improve or update documentation, tutorial

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
