### PR TITLE
Fix imports formatting in `image-service-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -286,7 +286,7 @@ Determines whether a given remote resource, identified by its source URL, is all
 
 
 ```ts
-import {isRemoteAllowed} from 'astro/assets/utils';
+import { isRemoteAllowed } from 'astro/assets/utils';
 
 const testImageURL = 'https://example.com/images/test.jpg';
 const domains = ['example.com', 'anotherdomain.com'];
@@ -310,7 +310,7 @@ console.log(`Is the remote image allowed? ${isAllowed}`);
 Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
 
 ```ts
-import {matchHostname} from 'astro/assets/utils';
+import { matchHostname } from 'astro/assets/utils';
 
 const testURL = new URL('https://sub.example.com/path/to/resource');
 
@@ -336,7 +336,7 @@ console.log(`Does the hostname match with wildcard? ${isMatchWithWildcard}`); //
 Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
 
 ```ts
-import {matchPathname} from 'astro/assets/utils';
+import { matchPathname } from 'astro/assets/utils';
 
 const testURL = new URL('https://example.com/images/photo.jpg');
 
@@ -363,7 +363,7 @@ console.log(`Does the pathname match with wildcard? ${isMatchWithWildcard}`); //
 Evaluates whether a given URL matches the specified remote pattern based on protocol, hostname, port, and pathname.
 
 ```ts
-import {matchPattern} from 'astro/assets/utils';
+import { matchPattern } from 'astro/assets/utils';
 
 const testURL = new URL('https://images.example.com/photos/test.jpg');
 
@@ -391,7 +391,7 @@ console.log(`Does the URL match the remote pattern? ${isPatternMatched}`); // Ou
 Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
 
 ```ts
-import {matchPort} from 'astro/assets/utils';
+import { matchPort } from 'astro/assets/utils';
 
 const testURL1 = new URL('https://example.com:8080/resource');
 const testURL2 = new URL('https://example.com/resource');
@@ -422,7 +422,7 @@ console.log(`Does the port match (no port specified)? ${isPortMatch3}`); // Outp
 Compares the protocol of the provided URL with a specified protocol.
 
 ```ts
-import {matchProtocol} from 'astro/assets/utils';
+import { matchProtocol } from 'astro/assets/utils';
 
 const testURL1 = new URL('https://example.com/resource');
 const testURL2 = new URL('http://example.com/resource');


### PR DESCRIPTION
#### Description (required)

This fixes a few imports' formatting in the sample code blocks in the page for consistency's sake.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
