### PR TITLE
[i18nIgnore] Fixed a missing closing <style> tag

### DIFF
--- a/src/content/docs/de/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/de/guides/migrate-to-astro/from-create-react-app.mdx
@@ -251,7 +251,7 @@ export default Component;
         text-align: center;
         margin-bottom: 1em;
       }
-    <style>
+    </style>
     ```
   </Fragment>
 </AstroJSXTabs>

--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -255,7 +255,7 @@ export default Component;
         text-align: center;
         margin-bottom: 1em;
       }
-    <style>
+    </style>
     ```
   </Fragment>
 </AstroJSXTabs>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
@@ -255,7 +255,7 @@ Comparez le composant CRA suivant et le composant Astro correspondant :
             text-align: center;
             margin-bottom: 1em;
           }
-        <style>
+        </style>
         ```
   </Fragment>
 </AstroJSXTabs>

--- a/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/ko/guides/migrate-to-astro/from-create-react-app.mdx
@@ -255,7 +255,7 @@ export default Component;
         text-align: center;
         margin-bottom: 1em;
       }
-    <style>
+    </style>
     ```
   </Fragment>
 </AstroJSXTabs>

--- a/src/content/docs/zh-cn/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/zh-cn/guides/migrate-to-astro/from-create-react-app.mdx
@@ -252,7 +252,7 @@ export default Component;
         text-align: center;
         margin-bottom: 1em;
       }
-    <style>
+    </style>
     ```
   </Fragment>
 </AstroJSXTabs>


### PR DESCRIPTION
#### Description (required)

This PR fixes incorrect `<style>` closing tags (`<style>` instead of `</style>`) in multiple documentation pages across different languages.  
I checked [i18n.docs.astro.build](https://i18n.docs.astro.build/) to ensure changes were only made to pages that were translated and needed fixing.  
No content was changed – only the HTML structure was corrected.

#### Related issues & labels (optional)

-   Suggested label: `fix`
