### PR TITLE
i18n(zh-cn): fix typo in `configuration-reference.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/configuration-reference.mdx
+++ b/src/content/docs/zh-cn/reference/configuration-reference.mdx
@@ -356,7 +356,7 @@ $ astro build --root ./my-project-directory
 指定 Astro 组件内部样式作用范围。可选项包括：
   - `'where'` - 使用 `:where` 选择器，不会增加特异性。
   - `'class'` - 使用基于类的选择器，会增加 +1 的特异性。
-  - `'attribute'` - 使用 `data-` 属性，不会增加特异性。
+  - `'attribute'` - 使用 `data-` 属性，会增加 +1 的特异性。
 
 使用 `'class'` 可以确保 Astro 组件内的元素选择器覆盖全局样式默认值（例如来自全局样式表）。
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

fix typo in `configuration-reference.mdx`

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
