### PR TITLE
feat(fonts): local inference

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -442,7 +442,9 @@ display: "block"
 **Default:** `undefined`
 </p>
 
-Determines the specific [range of unicode characters](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range) to be used from a font. It allows the browser to only download the font file if the characters specified are present on the page. This is useful for localization:
+Determines when a font must be downloaded and used based on a specific [range of unicode characters](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range). If a character on the page matches the configured range, the browser will download the font and all characters will be available for use on the page. To configure a subset of characters preloaded for a single font, see the [subsets](#subsets) property instead.
+
+This can be useful for localization to avoid unnecessary font downloads when a specific part of your website uses a different alphabet and will be displayed with a separate font. For example, a website that offers both English and Japanese versions can prevent the browser from downloading the Japanese font on English versions of the page that do not contain any of the Japanese characters provided in `unicodeRange`.
 
 ```js
 unicodeRange: ["U+26"]

--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -533,7 +533,8 @@ export default defineConfig({
 
 <p>
 
-**Type:** `number | string`
+**Type:** `number | string`<br />
+**Default:** `undefined`
 </p>
 
 A [font weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight):
@@ -548,11 +549,14 @@ If the associated font is a [variable font](https://developer.mozilla.org/en-US/
 weight: "100 900"
 ```
 
+If left undefined, Astro will try to infer the value based on the first [`source`](#src).
+
 #### style
 
 <p>
 
-**Type:** `"normal" | "italic" | "oblique"`
+**Type:** `"normal" | "italic" | "oblique"`<br />
+**Default:** `undefined`
 </p>
 
 A [font style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style):
@@ -560,6 +564,8 @@ A [font style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style):
 ```js
 style: "normal"
 ```
+
+If left undefined, Astro will try to infer the value based on the first [`source`](#src).
 
 #### src
 

--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -442,7 +442,7 @@ display: "block"
 **Default:** `undefined`
 </p>
 
-Determines the specific [range of unicode characters](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range) to be used from a font:
+Determines the specific [range of unicode characters](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range) to be used from a font. It allows the browser to only download the font file if the characters specified are present on the page. This is useful for localization:
 
 ```js
 unicodeRange: ["U+26"]


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
- Clarifies what unicodeRange does (feedback from Matt)
- Explains how to infer weight and style for the local provider. I'm not really happy about what I wrote because it's at the end of the section but it's important because it's teh default feedback welcome!

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.7.x`. See https://github.com/withastro/astro/pull/13640

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
