### PR TITLE
Disable Renovate Dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
 	$schema: 'https://docs.renovatebot.com/renovate-schema.json',
 	extends: [
-		':dependencyDashboard',
+		':disableDependencyDashboard',
 		':semanticPrefixFixDepsChoreOthers',
 		':ignoreModulesAndTests',
 		'workarounds:all',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed today in Talking & Doc'ing, considering we are at the moment only using Renovate for GitHub Actions updates, we want to mostly rely on new pull requests rather than the dashboard.

This PR [disables](https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard) the Renovate Dashboard.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: ci

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
