### PR TITLE
Update scoped styles documentation in guides

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -30,12 +30,12 @@ Astro `<style>` CSS rules are automatically **scoped by default**. Scoped styles
 This CSS:
 ```astro title="src/pages/index.astro"
 <style>
-  h1 { 
-    color: red; 
+  h1 {
+    color: red;
   }
 
-  .text { 
-    color: blue; 
+  .text {
+    color: blue;
   }
 </style>
 ```
@@ -214,7 +214,7 @@ import 'package-name/styles.css';
 <html><!-- Your page here --></html>
 ```
 
-If your package **does _not_ suggest using a file extension** (i.e. `package-name/styles`), you'll need to update your Astro config first! 
+If your package **does _not_ suggest using a file extension** (i.e. `package-name/styles`), you'll need to update your Astro config first!
 
 Say you are importing a CSS file from `package-name` called `normalize` (with the file extension omitted). To ensure we can prerender your page correctly, add `package-name` to [the `vite.ssr.noExternal` array](https://vite.dev/config/ssr-options.html#ssr-noexternal):
 
@@ -302,9 +302,9 @@ Astro CSS rules are evaluated in this order of appearance:
 - **imported styles**
 - **scoped styles** (highest precedence)
 
-### Scoped Styles 
+### Scoped Styles
 
-Using [scoped styles](#scoped-styles) does not increase the _specificity_ of your CSS, but they will always come last in the _order of appearance_. They will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style's value will apply:
+[Scoped styles](#scoped-styles) will always come last in the _order of appearance_. These styles will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style’s value will apply:
 
 ```css title="src/components/make-it-purple.css"
 h1 {
@@ -325,10 +325,10 @@ import "./make-it-purple.css"
 </div>
 ```
 
-If you make the imported style _more specific_, it will have higher precedence over the scoped style:
+Scoped styles attach a unique attribute selector to each element which increases the [CLASS column specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity#class_column) by 1. Scoped styles will be overwritten if the imported style is _more specific_. The style with a higher specificity will take precedence over the scoped style:
 
 ```css title="src/components/make-it-purple.css"
-div > h1 {
+#intro {
   color: purple;
 }
 ```
@@ -340,7 +340,7 @@ import "./make-it-purple.css"
   h1 { color: red }
 </style>
 <div>
-  <h1>
+  <h1 id="intro">
     This header will be purple!
   </h1>
 </div>
@@ -517,7 +517,7 @@ export default defineConfig({
     },
   },
 })
-  
+
 ```
 
 ### In framework components

--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -304,7 +304,9 @@ Astro CSS rules are evaluated in this order of appearance:
 
 ### Scoped Styles
 
-[Scoped styles](#scoped-styles) will always come last in the _order of appearance_. These styles will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style’s value will apply:
+Depending on your chosen value for [`scopedStyleStrategy`](/en/reference/configuration-reference/#scopedstylestrategy), scoped styles may or may not increase the [CLASS column specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity#class_column).
+
+That being said, [scoped styles](#scoped-styles) will always come last in the order of appearance. These styles will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style’s value will apply:
 
 ```css title="src/components/make-it-purple.css"
 h1 {
@@ -325,7 +327,7 @@ import "./make-it-purple.css"
 </div>
 ```
 
-Scoped styles attach a unique attribute selector to each element which increases the [CLASS column specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity#class_column) by 1. Scoped styles will be overwritten if the imported style is _more specific_. The style with a higher specificity will take precedence over the scoped style:
+Scoped styles will be overwritten if the imported style is _more specific_. The style with a higher specificity will take precedence over the scoped style:
 
 ```css title="src/components/make-it-purple.css"
 #intro {

--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -214,7 +214,7 @@ import 'package-name/styles.css';
 <html><!-- Your page here --></html>
 ```
 
-If your package **does _not_ suggest using a file extension** (i.e. `package-name/styles`), you'll need to update your Astro config first!
+If your package **does not suggest using a file extension** (i.e. `package-name/styles`), you'll need to update your Astro config first!
 
 Say you are importing a CSS file from `package-name` called `normalize` (with the file extension omitted). To ensure we can prerender your page correctly, add `package-name` to [the `vite.ssr.noExternal` array](https://vite.dev/config/ssr-options.html#ssr-noexternal):
 
@@ -306,7 +306,7 @@ Astro CSS rules are evaluated in this order of appearance:
 
 Depending on your chosen value for [`scopedStyleStrategy`](/en/reference/configuration-reference/#scopedstylestrategy), scoped styles may or may not increase the [CLASS column specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity#class_column).
 
-That being said, [scoped styles](#scoped-styles) will always come last in the order of appearance. These styles will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style’s value will apply:
+However, [scoped styles](#scoped-styles) will always come last in the order of appearance. These styles will therefore take precedence over other styles of the same specificity. For example, if you import a stylesheet that conflicts with a scoped style, the scoped style’s value will apply:
 
 ```css title="src/components/make-it-purple.css"
 h1 {
@@ -327,7 +327,7 @@ import "./make-it-purple.css"
 </div>
 ```
 
-Scoped styles will be overwritten if the imported style is _more specific_. The style with a higher specificity will take precedence over the scoped style:
+Scoped styles will be overwritten if the imported style is more specific. The style with a higher specificity will take precedence over the scoped style:
 
 ```css title="src/components/make-it-purple.css"
 #intro {


### PR DESCRIPTION
#### Description (required)
Previous docs state that scoped styles don't increase specificity which is inaccurate. Scoped styles will increase class specificity by 1.

The imported style in the second example will have a specificity of 0-0-2. This will not override the scoped style of 0-1-1. The example is updated to use an ID selector which will override the scoped style with its specificity of 1-0-0.