### PR TITLE
Disable Renovate package manager updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,12 @@
 			groupName: "dependencies",
 			matchDepTypes: ["devDependencies", "dependencies", "peerDependencies"],
 			enabled: false
+		},
+		{
+			description: 'Disable package manager version updates',
+			matchPackageNames: ['pnpm'],
+			matchDepTypes: ['packageManager'],
+			enabled: false,
 		}
 	],
 }


### PR DESCRIPTION
#### Description (required)

As [discussed on Discord](https://discord.com/channels/830184174198718474/1351934638658027520/1351955002415124561), this PR prevents Renovate from updating the package manager in the `package.json` file.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: ci

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->