### PR TITLE
fix(astro-components): update syntax highlighting and add link

### DIFF
--- a/src/content/docs/en/basics/astro-components.mdx
+++ b/src/content/docs/en/basics/astro-components.mdx
@@ -269,7 +269,7 @@ Use a `slot="my-slot"` attribute on the child element that you want to pass thro
 
 To pass multiple HTML elements into a component's `<slot/>` placeholder without a wrapping `<div>`, use the `slot=""` attribute on [Astro's `<Fragment/>` component](/en/reference/astro-syntax/#fragments):
 
-```astro title="src/components/CustomTable.astro" "<slot name="header"/>" "<slot name="body"/>"
+```astro title="src/components/CustomTable.astro" '<slot name="header" />' '<slot name="body" />'
 ---
 // Create a custom table with named slot placeholders for header and body content
 ---
@@ -281,7 +281,7 @@ To pass multiple HTML elements into a component's `<slot/>` placeholder without 
 
 Inject multiple rows and columns of HTML content using a `slot=""` attribute to specify the `"header"` and `"body"` content. Individual HTML elements can also be styled:
 
-```astro title="src/components/StockTable.astro" {5-7, 9-13} '<Fragment slot="header">' '<Fragment slot="body">'
+```astro title="src/components/StockTable.astro" {5-7, 9-13} '<Fragment slot="header">' '<Fragment slot="body">' '</Fragment>'
 ---
 import CustomTable from './CustomTable.astro';
 ---
@@ -392,7 +392,7 @@ Astro supports importing and using `.html` files as components or placing these 
 HTML components must contain only valid HTML, and therefore lack key Astro component features:
 
 - They don't support frontmatter, server-side imports, or dynamic expressions.
-- Any `<script>` tags are left unbundled, treated as if they had `is:inline`. 
+- Any `<script>` tags are left unbundled, treated as if they had an [`is:inline` directive](/en/reference/directives-reference/#isinline). 
 - They can only [reference assets that are in the `public/` folder](/en/basics/project-structure/#public).
 
 :::note


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the `basics/astro-components.mdx` file to:

* fix a broken syntax highlighting (noticed while updating the French file, in French this is broken... in English this is invisible)

|Before|After|
|---|---|
|![Broken syntax highlighting before](https://github.com/user-attachments/assets/9f4dd577-eb8d-4633-8219-f7713061fdc7)|![broken syntax highlighting after](https://github.com/user-attachments/assets/1e37eadd-6ad1-4b79-bf07-176c583e1783)|

* update a syntax highlighting because the example is describing using `slot` with `Fragment` so I think it could be useful to highlight the closing tag too:

|Before|After|
|---|---|
|![Incomplete syntax highlighting before](https://github.com/user-attachments/assets/b345e3f5-6fea-402f-8f89-5df90df2c647)|![Incomplete syntax highlighting after](https://github.com/user-attachments/assets/ad6d17e0-acca-413e-875f-13b9995e704c)|

* add a link to `is:inline` directive because in [HTML components](https://docs.astro.build/en/basics/astro-components/#html-components) we are referring twice to this directive so newcomers could ask themselves what it is.

#### Related issues & labels (optional)

- Suggested label:  code snippet update, typo/link/grammar - quick fix! 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
