### PR TITLE
fix(css): prevent social buttons from stretching in footer (tutorial)

### DIFF
--- a/src/content/docs/en/tutorial/3-components/2.mdx
+++ b/src/content/docs/en/tutorial/3-components/2.mdx
@@ -165,6 +165,7 @@ Since you might have multiple online accounts you can link to, you can make a si
     <style>
       footer {
         display: flex;
+        align-items: center;
         gap: 1rem;
         margin-top: 2rem;
       }


### PR DESCRIPTION
#### Description (required)

Adding `align-items: center` to the social buttons CSS ruleset because without it the buttons are stretched to the height of the footer, making them appear too large.