### PR TITLE
i18n(fr): update `guides/routing` & some `guides/cms`

### DIFF
--- a/src/content/docs/fr/guides/cms/preprcms.mdx
+++ b/src/content/docs/fr/guides/cms/preprcms.mdx
@@ -142,7 +142,7 @@ Votre répertoire racine doit contenir ces nouveaux fichiers :
 
 #### Création de pages individuelles pour les articles de blog
 
-Pour créer une page pour chaque article de blog, vous devez exécuter une nouvelle requête GraphQL sur une page [dynamic routing](/fr/guides/routing/#mode-serveur-ssr) `.astro`. Cette requête récupérera un article spécifique par son nom (slug) et une nouvelle page sera créée pour chaque article de blog.
+Pour créer une page pour chaque article de blog, vous devez exécuter une nouvelle requête GraphQL sur une page [dynamic routing](/fr/guides/routing/#routes-dynamiques-à-la-demande) `.astro`. Cette requête récupérera un article spécifique par son nom (slug) et une nouvelle page sera créée pour chaque article de blog.
 
 <Steps>
 1. Créez un fichier appelé `get-article-by-slug.js` dans le dossier `queries` et ajoutez ce qui suit pour interroger un article spécifique par son slug et renvoyer des données telles que le `title` et le `content` de l'article :

--- a/src/content/docs/fr/guides/cms/strapi.mdx
+++ b/src/content/docs/fr/guides/cms/strapi.mdx
@@ -323,7 +323,7 @@ Veillez à choisir le bon rendu pour votre contenu. Pour le markdown, consultez 
 
 #### Rendu à la demande
 
-Si vous avez [opté pour le rendu à la demande avec un adaptateur](/fr/guides/on-demand-rendering/), [générez vos routes dynamiques](/fr/guides/routing/#mode-serveur-ssr) en utilisant le code suivant :
+Si vous avez [opté pour le rendu à la demande avec un adaptateur](/fr/guides/on-demand-rendering/), [générez vos routes dynamiques](/fr/guides/routing/#routes-dynamiques-à-la-demande) en utilisant le code suivant :
 
 Créez le fichier `src/pages/blog/[slug].astro` :
 

--- a/src/content/docs/fr/guides/routing.mdx
+++ b/src/content/docs/fr/guides/routing.mdx
@@ -187,14 +187,15 @@ const { title, text } = Astro.props;
 </html>
 ```
 
-### Mode serveur (SSR)
+### Routes dynamiques à la demande
 
-En [mode SSR](/fr/guides/on-demand-rendering/), les routes dynamiques sont définies de la même manière : incluez des crochets `[param]` ou `[...path]` dans vos noms de fichiers pour faire correspondre des chaînes ou des chemins arbitraires. Mais comme les routes ne sont plus construites à l'avance, la page sera servie à toute route correspondante. Comme il ne s'agit pas de routes « statiques », `getStaticPaths` ne doit pas être utilisé.
+Pour [le rendu à la demande](/fr/guides/on-demand-rendering/) avec un adaptateur, les routes dynamiques sont définies de la même manière : incluez des crochets `[param]` ou `[...path]` dans vos noms de fichiers pour faire correspondre des chaînes de caractères ou des chemins arbitraires. Cependant, comme les routes ne sont plus construites à l'avance, la page sera servie à n'importe quelle route correspondante. Comme il ne s'agit pas de routes « statiques », `getStaticPaths` ne doit pas être utilisé.
 
 Pour les routes rendues à la demande, un seul paramètre reste utilisant la syntaxe de décomposition peut être utilisé dans le nom de fichier (par exemple `src/pages/[locale]/[...slug].astro` ou `src/pages/[...locale]/[slug].astro`, mais pas `src/pages/[...locale]/[...slug].astro`).
 
 ```astro title="src/pages/resources/[resource]/[id].astro"
 ---
+export const prerender = false; // Pas nécessaire en mode `server`
 const { resource, id } = Astro.params;
 ---
 <h1>{resource}: {id}</h1>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11501 to the French translation of `guides/routing.mdx` and updates links in `guides/cms/preprcms.mdx` and `guides/cms/strapi.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
