### PR TITLE
i18n(fr): update import list in `image-service-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/image-service-reference.mdx
+++ b/src/content/docs/fr/reference/image-service-reference.mdx
@@ -271,7 +271,16 @@ import {
     matchPathname,
     matchPattern,
     matchPort,
-    matchProtocol
+    matchProtocol,
+    isESMImportedImage,
+    isRemoteImage,
+    resolveSrc,
+    imageMetadata,
+    emitESMImage,
+    getOrigQueryParams,
+    inferRemoteSize,
+    propsToFilename,
+    hashTransform
 } from "astro/assets/utils";
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the import list from `astro/assets/utils` in the French translation of `image-service-reference.mx` (see #11298).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
