### PR TITLE
docs: replace await.then() in `routing-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -153,7 +153,8 @@ For example, if you generate pages with data fetched from a remote API, you can 
 ```astro title="src/pages/posts/[id].astro" {8}
 ---
 export async function getStaticPaths() {
-  const data = await fetch('...').then(response => response.json());
+  const response = await fetch('...');
+  const data = await response.json();
 
   return data.map((post) => {
     return {

--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -150,7 +150,7 @@ To pass additional data to each generated page, you can set a `props` value on e
 
 For example, if you generate pages with data fetched from a remote API, you can pass the full data object to the page component inside of `getStaticPaths()`. The page template can reference the data from each post using `Astro.props`.
 
-```astro title="src/pages/posts/[id].astro" {8}
+```astro title="src/pages/posts/[id].astro" {9}
 ---
 export async function getStaticPaths() {
   const response = await fetch('...');


### PR DESCRIPTION
#### Description (required)

syntax mixing async/await and chained promise methods found in `routing-reference.mdx`

the change also conforms with the format of the `paginate()` sample which sits a few lines below