### PR TITLE
Fix heading level in directives reference

### DIFF
--- a/src/content/docs/en/reference/directives-reference.mdx
+++ b/src/content/docs/en/reference/directives-reference.mdx
@@ -134,7 +134,7 @@ Load and hydrate the component JavaScript once the page is done with its initial
 <ShowHideButton client:idle />
 ```
 
-### `timeout`
+#### `timeout`
 
 <p><Since v="4.15.0" /></p>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This is a tiny PR that fixes a heading level in the directives reference. The `timeout` heading is describing a parameter of the preceding `client:idle` heading but is at the same level currently. This PR nests that one level lower.
