### PR TITLE
fix(guide/storyblok): adjust storyblok/astro import

### DIFF
--- a/src/content/docs/en/guides/cms/storyblok.mdx
+++ b/src/content/docs/en/guides/cms/storyblok.mdx
@@ -75,7 +75,7 @@ Modify your Astro config file to include the Storyblok integration:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
-import storyblok from '@storyblok/astro';
+import { storyblok } from '@storyblok/astro';
 import { loadEnv } from 'vite';
 
 const env = loadEnv("", process.cwd(), 'STORYBLOK');
@@ -172,7 +172,7 @@ Finally, to connect the `blogPost` Blok to the `BlogPost` component, add a new p
 
 ```js title="astro.config.mjs" ins={12}
 import { defineConfig } from 'astro/config';
-import storyblok from '@storyblok/astro';
+import { storyblok } from '@storyblok/astro';
 import { loadEnv } from 'vite';
 
 const env = loadEnv("", process.cwd(), 'STORYBLOK');
@@ -345,7 +345,7 @@ Finally, add your components to the `components` property of the `storyblok` con
 
 ```js title="astro.config.mjs" ins={12-14}
 import { defineConfig } from 'astro/config';
-import storyblok from '@storyblok/astro';
+import { storyblok } from '@storyblok/astro';
 import { loadEnv } from 'vite';
 
 const env = loadEnv("", process.cwd(), 'STORYBLOK');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I fixed an incorrect import statement in the Storyblok guide. The current code incorrectly imports Storyblok as a default export:

```js
import storyblok from "@storyblok/astro";
```

This causes an error as '@storyblok/astro' does not provide a default export. I've updated it to use the correct named import:

```js
import { storyblok } from "@storyblok/astro";
```

This change ensures the code example works correctly for users following the guide.

#### Related issues & labels (optional)

- Suggested label: `bug fix` `documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->