### PR TITLE
docs: fix typo of `srcDir`

### DIFF
--- a/src/content/docs/en/reference/modules/astro-config.mdx
+++ b/src/content/docs/en/reference/modules/astro-config.mdx
@@ -61,7 +61,7 @@ import {
   base,
   build,
   site,
-  srcDirc,
+  srcDir,
   cacheDir,
   outDir,
   publicDir,
@@ -114,7 +114,7 @@ See more about the configuration imports available from `astro:config/server`:
 - [`build.serverEntry`](/en/reference/configuration-reference/#buildserverentry)
 - [`build.assetsPrefix`](/en/reference/configuration-reference/#buildassetsprefix)
 - [`site`](/en/reference/configuration-reference/#site)
-- [`srcDirc`](/en/reference/configuration-reference/#srcdir)
+- [`srcDir`](/en/reference/configuration-reference/#srcdir)
 - [`cacheDir`](/en/reference/configuration-reference/#cachedir)
 - [`outDir`](/en/reference/configuration-reference/#outdir)
 - [`publicDir`](/en/reference/configuration-reference/#publicdir)

--- a/src/content/docs/fr/reference/modules/astro-config.mdx
+++ b/src/content/docs/fr/reference/modules/astro-config.mdx
@@ -61,7 +61,7 @@ import {
   base,
   build,
   site,
-  srcDirc,
+  srcDir,
   cacheDir,
   outDir,
   publicDir,
@@ -114,7 +114,7 @@ En savoir plus sur les importations de configuration disponibles à partir de `a
 - [`build.serverEntry`](/fr/reference/configuration-reference/#buildserverentry)
 - [`build.assetsPrefix`](/fr/reference/configuration-reference/#buildassetsprefix)
 - [`site`](/fr/reference/configuration-reference/#site)
-- [`srcDirc`](/fr/reference/configuration-reference/#srcdir)
+- [`srcDir`](/fr/reference/configuration-reference/#srcdir)
 - [`cacheDir`](/fr/reference/configuration-reference/#cachedir)
 - [`outDir`](/fr/reference/configuration-reference/#outdir)
 - [`publicDir`](/fr/reference/configuration-reference/#publicdir)

--- a/src/content/docs/ko/reference/modules/astro-config.mdx
+++ b/src/content/docs/ko/reference/modules/astro-config.mdx
@@ -61,7 +61,7 @@ import {
   base,
   build,
   site,
-  srcDirc,
+  srcDir,
   cacheDir,
   outDir,
   publicDir,
@@ -114,7 +114,7 @@ export default function() {
 - [`build.serverEntry`](/ko/reference/configuration-reference/#buildserverentry)
 - [`build.assetsPrefix`](/ko/reference/configuration-reference/#buildassetsprefix)
 - [`site`](/ko/reference/configuration-reference/#site)
-- [`srcDirc`](/ko/reference/configuration-reference/#srcdir)
+- [`srcDir`](/ko/reference/configuration-reference/#srcdir)
 - [`cacheDir`](/ko/reference/configuration-reference/#cachedir)
 - [`outDir`](/ko/reference/configuration-reference/#outdir)
 - [`publicDir`](/ko/reference/configuration-reference/#publicdir)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I noticed the typo while browsing the docs
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
