### PR TITLE
docs(en/editor-setup.mdx): IDX is now Firebase Studio

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -55,7 +55,7 @@ In addition to local editors, Astro also runs well on in-browser hosted editors,
 
 - [StackBlitz](https://stackblitz.com/) and [CodeSandbox](https://codesandbox.io/) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
 - [GitHub.dev](https://github.dev/) - allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
-- [IDX](https://idx.dev) and [Gitpod](https://gitpod.io/) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.
+- [Firebase Studio](https://studio.firebase.google.com/) and [Gitpod](https://gitpod.io/) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.
 
 ## Other tools
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Google changed the Project IDX name to "Firebase Studio", now with a new link that will be the standard one. I changed the reference in Astro Docs "Editors" page.
