### PR TITLE
Fix Markdoc partial tag documentation

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -287,7 +287,7 @@ import { Tabs } from '@astrojs/starlight/components';
 
 ## Markdoc Partials
 
-The `{% partial %}` tag allows you to render other `.mdoc` files inside your Markdoc content.
+The `{% partial /%}` tag allows you to render other `.mdoc` files inside your Markdoc content.
 
 This is useful for reusing content across multiple documents, and allows you to have `.mdoc` content files that do not follow your collection schema.
 
@@ -305,12 +305,12 @@ Social links:
 - [GitHub](https://github.com/withastro/astro)
 ```
 
-Use the `{% partial %}` tag with to render the footer at the bottom of a blog post entry. Apply the `file` attribute with the path to the file, using either a relative path or an import alias:
+Use the `{% partial /%}` tag with to render the footer at the bottom of a blog post entry. Apply the `file` attribute with the path to the file, using either a relative path or an import alias:
 
 ```md title="src/content/blog/post.mdoc" ins='file="_footer.mdoc"'
 # My Blog Post
 
-{% partial file="./_footer.mdoc" %}
+{% partial file="./_footer.mdoc" /%}
 ```
 
 ## Syntax highlighting


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In Markdoc, the [`partial`](https://markdoc.dev/docs/partials) tag is a [self-closed tag](https://markdoc.dev/docs/tags) that should be closed with a `/`.

This PR updates the documentation to reflect that issue [spotted in Discord](https://discord.com/channels/830184174198718474/1075516604428857344/1358738618931220630).

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->