### PR TITLE
fix(css): prevent `LearnAstroAd` from being cut off when TOC is long

### DIFF
--- a/src/components/starlight/PageSidebar.astro
+++ b/src/components/starlight/PageSidebar.astro
@@ -31,7 +31,7 @@ const Banner = LearnAstroAd || StarlightBanner;
 	.right-sidebar-panel {
 		flex-direction: column;
 		justify-content: space-between;
-		height: 100%;
+		min-height: 100%;
 		padding: 1rem var(--sl-sidebar-pad-x);
 	}
 	.sl-container {


### PR DESCRIPTION
#### Description

- This PR adjusts CSS to prevent `LearnAstroAd` component from being cut off when the table of contents is long

#### Related issues & labels

- Closes #11378
- Suggested label: `design`

#### Demonstration

| Before | After |
| ------ | ----- |
| ![long-toc-before](https://github.com/user-attachments/assets/42ea9beb-c282-49a6-9363-808215ebf66e) | ![long-toc-after](https://github.com/user-attachments/assets/f958d947-ecf8-4807-aa5f-7f01f988d969) |








