### PR TITLE
Fix code in actions.mdx example

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -680,7 +680,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Check if the action was called from a client-side function
   if (action?.calledFrom === 'rpc') {
     // If so, check for a user session token
-    if (context.cookies.has('user-session')) {
+    if (!context.cookies.has('user-session')) {
       return new Response('Forbidden', { status: 403 });
     }
   }


### PR DESCRIPTION
if check was missing a `!`

Before the example would return a 403 if the user HAD a user-session cookie, instead of when the user didn't have it

discord: dar.io_19940
