### PR TITLE
Add note to Cloudflare deploy guide about using Workers vs Pages

### DIFF
--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -17,6 +17,12 @@ This guide includes:
 - [How to deploy to Cloudflare Workers](#cloudflare-workers)
 - [How to deploy to Cloudflare Pages](#cloudflare-pages)
 
+:::note
+
+Cloudflare recommends using Cloudflare Workers for new projects. For existing Pages projects, refer to [Cloudflare's migration guide](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/) and [compatibility matrix](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/#compatibility-matrix).
+
+:::
+
 <ReadMore>Read more about [using the Cloudflare runtime](/en/guides/integrations-guide/cloudflare/) in your Astro project.</ReadMore>
 ## Prerequisites
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Recommend using workers instead of pages for new projects deployed to cloudflare as per https://blog.cloudflare.com/full-stack-development-on-cloudflare-workers.

@sarah11918 thanks for flagging this!