### PR TITLE
i18n(pt-BR): translate reference/errors/cant-use-astro-config-module-error.mdx

### DIFF
--- a/src/content/docs/pt-br/reference/errors/cant-use-astro-config-module-error.mdx
+++ b/src/content/docs/pt-br/reference/errors/cant-use-astro-config-module-error.mdx
@@ -1,0 +1,10 @@
+---
+title: Módulo astro:config não pode ser utilizado sem habilitar a funcionalidade experimental.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **CantUseAstroConfigModuleError**: O módulo "MODULE_NAME" não pode ser importado porque a funcionalidade experimental está desabilitada. Habilite `experimental.serializeConfig` em seu `astro.config.mjs` 
+
+## O que deu errado?
+Não é possível utilizar o módulo `astro:config` sem habilitar a funcionalidade experimental.


### PR DESCRIPTION
#### Description (required)

create file i18n pt-br docs/reference/errors/cant-use-astro-config-module-error.mdx