### PR TITLE
fix(data-fetching): typo in a code snippet

### DIFF
--- a/src/content/docs/en/guides/data-fetching.mdx
+++ b/src/content/docs/en/guides/data-fetching.mdx
@@ -48,9 +48,7 @@ The `fetch()` function is also globally available to any [framework components](
 ```tsx title="src/components/Movies.tsx" /await fetch\\(.*?\\)/
 import type { FunctionalComponent } from 'preact';
 
-const data = await fetch('https://example.com/movies.json').then((response) =>
-  response.json();
-);
+const data = await fetch('https://example.com/movies.json').then((response) => response.json());
 
 // Components that are build-time rendered also log to the CLI.
 // When rendered with a `client:*` directive, they also log to the browser console.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

A typo was introduced by #11196 in a code snippet of `guides/data-fetching`. My bad, when reviewing, I didn't notice that it was an arrow function, so the semicolon produces invalid code. To avoid confusion, I reformatted the function to be on one line.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
