### PR TITLE
Fix `i18n.mdx` snippet missing import and correct usage

### DIFF
--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -500,7 +500,6 @@ Translate the routes of your pages for each language.
     ```astro
     ---
     // src/components/LanguagePicker.astro
-    ---
     import { languages } from '../i18n/ui';
     import { getRouteFromUrl, useTranslatedPath } from '../i18n/utils';
 

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -503,7 +503,7 @@ Translate the routes of your pages for each language.
     ---
     import { languages } from '../i18n/ui';
     import { getRouteFromUrl, useTranslatedPath } from '../i18n/utils';
-    
+
     const route = getRouteFromUrl(Astro.url);
     ---
     <ul>

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -500,17 +500,21 @@ Translate the routes of your pages for each language.
     ```astro
     ---
     // src/components/LanguagePicker.astro
+    ---
     import { languages } from '../i18n/ui';
-    import { getRouteFromUrl } from '../i18n/utils';
-
+    import { getRouteFromUrl, useTranslatedPath } from '../i18n/utils';
+    
     const route = getRouteFromUrl(Astro.url);
     ---
     <ul>
-      {Object.entries(languages).map(([lang, label]) => (
-        <li>
-          <a href={translatePath(`/${route ? route : ''}`, lang)}>{label}</a>
-        </li>
-      ))}
+      {Object.entries(languages).map(([lang, label]) => {
+        const translatePath = useTranslatedPath(lang);
+        return (
+          <li>
+            <a href={translatePath(`/${route ? route : ''}`)}>{label}</a>
+          </li>
+        )
+      })}
     </ul>
     ```
 </Steps>


### PR DESCRIPTION
#### Description (required)

The code snippet didn't properly import `translatePath` that is actually returned from `useTranslatedPath`. This PR adds the proper usage.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
