### PR TITLE
fix: change access signature to `Astro.session`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -427,10 +427,10 @@ Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv
 
 3. You can then use sessions in your server code:
 
-    ```astro title="src/components/CartButton.astro" "Astro.session.get('cart')"
+    ```astro title="src/components/CartButton.astro" "Astro.session?.get('cart')"
     ---
     export const prerender = false;
-    const cart = await Astro.session.get('cart');
+    const cart = await Astro.session?.get('cart');
     ---
 
     <a href="/checkout">🛒 {cart?.length ?? 0} items</a>

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -18,7 +18,7 @@ Unlike [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored
 ```astro title="src/components/CartButton.astro" {3}
 ---
 export const prerender = false; // Not needed with 'server' output
-const cart = await Astro.session.get('cart');
+const cart = await Astro.session?.get('cart');
 ---
 
 <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
@@ -61,7 +61,7 @@ In `.astro` components and pages, you can access the session object via the glob
 ```astro title="src/components/CartButton.astro" "Astro.session"
 ---
 export const prerender = false; // Not needed with 'server' output
-const cart = await Astro.session.get('cart');
+const cart = await Astro.session?.get('cart');
 ---
 
 <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
@@ -73,13 +73,13 @@ In API endpoints, the session object is available on the `context` object. For e
 
 ```ts title="src/pages/api/addToCart.ts" "context.session"
 export async function POST(context: APIContext) {
-  const cart = await context.session.get('cart') || [];
+  const cart = await context.session?.get('cart') || [];
 	const data = await context.request.json<{ item: string }>();
   if(!data?.item) {
     return new Response('Item is required', { status: 400 });
   }
   cart.push(data.item);
-  await context.session.set('cart', cart);
+  await context.session?.set('cart', cart);
   return Response.json(cart);
 }
 ```
@@ -96,9 +96,9 @@ export const server = {
   addToCart: defineAction({
     input: z.object({ productId: z.string() }),
     handler: async (input, context) => {
-      const cart = await context.session.get('cart');
+      const cart = await context.session?.get('cart');
       cart.push(input.productId);
-      await context.session.set('cart', cart);
+      await context.session?.set('cart', cart);
       return cart;
     },
   }),
@@ -117,7 +117,7 @@ In middleware, the session object is available on the `context` object. For exam
 import { defineMiddleware } from 'astro:middleware';
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  context.session.set('lastVisit', new Date());
+  context.session?.set('lastVisit', new Date());
   return next();
 });
 ```
@@ -144,13 +144,13 @@ This will allow you to access the session data with type-checking and auto-compl
 
 ```ts title="src/components/CartButton.astro"
 ---
-const cart = await Astro.session.get('cart');
+const cart = await Astro.session?.get('cart');
 // const cart: string[] | undefined
 
-const something = await Astro.session.get('something');
+const something = await Astro.session?.get('something');
 // const something: any
 
-Astro.session.set('user', { id: 1, name: 'Houston' });
+Astro.session?.set('user', { id: 1, name: 'Houston' });
 // Error: Argument of type '{ id: number; name: string }' is not assignable to parameter of type '{ id: string; name: string; }'.
 ---
 ```

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -854,9 +854,9 @@ Returns the value of the given key in the session. If the key does not exist, it
 
 <Tabs>
   <TabItem label="Astro.session">
-    ```astro title="src/components/Cart.astro" "Astro.session.get('cart')"
+    ```astro title="src/components/Cart.astro" "Astro.session?.get('cart')"
     ---
-    const cart = await Astro.session.get('cart');
+    const cart = await Astro.session?.get('cart');
     ---
     <button>🛒 {cart?.length}</button>
     ```
@@ -886,10 +886,10 @@ Sets the value of the given key in the session. The value can be any serializabl
 
 <Tabs>
   <TabItem label="Astro.session">
-    ```astro title="src/pages/products/[slug].astro" "Astro.session.set('lastViewedProduct', slug)"
+    ```astro title="src/pages/products/[slug].astro" "Astro.session?.set('lastViewedProduct', slug)"
     ---
     const { slug } = Astro.params;
-    Astro.session.set('lastViewedProduct', slug);
+    Astro.session?.set('lastViewedProduct', slug);
     ---
     ```
   </TabItem>
@@ -922,9 +922,9 @@ Regenerates the session ID. Call this when a user logs in or escalates their pri
 
 <Tabs>
   <TabItem label="Astro.session">
-    ```astro title="src/pages/welcome.astro" "Astro.session.regenerate()"
+    ```astro title="src/pages/welcome.astro" "Astro.session?.regenerate()"
     ---
-    Astro.session.regenerate();
+    Astro.session?.regenerate();
     ---
     ```
   </TabItem>
@@ -956,9 +956,9 @@ Destroys the session, deleting the cookie and the object from the backend. Call 
 
 <Tabs>
   <TabItem label="Astro.session">
-    ```astro title="src/pages/logout.astro" "Astro.session.destroy()"
+    ```astro title="src/pages/logout.astro" "Astro.session?.destroy()"
     ---
-    Astro.session.destroy();
+    Astro.session?.destroy();
     return Astro.redirect('/login');
     ---
     ```
@@ -987,12 +987,12 @@ Loads a session by ID. In normal use, a session is loaded automatically from the
 
 <Tabs>
   <TabItem label="Astro.session">
-    ```astro title="src/pages/cart.astro" "Astro.session.load('session-id')"
+    ```astro title="src/pages/cart.astro" "Astro.session?.load('session-id')"
     ---
     // Load the session from a header instead of cookies
     const sessionId = Astro.request.headers.get('x-session-id');
-    await Astro.session.load(sessionId);
-    const cart = await Astro.session.get('cart');
+    await Astro.session?.load(sessionId);
+    const cart = await Astro.session?.get('cart');
     ---
     <h1>Your cart</h1>
     <ul>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR fixes the call of `Astro.session` and `ctx.session`. The `session` object *might* be `undefined`, so we need the `?` to gracefully handle its access.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

