### PR TITLE
Exclude Learn Astro ad from Algolia indexing

### DIFF
--- a/src/components/RightSidebar/LearnAstroAd.astro
+++ b/src/components/RightSidebar/LearnAstroAd.astro
@@ -10,7 +10,7 @@ const idCount = (((Astro.locals as any)._ad_render_id as number | undefined) ??=
 const headingId = `learn-astro-course-${idCount}`;
 ---
 
-<div class="container" lang="en" dir="ltr">
+<div class="container" lang="en" dir="ltr" data-algolia-exclude>
 	<aside aria-labelledby={headingId}>
 		<Image src={CodingInPublic} alt="" width="130" />
 		<h2 id={headingId}>Learn Astro with <strong>Coding in Public</strong></h2>


### PR DESCRIPTION
#### Description (required)

This PR adds a `data-algolia-exclude` attribute to the Coding in Public Learn Astro banner ad so it doesn’t get indexed when Algolia crawls the docs.

This attribute has been set up in our Algolia crawler configuration, so that next time we run the crawler, it will be applied.
