### PR TITLE
i18n(pt-BR): translate reference/errors/content-loader-returns-invalid-id.mdx

### DIFF
--- a/src/content/docs/pt-br/reference/errors/content-loader-returns-invalid-id.mdx
+++ b/src/content/docs/pt-br/reference/errors/content-loader-returns-invalid-id.mdx
@@ -14,4 +14,4 @@ O carregador de conteúdo para a coleção **blog** retornou uma entrada com um 
 ## O que deu errado?
 Um carregador de conteúdo retornou um `id` inválido.
 Certifique-se de que o `id` da entrada é uma string.
-Veja a [documentação Coleções de Conteúdo](/pt-br/guides/content-collections/) para mais informações.
+Veja a [documentação de Coleções de Conteúdo](/pt-br/guides/content-collections/) para mais informações.

--- a/src/content/docs/pt-br/reference/errors/content-loader-returns-invalid-id.mdx
+++ b/src/content/docs/pt-br/reference/errors/content-loader-returns-invalid-id.mdx
@@ -1,0 +1,17 @@
+---
+title: O carregador de conteúdo retornou uma entrada com id inválido.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Exemplo de mensagem de erro:**<br/>
+O carregador de conteúdo para a coleção **blog** retornou uma entrada com um `id` inválido:<br/>
+&#123;<br/>
+  "id": 1,<br/>
+  "title": "Olá, Mundo!"<br/>
+&#125;
+
+## O que deu errado?
+Um carregador de conteúdo retornou um `id` inválido.
+Certifique-se de que o `id` da entrada é uma string.
+Veja a [documentação Coleções de Conteúdo](/pt-br/guides/content-collections/) para mais informações.


### PR DESCRIPTION
#### Description (required)

create i18n pt-br file docs/reference/errors/content-loader-returns-invalid-id.mdx