### PR TITLE
Fix: Adds inline to Fonts Tailwind v4 instructions

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -116,7 +116,7 @@ body {
 
     <TabItem label="Tailwind CSS 4.0">
 
-    ```css title="src/styles/global.css" ins={4}
+    ```css title="src/styles/global.css" ins={4} ins="inline"
     @import 'tailwindcss';
 
     @theme inline {

--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -119,7 +119,7 @@ body {
     ```css title="src/styles/global.css" ins={4}
     @import 'tailwindcss';
 
-    @theme {
+    @theme inline {
         --font-sans: var(--font-roboto);
     }
     ```


### PR DESCRIPTION
#### Description (required)

Changes `@theme {}` instructions for tailwind to `@theme inline {}` per the tailwind docs:
<https://tailwindcss.com/docs/theme#referencing-other-variables>

#### Related issues & labels (optional)

- Closes #11490 

