### PR TITLE
Update 1.mdx

### DIFF
--- a/src/content/docs/en/tutorial/2-pages/1.mdx
+++ b/src/content/docs/en/tutorial/2-pages/1.mdx
@@ -42,10 +42,10 @@ Right now, your "About" page should look exactly the same as the first page, but
 
 Edit the HTML content to make this page about you.
 
-To change or add more content to your About page, add more HTML element tags containing content. You can copy and paste the HTML code below between the existing `<body></body>` tags, or create your own.
+To change or add more content to your About page, add more HTML element tags containing content. You can copy and paste the HTML code below between the existing `<Layout></Layout>` tags, or create your own.
 
 ```astro title="src/pages/about.astro" ins={3-8} del={2}
-<body>
+<Layout>
   <h1>My Astro Site</h1>
   <h1>About Me</h1>
   <h2>... and my new Astro site!</h2>
@@ -53,7 +53,7 @@ To change or add more content to your About page, add more HTML element tags con
   <p>I am working through Astro's introductory tutorial. This is the second page on my website, and it's the first one I built myself!</p>
 
   <p>This site will update as I complete more of the tutorial, so keep checking back and see how my journey is going!</p>
-</body>
+</Layout>
 ```
 
 Now, visit your `/about` page in your browser tab again, and you should see your updated content.


### PR DESCRIPTION
Changed `<body></body>` for `<Layout></Layout>`  in about.astro as the new astro setup wizard generate a Layout.astro

Place of the error:
https://docs.astro.build/en/tutorial/2-pages/1/

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
When beginners follow the "Build a blog" tutorial and create about.astro, the content of that page shouldn't include `<body</body>` tag as the new Astro setup wizard generate a layout.astro which already has `<body><slot/></body>`.
The `about.astro` page should be rendered as `<slot/>`, hence the proposed change.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
