### PR TITLE
Update README and add a summary of translation progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Join our i18n gang on Discord or jump into the PRs to help with reviewing existi
 
 Check out the dedicated [i18n guide](https://contribute.docs.astro.build/guides/i18n/) for more details.
 
+### Translation progress
+
+<a href="https://i18n.docs.astro.build/">
+  <img alt="Details of each language’s progress translating the Astro Docs" width="600" src="https://i18n.docs.astro.build/summary.svg" />
+</a>
+
 ## Next Steps
 
 - [Read the docs](https://docs.astro.build/)

--- a/scripts/lunaria.mts
+++ b/scripts/lunaria.mts
@@ -1,11 +1,13 @@
 import { createLunaria } from '@lunariajs/core';
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { Page } from './lunaria/components.ts';
+import { Page, SvgSummary } from './lunaria/components.ts';
 
 const lunaria = await createLunaria();
 const status = await lunaria.getFullStatus();
 
 const html = Page(lunaria.config, status, lunaria);
+const svg = SvgSummary(lunaria.config, status);
 
 mkdirSync('dist/lunaria', { recursive: true });
 writeFileSync('dist/lunaria/index.html', html);
+writeFileSync('dist/lunaria/summary.svg', svg);

--- a/scripts/lunaria/components.ts
+++ b/scripts/lunaria/components.ts
@@ -7,7 +7,10 @@ import {
 } from '@lunariajs/core';
 import { BaseStyles, CustomStyles } from './styles';
 
-export function html(strings: TemplateStringsArray, ...values: (string | string[])[]) {
+export function html(
+	strings: TemplateStringsArray,
+	...values: ((string | number) | (string | number)[])[]
+) {
 	const treatedValues = values.map((value) => (Array.isArray(value) ? value.join('') : value));
 
 	return String.raw({ raw: strings }, ...treatedValues);

--- a/scripts/lunaria/components.ts
+++ b/scripts/lunaria/components.ts
@@ -363,3 +363,72 @@ export const TitleParagraph = html`
 		to learn about our translation process and how you can get involved.
 	</p>
 `;
+
+/**
+ * Build an SVG file showing a summary of each language’s translation progress.
+ */
+export const SvgSummary = (config: LunariaConfig, status: LunariaStatus): string => {
+	const localeHeight = 56; // Each locale’s summary is 56px high.
+	const svgHeight = localeHeight * Math.ceil(config.locales.length / 2);
+	return html`<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 400 ${svgHeight}"
+		font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"
+	>
+		${config.locales
+			.map((locale) => SvgLocaleSummary(status, locale))
+			.sort((a, b) => b.progress - a.progress)
+			.map(
+				({ svg }, index) =>
+					html`<g transform="translate(${(index % 2) * 215} ${Math.floor(index / 2) * 56})"
+						>${svg}</g
+					>`
+			)}
+	</svg>`;
+};
+
+function SvgLocaleSummary(
+	status: LunariaStatus,
+	{ label, lang }: Locale
+): { svg: string; progress: number } {
+	const missingFiles = status.filter(
+		(file) =>
+			file.localizations.find((localization) => localization.lang === lang)?.status === 'missing'
+	);
+	const outdatedFiles = status.filter((file) => {
+		const localization = file.localizations.find((localization) => localization.lang === lang);
+		if (!localization || localization.status === 'missing') {
+			return false;
+		} else if (file.type === 'dictionary') {
+			return 'missingKeys' in localization ? localization.missingKeys.length > 0 : false;
+		} else {
+			return (
+				localization.status === 'outdated' ||
+				('missingKeys' in localization && localization.missingKeys.length > 0)
+			);
+		}
+	});
+
+	const doneLength = status.length - outdatedFiles.length - missingFiles.length;
+	const barWidth = 184;
+	const doneFraction = doneLength / status.length;
+	const outdatedFraction = outdatedFiles.length / status.length;
+	const doneWidth = (doneFraction * barWidth).toFixed(2);
+	const outdatedWidth = ((outdatedFraction + doneFraction) * barWidth).toFixed(2);
+
+	return {
+		progress: doneFraction,
+		svg: html`<text x="0" y="12" font-size="11" font-weight="600" fill="#999"
+				>${label} (${lang})</text
+			>
+			<text x="0" y="26" font-size="9" fill="#999">
+				${missingFiles.length == 0 && outdatedFiles.length == 0
+					? '100% complete, amazing job! 🎉'
+					: html`${doneLength} done, ${outdatedFiles.length} outdated, ${missingFiles.length}
+						missing`}
+			</text>
+			<rect x="0" y="34" width="${barWidth}" height="8" fill="#999" opacity="0.25"></rect>
+			<rect x="0" y="34" width="${outdatedWidth}" height="8" fill="#fb923c"></rect>
+			<rect x="0" y="34" width="${doneWidth}" height="8" fill="#c084fc"></rect>`,
+	};
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Generates a `summary.svg` file as part of Lunaria builds that shows progress for each locale.
- Adds this with a link to our Lunaria dashboard to the README.


#### Notes

- To support reasonable display on both light and dark backgrounds, this uses a somewhat muted grey text colour. This colour has roughly a 10:1 contrast ratio against both black and white.
- On mobile screens the text will appear slightly small, but I tried to strike a balance between a decent display on desktop and mobile.
- We only build Lunaria on `main` so can’t really preview this PR but here are a few examples:

##### Example output

<img alt="a grid of language entries each showing a language’s name, the number of completed, outdated, and missing translations, and a progress bar representing the same" width="600" src="https://github.com/user-attachments/assets/2f138725-cb06-4201-8c57-89af77f306b9">

##### Example in context in `README.md`

<img width="1055" alt="the same image as above but now embedded in the docs README with a “Translation progress” heading above it" src="https://github.com/user-attachments/assets/01df6436-e45f-4d30-89ca-fb4526527f63" />
