### PR TITLE
i18n(ja) Create `guides/integrations-guide/cloudflare`

### DIFF
--- a/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
@@ -1,0 +1,539 @@
+---
+type: integration
+title: '@astrojs/cloudflare'
+description: "@astrojs/cloudflare" SSRアダプターを使用してAstroプロジェクトをデプロイする方法
+sidebar:
+  label: Cloudflare
+githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
+category: adapter
+i18nReady: false
+---
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import ReadMore from '~/components/ReadMore.astro';
+import Since from '~/components/Since.astro';
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+
+
+この**[Astroインテグレーション][astro-integration]**で[Cloudflare](https://www.cloudflare.com/)の[オンデマンドレンダリング](/ja/guides/on-demand-rendering/)を有効にできます。
+
+Astroを静的サイトジェネレーターとして使用している場合、このアダプターは必要ありません。
+
+Astroサイトのデプロイ方法については、[Cloudflareデプロイメントガイド](/ja/guides/deploy/cloudflare/)をご覧ください。
+
+
+## Astro Cloudflareを選ぶ理由
+
+Cloudflareの[開発者プラットフォーム](https://developers.cloudflare.com/)では、ストレージやAIなどのリソースにアクセスできるフルスタックアプリケーションを開発でき、すべてグローバルエッジネットワークにデプロイされます。このアダプターはAstroプロジェクトをCloudflareにデプロイできるようにビルドします。
+
+## インストール
+
+Astroには公式インテグレーションを自動でセットアップするための`astro add`コマンドが含まれています。お好みで、[手動でインストール](#手動インストール)することもできます。
+
+`astro add`コマンドでCloudflareアダプターを追加して、AstroプロジェクトでSSRを有効にします。 これにより、`@astrojs/cloudflare`がインストールされ、`astro.config.mjs`ファイルに適切な変更が1ステップで行われます。
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npx astro add cloudflare
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm astro add cloudflare
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn astro add cloudflare
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+### 手動インストール
+
+まず、お好みのパッケージマネージャーを使用して、プロジェクトの依存関係に`@astrojs/cloudflare`アダプターを追加します。
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install @astrojs/cloudflare
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add @astrojs/cloudflare
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add @astrojs/cloudflare
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+次に、アダプターと[アウトプットモード](/ja/guides/on-demand-rendering/) を`astro.config.mjs`ファイルに追加します。
+
+```js title="astro.config.mjs" ins={2,5-6}
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  output: 'server',
+  adapter: cloudflare(),
+});
+```
+
+## オプション
+
+Cloudflareアダプターは、次のオプションをサポートしています。
+### `cloudflareModules`
+
+<p>
+**データー型:** `true | false`<br />
+**デフォルト値:** `true`
+</p>
+
+['.wasm'、'.bin'、および '.txt' モジュールのインポート](#モジュールのインポート) を有効にします。
+
+この機能はデフォルトで有効になっています。無効にする場合は、「cloudflareModules: false」を設定します。
+
+### imageService
+
+<p>
+**Type:** `'passthrough' | 'cloudflare' | 'compile' | 'custom'`<br />
+**Default:** `'compile'`
+</p>
+
+Determines which image service is used by the adapter. The adapter will default to `compile` mode when an incompatible image service is configured. Otherwise, it will use the globally configured image service:
+
+* **`cloudflare`:** Uses the [Cloudflare Image Resizing](https://developers.cloudflare.com/images/image-resizing/) service.
+* **`passthrough`:** Uses the existing [`noop`](/en/guides/images/#configure-no-op-passthrough-service) service.
+* **`compile`:** Uses Astro's default service (sharp), but only on pre-rendered routes at build time. During SSR for pages rendered on-demand, all `astro:assets` features are disabled.
+* **`custom`:** Always uses the image service configured in [Image Options](/en/reference/configuration-reference/#image-options). **This option will not check to see whether the configured image service works in Cloudflare's `workerd` runtime.**
+
+```js title="astro.config.mjs" ins={6}
+import {defineConfig} from "astro/config";
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare({
+     imageService: 'cloudflare'
+  }),
+  output: 'server'
+})
+```
+
+### platformProxy
+
+Determines whether and how the Cloudflare runtime is added to `astro dev`. It contains proxies to local `workerd` bindings and emulations of Cloudflare specific values, allowing the emulation of the runtime in the Node.js dev process. Read more about the [Cloudflare Runtime](#cloudflare-runtime).
+
+:::note
+Proxies provided by this are a best effort emulation of the real production. Although they are designed to be as close as possible to the real thing, there might be a slight differences and inconsistencies between the two.
+:::
+
+#### platformProxy.enabled
+<p>
+**Type:** `{ enabled?: boolean }`<br />
+**Default:** `{ enabled: false }`
+</p>
+
+The `enabled` property allows you to enable the Cloudflare runtime in `astro dev`.
+
+#### platformProxy.configPath
+<p>
+**Type:** `{ configPath?: string }`<br />
+**Default:** `{ configPath: 'wrangler.toml' }`
+</p>
+
+The `configPath` property allows you to define your Wrangler configuration file, relative to the root of your Astro project. 
+
+#### platformProxy.environment
+<p>
+**Type:** `{ environment?: string }`<br />
+**Default:** `{ environment: undefined }`
+</p>
+
+The `environment` property allows you to define which [environment configuration](https://developers.cloudflare.com/workers/wrangler/environments/) in your Wrangler configuration to use.
+
+#### platformProxy.persist
+<p>
+**Type:** `{ persist?: boolean | { path: string } }`<br />
+**Default:** `{ persist: true }`
+</p>
+
+The `persist` property defines if and where the bindings data is persistent. `true` defaults to the same location used by Wrangler so data can be shared between the two. If `false`, no data is persisted to or read from the filesystem.
+
+:::note
+`wrangler`'s `--persist-to` option adds a sub directory called `v3` under the hood while the `@astrojs/cloudflare` `persist` property does not. For example, to reuse the same location as running `wrangler dev --persist-to ./my-directory`, you must specify: `persist: { path: "./my-directory/v3" }`.
+:::
+
+The following configuration shows an example of enabling the Cloudflare runtime when running the development server, as well as using a `wrangler.json` config file. It also specifies a custom location for persisting data to the filesystem:
+
+
+```js
+import cloudflare from '@astrojs/cloudflare';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	adapter: cloudflare({
+		platformProxy: {
+			enabled: true,
+			configPath: 'wrangler.json',
+			persist: {
+				path: './.cache/wrangler/v3'
+			},
+		},
+	}),
+});
+```
+### routes.extend
+
+On Cloudflare Workers, this option is not applicable. Refer to [Routing on Cloudflare Workers](#routing-on-cloudflare-workers) for more information.
+
+On Cloudflare Pages, this option allows you to add or exclude custom patterns (e.g. `/fonts/*`) to the generated `_routes.json` file that determines which routes are generated on-demand. This can be useful if you need to add route patterns which cannot be automatically generated, or exclude prerendered routes.
+
+More information about the custom route patterns can be found in [Cloudflare's routing docs](https://developers.cloudflare.com/pages/functions/routing/#functions-invocation-routes). Any routes specified are not automatically deduplicated and will be appended to the existing routes as is.
+
+#### routes.extend.include
+
+<p>
+**Type:** `{ pattern: string }[]`<br />
+**Default:** `undefined`
+</p>
+
+Configure additional routes to be generated on demand by the Cloudflare adapter in the `routes.extend.include` array.
+
+#### routes.extend.exclude
+
+<p>
+**Type:** `{ pattern: string }[]`<br />
+**Default:** `undefined`
+</p>
+
+Configure routes to be excluded from on-demand rendering in the `routes.extend.exclude` array. These routes will be prerendered and served statically instead, and will not invoke the SSR function. Additionally you can use this option to serve any static asset (e.g. images, fonts, css, js, html, txt, json, etc.) files directly without routing the request through the SSR function.
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  adapter: cloudflare({
+    routes: {
+      extend: {
+        include: [{ pattern: '/static' }], // Route a prerended page to the SSR function for on-demand rendering
+        exclude: [{ pattern: '/pagefind/*' }], // Use Starlight's pagefind search, which is generated statically at build time
+      }
+    },
+  }),
+});
+```
+
+### sessionKVBindingName
+<p>
+**Type:** `string`<br />
+**Default:** `SESSION`
+<Since v="5.6.0" />
+</p>
+
+The `sessionKVBindingName` option allows you to specify the name of the KV binding used for session storage. By default, this is set to `SESSION`, but you can change it to match your own KV binding name. See [Sessions](#sessions) for more information.
+
+```js title="astro.config.mjs" "MY_SESSION_BINDING"
+export default defineConfig({
+  adapter: cloudflare({
+    sessionKVBindingName: 'MY_SESSION_BINDING',
+  }),
+});
+```
+
+## Cloudflare runtime
+
+### Usage
+
+The Cloudflare runtime gives you access to environment variables and bindings to Cloudflare resources.
+The Cloudflare runtime uses bindings found in the `wrangler.toml`/`wrangler.json` configuration file. 
+
+You can access the bindings from `Astro.locals.runtime`:
+
+```astro title="src/pages/index.astro"
+---
+const { env } = Astro.locals.runtime;
+---
+```
+You can access the runtime from API endpoints through `context.locals`:
+
+```js title="src/pages/api/someFile.js"
+export function GET(context) {
+  const runtime = context.locals.runtime;
+
+  return new Response('Some body');
+}
+```
+
+See the [list of all supported bindings](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings) in the Cloudflare documentation.
+
+
+### Environment variables and secrets
+
+The Cloudflare runtime treats environment variables as a type of binding.
+
+For example, you can define an [environment variable](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) in `wrangler.json` as follows:
+
+```json title="wrangler.json"
+{
+  "vars" : {
+    "MY_VARIABLE": "test"
+  }
+}
+```
+
+Secrets are a special type of environment variable that allow you to attach encrypted text values to your Worker. They need to be defined differently to ensure they are not visible after you set them.
+
+To define `secrets`, add them through the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) rather than in your Wrangler config file. 
+
+```bash
+npx wrangler secret put <KEY>
+```
+
+To set secrets for local development, you also need to add a `.dev.vars` file to the root of the Astro project:
+
+```ini title=".dev.vars"
+DB_PASSWORD=myPassword
+```
+
+You can then access environment variables, including secrets, from the `env` object available from `Astro.locals.runtime`:  
+
+```astro title="src/pages/index.astro"
+---
+const { env } = Astro.locals.runtime;
+const myVariable = env.MY_VARIABLE;
+const secret = env.DB_PASSWORD;
+---
+```
+
+Cloudflare environment variables and secrets are compatible with the [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables).
+
+### Typing
+
+`wrangler` provides a `types` command to generate TypeScript types for the bindings. This allows you to type locals without the need to manually type them. Refer to the [Cloudflare documentation](https://developers.cloudflare.com/workers/wrangler/commands/#types) for more information.
+
+Every time you change your configuration files (e.g. `wrangler.toml`, `.dev.vars`) you need to run `wrangler types`.
+
+:::note
+You can create a pnpm script to run `wrangler types` automatically before other commands.
+
+```json title="package.json"
+{
+  "scripts": {
+    "dev": "wrangler types && astro dev",
+    "start": "wrangler types && astro dev",
+    "build": "wrangler types && astro check && astro build",
+    "preview": "wrangler types && astro preview",
+    "astro": "astro"
+  }
+}
+```
+:::
+
+You can type the `runtime` object using `Runtime`:
+
+```ts title="src/env.d.ts"
+type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
+
+declare namespace App {
+  interface Locals extends Runtime {
+    otherLocals: {
+      test: string;
+    };
+  }
+}
+```
+
+## Cloudflare Platform
+
+### Headers
+
+You can attach [custom headers](https://developers.cloudflare.com/pages/platform/headers/) to your responses by adding a `_headers` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
+
+This is available on Cloudflare Workers and Pages.
+
+### Assets
+Assets built by Astro are all named with a hash and therefore can be given long cache headers. By default, Astro on Cloudflare will add such a header for these files.
+
+### Redirects
+
+You can declare [custom redirects](https://developers.cloudflare.com/pages/platform/redirects/) to redirect requests to a different URL. To do so, add a `_redirects` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
+
+This is available on Cloudflare Workers and Pages.
+
+### Routes
+#### Routing on Cloudflare Workers
+
+Routing for static assets is based on the file structure in the build directory (e.g. `./dist`). If no match is found, this will fall back to the Worker for SSR. Read more about [static asset routing with Cloudflare Workers](https://developers.cloudflare.com/workers/static-assets/routing/).
+
+Unlike [Cloudflare Pages](#routing-on-cloudflare-pages), with Workers, you do not need a `_routes.json` file. 
+
+Currently, the Cloudflare adapter always generates this file. To work around this, create a `.assetsignore` file in your `public/` folder, and add the following lines to it:
+  ```txt title="public/.assetsignore"
+  _worker.js
+  _routes.json
+  ```
+
+#### Routing on Cloudflare Pages
+
+For Cloudflare Pages, [routing](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) uses a `_routes.json` file to determine which requests are routed to the server function and which are served as static assets. By default, a `_routes.json` file will be automatically generated for your project based on its files and configuration.
+
+You can [specify additional routing patterns to follow](#routesextend) in your adapter config, or create your own custom `_routes.json` file to fully override the automatic generation.
+
+
+Creating a custom `public/_routes.json` will override the automatic generation. See [Cloudflare's documentation on creating a custom `_routes.json`](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file) for more details.
+
+## Sessions
+
+The Astro [Sessions API](/en/guides/sessions/) allows you to easily store user data between requests. This can be used for things like user data and preferences, shopping carts, and authentication credentials. Unlike cookie storage, there are no size limits on the data, and it can be restored on different devices. 
+
+Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv/) for session storage when using the Cloudflare adapter. Before using sessions, you need to create a KV namespace to store the data and configure a KV binding in your Wrangler config file. By default, Astro expects the KV binding to be named `SESSION`, but you can choose a different name if you prefer by setting the [`sessionKVBindingName`](#sessionkvbindingname) option in the adapter config.
+
+<Steps>
+
+1. Create a KV namespace using the Wrangler CLI and make note of the ID of the new namespace:
+
+   ```sh
+   npx wrangler kv namespace create "SESSION"
+   ```
+
+2. Declare the KV namespace in your Wrangler config, setting the namespace ID to the one returned by the previous command:
+
+    <Tabs>
+      <TabItem label="wrangler.json">
+        ```json title="wrangler.json" "<KV_NAMESPACE_ID>"
+        {
+          "kv_namespaces": [
+            {
+              "binding": "SESSION",
+              "id": "<KV_NAMESPACE_ID>"
+            }
+          ]
+        }
+        ```
+      </TabItem>
+      <TabItem label="wrangler.toml">
+        ```toml title="wrangler.toml" "<KV_NAMESPACE_ID>"
+        kv_namespaces = [
+          { binding = "SESSION", id = "<KV_NAMESPACE_ID>" }
+        ]
+        ```
+      </TabItem>
+    </Tabs>
+
+3. You can then use sessions in your server code:
+
+    ```astro title="src/components/CartButton.astro" "Astro.session?.get('cart')"
+    ---
+    export const prerender = false;
+    const cart = await Astro.session?.get('cart');
+    ---
+
+    <a href="/checkout">🛒 {cart?.length ?? 0} items</a>
+    ```
+
+</Steps>
+
+:::note
+Writes to Cloudflare KV are [eventually consistent](https://developers.cloudflare.com/kv/concepts/how-kv-works/#consistency) between regions. This means that changes are available immediately within the same region but may take up to 60 seconds to propagate globally. This won't affect most users as they are unlikely to switch regions between requests, but it may be a consideration for some use cases, such as VPN users.
+:::
+
+
+## モジュールのインポート
+
+The Cloudflare `workerd` runtime supports imports of some [non-standard module types](https://developers.cloudflare.com/workers/wrangler/bundling/#including-non-javascript-modules). Most additional file types are also available in Astro:
+
+- `.wasm` or `.wasm?module`: exports a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) that can then be instantiated
+- `.bin`: exports an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) of the raw binary contents of the file
+- `.txt`: Exports a string of the file contents
+
+All module types export a single default value. Modules can be imported both from server-side rendered pages, or from prerendered pages for static site generation.
+
+The following is an example of importing a Wasm module that then responds to requests by adding the request's number parameters together.
+
+```js title="pages/add/[a]/[b].js"
+// Import the WebAssembly module
+import mod from '../util/add.wasm';
+
+// Instantiate first in order to use it
+const addModule: any = new WebAssembly.Instance(mod);
+
+export async function GET(context) {
+  const a = Number.parseInt(context.params.a);
+  const b = Number.parseInt(context.params.b);
+  return new Response(`${addModule.exports.add(a, b)}`);
+}
+```
+
+While this example is trivial, Wasm can be used to accelerate computationally intensive operations which do not involve significant I/O such as embedding an image processing library, or embedding a small pre-indexed database for search over a read-only dataset.
+
+## Node.js compatibility
+
+Out of the box, Cloudflare does not support the Node.js runtime APIs. With some configuration, Cloudflare does support a subset of the Node.js runtime APIs. You can find supported Node.js runtime APIs in Cloudflare's [documentation](https://developers.cloudflare.com/workers/runtime-apis/nodejs).
+
+To use these APIs, your page or endpoint must be server-side rendered (not pre-rendered) and must use the `import {} from 'node:*'` import syntax.
+
+```js title="pages/api/endpoint.js"
+export const prerender = false;
+import { Buffer } from 'node:buffer';
+```
+
+You'll also need to modify the `vite` configuration in your Astro config to allow for the `node:*` import syntax:
+
+```js title="astro.config.mjs" ins={7-11}
+import {defineConfig} from "astro/config";
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare({}),
+  output: 'server',
+  vite: {
+		ssr: {
+			external: ['node:buffer'],
+		},
+	},
+})
+```
+
+Additionally, you'll need to follow Cloudflare's documentation on how to enable support. For detailed guidance, please refer to the [Cloudflare documentation on enabling Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+
+:::note[Package Compatibility Implications]
+If a project imports a package into the server that uses the Node.js runtime APIs, this can cause issues when deploying to Cloudflare. This issue arises with package that do not use the `node:*` import syntax. It is recommended that you contact the authors of the package to determine if the package supports the above import syntax. If the package does not support this, you may need to use a different package.
+:::
+
+## Preview with Wrangler
+
+To use [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) to run your application locally, update the preview script.
+
+For Workers:
+
+```json title="package.json"
+"preview": "wrangler dev ./dist"
+```
+
+For Pages:
+
+```json title="package.json"
+"preview": "wrangler pages dev ./dist"
+```
+
+Developing with [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) gives you access to [Cloudflare bindings](https://developers.cloudflare.com/pages/platform/functions/bindings), [environment variables](https://developers.cloudflare.com/pages/platform/functions/bindings/#environment-variables), and the [cf object](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties). Getting hot reloading of the Astro dev server to work with Wrangler might require custom setup. See [community examples](https://github.com/withastro/roadmap/discussions/590).
+
+### Meaningful error messages
+
+Currently, errors during running your application in Wrangler are not very useful, due to the minification of your code. For better debugging, you can add `vite.build.minify = false` setting to your `astro.config.mjs`.
+
+```js title="astro.config.mjs" ins={4-8}
+export default defineConfig({
+  adapter: cloudflare(),
+  output: 'server',
+  vite: {
+    build: {
+      minify: false,
+    },
+  },
+});
+```
+
+[astro-integration]: /en/guides/integrations-guide/

--- a/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/cloudflare'
-description: "@astrojs/cloudflare" SSRアダプターを使用してAstroプロジェクトをデプロイする方法
+description: \@astrojs/cloudflare SSR アダプターを使用して、Astroプロジェクトをデプロイする方法を学びます。
 sidebar:
   label: Cloudflare
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
@@ -14,7 +14,7 @@ import Since from '~/components/Since.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 
-この**[Astroインテグレーション][astro-integration]**で[Cloudflare](https://www.cloudflare.com/)の[オンデマンドレンダリング](/ja/guides/on-demand-rendering/)を有効にできます。
+この **[Astroインテグレーション][astro-integration]** で[Cloudflare](https://www.cloudflare.com/)の[オンデマンドレンダリング](/ja/guides/on-demand-rendering/)を有効にできます。
 
 Astroを静的サイトジェネレーターとして使用している場合、このアダプターは必要ありません。
 
@@ -27,7 +27,7 @@ Cloudflareの[開発者プラットフォーム](https://developers.cloudflare.c
 
 ## インストール
 
-Astroには公式インテグレーションを自動でセットアップするための`astro add`コマンドが含まれています。お好みで、[手動でインストール](#手動インストール)することもできます。
+Astroには公式インテグレーションを自動でセットアップするための`astro add`コマンドが含まれています。これを使用しない場合、[手動でインストール](#手動インストール)することもできます。
 
 `astro add`コマンドでCloudflareアダプターを追加して、AstroプロジェクトでSSRを有効にします。 これにより、`@astrojs/cloudflare`がインストールされ、`astro.config.mjs`ファイルに適切な変更が1ステップで行われます。
 
@@ -71,7 +71,7 @@ Astroには公式インテグレーションを自動でセットアップする
   </Fragment>
 </PackageManagerTabs>
 
-次に、アダプターと[アウトプットモード](/ja/guides/on-demand-rendering/) を`astro.config.mjs`ファイルに追加します。
+次に、アダプターと[`output: 'server'`](/ja/guides/on-demand-rendering/) を`astro.config.mjs`ファイルに追加します。
 
 ```js title="astro.config.mjs" ins={2,5-6}
 import { defineConfig } from 'astro/config';
@@ -95,21 +95,21 @@ Cloudflareアダプターは、次のオプションをサポートしていま�
 
 ['.wasm'、'.bin'、および '.txt' モジュールのインポート](#モジュールのインポート) を有効にします。
 
-この機能はデフォルトで有効になっています。無効にする場合は、「cloudflareModules: false」を設定します。
+この機能はデフォルトで有効になっています。無効にする場合は、`cloudflareModules: false`を設定します。
 
 ### imageService
 
 <p>
-**Type:** `'passthrough' | 'cloudflare' | 'compile' | 'custom'`<br />
-**Default:** `'compile'`
+**データー型:** `'passthrough' | 'cloudflare' | 'compile' | 'custom'`<br />
+**デフォルト:** `'compile'`
 </p>
 
-Determines which image service is used by the adapter. The adapter will default to `compile` mode when an incompatible image service is configured. Otherwise, it will use the globally configured image service:
+アダプターが使用する画像サービスを決定します。アダプターは、互換性のない画像サービスが構成されている場合、`compile`モードをデフォルトとして使用します。それ以外の場合は、グローバルに構成された画像サービスを使用します。
 
-* **`cloudflare`:** Uses the [Cloudflare Image Resizing](https://developers.cloudflare.com/images/image-resizing/) service.
-* **`passthrough`:** Uses the existing [`noop`](/en/guides/images/#configure-no-op-passthrough-service) service.
-* **`compile`:** Uses Astro's default service (sharp), but only on pre-rendered routes at build time. During SSR for pages rendered on-demand, all `astro:assets` features are disabled.
-* **`custom`:** Always uses the image service configured in [Image Options](/en/reference/configuration-reference/#image-options). **This option will not check to see whether the configured image service works in Cloudflare's `workerd` runtime.**
+* **`cloudflare`:** [Cloudflare Image Resizing](https://developers.cloudflare.com/images/image-resizing/)サービスを使用します。
+* **`passthrough`:** 既存の ['noop'](/ja/guides/images/#configure-no-op-passthrough-service) サービスを使用します。
+* **`compile`:** Astroのデフォルトサービス(sharp)を使用しますが、ビルド時に事前にレンダリングされたルートでのみ使用されます。オンデマンドでレンダリングされたページのSSR中は、すべての`astro:assets`機能が無効になります。
+* **`custom`:** [Image Options](/ja/reference/configuration-reference/#image-options)で設定したイメージサービスを常に使用します。 **このオプションでは、設定された画像サービスがCloudflareの`workerd`ランタイムで動作するかどうかは確認されません。**
 
 ```js title="astro.config.mjs" ins={6}
 import {defineConfig} from "astro/config";
@@ -125,49 +125,52 @@ export default defineConfig({
 
 ### platformProxy
 
-Determines whether and how the Cloudflare runtime is added to `astro dev`. It contains proxies to local `workerd` bindings and emulations of Cloudflare specific values, allowing the emulation of the runtime in the Node.js dev process. Read more about the [Cloudflare Runtime](#cloudflare-runtime).
+Cloudflareランタイムを「astro dev」に追加するかどうか、またどのように追加するかを指定します。
+これはローカルのworkerdバインディングへのプロキシとCloudflare固有の値のエミュレーションを含んでおり、Node.jsの開発プロセスでランタイムをエミュレートすることができます。
+[Cloudflare Runtime](#ランタイム)の詳細については、こちらをご覧ください。
 
 :::note
-Proxies provided by this are a best effort emulation of the real production. Although they are designed to be as close as possible to the real thing, there might be a slight differences and inconsistencies between the two.
+このプロキシは本番環境の最適なエミュレーションを提供するためのものです。できるだけ実際の環境に近づけるよう設計されていますが、若干の差異や不一致が存在する可能性があります。
 :::
 
 #### platformProxy.enabled
 <p>
-**Type:** `{ enabled?: boolean }`<br />
-**Default:** `{ enabled: false }`
+**データ型:** `{ enabled?: boolean }`<br />
+**デフォルト値:** `{ enabled: false }`
 </p>
 
-The `enabled` property allows you to enable the Cloudflare runtime in `astro dev`.
+有効にすると`astro dev`でCloudflareランタイムを有効にできます。
 
 #### platformProxy.configPath
 <p>
-**Type:** `{ configPath?: string }`<br />
-**Default:** `{ configPath: 'wrangler.toml' }`
+**データ型:** `{ configPath?: string }`<br />
+**デフォルト値:** `{ configPath: 'wrangler.toml' }`
 </p>
 
-The `configPath` property allows you to define your Wrangler configuration file, relative to the root of your Astro project. 
+Astroプロジェクトのルートを基準にして、Wrangler設定ファイルを定義できます。
 
 #### platformProxy.environment
 <p>
-**Type:** `{ environment?: string }`<br />
-**Default:** `{ environment: undefined }`
+**データ型:** `{ environment?: string }`<br />
+**デフォルト値:** `{ environment: undefined }`
 </p>
 
-The `environment` property allows you to define which [environment configuration](https://developers.cloudflare.com/workers/wrangler/environments/) in your Wrangler configuration to use.
+Wrangler設定のどの[環境設定](https://developers.cloudflare.com/workers/wrangler/environments/)を使用するかを定義できます。
+
 
 #### platformProxy.persist
 <p>
-**Type:** `{ persist?: boolean | { path: string } }`<br />
-**Default:** `{ persist: true }`
+**データ型:** `{ persist?: boolean | { path: string } }`<br />
+**デフォルト値:** `{ persist: true }`
 </p>
 
-The `persist` property defines if and where the bindings data is persistent. `true` defaults to the same location used by Wrangler so data can be shared between the two. If `false`, no data is persisted to or read from the filesystem.
+`persist`プロパティは、バインディングデータを永続化するかどうか、およびその保存先を定義します。`true`を設定すると、Wranglerと同じ場所にデータが保存され、両者間でデータを共有できます。`false`の場合、データはファイルシステムに永続化されず、読み込みも行われません。
 
 :::note
-`wrangler`'s `--persist-to` option adds a sub directory called `v3` under the hood while the `@astrojs/cloudflare` `persist` property does not. For example, to reuse the same location as running `wrangler dev --persist-to ./my-directory`, you must specify: `persist: { path: "./my-directory/v3" }`.
+`wrangler`の`--persist-to`オプションは内部的に`v3`というサブディレクトリを追加しますが、`@astrojs/cloudflare`の`persist`プロパティはそれを行いません。例えば、`wrangler dev --persist-to ./my-directory`と同じ場所を再利用するには、`persist: { path: "./my-directory/v3" }`と指定する必要があります。
 :::
 
-The following configuration shows an example of enabling the Cloudflare runtime when running the development server, as well as using a `wrangler.json` config file. It also specifies a custom location for persisting data to the filesystem:
+以下の設定は、開発サーバー実行時にCloudflareランタイムを有効にする例と、`wrangler.json`設定ファイルを使用する例を示しています。また、ファイルシステムにデータを永続化するためのカスタムの場所も指定しています。
 
 
 ```js
@@ -188,37 +191,39 @@ export default defineConfig({
 ```
 ### routes.extend
 
-On Cloudflare Workers, this option is not applicable. Refer to [Routing on Cloudflare Workers](#routing-on-cloudflare-workers) for more information.
+CloudflareのWorkersでは、このオプションは適用されません。詳細については[Cloudflare Workersでのルーティング](#cloudflare-workersでのルーティング)をご覧ください。
 
-On Cloudflare Pages, this option allows you to add or exclude custom patterns (e.g. `/fonts/*`) to the generated `_routes.json` file that determines which routes are generated on-demand. This can be useful if you need to add route patterns which cannot be automatically generated, or exclude prerendered routes.
+CloudflareのPagesでは、このオプションを使用して、オンデマンドで生成されるルートを決定する`_routes.json`ファイルにカスタムパターン（例：`/fonts/*`）を追加したり除外したりできます。これは、自動的に生成できないルートパターンを追加する場合や、事前レンダリングされたルートを除外する場合に便利です。
 
-More information about the custom route patterns can be found in [Cloudflare's routing docs](https://developers.cloudflare.com/pages/functions/routing/#functions-invocation-routes). Any routes specified are not automatically deduplicated and will be appended to the existing routes as is.
+カスタムルートパターンの詳細については、[Cloudflareのルーティングドキュメント](https://developers.cloudflare.com/pages/functions/routing/#functions-invocation-routes)をご覧ください。指定されたルートは自動的に重複排除されず、既存のルートにそのまま追加されます。
 
 #### routes.extend.include
 
 <p>
-**Type:** `{ pattern: string }[]`<br />
-**Default:** `undefined`
+**データ型:** `{ pattern: string }[]`<br />
+**デフォルト値:** `undefined`
 </p>
 
-Configure additional routes to be generated on demand by the Cloudflare adapter in the `routes.extend.include` array.
+Cloudflareアダプターでオンデマンド生成される追加ルートを`routes.extend.include`配列で設定できます。
+
 
 #### routes.extend.exclude
 
 <p>
-**Type:** `{ pattern: string }[]`<br />
-**Default:** `undefined`
+**データ型:** `{ pattern: string }[]`<br />
+**デフォルト値:** `undefined`
 </p>
 
-Configure routes to be excluded from on-demand rendering in the `routes.extend.exclude` array. These routes will be prerendered and served statically instead, and will not invoke the SSR function. Additionally you can use this option to serve any static asset (e.g. images, fonts, css, js, html, txt, json, etc.) files directly without routing the request through the SSR function.
+`routes.extend.exclude`配列に定義したルートは、オンデマンドレンダリングから除外されます。これらのルートは事前レンダリングされて静的に提供され、SSR関数を呼び出しません。また、このオプションを使用して静的アセット（画像、フォント、CSS、JS、HTML、TXT、JSONなど）をSSR関数を経由せずに直接提供することもできます。
+
 
 ```js title="astro.config.mjs"
 export default defineConfig({
   adapter: cloudflare({
     routes: {
       extend: {
-        include: [{ pattern: '/static' }], // Route a prerended page to the SSR function for on-demand rendering
-        exclude: [{ pattern: '/pagefind/*' }], // Use Starlight's pagefind search, which is generated statically at build time
+        include: [{ pattern: '/static' }], // 静的ページをオンデマンドレンダリング用のSSR関数にルーティング
+        exclude: [{ pattern: '/pagefind/*' }], // Starlight のページ検索は、ビルド時に静的に生成
       }
     },
   }),
@@ -227,12 +232,13 @@ export default defineConfig({
 
 ### sessionKVBindingName
 <p>
-**Type:** `string`<br />
-**Default:** `SESSION`
+**データ型:** `string`<br />
+**デフォルト値:** `SESSION`
 <Since v="5.6.0" />
 </p>
 
-The `sessionKVBindingName` option allows you to specify the name of the KV binding used for session storage. By default, this is set to `SESSION`, but you can change it to match your own KV binding name. See [Sessions](#sessions) for more information.
+`sessionKVBindingName` オプションを使用すると、セッションストレージに使用するKVバインディングの名前を指定できます。デフォルトでは `SESSION` に設定されていますが、独自のKVバインディング名に変更することができます。詳細については[セッション](#セッション)をご覧ください。
+
 
 ```js title="astro.config.mjs" "MY_SESSION_BINDING"
 export default defineConfig({
@@ -242,21 +248,22 @@ export default defineConfig({
 });
 ```
 
-## Cloudflare runtime
+## ランタイム
 
-### Usage
+### 使用方法
 
-The Cloudflare runtime gives you access to environment variables and bindings to Cloudflare resources.
-The Cloudflare runtime uses bindings found in the `wrangler.toml`/`wrangler.json` configuration file. 
+Cloudflareランタイムでは、環境変数やCloudflareリソースへのバインディングにアクセスできます。
+Cloudflareランタイムは、`wrangler.toml`/`wrangler.json`設定ファイルに定義されたバインディングを使用します。
 
-You can access the bindings from `Astro.locals.runtime`:
+バインディングには Astro.locals.runtime からアクセスできます。
 
 ```astro title="src/pages/index.astro"
 ---
 const { env } = Astro.locals.runtime;
 ---
 ```
-You can access the runtime from API endpoints through `context.locals`:
+
+API エンドポイントからは、`context.locals`を介してアクセスできます。
 
 ```js title="src/pages/api/someFile.js"
 export function GET(context) {
@@ -266,14 +273,14 @@ export function GET(context) {
 }
 ```
 
-See the [list of all supported bindings](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings) in the Cloudflare documentation.
+サポートされている全てのバインディングについては、Cloudflareのドキュメントにある[バインディング一覧](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings)をご覧ください。
 
 
-### Environment variables and secrets
+### 環境変数とシークレット
 
-The Cloudflare runtime treats environment variables as a type of binding.
+Cloudflareランタイムでは、環境変数はバインディングの一種として扱われます。
 
-For example, you can define an [environment variable](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) in `wrangler.json` as follows:
+たとえば、以下のように[環境変数](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-wrangler)を`wrangler.json`に定義できます。
 
 ```json title="wrangler.json"
 {
@@ -283,21 +290,21 @@ For example, you can define an [environment variable](https://developers.cloudfl
 }
 ```
 
-Secrets are a special type of environment variable that allow you to attach encrypted text values to your Worker. They need to be defined differently to ensure they are not visible after you set them.
+シークレットは、Workerに暗号化されたテキスト値を添付するための特別なタイプの環境変数です。シークレットは、設定後に表示されないようにするために異なる方法で定義する必要があります。
 
-To define `secrets`, add them through the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) rather than in your Wrangler config file. 
+`secrets`を定義するには、設定ファイルではなく、[Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/)を使用します。
 
 ```bash
 npx wrangler secret put <KEY>
 ```
 
-To set secrets for local development, you also need to add a `.dev.vars` file to the root of the Astro project:
+ローカル開発用にシークレットを設定したい場合、`.dev.vars`ファイルをプロジェクトのルートに追加する必要があります。
 
 ```ini title=".dev.vars"
 DB_PASSWORD=myPassword
 ```
 
-You can then access environment variables, including secrets, from the `env` object available from `Astro.locals.runtime`:  
+これで、`Astro.locals.runtime`の`env`オブジェクトから環境変数やシークレットにアクセスできます。
 
 ```astro title="src/pages/index.astro"
 ---
@@ -307,16 +314,16 @@ const secret = env.DB_PASSWORD;
 ---
 ```
 
-Cloudflare environment variables and secrets are compatible with the [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables).
+Cloudflareの環境変数とシークレットは[`astro:env` API](/ja/guides/environment-variables/#type-safe-environment-variables)と互換性があります。
 
-### Typing
+### 型
 
-`wrangler` provides a `types` command to generate TypeScript types for the bindings. This allows you to type locals without the need to manually type them. Refer to the [Cloudflare documentation](https://developers.cloudflare.com/workers/wrangler/commands/#types) for more information.
+`wrangler`はバインディングに使用するTypeScriptの型を生成するための`types`コマンドを提供します。これにより、手動で型を指定することなくローカルを型付けできます。詳細については、[Cloudflareのドキュメント](https://developers.cloudflare.com/workers/wrangler/commands/#types)を参照してください。
 
-Every time you change your configuration files (e.g. `wrangler.toml`, `.dev.vars`) you need to run `wrangler types`.
+毎回、設定ファイル（例：`wrangler.toml`、`.dev.vars`）を変更するたびに、`wrangler types`を実行する必要があります。
 
 :::note
-You can create a pnpm script to run `wrangler types` automatically before other commands.
+pnpmスクリプトを作成して、他のコマンドの前に「wrangler types」を自動的に実行できます。
 
 ```json title="package.json"
 {
@@ -331,7 +338,7 @@ You can create a pnpm script to run `wrangler types` automatically before other 
 ```
 :::
 
-You can type the `runtime` object using `Runtime`:
+'runtime' オブジェクトには 'Runtime' を使用して入力できます。
 
 ```ts title="src/env.d.ts"
 type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
@@ -345,60 +352,60 @@ declare namespace App {
 }
 ```
 
-## Cloudflare Platform
+## Cloudflareプラットフォーム
 
-### Headers
+### ヘッダー
 
-You can attach [custom headers](https://developers.cloudflare.com/pages/platform/headers/) to your responses by adding a `_headers` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
+プロジェクトの`public/`フォルダに`_headers`ファイルを追加することで、レスポンスに[カスタムヘッダー](https://developers.cloudflare.com/pages/platform/headers/)を追加できます。このファイルはビルド出力ディレクトリにコピーされます。
 
-This is available on Cloudflare Workers and Pages.
+Cloudflare WorkersとPagesで利用できます。
 
-### Assets
-Assets built by Astro are all named with a hash and therefore can be given long cache headers. By default, Astro on Cloudflare will add such a header for these files.
+### アセット
 
-### Redirects
+Astroによるアセットのビルドはすべてハッシュ付きの名前が付けられているため、長いキャッシュヘッダーを付けることができます。デフォルトでは、CloudflareでのAstroはこれらのファイルにそのようなヘッダーを追加します。
 
-You can declare [custom redirects](https://developers.cloudflare.com/pages/platform/redirects/) to redirect requests to a different URL. To do so, add a `_redirects` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
+### リダイレクト
 
-This is available on Cloudflare Workers and Pages.
+プロジェクトの`public/`フォルダに`_redirects`ファイルを追加することで、[custom redirects](https://developers.cloudflare.com/pages/platform/redirects/)を使用してリクエストを別のURLにリダイレクトできます。このファイルはビルド出力ディレクトリにコピーされます。
 
-### Routes
-#### Routing on Cloudflare Workers
+この機能はCloudflare WorkersとPagesで利用可能です。
 
-Routing for static assets is based on the file structure in the build directory (e.g. `./dist`). If no match is found, this will fall back to the Worker for SSR. Read more about [static asset routing with Cloudflare Workers](https://developers.cloudflare.com/workers/static-assets/routing/).
+### ルーティング
+#### Cloudflare Workersでのルーティング
 
-Unlike [Cloudflare Pages](#routing-on-cloudflare-pages), with Workers, you do not need a `_routes.json` file. 
+静的アセットのルーティングは、ビルドディレクトリ（例：`./dist`）のファイル構造に基づいています。マッチが見つからない場合、SSRのためにWorkerにフォールバックします。より詳しい情報はCloudflare Workersの[静的アセットのルーティング](https://developers.cloudflare.com/workers/static-assets/routing/)もご覧ください。
 
-Currently, the Cloudflare adapter always generates this file. To work around this, create a `.assetsignore` file in your `public/` folder, and add the following lines to it:
+[Cloudflare Pages](#cloudflare-pagesでのルーティング)とは異なり、Workersでは「_routes.json」ファイルは必要ありません。
+
+現在、Cloudflareアダプターは常にこのファイルを生成します。これを回避するには、`public/`フォルダに`.assetsignore`ファイルを作成し、以下の行を追加してください。
   ```txt title="public/.assetsignore"
   _worker.js
   _routes.json
   ```
 
-#### Routing on Cloudflare Pages
+#### Cloudflare Pagesでのルーティング
 
-For Cloudflare Pages, [routing](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) uses a `_routes.json` file to determine which requests are routed to the server function and which are served as static assets. By default, a `_routes.json` file will be automatically generated for your project based on its files and configuration.
+Cloudflare Pagesでは、[ルーティング](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes)に`_routes.json`ファイルを使用して、どのリクエストがサーバー関数にルーティングされ、どのリクエストが静的アセットとして提供されるかを決定します。デフォルトでは、プロジェクトのファイルと設定に基づいて`_routes.json`ファイルが自動的に生成されます。
 
-You can [specify additional routing patterns to follow](#routesextend) in your adapter config, or create your own custom `_routes.json` file to fully override the automatic generation.
+アダプターの設定で[追加のルーティングパターンを指定](#routesextend)したり、独自のカスタム`_routes.json`ファイルを作成して自動生成を完全に上書きしたりすることもできます。
 
+カスタム`public/_routes.json`を作成すると、自動生成が上書きされます。詳細については[カスタム`_routes.json`ファイル作成に関するCloudflareのドキュメント](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file)をご覧ください。
 
-Creating a custom `public/_routes.json` will override the automatic generation. See [Cloudflare's documentation on creating a custom `_routes.json`](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file) for more details.
+## セッション
 
-## Sessions
+Astroの[セッションAPI](/ja/guides/sessions/)を使用すると、リクエスト間でユーザーデータを簡単に保存できます。これはユーザーデータや設定、ショッピングカート、認証情報などの保存に使用できます。Cookieストレージとは異なり、データサイズに制限がなく、異なるデバイスでも復元できます。
 
-The Astro [Sessions API](/en/guides/sessions/) allows you to easily store user data between requests. This can be used for things like user data and preferences, shopping carts, and authentication credentials. Unlike cookie storage, there are no size limits on the data, and it can be restored on different devices. 
-
-Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv/) for session storage when using the Cloudflare adapter. Before using sessions, you need to create a KV namespace to store the data and configure a KV binding in your Wrangler config file. By default, Astro expects the KV binding to be named `SESSION`, but you can choose a different name if you prefer by setting the [`sessionKVBindingName`](#sessionkvbindingname) option in the adapter config.
+Astroは、Cloudflareアダプターを使用する際に、セッションストレージ用の[Workers KV](https://developers.cloudflare.com/kv/)を自動的に設定します。セッションを使用する前に、データを保存するためのKVネームスペースを作成し、Wrangler設定ファイルでKVバインディングを構成する必要があります。デフォルトでは、AstroはKVバインディングが`SESSION`という名前であることを想定していますが、アダプター設定の[`sessionKVBindingName`](#sessionkvbindingname)オプションを設定することで、別の名前を選択することもできます。
 
 <Steps>
 
-1. Create a KV namespace using the Wrangler CLI and make note of the ID of the new namespace:
+1. Wrangler CLI を使用して KV 名前空間を作成し、新しい名前空間の ID をメモする。
 
    ```sh
    npx wrangler kv namespace create "SESSION"
    ```
 
-2. Declare the KV namespace in your Wrangler config, setting the namespace ID to the one returned by the previous command:
+2. Wrangler の設定で KV 名前空間を宣言し、名前空間 ID を前のコマンドで返されたものに設定する。
 
     <Tabs>
       <TabItem label="wrangler.json">
@@ -422,7 +429,7 @@ Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv
       </TabItem>
     </Tabs>
 
-3. You can then use sessions in your server code:
+3. サーバーサイドのコードでセッションを使用する。
 
     ```astro title="src/components/CartButton.astro" "Astro.session?.get('cart')"
     ---
@@ -436,27 +443,27 @@ Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv
 </Steps>
 
 :::note
-Writes to Cloudflare KV are [eventually consistent](https://developers.cloudflare.com/kv/concepts/how-kv-works/#consistency) between regions. This means that changes are available immediately within the same region but may take up to 60 seconds to propagate globally. This won't affect most users as they are unlikely to switch regions between requests, but it may be a consideration for some use cases, such as VPN users.
+Cloudflare KVへの書き込みは、リージョン間で[結果整合性](https://developers.cloudflare.com/kv/concepts/how-kv-works/#consistency)を持っています。つまり、変更は同じリージョン内ですぐに利用可能になりますが、グローバルに伝播するには最大60秒かかる場合があります。これはほとんどのユーザーには影響しませんが、VPNユーザーなど、リクエスト間でリージョンを切り替える可能性がある場合には考慮すべき点かもしれません。
 :::
 
 
 ## モジュールのインポート
 
-The Cloudflare `workerd` runtime supports imports of some [non-standard module types](https://developers.cloudflare.com/workers/wrangler/bundling/#including-non-javascript-modules). Most additional file types are also available in Astro:
+Cloudflareの`workerd`ランタイムは、一部の[非標準モジュールタイプ](https://developers.cloudflare.com/workers/wrangler/bundling/#including-non-javascript-modules)のインポートをサポートしています。ほとんどの追加ファイルタイプはAstroでも利用できます。
 
-- `.wasm` or `.wasm?module`: exports a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) that can then be instantiated
-- `.bin`: exports an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) of the raw binary contents of the file
-- `.txt`: Exports a string of the file contents
+- `.wasm` / `.wasm?module`: [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module)をエクスポートし、インスタンス化。
+- `.bin`: ファイルの生のバイナリ内容の[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)をエクスポート。
+- `.txt`: ファイル内容の文字列をエクスポート。
 
-All module types export a single default value. Modules can be imported both from server-side rendered pages, or from prerendered pages for static site generation.
+すべてのモジュールタイプはデフォルト値を1つエクスポートします。モジュールは、サーバーサイドレンダリングのページからでも、静的サイト生成用の事前レンダリングのページからでもインポートできます。
 
-The following is an example of importing a Wasm module that then responds to requests by adding the request's number parameters together.
+以下は、Wasmモジュールをインポートして、リクエストの数値パラメータを足し合わせて応答する例です。
 
 ```js title="pages/add/[a]/[b].js"
-// Import the WebAssembly module
+// WebAssembly モジュールのインポート
 import mod from '../util/add.wasm';
 
-// Instantiate first in order to use it
+// 最初にインスタンス化しておく
 const addModule: any = new WebAssembly.Instance(mod);
 
 export async function GET(context) {
@@ -466,20 +473,20 @@ export async function GET(context) {
 }
 ```
 
-While this example is trivial, Wasm can be used to accelerate computationally intensive operations which do not involve significant I/O such as embedding an image processing library, or embedding a small pre-indexed database for search over a read-only dataset.
+これは単純な例ですが、Wasmは、画像処理ライブラリの埋め込みや、読み取り専用データセットの検索用にインデックス付けされた小さなデータベースの埋め込みなど、大きなI/Oを伴わない計算集約型の処理を高速化するのに使用できます。
 
-## Node.js compatibility
+## Node.js互換性
 
-Out of the box, Cloudflare does not support the Node.js runtime APIs. With some configuration, Cloudflare does support a subset of the Node.js runtime APIs. You can find supported Node.js runtime APIs in Cloudflare's [documentation](https://developers.cloudflare.com/workers/runtime-apis/nodejs).
+CloudflareはデフォルトではNode.jsランタイムAPIをサポートしていません。ただし、設定によってNode.jsランタイムAPIのサブセットをサポートすることができます。サポートされているNode.jsランタイムAPIについては、Cloudflareの[ドキュメント](https://developers.cloudflare.com/workers/runtime-apis/nodejs)を参照してください。
 
-To use these APIs, your page or endpoint must be server-side rendered (not pre-rendered) and must use the `import {} from 'node:*'` import syntax.
+これらのAPIを使用するには、ページまたはエンドポイントがサーバーサイドレンダリングされる必要があり（事前レンダリングではなく）、`import {} from 'node:*'`のインポート構文を使用する必要があります。
 
 ```js title="pages/api/endpoint.js"
 export const prerender = false;
 import { Buffer } from 'node:buffer';
 ```
 
-You'll also need to modify the `vite` configuration in your Astro config to allow for the `node:*` import syntax:
+また、Astroの設定で`vite`設定を変更して、`node:*`インポート構文を許可する必要があります。
 
 ```js title="astro.config.mjs" ins={7-11}
 import {defineConfig} from "astro/config";
@@ -496,33 +503,34 @@ export default defineConfig({
 })
 ```
 
-Additionally, you'll need to follow Cloudflare's documentation on how to enable support. For detailed guidance, please refer to the [Cloudflare documentation on enabling Node.js compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+また、サポートを有効にするには、Cloudflareのドキュメントに従う必要があります。詳細については、[Node.js互換性を有効にするためのCloudflareドキュメント](https://developers.cloudflare.com/workers/runtime-apis/nodejs/)を参照してください。
 
-:::note[Package Compatibility Implications]
-If a project imports a package into the server that uses the Node.js runtime APIs, this can cause issues when deploying to Cloudflare. This issue arises with package that do not use the `node:*` import syntax. It is recommended that you contact the authors of the package to determine if the package supports the above import syntax. If the package does not support this, you may need to use a different package.
+:::note[パッケージの互換性への影響]
+プロジェクトがNode.jsランタイムAPIを使用するパッケージをサーバーにインポートすると、Cloudflareへのデプロイ時に問題が発生する可能性があります。この問題は、`node:*`インポート構文を使用していないパッケージで発生します。パッケージの作者に連絡して、上記のインポート構文をサポートしているかどうかを確認することをお勧めします。パッケージがこれをサポートしていない場合は、別のパッケージを使用する必要があるかもしれません。
 :::
 
-## Preview with Wrangler
+## Wranglerによるプレビュー
 
-To use [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) to run your application locally, update the preview script.
+[wrangler](https://developers.cloudflare.com/workers/wrangler/)を使用して、アプリケーションをローカルで実行するには、プレビュースクリプトを更新します。
 
-For Workers:
+<Tabs>
+  <TabItem label="Worker">
+    ```json title="package.json"
+    "preview": "wrangler dev ./dist"
+    ```
+  </TabItem>
+  <TabItem label="Pages">
+  ```json title="package.json"
+  "preview": "wrangler pages dev ./dist"
+  ```
+  </TabItem>
+</Tabs>
 
-```json title="package.json"
-"preview": "wrangler dev ./dist"
-```
+[`wrangler`](https://developers.cloudflare.com/workers/wrangler/)を使用した開発では、[Cloudflareバインディング](https://developers.cloudflare.com/pages/platform/functions/bindings)、[環境変数](https://developers.cloudflare.com/pages/platform/functions/bindings/#environment-variables)、および[cfオブジェクト](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties)にアクセスできます。AstroのDEVサーバーのホットリロードをWranglerで動作させるには、カスタムセットアップが必要になる場合があります。詳しくは[コミュニティのサンプル](https://github.com/withastro/roadmap/discussions/590)をご覧ください。
 
-For Pages:
+### エラーメッセージの説明
 
-```json title="package.json"
-"preview": "wrangler pages dev ./dist"
-```
-
-Developing with [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) gives you access to [Cloudflare bindings](https://developers.cloudflare.com/pages/platform/functions/bindings), [environment variables](https://developers.cloudflare.com/pages/platform/functions/bindings/#environment-variables), and the [cf object](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties). Getting hot reloading of the Astro dev server to work with Wrangler might require custom setup. See [community examples](https://github.com/withastro/roadmap/discussions/590).
-
-### Meaningful error messages
-
-Currently, errors during running your application in Wrangler are not very useful, due to the minification of your code. For better debugging, you can add `vite.build.minify = false` setting to your `astro.config.mjs`.
+現在、Wranglerでアプリケーションを実行中に発生するエラーは、コードが縮小化されているため、あまり役立ちません。デバッグをしやすくするために、`astro.config.mjs`に`vite.build.minify = false`設定を追加することができます。
 
 ```js title="astro.config.mjs" ins={4-8}
 export default defineConfig({
@@ -536,4 +544,4 @@ export default defineConfig({
 });
 ```
 
-[astro-integration]: /en/guides/integrations-guide/
+[astro-integration]: /ja/guides/integrations-guide/

--- a/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/ja/guides/integrations-guide/cloudflare.mdx
@@ -1,12 +1,12 @@
 ---
 type: integration
 title: '@astrojs/cloudflare'
-description: \@astrojs/cloudflare SSR アダプターを使用して、Astroプロジェクトをデプロイする方法を学びます。
+description: \@astrojs/cloudflare SSR アダプターを使用して、Astroプロジェクトをデプロイする方法
 sidebar:
   label: Cloudflare
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/cloudflare/'
 category: adapter
-i18nReady: false
+i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import ReadMore from '~/components/ReadMore.astro';


### PR DESCRIPTION
#### Description (required)

Target language: Japanese (日本語)

This PR add `..ja/guides/integrations-guide/cloudflare.mdx` translate from `..en/guides/integrations-guide/cloudflare.mdx`

#### Related issues & labels (optional)
- Suggested label: i18n
