### PR TITLE
i18n(zh-CN): unify translation of "headless CMS"

### DIFF
--- a/src/content/docs/zh-cn/getting-started.mdx
+++ b/src/content/docs/zh-cn/getting-started.mdx
@@ -60,7 +60,7 @@ import Discord from '~/components/Landing/Discord.astro'
     - [添加集成比如 React 和 Tailwind](/zh-cn/guides/integrations-guide/)
     - [创建类型安全的内容集合](/zh-cn/guides/content-collections/)
     - [通过视图过渡增强导航](/zh-cn/guides/view-transitions/)
-    - [连接 headless CMS 到你的项目](/zh-cn/guides/cms/)
+    - [连接无头 CMS 到你的项目](/zh-cn/guides/cms/)
   </ListCard>
 </CardGrid>
 

--- a/src/content/docs/zh-cn/guides/cms/buttercms.mdx
+++ b/src/content/docs/zh-cn/guides/cms/buttercms.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import { Steps } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-[ButterCMS](https://buttercms.com/) 是一种允许你在项目中发布结构化内容的 headless CMS和博客引擎。
+[ButterCMS](https://buttercms.com/) 是一种允许你在项目中发布结构化内容的无头 CMS 和博客引擎。
 
 ## 与 Astro 集成
 :::note

--- a/src/content/docs/zh-cn/guides/cms/datocms.mdx
+++ b/src/content/docs/zh-cn/guides/cms/datocms.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import { Steps } from '@astrojs/starlight/components';
 import { FileTree } from '@astrojs/starlight/components';
 
-[DatoCMS](https://datocms.com/) 是一个基于 Web 的 headless CMS，用于管理你站点和应用程序的数字内容。
+[DatoCMS](https://datocms.com/) 是一个基于 Web 的无头 CMS，用于管理你站点和应用程序的数字内容。
 
 ## 与 Astro 集成
 

--- a/src/content/docs/zh-cn/guides/cms/payload.mdx
+++ b/src/content/docs/zh-cn/guides/cms/payload.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-[PayloadCMS](https://payloadcms.com/) 是一个开源的 headless CMS（Content Management System，内容管理系统），可以用来为你的 Astro 项目提供内容。
+[PayloadCMS](https://payloadcms.com/) 是一个开源的无头 CMS（Content Management System，内容管理系统），可以用来为你的 Astro 项目提供内容。
 
 ## 与 Astro 集成
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Most files translate "headless CMS" as "无头 CMS" instead of keeping the original term. This PR unifies the translation to follow this practice.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
