### PR TITLE
[tutorial] update install commands for create astro

### DIFF
--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -31,7 +31,7 @@ The preferred way to create a new Astro site is through our `create astro` setup
       <Fragment slot="npm">
       ```shell
       # create a new project with npm
-      npm create astro@lastest
+      npm create astro@latest
       ```
       </Fragment>
       <Fragment slot="pnpm">

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -31,24 +31,24 @@ The preferred way to create a new Astro site is through our `create astro` setup
       <Fragment slot="npm">
       ```shell
       # create a new project with npm
-      npm create astro@latest -- --template minimal
+      npm create astro@lastest
       ```
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
       # create a new project with pnpm
-      pnpm create astro@latest --template minimal
+      pnpm create astro@latest
       ```
       </Fragment>
       <Fragment slot="yarn">
       ```shell
       # create a new project with yarn
-      yarn create astro --template minimal
+      yarn create astro
       ```
       </Fragment>
     </PackageManagerTabs>
 
-2. Confirm `y` to install `create-astro`
+2. Confirm `y` to install `create-astro`.
 3. When the prompt asks you where to create the project, type in the name of a folder to create a new directory for your project, e.g.
 `./tutorial`
 
@@ -56,9 +56,11 @@ The preferred way to create a new Astro site is through our `create astro` setup
     A new Astro project can only be created in a completely empty folder, so choose a name for your folder that does not already exist!
     :::
 
-4. When the prompt asks you whether or not to install dependencies, type or select `y`.
+4. You will see a short list of starter templates to choose from. Use the arrow keys (up and down) to navigate to the minimal (empty) template, and then press return (enter) to submit your choice.
 
-5. When the prompt asks you whether or not to initialize a new git repository, type or select `y`.
+5. When the prompt asks you whether or not to install dependencies, type or select `y`.
+
+6. When the prompt asks you whether or not to initialize a new git repository, type or select `y`.
 </Steps>
 
 When the install wizard is complete, you no longer need this terminal. You can now open VS Code to continue.

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -48,7 +48,7 @@ The preferred way to create a new Astro site is through our `create astro` setup
       </Fragment>
     </PackageManagerTabs>
 
-2. Confirm `y` to install `create-astro`.
+2. Press `y` to install `create-astro`.
 3. When the prompt asks you where to create the project, type in the name of a folder to create a new directory for your project, e.g.
 `./tutorial`
 

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -48,7 +48,7 @@ The preferred way to create a new Astro site is through our `create astro` setup
       </Fragment>
     </PackageManagerTabs>
 
-2. Press `y` to install `create-astro`.
+2. Enter `y` to install `create-astro`.
 3. When the prompt asks you where to create the project, type in the name of a folder to create a new directory for your project, e.g.
 `./tutorial`
 
@@ -58,9 +58,9 @@ The preferred way to create a new Astro site is through our `create astro` setup
 
 4. You will see a short list of starter templates to choose from. Use the arrow keys (up and down) to navigate to the minimal (empty) template, and then press return (enter) to submit your choice.
 
-5. When the prompt asks you whether or not to install dependencies, type or select `y`.
+5. When the prompt asks you whether or not to install dependencies, enter `y`.
 
-6. When the prompt asks you whether or not to initialize a new git repository, type or select `y`.
+6. When the prompt asks you whether or not to initialize a new git repository, enter `y`.
 </Steps>
 
 When the install wizard is complete, you no longer need this terminal. You can now open VS Code to continue.

--- a/src/content/docs/en/tutorial/1-setup/2.mdx
+++ b/src/content/docs/en/tutorial/1-setup/2.mdx
@@ -68,11 +68,11 @@ When the install wizard is complete, you no longer need this terminal. You can n
 ## Open your project in VS Code
 
 <Steps>
-6. Open VS Code. You will be prompted to open a folder. Choose the folder that you created during the setup wizard.
+7. Open VS Code. You will be prompted to open a folder. Choose the folder that you created during the setup wizard.
 
-7. If this is your first time opening an Astro project, you should see a notification asking if you would like to install recommended extensions. Click to see the recommended extensions, and choose the [Astro language support extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode). This will provide syntax highlighting and autocompletions for your Astro code.
+8. If this is your first time opening an Astro project, you should see a notification asking if you would like to install recommended extensions. Click to see the recommended extensions, and choose the [Astro language support extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode). This will provide syntax highlighting and autocompletions for your Astro code.
 
-8. Make sure the terminal is visible and that you can see the command prompt, such as:
+9. Make sure the terminal is visible and that you can see the command prompt, such as:
 
     ```sh
     user@machine:~/tutorial$
@@ -94,7 +94,7 @@ In order to preview your project files _as a website_ while you work, you will n
 ### Start the dev server
 
 <Steps>
-9. Run the command to start the Astro dev server by typing into VS Code's terminal:
+10. Run the command to start the Astro dev server by typing into VS Code's terminal:
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -122,7 +122,7 @@ In order to preview your project files _as a website_ while you work, you will n
 Your project files contain all the code necessary to display an Astro website, but the browser is responsible for displaying your code as web pages.
 
 <Steps>
-10. Click on the `localhost` link in your terminal window to see a live preview of your new Astro website! 
+11. Click on the `localhost` link in your terminal window to see a live preview of your new Astro website! 
 
     (Astro uses `http://localhost:4321` by default if port `4321` is available.)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the tutorial installation instructions because they can now choose the minimal template directly from create astro and no longer need a flag to install it. Yay!

#### Related issues & labels (optional)

- Closes #10843 
