### PR TITLE
fix: broken async await chain

### DIFF
--- a/src/content/docs/en/recipes/rss.mdx
+++ b/src/content/docs/en/recipes/rss.mdx
@@ -202,18 +202,18 @@ When using glob imports with Markdown, you may use the `compiledContent()` helpe
 import rss from '@astrojs/rss';
 import sanitizeHtml from 'sanitize-html';
 
-export function GET(context) {
+export async function GET(context) {
   const postImportResult = import.meta.glob('../posts/**/*.md', { eager: true });
   const posts = Object.values(postImportResult);
   return rss({
     title: 'Buzz’s Blog',
     description: 'A humble Astronaut’s guide to the stars',
     site: context.site,
-    items: posts.map((post) => ({
+    items: await Promise.all(posts.map(async (post) => ({
       link: post.url,
       content: sanitizeHtml((await post.compiledContent())),
       ...post.frontmatter,
-    })),
+    }))),
   });
 }
 ```


### PR DESCRIPTION
#### Description (required)
![image](https://github.com/user-attachments/assets/07caf1a0-bdcc-49c1-b11e-d0986d66ac54)

Ran into this `RollupError` when completing the tutorial and setting up my RSS feed.
Fixed the example - Tested on my local build.

#### First-time contributor to Astro Docs?
sitong on Discord 👋
