### PR TITLE
Update routing.mdx to reflect the need for adapters and prerender binding in SSR mode

### DIFF
--- a/src/content/docs/en/guides/cms/preprcms.mdx
+++ b/src/content/docs/en/guides/cms/preprcms.mdx
@@ -142,7 +142,7 @@ Your root directory should include these new files:
 
 #### Creating individual blog post pages
 
-To create a page for each blog post, you will execute a new GraphQL query on a [dynamic routing](/en/guides/routing/#server-ssr-mode) `.astro` page. This query will fetch a specific article by its slug and a new page will be created for each individual blog post.
+To create a page for each blog post, you will execute a new GraphQL query on a [dynamic routing](/en/guides/routing/#on-demand-dynamic-routes) server-ssr-mode) `.astro` page. This query will fetch a specific article by its slug and a new page will be created for each individual blog post.
 
 <Steps>
 1. Create a file called `get-article-by-slug.js` in the `queries` folder and add the following to query a specific article by its slug and return data such as the article `title` and `content`:

--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -320,7 +320,7 @@ Make sure to choose the right rendering for your content. For markdown check out
 
 #### On-demand rendering
 
-If you've [opted into on-demand rendering with an adapter](/en/guides/on-demand-rendering/), [generate your dynamic routes](/en/guides/routing/#server-ssr-mode) using the following code:
+If you've [opted into on-demand rendering with an adapter](/en/guides/on-demand-rendering/), [generate your dynamic routes](/en/guides/routing/#on-demand-dynamic-routes) using the following code:
 
 Create the `src/pages/blog/[slug].astro` file:
 

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -193,8 +193,10 @@ In [SSR mode](/en/guides/on-demand-rendering/), dynamic routes are defined the s
 
 For on-demand rendered routes, only one rest parameter using the spread notation may be used in the file name (e.g. `src/pages/[locale]/[...slug].astro` or `src/pages/[...locale]/[slug].astro`, but not `src/pages/[...locale]/[...slug].astro`).
 
+you will need a [adapter](https://docs.astro.build/en/guides/integrations-guide/)
 ```astro title="src/pages/resources/[resource]/[id].astro"
 ---
+export const prerender = false;
 const { resource, id } = Astro.params;
 ---
 <h1>{resource}: {id}</h1>

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -187,16 +187,15 @@ const { title, text } = Astro.props;
 </html>
 ```
 
-### Server (SSR) Mode
+### On-demand dynamic routes
 
-In [SSR mode](/en/guides/on-demand-rendering/), dynamic routes are defined the same way: include `[param]` or `[...path]` brackets in your file names to match arbitrary strings or paths. But because the routes are no longer built ahead of time, the page will be served to any matching route. Since these are not "static" routes, `getStaticPaths` should not be used.
+For [on-demand rendering](/en/guides/on-demand-rendering/) with an adapter, dynamic routes are defined the same way: include `[param]` or `[...path]` brackets in your file names to match arbitrary strings or paths. But because the routes are no longer built ahead of time, the page will be served to any matching route. Since these are not "static" routes, `getStaticPaths` should not be used.
 
 For on-demand rendered routes, only one rest parameter using the spread notation may be used in the file name (e.g. `src/pages/[locale]/[...slug].astro` or `src/pages/[...locale]/[slug].astro`, but not `src/pages/[...locale]/[...slug].astro`).
 
-you will need a [adapter](https://docs.astro.build/en/guides/integrations-guide/)
 ```astro title="src/pages/resources/[resource]/[id].astro"
 ---
-export const prerender = false;
+export const prerender = false; // Not needed in 'server' mode
 const { resource, id } = Astro.params;
 ---
 <h1>{resource}: {id}</h1>


### PR DESCRIPTION
I added a change to the “SSR Mode” topic, because an error occurred when I tried to create dynamic routes using SSR instead of SSG. The error in question complains about the lack of “getStaticPaths()” when I try to create the build with dynamic routes without a “getStaticPaths()”. The solution I found in programming communities was to add an extra line, disabling “pre-rendering” in conjunction with an integrated SSR adapter.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
