### PR TITLE
i18n(zh-cn): fix missing code block closing tag in `configuring-astro.mdx`

### DIFF
--- a/src/content/docs/zh-cn/guides/configuring-astro.mdx
+++ b/src/content/docs/zh-cn/guides/configuring-astro.mdx
@@ -94,6 +94,7 @@ const { ...props } = Astro.props;
     <!-- 你的页面内容在这 -->
   </body>
 </html>
+```
 
 因为 `Head.astro` 只是一个常规的 Astro 组件，所以你可以导入文件并接收从其他组件传递的 props，例如特定的页面标题。
 


### PR DESCRIPTION
**Description (required)**

Added missing ``` marker in `configuring-astro.mdx`.