### PR TITLE
chore: add renovate to repository

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,10 @@
 {
 	$schema: 'https://docs.renovatebot.com/renovate-schema.json',
 	extends: [
-		":dependencyDashboard",
-		":semanticPrefixFixDepsChoreOthers",
-		":ignoreModulesAndTests",
-		"workarounds:all",
+		':dependencyDashboard',
+		':semanticPrefixFixDepsChoreOthers',
+		':ignoreModulesAndTests',
+		'workarounds:all',
 		'helpers:pinGitHubActionDigestsToSemver',
 	],
 	rangeStrategy: 'bump',
@@ -14,5 +14,11 @@
 			groupName: 'github-actions',
 			matchManagers: ['github-actions'],
 		},
+		{
+			matchManagers: ["npm"],
+			groupName: "dependencies",
+			matchDepTypes: ["devDependencies", "dependencies", "peerDependencies"],
+			enabled: false
+		}
 	],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		"schedule:weekly",
+		"group:allNonMajor",
+		":disablePeerDependencies",
+		"helpers:pinGitHubActionDigestsToSemver"
+	],
+	"rangeStrategy": "bump",
+	"postUpdateOptions": ["pnpmDedupe"],
+	"ignorePaths": ["**/node_modules/**"],
+	"packageRules": [
+		{
+			"groupName": "github-actions",
+			"matchManagers": [
+				"github-actions"
+			]
+		}
+	]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,21 +1,18 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended",
-		"schedule:weekly",
-		"group:allNonMajor",
-		":disablePeerDependencies",
-		"helpers:pinGitHubActionDigestsToSemver"
+	$schema: 'https://docs.renovatebot.com/renovate-schema.json',
+	extends: [
+		":dependencyDashboard",
+		":semanticPrefixFixDepsChoreOthers",
+		":ignoreModulesAndTests",
+		"workarounds:all",
+		'helpers:pinGitHubActionDigestsToSemver',
 	],
-	"rangeStrategy": "bump",
-	"postUpdateOptions": ["pnpmDedupe"],
-	"ignorePaths": ["**/node_modules/**"],
-	"packageRules": [
+	rangeStrategy: 'bump',
+	ignorePaths: ['**/node_modules/**'],
+	packageRules: [
 		{
-			"groupName": "github-actions",
-			"matchManagers": [
-				"github-actions"
-			]
-		}
-	]
+			groupName: 'github-actions',
+			matchManagers: ['github-actions'],
+		},
+	],
 }


### PR DESCRIPTION
This PR adds renovate to this repository. 

It uses the same configuration of `withastro/astro`, less all the specific configurations of the repository.

The main reason for adding renovate is to keep the github actions pinned using their digest.
