### PR TITLE
view-transitions: add warning about Firefox video breakage with animate

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -483,6 +483,8 @@ import { ClientRouter } from "astro:transitions";
 
 :::note[Known limitations]
 The `initial` browser animation is not simulated by Astro. So any element using this animation will not currently be animated.
+
+On Firefox using `animate` will cause video playback on the new page to break. See [this GitHub issue](https://github.com/withastro/astro/issues/13477) for more information.
 :::
 
 ## Client-side navigation process


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The Astro view transition script has a limitation where video playback on the new page will fail on Firefox, since it is using Javascript to emulate view transitions on Firefox. This should be documented so that users are aware that video playback won't work with swapped pages on Firefox if the `animate` fallback is used.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
