### PR TITLE
fix(recipes/i18n): update code snippet to use collection `id`

### DIFF
--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -120,7 +120,7 @@ If you prefer the default language to not be visible in the URL unlike other lan
           const pages = await getCollection('blog');
 
           const paths = pages.map(page => {
-            const [lang, ...slug] = page.slug.split('/');
+            const [lang, ...slug] = page.id.split('/');
             return { params: { lang, slug: slug.join('/') || undefined }, props: page };
           });
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

A code snippet in the `i18n` recipe was still using `slug` (legacy content collections) instead of `id` (content layer), so I replaced `page.slug` with `page.id`.

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
