### PR TITLE
fix(docs-10876): Fix incorrect suggestion about output: "server" in forms recipe

### DIFF
--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -6,10 +6,10 @@ type: recipe
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-In SSR mode, Astro pages can both display and handle forms. In this recipe, you'll use a standard HTML form to submit data to the server. Your frontmatter script will handle the data on the server, sending no JavaScript to the client.
+Astro pages that are rendered on demand can both display and handle forms. In this recipe, you'll use a standard HTML form to submit data to the server. Your frontmatter script will handle the data on the server, sending no JavaScript to the client.
 
 ## Prerequisites
-- A project with [SSR](/en/guides/on-demand-rendering/) (`output: 'server'`) enabled
+- An Astro project with a [server adapter](/en/guides/on-demand-rendering/#server-adapters) installed.
 
 ## Recipe
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the Build Forms recipe to correct the suggestion about changing output to "server". The previous wording was misleading, and this update ensures clarity on rendering forms correctly.

#### Related issues & labels (optional)

- Closes #[10876](https://github.com/withastro/docs/issues/10876)
- Suggested label: good-first-issue

