### PR TITLE
[issue template] improve distinction between issue and discussion topics

### DIFF
--- a/.github/ISSUE_TEMPLATE/CONTENT.yml
+++ b/.github/ISSUE_TEMPLATE/CONTENT.yml
@@ -1,7 +1,7 @@
 name: "Incorrect Content Report 📄"
 description: Report a correction to docs.
 labels: [
-  "improve documentation"
+  "improve or update documentation"
 ]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/CONTENT.yml
+++ b/.github/ISSUE_TEMPLATE/CONTENT.yml
@@ -1,5 +1,5 @@
 name: "Incorrect Content Report 📄"
-description: Report an issue with existing content.
+description: Report a correction to docs.
 labels: [
   "improve documentation"
 ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: 💡 New content idea
+  - name: 💡 Ideas for docs improvements or new content
     url: https://github.com/withastro/docs/discussions/new?category=ideas
-    about: Share an idea for new content.
+    about: Share an idea for updating the docs with new or improved content.
   - name: 💁 Support & Community
     url: https://astro.build/chat
     about: 'This issue tracker is not for support questions. Join us on Discord for assistance!'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This helps to guide people to making discussions for topics that are not errors/incorrect statements to be fixed in docs. It emphasizes that improvements (not just new content) should be made as discussion topics, so that critical errors are easier to spot and triage.