### PR TITLE
i18n(fr): update responsive image translation

### DIFF
--- a/src/content/docs/fr/guides/images.mdx
+++ b/src/content/docs/fr/guides/images.mdx
@@ -11,7 +11,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Astro vous propose plusieurs façons d'utiliser des images sur votre site, qu'elles soient stockées localement dans votre projet, liées à une URL externe ou gérées dans un CMS ou un CDN.
 
-Astro fournit des composants [Image](#afficher-des-images-optimisées-avec-le-composant-image-) et [Picture](#créez-des-images-réactives-avec-le-composant-picture-), le traitement de la [syntaxe d'image Markdown](#images-dans-les-fichiers-markdown), [des composants SVG](#composants-svg) et [une fonction de génération d'images](#générer-des-images-avec-getimage) pour optimiser et/ou transformer vos images.
+Astro fournit des composants [Image](#afficher-des-images-optimisées-avec-le-composant-image-) et [Picture](#créez-des-images-adaptatives-avec-le-composant-picture-), le traitement de la [syntaxe d'image Markdown](#images-dans-les-fichiers-markdown), [des composants SVG](#composants-svg) et [une fonction de génération d'images](#générer-des-images-avec-getimage) pour optimiser et/ou transformer vos images.
 
 Vous pouvez toujours choisir d'utiliser des images et des fichiers SVG en utilisant des éléments HTML natifs dans les fichiers `.astro` ou Markdown, ou la manière standard pour votre type de fichier (par exemple `<img />` dans MDX et JSX). Cependant, Astro n'effectue aucun traitement ni optimisation de ces images.
 
@@ -40,7 +40,7 @@ Dans les fichiers `.astro`, une image locale doit être importée depuis son che
 
 Les images distantes et celles dans `public/` ne nécessitent pas d'importation, mais nécessitent à la place une URL (chemin complet ou relatif à votre site) pour `src`.
 
-Importez et utilisez les composants [`<Image />`](#afficher-des-images-optimisées-avec-le-composant-image-) et [`<Picture />`](#créez-des-images-réactives-avec-le-composant-picture-) natifs d'Astro pour des images optimisées. La syntaxe Astro prend également en charge [l'écriture directe d'une balise HTML `<img>`](#afficher-les-images-non-traitées-avec-la-balise-html-img), ce qui évite le traitement de l'image.
+Importez et utilisez les composants [`<Image />`](#afficher-des-images-optimisées-avec-le-composant-image-) et [`<Picture />`](#créez-des-images-adaptatives-avec-le-composant-picture-) natifs d'Astro pour des images optimisées. La syntaxe Astro prend également en charge [l'écriture directe d'une balise HTML `<img>`](#afficher-les-images-non-traitées-avec-la-balise-html-img), ce qui évite le traitement de l'image.
 
 ```astro title="src/pages/blog/my-images.astro"
 ---
@@ -137,11 +137,11 @@ Vous pouvez également utiliser le composant `<Image />` pour les images du doss
 
 Cependant, l'utilisation du composant Image pour toutes les images offre une expérience de création cohérente et empêche le décalage de mise en page cumulé (CLS), même pour vos images non optimisées.
 :::
-### Créez des images réactives avec le composant `<Picture />`
+### Créez des images adaptatives avec le composant `<Picture />`
 
 <p><Since v="3.3.0" /></p>
 
-Utilisez le composant Astro intégré `<Picture />` pour afficher une image réactive avec plusieurs formats et/ou tailles. Comme pour le [composant `<Image />`](#afficher-des-images-optimisées-avec-le-composant-image-), les images sont traitées au moment de la construction des pages pré-rendues. Lorsque votre page est rendue à la demande, le traitement s'effectue à la volée lors de son affichage.
+Utilisez le composant Astro intégré `<Picture />` pour afficher une image adaptative avec plusieurs formats et/ou tailles. Comme pour le [composant `<Image />`](#afficher-des-images-optimisées-avec-le-composant-image-), les images sont traitées au moment de la construction des pages pré-rendues. Lorsque votre page est rendue à la demande, le traitement s'effectue à la volée lors de son affichage.
 
 ```astro title="src/pages/index.astro"
 ---

--- a/src/content/docs/fr/recipes/build-custom-img-component.mdx
+++ b/src/content/docs/fr/recipes/build-custom-img-component.mdx
@@ -6,7 +6,7 @@ type: recipe
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-Astro fournit deux composants intégrés que vous pouvez utiliser pour afficher et optimiser vos images.  Le composant `<Picture>` vous permet d'afficher des images réactives et de travailler avec différents formats et tailles. Le composant `<Image>` optimisera vos images et vous permettra de passer dans différents formats et propriétés de qualité.
+Astro fournit deux composants intégrés que vous pouvez utiliser pour afficher et optimiser vos images.  Le composant `<Picture>` vous permet d'afficher des images adaptatives et de travailler avec différents formats et tailles. Le composant `<Image>` optimisera vos images et vous permettra de passer dans différents formats et propriétés de qualité.
 
 Lorsque vous avez besoin d'options que les composants `<Picture>` et `<Image>` ne supportent pas actuellement, vous pouvez utiliser la fonction `getImage()` pour créer un composant personnalisé. 
 
@@ -42,7 +42,7 @@ Dans cette recette, vous utiliserez la fonction [`getImage()`](/fr/guides/images
 
     ```
 
-3. Définissez chacune de vos images réactives en appelant la fonction `getImage()` avec les propriétés souhaitées.
+3. Définissez chacune de vos images adaptatives en appelant la fonction `getImage()` avec les propriétés souhaitées.
 
     ```astro title="src/components/MyCustomImageComponent.astro" ins={13-18, 20-25}
     ---

--- a/src/content/docs/fr/reference/configuration-reference.mdx
+++ b/src/content/docs/fr/reference/configuration-reference.mdx
@@ -1114,7 +1114,7 @@ Vous pouvez utiliser des caractères génériques pour définir les valeurs auto
 **Par défaut :** `undefined`
 </p>
 
-Le type de mise en page par défaut pour les images réactives. Peut être remplacé par la propriété `layout` sur le composant image.
+Le type de mise en page par défaut pour les images adaptatives. Peut être remplacé par la propriété `layout` sur le composant image.
 Nécessite que l'option `experimental.responsiveImages` soit activée.
 - `constrained` - L'image sera mise à l'échelle pour s'adapter au conteneur, en conservant son rapport hauteur/largeur, mais ne dépassera pas les dimensions spécifiées.
 - `fixed` - L'image conservera ses dimensions d'origine.
@@ -1128,7 +1128,7 @@ Nécessite que l'option `experimental.responsiveImages` soit activée.
 **Par défaut :** `"cover"`
 </p>
 
-La valeur d'ajustement d'objet par défaut pour les images réactives. Peut être remplacée par la propriété `fit` sur le composant image.
+La valeur d'ajustement d'objet par défaut pour les images adaptatives. Peut être remplacée par la propriété `fit` sur le composant image.
 Nécessite que l'option `experimental.responsiveImages` soit activée.
 
 ### image.experimentalObjectPosition
@@ -1139,7 +1139,7 @@ Nécessite que l'option `experimental.responsiveImages` soit activée.
 **Par défaut :** `"center"`
 </p>
 
-La valeur de position d'objet par défaut pour les images réactives. Peut être remplacée par la propriété `position` sur le composant image.
+La valeur de position d'objet par défaut pour les images adaptatives. Peut être remplacée par la propriété `position` sur le composant image.
 Nécessite que l'option `experimental.responsiveImages` soit activée.
 
 ### image.experimentalBreakpoints
@@ -1150,7 +1150,7 @@ Nécessite que l'option `experimental.responsiveImages` soit activée.
 **Par défaut :** `[640, 750, 828, 1080, 1280, 1668, 2048, 2560] | [640, 750, 828, 960, 1080, 1280, 1668, 1920, 2048, 2560, 3200, 3840, 4480, 5120, 6016]`
 </p>
 
-Les points d'arrêt utilisés pour générer des images réactives. Nécessite que l'option `experimental.responsiveImages` soit activée. La liste complète n'est normalement pas utilisée, mais est filtrée en fonction de la source et de la taille de sortie. Les valeurs par défaut utilisées dépendent du service d'image utilisé (local ou distant). Pour les services distants, la liste la plus complète est utilisée, car seules les tailles requises sont générées. Pour les services locaux, la liste est plus courte pour réduire le nombre d'images générées.
+Les points d'arrêt utilisés pour générer des images adaptatives. Nécessite que l'option `experimental.responsiveImages` soit activée. La liste complète n'est normalement pas utilisée, mais est filtrée en fonction de la source et de la taille de sortie. Les valeurs par défaut utilisées dépendent du service d'image utilisé (local ou distant). Pour les services distants, la liste la plus complète est utilisée, car seules les tailles requises sont générées. Pour les services locaux, la liste est plus courte pour réduire le nombre d'images générées.
 
 ## Options de Markdown
 

--- a/src/content/docs/fr/reference/experimental-flags/responsive-images.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/responsive-images.mdx
@@ -37,7 +37,7 @@ L'activation de cette option ne changera rien par défaut, mais les images adapt
 Pour ce faire, vous avez accès à des [paramètres supplémentaires de configuration d'`image`](#paramètres-de-configuration) pour contrôler le comportement par défaut de toutes les images traitées et optimisées par Astro :
 
 - Les images locales et distantes utilisant [la syntaxe Markdown `![]()`](/fr/guides/images/#images-dans-les-fichiers-markdown).
-- Les composants [`<Image />`](/fr/guides/images/#afficher-des-images-optimisées-avec-le-composant-image-) et [`<Picture />`](/fr/guides/images/#créez-des-images-réactives-avec-le-composant-picture-).
+- Les composants [`<Image />`](/fr/guides/images/#afficher-des-images-optimisées-avec-le-composant-image-) et [`<Picture />`](/fr/guides/images/#créez-des-images-adaptatives-avec-le-composant-picture-).
 
 De plus, les composants d'image d'Astro peuvent recevoir [des props d'images adaptatives](#propriétés-des-images-adaptatives) pour remplacer ces valeurs par défaut pour chaque image.
 

--- a/src/content/docs/fr/reference/modules/astro-assets.mdx
+++ b/src/content/docs/fr/reference/modules/astro-assets.mdx
@@ -271,7 +271,7 @@ import { Image } from 'astro:assets';
 
 <p><Since v="3.3.0" /></p>
 
-Utilisez le composant Astro intégré `<Picture />` pour afficher une image réactive avec plusieurs formats et/ou tailles.
+Utilisez le composant Astro intégré `<Picture />` pour afficher une image adaptative avec plusieurs formats et/ou tailles.
 
 ```astro title="src/pages/index.astro"
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed with @thomasbnt  in https://github.com/withastro/docs/pull/11543#discussion_r2063497285 other docs use `images adaptatives` instead of `images réactives` for `responsive images` so we should be consistent to avoid confusion (e.g. an external link to a page with another translation...).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
