### PR TITLE
i18n(fr): update `guides/client-side-scripts.mdx`

### DIFF
--- a/src/content/docs/fr/guides/client-side-scripts.mdx
+++ b/src/content/docs/fr/guides/client-side-scripts.mdx
@@ -15,13 +15,13 @@ Les scripts peuvent être utilisés pour écouter des événements envoyer des d
 
 ```astro
 <!-- src/components/ConfettiButton.astro -->
-<button data-confetti-button>Celebrate!</button>
+<button data-confetti-button>Célébrer !</button>
 
 <script>
-  // Import le module NPM.
+  // Importer des modules npm.
   import confetti from 'canvas-confetti';
 
-  // Trouver le composant DOM dans la page.
+  // Trouver le DOM de notre composant dans la page.
   const buttons = document.querySelectorAll('[data-confetti-button]');
 
   // Ajouter l'écouteur d'événement pour déclencher des confettis lorsqu'un bouton est cliqué.
@@ -33,7 +33,7 @@ Les scripts peuvent être utilisés pour écouter des événements envoyer des d
 
 Par défaut, Astro traite et regroupe les balises `<script>`, ce qui permet d'importer des modules npm, d'écrire du TypeScript, etc.
 
-## Utilisation du `<script>` dans Astro.
+## Utilisation du `<script>` dans Astro
 
 Dans les fichiers `.astro`, vous pouvez ajouter du JavaScript côté client en ajoutant une (ou plusieurs) balises `<script>`.
 
@@ -47,25 +47,25 @@ Dans cet exemple, l'ajout du composant `<Hello />` à un page enregistrera un me
 </script>
 ```
 
-### Regroupement de script
+### Traitement des scripts
 
 Par défaut, les balises `<script>` sont optimisées par Astro.
 
 - Toutes les importations seront regroupées, ce qui vous permettra d'importer des fichiers locaux ou des modules Node.
 - Le script optimisé sera injecté à l'endroit où il est déclaré avec [`type="module"`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Guide/Modules).
 - TypeScript est entièrement supporté, y compris l'import de fichiers TypeScript.
-- Si votre composant est utilisé plusieurs fois sur un page, le script ne sera inclus qu'une seule fois.
+- Si votre composant est utilisé plusieurs fois sur une page, le script ne sera inclus qu'une seule fois.
 
 ```astro title="src/components/Example.astro"
 <script>
-  // Optimisé ! Regroupé ! TypeScript supporté !
+  // Optimisé ! Regroupé ! Compatible avec TypeScript !
   // L'importation de fichiers locaux et de modules Node est supportée.
 </script>
 ```
 
 L'attribut `type="module"` permet au navigateur de traiter le script comme un module JavaScript. Cela présente plusieurs avantages en termes de performances :
 - Le rendu n'est pas bloqué. Le navigateur continue de traiter le reste du code HTML pendant que le script du module et ses dépendances se chargent.
-- Le navigateur attend que le HTML soit traité avant d'exécuter les scripts de module. Vous n'avez pas besoin d'écouter l'événement "load".
+- Le navigateur attend que le HTML soit traité avant d'exécuter les scripts de module. Vous n'avez pas besoin d'écouter l'événement « load ».
 - Les attributs `async` et `defer` ne sont pas nécessaires. Les scripts de module sont toujours différés.
 
 :::note
@@ -88,18 +88,18 @@ Pour empêcher Astro de traiter un script, ajoutez la directive `is:inline`.
 Astro ne traitera pas vos balises de script dans certaines situations. En particulier, l'ajout de `type="module"` ou de tout autre attribut que `src` à une balise `<script>` fera qu'Astro traitera la balise comme si elle avait une directive `is:inline`.
 :::
 
-<ReadMore>Voir notre page [directives reference](/fr/reference/directives-reference/#directives-de-script-et-de-style) pour plus d'informations sur les directives disponibles sur les balises `<script>`.</ReadMore>
+<ReadMore>Consultez notre page de [référence des directives](/fr/reference/directives-reference/#directives-de-script-et-de-style) pour plus d'informations sur les directives disponibles sur les balises `<script>`.</ReadMore>
 
 
 ### Inclure des fichiers JavaScript dans la page
 
-Vous pouvez vouloir écrire vos scripts comme des fichiers `.js`/`.ts` séparés ou avoir besoin de référencer un script externe sur un autre serveur. Vous pouvez le faire en les référençant dans l'attribut src' d'une balise `<script>`.
+Vous pouvez vouloir écrire vos scripts comme des fichiers `.js`/`.ts` séparés ou avoir besoin de référencer un script externe sur un autre serveur. Vous pouvez le faire en les référençant dans l'attribut `src` d'une balise `<script>`.
 
-### Importer des scripts locaux
+#### Importer des scripts locaux
 
 **Quand l'utiliser :** Si votre script se trouve dans `src/`.
 
-Astro construira, optimisera et ajoutera ces scripts à la page pour vous, en suivant ses [règles de regroupement des scripts](#regroupement-de-script)
+Astro construira, optimisera et ajoutera ces scripts à la page pour vous, en suivant ses [règles de traitement des scripts](#traitement-des-scripts).
 
 ```astro title="src/components/LocalScripts.astro"
 <!-- chemin relatif du script dans `src/scripts/local.js` -->
@@ -141,7 +141,7 @@ Au lieu de cela, vous pouvez utiliser [`addEventListener`](https://developer.moz
   // Gérer les clics sur chaque bouton.
   buttons.forEach((button) => {
     button.addEventListener('click', () => {
-      alert('Button was clicked !');
+      alert('Le bouton a été cliqué !');
     });
   });
 </script>
@@ -153,9 +153,9 @@ Si vous avez plusieurs composants `<AlertButton />` sur une page, Astro n'exécu
 
 ### Composants Web avec des éléments personnalisés
 
-Vous pouvez créer vos propres éléments HTML avec un comportement personnalisé en utilisant le standard Web Components. La définition d'un [élément personnalisé](https://developer.mozilla.org/fr/docs/Web/API/Web_components/Using_custom_elements) dans un composant `.astro` vous permet de créer des composants interactifs sans avoir besoin d'une bibliothèque de Framwork utilisateur.
+Vous pouvez créer vos propres éléments HTML avec un comportement personnalisé en utilisant la norme Web Components. La définition d'un [élément personnalisé](https://developer.mozilla.org/fr/docs/Web/API/Web_components/Using_custom_elements) dans un composant `.astro` vous permet de créer des composants interactifs sans avoir besoin d'une bibliothèque de framework UI.
 
-Dans cet exemple, nous définissons un nouvel élément HTML `<astro-heart>` qui enregistre le nombre de fois que vous cliquez sur le bouton "cœur" et met à jour l'élément `<span>` avec le dernier décompte.
+Dans cet exemple, nous définissons un nouvel élément HTML `<astro-heart>` qui enregistre le nombre de fois que vous cliquez sur le bouton en forme de cœur et met à jour l'élément `<span>` avec le dernier décompte.
 
 ```astro title="src/components/AstroHeart.astro"
 <!-- Enveloppez les éléments du composant dans notre élément personnalisé "astro-heart" -->
@@ -194,9 +194,9 @@ L'utilisation d'un élément personnalisé présente deux avantages :
 <ReadMore>Pour en savoir plus sur les éléments personnalisés, consultez [le guide des composants Web réutilisables de web.dev (EN)](https://web.dev/custom-elements-v1/) et [l'introduction aux éléments personnalisés de MDN](https://developer.mozilla.org/fr/docs/Web/API/Web_components/Using_custom_elements).</ReadMore>
 
 
-### Passer les variables frontmatter aux scripts
+### Transmettre les variables du frontmatter aux scripts
 
-Dans les composants Astro, le code dans [le frontmatter](/fr/basics/astro-components/#le-script-du-composant) entre les codes barres “---” s'exécute sur le serveur et n'est pas disponible dans le navigateur. Pour envoyer des variables du serveur au client, nous avons besoin d'un moyen de stocker nos variables et de les lire lorsque le JavaScript s'exécute dans le navigateur.
+Dans les composants Astro, le code dans [le frontmatter](/fr/basics/astro-components/#le-script-du-composant) entre les barrières `---` s'exécute sur le serveur et n'est pas disponible dans le navigateur. Pour envoyer des variables du serveur au client, nous avons besoin d'un moyen de stocker nos variables, puis de les lire lorsque le JavaScript s'exécute dans le navigateur.
 
 Une façon d'y parvenir est d'utiliser les attributs [`data-*`](https://developer.mozilla.org/fr/docs/Learn/HTML/Howto/Use_data_attributes) pour stocker la valeur des variables dans votre sortie HTML. Les scripts, y compris les éléments personnalisés, peuvent alors lire ces attributs en utilisant la propriété `dataset` d'un élément une fois que votre HTML se charge dans le navigateur.
 
@@ -204,12 +204,12 @@ Dans cet exemple de composant, une variable `message` est stockée dans un attri
 
 ```astro title="src/components/AstroGreet.astro" {2} /data-message={.+}/ "this.dataset.message"
 ---
-const { message = 'Bienvenue, le monde!' } = Astro.props;
+const { message = 'Bienvenue, le monde !' } = Astro.props;
 ---
 
 <!-- Stocker la propriété message comme attribut de données. -->
 <astro-greet data-message={message}>
-  <button>Saluer!</button>
+  <button>Saluer !</button>
 </astro-greet>
 
 <script>
@@ -235,7 +235,7 @@ Nous pouvons maintenant utiliser notre composant plusieurs fois et être accueil
 import AstroGreet from '../components/AstroGreet.astro';
 ---
 
-<!-- Utilisez le message par défaut: "Bienvenue, monde!" -->
+<!-- Utilisez le message par défaut: "Bienvenue, le monde !" -->
 <AstroGreet />
 
 <!-- Utiliser des messages personnalisés passés comme props. -->
@@ -248,5 +248,5 @@ C'est en fait ce qu'Astro fait dans les coulisses lorsque vous passez des props 
 :::
 
 ### Combinaison de scripts et de Frameworks UI
-          
+
 Les éléments rendus par un framework UI peuvent ne pas être disponibles au moment de l'exécution d'une balise `<script>`. Si votre script doit également gérer les [composants du framework UI](/fr/guides/framework-components/), il est recommandé d'utiliser un élément personnalisé.

--- a/src/content/docs/fr/guides/view-transitions.mdx
+++ b/src/content/docs/fr/guides/view-transitions.mdx
@@ -527,7 +527,7 @@ Lorsque l'on navigue entre les pages avec le composant `<ClientRouter />`, les s
 
 ### Réexécution du script
 
-Les [scripts des modules intégrés](/fr/guides/client-side-scripts/#regroupement-de-script), qui sont les scripts par défaut dans Astro, ne sont exécutés qu'une seule fois. Après l'exécution initiale, ils seront ignorés, même si le script existe sur la nouvelle page après une transition.
+Les [scripts des modules intégrés](/fr/guides/client-side-scripts/#traitement-des-scripts), qui sont les scripts par défaut dans Astro, ne sont exécutés qu'une seule fois. Après l'exécution initiale, ils seront ignorés, même si le script existe sur la nouvelle page après une transition.
 
 Contrairement aux scripts de modules intégrés, les scripts [inline](/fr/guides/client-side-scripts/#inclure-des-fichiers-javascript-dans-la-page) peuvent être réexécutés au cours de la visite d'un utilisateur sur un site s'ils se trouvent sur une page visitée plusieurs fois. Les scripts en ligne peuvent également être réexécutés lorsqu'un visiteur navigue vers une page sans script, puis de nouveau vers une page avec le script.
 

--- a/src/content/docs/fr/reference/directives-reference.mdx
+++ b/src/content/docs/fr/reference/directives-reference.mdx
@@ -306,7 +306,7 @@ L'utilisation de `define:vars` sur une balise `<script>` implique la [directive 
 
 En effet, lorsque Astro regroupe un script, il inclut et exécute le script une seule fois même si vous incluez le composant contenant le script plusieurs fois sur une même page. `define:vars` nécessite qu'un script soit réexécuté avec chaque ensemble de valeurs, donc Astro crée un script en ligne à la place.
 
-Pour les scripts, essayez plutôt de [transmettre les variables aux scripts manuellement](/fr/guides/client-side-scripts/#passer-les-variables-frontmatter-aux-scripts).
+Pour les scripts, essayez plutôt de [transmettre les variables aux scripts manuellement](/fr/guides/client-side-scripts/#transmettre-les-variables-du-frontmatter-aux-scripts).
 :::
 
 ## Directives Avancées


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I noticed a heading in the French version that shouldn't be in the ToC ([`Import local scripts`/`Importer des scripts locaux`](https://docs.astro.build/fr/guides/client-side-scripts/#importer-des-scripts-locaux)) so while fixing that, I also:
* translated some missing parts (mainly in code snippets)
* fixed some typo
* reworded some parts/headings to make reading smoother and more accurate (`processing` !== `bundling` so we shouldn't use `regroupement` but `traitement` for the scripts heading)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
