### PR TITLE
fix: add missing frontmatter prop in `heading-id-compat.mdx` [i18nIgnore]

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/heading-id-compat.mdx
+++ b/src/content/docs/en/reference/experimental-flags/heading-id-compat.mdx
@@ -2,6 +2,7 @@
 title: Experimental Markdown heading ID compatibility
 sidebar:
   label: Markdown heading ID compatibility
+i18nReady: true
 ---
 
 import Since from '~/components/Since.astro'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Unless I'm missing something, there's no reason for [`experimental-flags/heading-id-compat`](https://docs.astro.build/en/reference/experimental-flags/heading-id-compat/) not to be translated. Currently this file does not appear in the [Lunaria dashboard](https://i18n.docs.astro.build/) (e.g. under `Français (fr)`). I think it's because the `i18nReady` property is missing in the frontmatter so I added it.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n?

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
