### PR TITLE
fix(guides/imports): update Node.js built-ins section

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -361,21 +361,24 @@ Astro supports loading WASM files directly into your application using the brows
 
 ## Node Builtins
 
-We encourage Astro users to avoid Node.js builtins (`fs`, `path`, etc.) whenever possible. Astro is compatible with multiple runtimes using [adapters](/en/guides/on-demand-rendering/). This includes [Deno](https://github.com/denoland/deno-astro-adapter) and [Cloudflare Workers](/en/guides/integrations-guide/cloudflare/) which do not support Node builtin modules such as `fs`.
+Astro supports Node.js built-ins, with some limitations, using Node’s newer `node:` prefix. There may be differences between development and production, and some features may be incompatible with on-demand rendering. Some [adapters](/en/guides/on-demand-rendering/) may also be incompatible with these built-ins modules or require configuration to support a subset (e.g., [Cloudflare Workers](/en/guides/integrations-guide/cloudflare/) or [Deno](https://github.com/denoland/deno-astro-adapter)).
 
-Our aim is to provide Astro alternatives to common Node.js builtins. However, no such alternatives exist today. So, if you _really_ need to use these builtin modules we don't want to stop you. Astro supports Node.js builtins using Node’s newer `node:` prefix. If you want to read a file, for example, you can do so like this:
+The following example imports the `util` module from Node to parse a media type (MIME):
 
 ```astro title="src/components/MyComponent.astro"
 ---
-// Example: import the "fs/promises" builtin from Node.js
-import fs from 'node:fs/promises';
+// Example: import the "util" built-in from Node.js
+import util from 'node:util';
 
-const url = new URL('../../package.json', import.meta.url);
-const json = await fs.readFile(url, 'utf-8');
-const data = JSON.parse(json);
+export interface Props {
+  mimeType: string,
+}
+
+const mime = new util.MIMEType(Astro.props.mimeType)
 ---
 
-<span>Version: {data.version}</span>
+<span>Type: {mime.type}</span>
+<span>SubType: {mime.subtype}</span>
 ```
 
 ## Extending file type support


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the `Node.js builtins` section in `guides/imports` to fix an incorrect example and to improve the wordings:
* replace the example with the one provided by Fryuni in the issue
* reword the intro to avoid blaming people that use Node.js built-ins
* remove incorrect statement 

I don't think I was in this (these? 😅 ) T&D or I don't recall... so maybe the idea was to not mention adapters at all? I'm referring to this comment: https://github.com/withastro/docs/issues/7785#issuecomment-2371273677

Note: I'm not a native speaker but I believe `built-in`/`builtin` are the same... I used `built-in` because it seems to be the syntax used in other pages (I checked with Algolia). Should we update the heading as well?

#### Related issues & labels (optional)

- Closes #7785 (I think after a year it's time to close this one 😄 )
- Suggested label: improve or update documentation

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
