### PR TITLE
Document dev server hot keys in CLI reference

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -180,6 +180,12 @@ You will often use these `astro` commands, or the scripts that run them, without
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
+You can use the following hotkeys in the terminal where the Astro develpment server is running.
+
+- `s + enter` to sync content layer.
+- `o + enter` to open your Astro site in the browser.
+- `q + enter` to quit the development server.
+
 ## `astro build`
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If any routes are [rendered on demand](/en/guides/on-demand-rendering/), this will generate the necessary server files to serve your site.

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -180,7 +180,7 @@ You will often use these `astro` commands, or the scripts that run them, without
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
-You can use the following hotkeys in the terminal where the Astro develpment server is running.
+The following hotkeys can be used in the terminal where the Astro develpment server is running.
 
 - `s + enter` to sync content layer.
 - `o + enter` to open your Astro site in the browser.

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -182,7 +182,7 @@ Runs Astro's development server. This is a local HTTP server that doesn't bundle
 
 The following hotkeys can be used in the terminal where the Astro develpment server is running.
 
-- `s + enter` to sync content layer.
+- `s + enter` to sync content layer (content and types).
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -180,7 +180,7 @@ You will often use these `astro` commands, or the scripts that run them, without
 
 Runs Astro's development server. This is a local HTTP server that doesn't bundle assets. It uses Hot Module Replacement (HMR) to update your browser as you save changes in your editor.
 
-The following hotkeys can be used in the terminal where the Astro develpment server is running.
+The following hotkeys can be used in the terminal where the Astro development server is running:
 
 - `s + enter` to sync the content layer data (content and types).
 - `o + enter` to open your Astro site in the browser.

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -182,7 +182,7 @@ Runs Astro's development server. This is a local HTTP server that doesn't bundle
 
 The following hotkeys can be used in the terminal where the Astro develpment server is running.
 
-- `s + enter` to sync content layer (content and types).
+- `s + enter` to sync the content layer data (content and types).
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 


### PR DESCRIPTION
#### Description

Adds dev server hot keys in CLI `astro dev` reference.

#### Related issues & labels (optional)

- Closes #11516
- Suggested label: add new content

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

#### First-time contributor to Astro Docs?

Discord Username: jonoyeong