### PR TITLE
Fixes type syntax generated by our config reference script

### DIFF
--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -157,9 +157,13 @@ function getCommentProperties(comment) {
 	if (comment.kind !== 'heading' && !comment.type && !typerawFlag) {
 		throw new Error(`Missing @docs JSDoc tag: @type or @typeraw`);
 	}
-	const typesFormatted = typerawFlag
-		? typerawFlag.text.replace(/\{(.*)\}/, '$1')
-		: comment.type?.names.join(' | ');
+	const typesFormatted = (
+		typerawFlag ? typerawFlag.text.replace(/\{(.*)\}/, '$1') : comment.type?.names.join(' | ')
+	)
+		// JSDoc represents types like objects and arrays using an old Closure-style notation,
+		// e.g. `Array.<string>` or `Record.<string, string>`. This `replace()` removes the `.` to match
+		// the notation used for TypeScript-style generics.
+		?.replace('.<', '<');
 
 	const properties = [
 		typesFormatted ? `**Type:** \`${typesFormatted}\`` : undefined,

--- a/scripts/docgen.mjs
+++ b/scripts/docgen.mjs
@@ -163,7 +163,7 @@ function getCommentProperties(comment) {
 		// JSDoc represents types like objects and arrays using an old Closure-style notation,
 		// e.g. `Array.<string>` or `Record.<string, string>`. This `replace()` removes the `.` to match
 		// the notation used for TypeScript-style generics.
-		?.replace('.<', '<');
+		?.replaceAll('.<', '<');
 
 	const properties = [
 		typesFormatted ? `**Type:** \`${typesFormatted}\`` : undefined,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR fixes a subtle issue with the docgen script used to generate our configuration reference.

The script uses `jsdoc-api` to parse JSDoc comments. This converts certain types to use JSDoc’s old-school Closure-style type notation. For example, `string[]` becomes `Array.<string>`, which looks a little odd these days with most people expecting TypeScript’s type syntax.

This PR adds a hotfix to remove the unexpected `.` in generic types like this fixing several instances of `Array.<...>` and `Record.<...>` in our config reference.

(I did not include the changes to the page itself in this PR as there are several things in flight there that will need handling anyway in #11212.)

H/T @ArmandPhilippot for spotting this issue