### PR TITLE
fix: correct steps numbers and link format in `deploy/cloudflare`

### DIFF
--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -43,7 +43,7 @@ To get started, you will need:
       ```
     <ReadMore>Read more about [on demand rendering (also known as SSR) in Astro](/en/guides/on-demand-rendering/).</ReadMore>
 
-2. Create a [Wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).
+3. Create a [Wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/).
 
     <StaticSsrTabs>
       <Fragment slot="static">
@@ -83,12 +83,12 @@ To get started, you will need:
     </StaticSsrTabs>
 
 
-3. Preview your project locally with Wrangler.
+4. Preview your project locally with Wrangler.
     ```bash
       npx astro build && npx wrangler dev
     ```
 
-4. Deploy using `npx wrangler deploy`.
+5. Deploy using `npx wrangler deploy`.
     ```bash
       npx astro build && npx wrangler deploy
     ```
@@ -120,7 +120,7 @@ If you're using Workers Builds:
 ### How to deploy with Wrangler
 
 <Steps>
-1. Install [Wrangler CLI].(https://developers.cloudflare.com/workers/wrangler/get-started/).
+1. Install [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/).
     ```bash
       npm install wrangler@latest --save-dev
     ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates `deploy/cloudflare.mdx` to:
* fix a link (unwanted dot in markdown notation)
* update the steps numbers in `Cloudflare Workers` > `How to deploy with Wrangler` (they are fixed once rendered but might as well correct them in the file).

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
