### PR TITLE
i18n(es): translate `unsupported-external-redirect.mdx`

### DIFF
--- a/src/content/docs/ar/reference/errors/unsupported-external-redirect.mdx
+++ b/src/content/docs/ar/reference/errors/unsupported-external-redirect.mdx
@@ -1,0 +1,15 @@
+---
+title: URL no compatible o con formato incorrecto.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **UnsupportedExternalRedirect**: Una redirección externa debe comenzar con http o https, y debe ser una URL válida.
+
+## ¿Qué salió mal?
+
+Una redirección externa debe comenzar con http o https, y debe ser una URL válida.
+
+**Ver también:**
+
+- [Astro.redirect](/es/reference/api-reference/#redirect)


### PR DESCRIPTION

#### Description (required)
translate to spanish