### PR TITLE
Update environment-variables.mdx - Add caution from Vite docs about i…

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -52,7 +52,7 @@ interface ImportMeta {
 :::caution
 Imports will break type augmentation
 
-If the ImportMetaEnv augmentation does not work, make sure you do not have any import statements in env.d.ts. This issue is also documented in [Vite's TypeScript documentation](https://vitejs.dev/guide/features.html#client-types) for the same reason.
+If the ImportMetaEnv augmentation does not work, make sure you do not have any import statements in env.d.ts. This issue is also documented in [Vite's TypeScript documentation](https://vite.dev/guide/env-and-mode#intellisense-for-typescript) for the same reason.
 :::
 
 ## Default environment variables

--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -49,6 +49,12 @@ interface ImportMeta {
 }
 ```
 
+:::caution
+Imports will break type augmentation
+
+If the ImportMetaEnv augmentation does not work, make sure you do not have any import statements in env.d.ts. This issue is also documented in [Vite's TypeScript documentation](https://vitejs.dev/guide/features.html#client-types) for the same reason.
+:::
+
 ## Default environment variables
 
 Astro includes a few environment variables out of the box:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Add a caution note about imports breaking type augmentation in env.d.ts files when working with ImportMetaEnv. This issue is documented in Vite's documentation but not explicitly in Astro's docs, even though Astro uses Vite under the hood.

#### Related issues & labels (optional)

- Suggested label: `documentation`
- Suggested label: `typescript`

#### First-time contributor to Astro Docs?

Hello, i'm filipe.k.gregorio on Discord.

<!-- https://astro.build/chat -->