### PR TITLE
i18n(fr): add `reference/errors/actions-cant-be-loaded.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -135,6 +135,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**ActionsReturnedInvalidDataError**](/fr/reference/errors/actions-returned-invalid-data-error/)<br/>Le gestionnaire d’actions a renvoyé des données non valides.
 - [**ActionNotFoundError**](/fr/reference/errors/action-not-found-error/)<br/>Action non trouvée.
 - [**ActionCalledFromServerError**](/fr/reference/errors/action-called-from-server-error/)<br/>Action inattendue demandée par le serveur.
+- [**ActionsCantBeLoaded**](/fr/reference/errors/actions-cant-be-loaded/)<br/>Impossible de charger les actions Astro.
 
 ## Erreurs de Session
 

--- a/src/content/docs/fr/reference/errors/actions-cant-be-loaded.mdx
+++ b/src/content/docs/fr/reference/errors/actions-cant-be-loaded.mdx
@@ -1,0 +1,10 @@
+---
+title: Impossible de charger les actions Astro.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **ActionsCantBeLoaded**: An unknown error was thrown while loading the Astro actions file.
+
+## Qu'est-ce qui a mal tourné ?
+Émis en mode développement lorsque le fichier d'actions ne peut pas être chargé.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Creates the French translation for `actions-cant-be-loaded.mdx` and updates the errors reference list. (see #11160)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
