### PR TITLE
i18n(fr): improves the wording in `basics`

### DIFF
--- a/src/content/docs/fr/basics/astro-pages.mdx
+++ b/src/content/docs/fr/basics/astro-pages.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 import ReadMore from '~/components/ReadMore.astro';
 import Since from '~/components/Since.astro'
 
-Les **pages** sont des fichiers qui se trouvent dans le sous-répertoire `src/pages/` de votre projet Astro. Ils sont responsables de la gestion du routage, du chargement des données et de la mise en page globale de chaque page de votre site Web.
+Les **pages** sont des fichiers qui se trouvent dans le sous-répertoire `src/pages/` de votre projet Astro. Ils sont responsables de la gestion du routage, du chargement des données et de la mise en page globale de chaque page de votre site web.
 
 ## Fichiers de page pris en charge 
 
@@ -16,7 +16,7 @@ Astro prend en charge les types de fichiers suivants dans le répertoire `src/pa
 - [`.md`](#pages-markdownmdx)
 - `.mdx` (avec l'[intégration MDX installée](/fr/guides/integrations-guide/mdx/#installation))
 - [`.html`](#pages-html)
-- `.js`/`.ts` (comme [endpoints](/fr/guides/endpoints/))
+- `.js`/`.ts` (comme [points de terminaison](/fr/guides/endpoints/))
 
 ## Routage basé sur les fichiers
 
@@ -24,7 +24,7 @@ Astro utilise une stratégie de routage appelée **routage basé sur les fichier
 
 Un seul fichier peut également générer plusieurs pages en utilisant le [routage dynamique](/fr/guides/routing/#routes-dynamiques). Cela vous permet de créer des pages même si votre contenu se trouve en dehors du répertoire spécial `/pages/`, par exemple dans une [collection de contenu](/fr/guides/content-collections/) ou un [CMS](/fr/guides/cms/).
 
-<ReadMore>En savoir plus sur [Le routage dans Astro](/fr/guides/routing/).</ReadMore>
+<ReadMore>En savoir plus sur [le routage dans Astro](/fr/guides/routing/).</ReadMore>
 
 ### Lien entre les pages
 
@@ -53,7 +53,7 @@ Les pages Astro utilisent l'extension de fichier `.astro` et prennent en charge 
 </html>
 ```
 
-Une page doit produire un document HTML complet. S'il n'est pas explicitement inclus, Astro ajoutera la déclaration `<!DOCTYPE html>` et le contenu `<head>` nécessaires à tout composant `.astro` situé dans `src/pages/` par défaut. Vous pouvez renoncer à ce comportement pour chaque composant en le marquant comme une page [partielle](#page-partielle).
+Une page doit produire un document HTML complet. S'il n'est pas explicitement inclus, Astro ajoutera la déclaration `<!DOCTYPE html>` et le contenu `<head>` nécessaires à tout composant `.astro` situé dans `src/pages/` par défaut. Vous pouvez renoncer à ce comportement pour chaque composant en le marquant comme une page [partielle](#pages-partielles).
 
 Pour éviter de répéter les mêmes éléments HTML sur chaque page, vous pouvez déplacer les éléments communs `<head>` et `<body>` dans vos propres [composants de mise en page](/fr/basics/layouts/). Vous pouvez utiliser autant, ou aussi peu de composants de mise en page que vous le souhaitez.
 
@@ -70,7 +70,7 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 
 ## Pages Markdown/MDX
 
-Astro traite également tous les fichiers Markdown (`.md`) contenus dans `src/pages/` comme des pages de votre site Web final. Si vous avez [installé l'intégration MDX](/fr/guides/integrations-guide/mdx/#installation), les fichiers MDX (`.mdx`) sont traités de la même manière.
+Astro traite également tous les fichiers Markdown (`.md`) contenus dans `src/pages/` comme des pages de votre site web final. Si vous avez [installé l'intégration MDX](/fr/guides/integrations-guide/mdx/#installation), les fichiers MDX (`.mdx`) sont traités de la même manière.
 
 :::tip
 Envisagez de créer des [collections de contenu](/fr/guides/content-collections/) au lieu de pages pour les répertoires de fichiers Markdown connexes qui partagent une structure similaire, tels que les articles de blog ou les pages de produits.
@@ -89,17 +89,17 @@ title: Ma page Markdown
 Voici ma page, écrite en **Markdown**.
 ```
 
-<ReadMore>En savoir plus sur le [Markdown](/fr/guides/markdown-content/) dans Astro.</ReadMore>
+<ReadMore>En savoir plus sur l'utilisation de [Markdown](/fr/guides/markdown-content/) dans Astro.</ReadMore>
 
 ## Pages HTML
 
-Les fichiers portant l'extension `.html` peuvent être placés dans le répertoire `src/pages/` et utilisés directement comme pages sur votre site. Notez que certaines fonctionnalités clés d'Astro ne sont pas prises en charge dans les [Composants HTML](/fr/basics/astro-components/#composants-html).
+Les fichiers portant l'extension `.html` peuvent être placés dans le répertoire `src/pages/` et utilisés directement comme pages sur votre site. Notez que certaines fonctionnalités clés d'Astro ne sont pas prises en charge dans les [composants HTML](/fr/basics/astro-components/#composants-html).
 
 ## Page d'erreur 404 personnalisée
 
 Pour une page d'erreur 404 personnalisée, vous pouvez créer un fichier `404.astro` ou `404.md` dans `src/pages`.
 
-Il sera construit en une page `404.html`. La plupart des [services de déploiement](/fr/guides/deploy/) le trouveront et l'utiliseront.
+Ce dernier servira à générer une page `404.html`. La plupart des [services de déploiement](/fr/guides/deploy/) le trouveront et l'utiliseront.
 
 ## Page d'erreur 500 personnalisée
 
@@ -109,7 +109,7 @@ Si une erreur survient lors du rendu de cette page, la page d'erreur 500 par dé
 
 <p><Since v="4.10.3" /></p>
 
-Pendant le développement, si vous avez un `500.astro`, l'erreur lancée à l'exécution est enregistrée dans votre terminal, au lieu d'être affichée dans la fenêtre d'erreur.
+Pendant le développement, si vous avez un fichier `500.astro`, l'erreur générée lors de l'exécution est affichée dans votre terminal, au lieu d'être présentée dans la fenêtre d'erreur superposée.
 
 ### `error`
 
@@ -132,36 +132,36 @@ const { error } = Astro.props;
 
 Pour éviter la fuite d'informations sensibles lors de l'affichage du contenu de la propriété `error`, envisagez d'évaluer d'abord l'erreur, et de renvoyer le contenu approprié en fonction de l'erreur provoquée. Par exemple, vous devriez éviter d'afficher la pile de l'erreur, car elle contient des informations sur la façon dont votre code est structuré sur le serveur.
 
-## Page Partielle
+## Pages partielles
 
 <p><Since v="3.4.0" /></p>
 
 :::caution
 Les pages partielles sont destinées à être utilisées en conjonction avec une bibliothèque front-end, telle que [htmx](https://htmx.org/) ou [Unpoly](https://unpoly.com/). Vous pouvez également les utiliser si vous êtes à l'aise avec l'écriture d'un JavaScript front-end de bas niveau. C'est pourquoi il s'agit d'une fonctionnalité avancée.
 
-En outre, les pages partielles ne doivent pas être utilisées si le composant contient des styles ou des scripts, car ces éléments seront supprimés de la sortie HTML. Si vous avez besoin de styles délimités, il est préférable d'utiliser des pages régulières, non partielles, ainsi qu'une bibliothèque front-end qui sait comment fusionner le contenu dans l'en-tête.
+En outre, les pages partielles ne doivent pas être utilisées si le composant contient des styles ou des scripts, car ces éléments seront supprimés de la sortie HTML. Si vous avez besoin de styles à portée limitée, il est préférable d'utiliser des pages régulières, non partielles, ainsi qu'une bibliothèque front-end qui sait comment fusionner le contenu dans l'en-tête.
 :::
 
-Les partiels sont des composants de page situés dans `src/pages/` qui ne sont pas destinés à être affichés comme des pages complètes.
+Les pages partielles sont des composants de page situés dans `src/pages/` qui ne sont pas destinés à être affichés comme des pages complètes.
 
-Comme les composants situés en dehors de ce dossier, ces fichiers n'incluent pas automatiquement la déclaration `<!DOCTYPE html>`, ni aucun contenu `<head>` tel que les styles et les scripts.
+Comme les composants situés en dehors de ce dossier, ces fichiers n'incluent pas automatiquement la déclaration `<!DOCTYPE html>`, ni aucun contenu `<head>` tel que les styles à portée limitée et les scripts.
 
 Cependant, parce qu'ils sont situés dans le répertoire spécial `src/pages/`, le HTML généré est disponible à une URL correspondant à son chemin de fichier. Cela permet à une bibliothèque de rendu (par exemple [htmx](https://htmx.org/), [Stimulus](https://stimulus.hotwired.dev/), [jQuery](https://jquery.com/)) d'y accéder sur le client et de charger des sections de HTML dynamiquement sur une page sans rafraîchissement du navigateur ni navigation dans la page.
 
-Les partiels, lorsqu'ils sont associés à une bibliothèque de rendu, constituent une alternative aux [îles Astro](/fr/concepts/islands/) et aux [balises `<script>`](/fr/guides/client-side-scripts/) pour la création de contenu dynamique dans Astro.
+Les pages partielles, lorsqu'elles sont associées à une bibliothèque de rendu, constituent une alternative aux [îlots d'Astro](/fr/concepts/islands/) et aux [balises `<script>`](/fr/guides/client-side-scripts/) pour la création de contenu dynamique dans Astro.
 
-Les fichiers de pages qui peuvent exporter une valeur pour [`partial`](/fr/reference/routing-reference/#partial) (par exemple `.astro` et `.mdx`, mais pas `.md`) peuvent être marqués comme partiels.
+Les fichiers de pages qui peuvent exporter une valeur pour [`partial`](/fr/reference/routing-reference/#partial) (par exemple `.astro` et `.mdx`, mais pas `.md`) peuvent être marqués comme étant partiels.
 
 ```astro title="src/pages/partial.astro" ins={2}
 ---
 export const partial = true;
 ---
-<li>Je suis un partiel !</li>
+<li>Je suis une page partielle !</li>
 ```
 
 ### Utilisation avec une bibliothèque
 
-Les partiels sont utilisés pour mettre à jour dynamiquement une section d'une page en utilisant une bibliothèque telle que [htmx](https://htmx.org/).
+Les pages partielles sont utilisées pour mettre à jour dynamiquement une section d'une page en utilisant une bibliothèque telle que [htmx](https://htmx.org/).
 
 L'exemple suivant montre un attribut `hx-post` défini sur l'URL d'une page partielle. Le contenu de la page partielle sera utilisé pour mettre à jour l'élément HTML ciblé sur cette page. 
 
@@ -189,7 +189,7 @@ L'exemple suivant montre un attribut `hx-post` défini sur l'URL d'une page part
 </html>
 ```
 
-Le fichier partiel `.astro` doit exister dans le chemin d'accès correspondant et inclure une exportation définissant la page comme un fichier partiel :
+Le fichier partiel `.astro` doit exister dans le chemin d'accès correspondant et inclure une exportation définissant la page comme étant partielle :
 
 ```astro title="src/pages/partials/clicked.astro" {2}
 ---

--- a/src/content/docs/fr/basics/layouts.mdx
+++ b/src/content/docs/fr/basics/layouts.mdx
@@ -1,22 +1,22 @@
 ---
-title: Composants Layout
+title: Mises en page
 description: Une introduction aux mises en page dans Astro.
 i18nReady: true
 ---
 
 import ReadMore from '~/components/ReadMore.astro'
 
-Les **Layouts** (ou « mise-en-pages » en français) sont des [composants Astro](/fr/basics/astro-components/) utilisés pour fournir une structure d'interface utilisateur réutilisable, comme un modèle de page.
+Les **mises en page** sont des [composants Astro](/fr/basics/astro-components/) utilisés pour fournir une structure d'interface utilisateur réutilisable, comme un modèle de page.
 
-Par convention, nous utilisons le terme « mise en page » pour les composants Astro qui fournissent des éléments d'interface utilisateur communs à toutes les pages, tels que les en-têtes, les barres de navigation et les pieds de page. Un composant de mise en page typique d'Astro fournit [aux pages Astro, Markdown ou MDX](/fr/basics/astro-pages/) les éléments suivants :
-- une **coquille de page** (`balises <html>`, `<head>` et `<body>`)
+Par convention, nous utilisons le terme « mise en page » pour les composants Astro qui fournissent des éléments d'interface utilisateur communs à toutes les pages, tels que les en-têtes, les barres de navigation et les pieds de page. Un composant Astro de mise en page typique fournit [aux pages Astro, Markdown ou MDX](/fr/basics/astro-pages/) les éléments suivants :
+- une **enveloppe de page** (balises `<html>`, `<head>` et `<body>`)
 - un [**`<slot />`**](/fr/basics/astro-components/#les-slots) pour spécifier où le contenu de chaque page doit être injecté.
 
-Mais, un composant de mise en page n'a rien de spécial ! Ils peuvent [accepter des props](/fr/basics/astro-components/#props-de-composant) et [importer et utiliser d'autres composants](/fr/basics/astro-components/#structure-du-composant) comme n'importe quel autre composant Astro. Ils peuvent inclure [des composants de frameworks d'interface utilisateur](/fr/guides/framework-components/) et [des scripts côté client](/fr/guides/client-side-scripts/). Ils ne sont même pas obligés de fournir une coquille de page complète, et peuvent plutôt être utilisés comme des modèles d'interface utilisateur partielle.
+Mais, un composant de mise en page n'a rien de spécial ! Ils peuvent [accepter des props](/fr/basics/astro-components/#props-de-composant) et [importer et utiliser d'autres composants](/fr/basics/astro-components/#structure-du-composant) comme n'importe quel autre composant Astro. Ils peuvent inclure [des composants de frameworks d'interface utilisateur](/fr/guides/framework-components/) et [des scripts côté client](/fr/guides/client-side-scripts/). Ils ne sont même pas obligés de fournir une enveloppe de page complète, et peuvent plutôt être utilisés comme des modèles d'interface utilisateur partiels.
 
 Cependant, si un composant de mise en page contient une enveloppe de page, son élément `<html>` doit être le parent de tous les autres éléments du composant.
 
-Les composants de mise en pages sont généralement placés dans un dossier `src/layouts` dans votre projet pour l'organisation, mais ce n'est pas une obligation ; vous pouvez choisir de les placer n'importe où dans votre projet. Vous pouvez même placer des composants de mise en page à côté de vos pages en [préfixant les noms de mise en page par `_`](/fr/guides/routing/#exclure-des-pages).
+Les composants de mise en page sont généralement placés dans un dossier `src/layouts` dans votre projet pour l'organisation, mais ce n'est pas une obligation ; vous pouvez choisir de les placer n'importe où dans votre projet. Vous pouvez même placer des composants de mise en page à côté de vos pages en [préfixant les noms de mise en page par `_`](/fr/guides/routing/#exclure-des-pages).
 
 ## Exemple de composant de mise en page
 
@@ -62,11 +62,11 @@ import MySiteLayout from '../layouts/MySiteLayout.astro';
 </MySiteLayout>
 ```
 
-<ReadMore>Apprenez-en plus sur [les Slots](/fr/basics/astro-components/#les-slots).</ReadMore>
+<ReadMore>Apprenez-en plus sur [les slots](/fr/basics/astro-components/#les-slots).</ReadMore>
 
 ## Utiliser TypeScript avec des mises en page
 
-Toute présentation Astro peut être modifiée pour introduire la sécurité des types et l'autocomplétion en fournissant les types de vos props :
+Toute mise en page Astro peut être modifiée pour introduire la sûreté du typage et l'autocomplétion en fournissant les types de vos props :
 
 ```astro ins={2-7} title="src/components/MyLayout.astro"
 ---
@@ -100,9 +100,9 @@ const { title, description, publishDate, viewCount } = Astro.props;
 
 Les mises en page sont particulièrement utiles pour les pages Markdown individuelles qui, autrement, n'auraient pas de formatage de page.
 
-Astro fournit une propriété spéciale `layout` frontmatter destinée aux [fichiers `.md` individuels situés dans `src/pages/` utilisant un routage basé sur les fichiers](/fr/guides/markdown-content/#pages-markdown-individuelles) pour spécifier quel composant `.astro` utiliser comme layout de la page. Ce composant vous permet de fournir du contenu `<head>` comme des balises méta (par exemple `<meta charset="utf-8">`) et des styles pour la page Markdown. Par défaut, ce composant spécifié peut accéder automatiquement aux données du fichier Markdown.
+Astro fournit une propriété de frontmatter spéciale nommée `layout` et destinée aux [fichiers `.md` individuels situés dans `src/pages/` et reposant sur le routage basé sur les fichiers](/fr/guides/markdown-content/#pages-markdown-individuelles). Elle vous permet de spécifier quel composant `.astro` utiliser comme mise en page. Ce composant vous permet de fournir du contenu `<head>` comme des balises méta (par exemple `<meta charset="utf-8">`) et des styles pour la page Markdown. Par défaut, ce composant spécifié peut accéder automatiquement aux données du fichier Markdown.
 
-Ceci n'est pas reconnu comme une propriété spéciale lors de l'utilisation de [content collections](/fr/guides/content-collections/) pour interroger et rendre votre contenu.
+Ceci n'est pas reconnu comme une propriété spéciale lors de l'utilisation des [collections de contenu](/fr/guides/content-collections/) pour interroger et afficher votre contenu.
 
 ```markdown title="src/pages/page.md" {2} 
 ---
@@ -181,8 +181,8 @@ const { frontmatter, url } = Astro.props;
 
 Une mise en page Markdown aura accès aux informations suivantes via `Astro.props` :
 
-- **`file`** - Le chemin absolu de ce fichier (exemple : `/home/user/projects/.../file.md`).
-- **`url`** - L'URL de cette page (exemple : `/fr/guides/markdown-content`).
+- **`file`** - Le chemin absolu de ce fichier (par exemple : `/home/user/projects/.../file.md`).
+- **`url`** - L'URL de cette page (par exemple : `/fr/guides/markdown-content`).
 - **`frontmatter`** - Tous les éléments frontmatter du document Markdown ou MDX.
   - **`frontmatter.file`** - Identique à la propriété `file` de premier niveau.
   - **`frontmatter.url`** - Identique à la propriété `url` de premier niveau.
@@ -203,7 +203,7 @@ Une mise en page Markdown aura accès à toutes les [propriétés disponibles](/
 
 Vous pouvez également utiliser la propriété spéciale `layout` de Markdown dans le frontmatter des fichiers MDX pour transmettre les props `frontmatter` et `headings` directement à un composant de mise en page spécifié de la même manière.
 
-Pour passer à votre layout MDX des informations qui n'existent pas (ou ne peuvent pas exister) dans votre frontmatter, vous pouvez importer et utiliser un composant `<Layout />`. Ce composant fonctionne comme n'importe quel autre composant Astro, et ne recevra pas de props automatiquement. Passez-lui directement les props nécessaires :
+Pour passer à votre mise en page MDX des informations qui n'existent pas (ou ne peuvent pas exister) dans votre frontmatter, vous pouvez importer et utiliser un composant `<Layout />`. Ce composant fonctionne comme n'importe quel autre composant Astro, et ne recevra pas de props automatiquement. Passez-lui directement les props nécessaires :
 
 ```mdx title="src/pages/posts/first-post.mdx" ins={6} del={2} /</?BaseLayout>/ /</?BaseLayout title={frontmatter.title} fancyJsHelper={fancyJsHelper}>/
 ---
@@ -243,7 +243,7 @@ const { title, fancyJsHelper } = Astro.props;
 </html>
 ```
 
-Lorsque vous utilisez une mise en page (que ce soit via la propriété `layout` de frontmatter ou en important une mise en page), vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement à votre page MDX.
+Lorsque vous utilisez une mise en page (que ce soit via la propriété `layout` du frontmatter ou en important une mise en page), vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement à votre page MDX.
 
 <ReadMore>Pour en savoir plus sur la prise en charge de Markdown et de MDX par Astro, consultez notre [guide Markdown](/fr/guides/markdown-content/).</ReadMore>
 
@@ -251,7 +251,7 @@ Lorsque vous utilisez une mise en page (que ce soit via la propriété `layout` 
 
 Les composants de mise en page ne doivent pas nécessairement contenir une page entière de code HTML. Vous pouvez diviser vos mises en page en composants plus petits et combiner les composants de mise en page pour créer des modèles de page encore plus flexibles. Ce modèle est utile lorsque vous souhaitez partager du code entre plusieurs mises en page.
 
-Par exemple, un composant de mise en page `BlogPostLayout.astro` pourrait styliser le titre, la date et l'auteur d'un article. Ensuite, un `BaseLayout.astro` au niveau du site pourrait gérer le reste de votre modèle de page, comme la navigation, les pieds de page, les balises méta SEO, les styles globaux et les polices de caractères. Vous pouvez également passer les props reçues de votre article à un autre layout, comme n'importe quel autre composant imbriqué.
+Par exemple, un composant de mise en page `BlogPostLayout.astro` pourrait mettre en forme le titre, la date et l'auteur d'un article. Ensuite, un `BaseLayout.astro` au niveau du site pourrait gérer le reste de votre modèle de page, comme la navigation, les pieds de page, les balises méta SEO, les styles globaux et les polices de caractères. Vous pouvez également passer les props reçues de votre article à une autre mise en page, comme n'importe quel autre composant imbriqué.
 
 ```astro {3} /</?BaseLayout>/ /</?BaseLayout url={frontmatter.url}>/
 ---

--- a/src/content/docs/fr/basics/project-structure.mdx
+++ b/src/content/docs/fr/basics/project-structure.mdx
@@ -5,21 +5,21 @@ i18nReady: true
 ---
 import { FileTree } from '@astrojs/starlight/components';
 
-Votre nouveau projet Astro généré à partir de l'assistant de création `create astro` inclut déjà quelques fichiers et dossiers. D'autres seront créés par vous-même et ajoutés à la structure existante d'Astro.
+Votre nouveau projet Astro généré à partir de l'assistant CLI `create astro` inclut déjà quelques fichiers et dossiers. D'autres seront créés par vous-même et ajoutés à la structure existante d'Astro.
 
 Voici comment un projet Astro est organisé, ainsi que quelques fichiers que vous trouverez dans votre nouveau projet.
 
 ## Répertoires et fichiers
 
-Astro s'appuie sur une disposition des dossiers propre à chaque projet. La racine de chaque projet Astro doit inclure les répertoires et fichiers suivants :
+Astro s'appuie sur une structure de dossier opiniâtre pour votre projet. La racine de chaque projet Astro doit inclure les répertoires et fichiers suivants :
 
-- `src/*` - Le code source de votre projet (composants, pages, styles, images, etc...)
-- `public/*` - Tout ce qui n'est pas du code et/ou des fichiers qui n'ont pas à être traités (polices d'écritures, icônes, etc...)
+- `src/*` - Le code source de votre projet (composants, pages, styles, images, etc.)
+- `public/*` - Tout ce qui n'est pas du code et/ou des fichiers qui n'ont pas à être traités (polices d'écritures, icônes, etc.)
 - `package.json` - Le manifeste de votre projet.
-- `astro.config.mjs` - Un fichier de configuration d'Astro (recommandé)
+- `astro.config.mjs` - Un fichier de configuration d'Astro. (recommandé)
 - `tsconfig.json` - Un fichier de configuration TypeScript. (recommandé)
 
-### Exemple de structure de projet
+### Exemple d'arborescence d'un projet
 
 Un répertoire de projet Astro courant peut ressembler à ceci :
 
@@ -27,12 +27,12 @@ Un répertoire de projet Astro courant peut ressembler à ceci :
 - public/
   - robots.txt
   - favicon.svg
-  - my-cv.pdf
+  - mon-cv.pdf
 - src/
-  - blog/
-      - post1.md
-      - post2.md
-      - post3.md
+    - blog/
+      - article1.md
+      - article2.md
+      - article3.md
   - components/
     - Header.astro
     - Button.jsx
@@ -40,18 +40,12 @@ Un répertoire de projet Astro courant peut ressembler à ceci :
     - image1.jpg
     - image2.jpg
     - image3.jpg
-  - content/
-      - config.ts
-      - posts/
-        - post1.md
-        - post2.md
-        - post3.md
   - layouts/
     - PostLayout.astro
   - pages/
-    - posts/
-      - [post].astro
-    - about.astro
+    - articles/
+      - [article].astro
+    - a-propos.astro
     - **index.astro**
     - rss.xml.js
   - styles/
@@ -64,17 +58,17 @@ Un répertoire de projet Astro courant peut ressembler à ceci :
 
 ### `src/`
 
-Le code source de votre project se trouve dans le dossier `src/`. Il comprend en général :
+Le dossier `src/` est l'endroit où se trouve la majeure partie du code source de votre projet. Il comprend :
 
-- [Des composants Pages](/fr/basics/astro-pages/)
-- [Des composants Layouts](/fr/basics/layouts/)
+- [Des pages](/fr/basics/astro-pages/)
+- [Des mises en page](/fr/basics/layouts/)
 - [Des composants Astro](/fr/basics/astro-components/)
-- [Des composants Frontend (React, etc...)](/fr/guides/framework-components/)
+- [Des composants de framework UI (React, etc...)](/fr/guides/framework-components/)
 - [Des fichiers de style (CSS, Sass)](/fr/guides/styling/)
 - [Du Markdown](/fr/guides/markdown-content/)
-- [Images optimisées et traitées par Astro](/fr/guides/images/)
+- [Des images à optimiser et à traiter par Astro](/fr/guides/images/)
 
-Astro traite, optimise et regroupe vos fichiers `src/` pour créer le site web final qui est livré au navigateur. Contrairement au répertoire statique `public/`, les fichiers `src/` sont traités et assemblés pour vous par Astro.
+Astro traite, optimise et regroupe les fichiers placés dans votre dossier `src/` pour créer le site web final qui est livré au navigateur. Contrairement au répertoire statique `public/`, les fichiers dans `src/` sont traités et gérés pour vous par Astro.
 
 Certains fichiers (comme les composants Astro) ne sont pas envoyés au navigateur tels qu'ils sont écrits, mais sont rendus en HTML statique. D'autres fichiers (CSS par exemple) sont envoyés au navigateur, mais peuvent être optimisés ou regroupés avec d'autres fichiers CSS pour améliorer les performances.
 
@@ -98,9 +92,9 @@ C'est une convention courante dans les projets Astro, mais elle n'est pas obliga
 
 ### `src/layouts`
 
-Les [composants de mise en page](/fr/basics/layouts/) sont des composants Astro qui définissent la structure de l'interface partagée par une ou plusieurs [pages](/fr/basics/astro-pages/).
+Les [mises en page](/fr/basics/layouts/) sont des composants Astro qui définissent la structure de l'interface partagée par une ou plusieurs [pages](/fr/basics/astro-pages/).
 
-Tout comme `src/components`, ce répertoire est une convention commune mais n'est pas obligatoire.
+Tout comme `src/components`, ce répertoire est une convention courante mais n'est pas obligatoire.
 
 ### `src/styles`
 
@@ -108,36 +102,36 @@ Il est courant de stocker vos fichiers CSS ou Sass dans un répertoire `src/styl
 
 ### `public/`
 
-Le dossier `public/` contient les fichiers et les ressources qui n'ont pas besoin d'être traités pendant le processus de construction d'Astro. Les fichiers de ce répertoire seront copiés dans le répertoire de construction sans être modifiés, puis votre site sera construit.
+Le dossier `public/` contient les fichiers et les ressources qui n'ont pas besoin d'être traités pendant le processus de compilation d'Astro. Les fichiers de ce répertoire seront copiés dans le répertoire de sortie sans être modifiés, puis votre site sera créé.
 
 Ce comportement fait du dossier `public/` un endroit idéal pour les ressources communes qui ne nécessitent aucun traitement, comme certaines images et polices, ou des fichiers spéciaux tels que `robots.txt` et `manifest.webmanifest`.
 
-Vous pouvez placer des fichiers CSS et JavaScript dans le dossier `public/`, mais gardez à l'esprit que ces fichiers ne seront pas regroupés et/ou optimisés dans votre construction final.
+Vous pouvez placer des fichiers CSS et JavaScript dans le dossier `public/`, mais gardez à l'esprit que ces fichiers ne seront pas regroupés ou optimisés dans votre construction final.
 
 :::tip
-En règle générale, tout CSS ou JavaScript que vous ajoutez devrait être mis dans le dossier `src/`.
+En règle générale, tout CSS ou JavaScript que vous écrivez vous-même devrait se trouver dans votre dossier `src/`.
 :::
 
 ### `package.json`
 
-C'est un fichier utilisé par les gestionnaires de paquets JavaScript pour gérer vos dépendances. Il définit également les scripts qui sont utilisés pour exécuter Astro (ex: `npm run dev`, `npm run build`).
+C'est un fichier utilisé par les gestionnaires de paquets JavaScript pour gérer vos dépendances. Il définit également les scripts qui sont utilisés pour exécuter Astro (p. ex. : `npm run dev`, `npm run build`).
 
-Il existe [deux types de dépendances](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) que vous pouvez spécifier dans le fichier `package.json` : `dependencies` et `devDependencies`. Dans la plupart des cas, elles fonctionnent de la même manière : Astro a besoin de toutes les dépendances au moment de la construction, et votre gestionnaire de paquets les installera toutes les deux. Nous recommandons de mettre toutes vos dépendances dans `dependencies` pour commencer, et de n'utiliser `devDependencies` que si vous avez un besoin spécifique.
+Il existe [deux types de dépendances](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) que vous pouvez spécifier dans le fichier `package.json` : `dependencies` et `devDependencies`. Dans la plupart des cas, elles fonctionnent de la même manière : Astro a besoin de toutes les dépendances au moment de la compilation, et votre gestionnaire de paquets les installera toutes les deux. Nous recommandons de mettre toutes vos dépendances dans `dependencies` pour commencer, et de n'utiliser `devDependencies` que si vous avez un besoin spécifique.
 
-Pour plus d'informations en ce qui concerne la création d'un nouveau fichier `package.json` pour votre projet, consultez les instructions de [configuration manuelle](/fr/install-and-setup/#configuration-manuelle).
+Pour obtenir de l'aide sur la création d'un nouveau fichier `package.json` pour votre projet, consultez les instructions de [configuration manuelle](/fr/install-and-setup/#configuration-manuelle).
 
 ### `astro.config.mjs`
 
-Ce fichier est généré dans chaque modèle de démarrage et contient des options de configuration pour votre projet Astro. Ici, vous pouvez spécifier les intégrations à utiliser, les options de construction, les options du serveur, et plus encore.
+Ce fichier est généré dans chaque modèle de démarrage et contient des options de configuration pour votre projet Astro. Ici, vous pouvez spécifier les intégrations à utiliser, les options de compilation, les options du serveur, et plus encore.
 
 Astro prend en charge plusieurs formats de fichiers pour son fichier de configuration JavaScript : `astro.config.js`, `astro.config.mjs`, `astro.config.cjs` et `astro.config.ts`. Nous vous recommandons d'utiliser `.mjs` dans la plupart des cas ou `.ts` si vous souhaitez utiliser TypeScript dans votre fichier de configuration.
 
 Le chargement du fichier de configuration TypeScript est géré à l'aide de [`tsm`](https://github.com/lukeed/tsm) et respectera les options `tsconfig` de votre projet.
 
-Allez voir la [référence de configuration](/fr/reference/configuration-reference/) pour plus d'informations.
+Consultez la [référence de configuration](/fr/reference/configuration-reference/) pour plus d'informations.
 
 ### `tsconfig.json`
 
 Ce fichier est généré dans chaque modèle de démarrage et comprend des options de configuration TypeScript pour votre projet Astro. Certaines fonctionnalités (comme les importations de paquets npm) ne sont pas entièrement prises en charge dans l'éditeur sans un fichier `tsconfig.json`.
 
-Voir le [Guide TypeScript](/fr/guides/typescript/) pour plus de détails sur le paramétrage des configurations.
+Consultez le [guide TypeScript](/fr/guides/typescript/) pour plus de détails sur le paramétrage des configurations.

--- a/src/content/docs/fr/reference/routing-reference.mdx
+++ b/src/content/docs/fr/reference/routing-reference.mdx
@@ -68,7 +68,7 @@ Une valeur exportée à partir d'une route individuelle pour déterminer si elle
 
 Par défaut, tous les fichiers situés dans le répertoire réservé `src/pages/` incluent automatiquement la déclaration `<!DOCTYPE html>` et le contenu supplémentaire `<head>` tel que les styles et scripts à portée limitée d'Astro.
 
-Vous pouvez remplacer la valeur par défaut pour désigner le contenu comme une [partie de page](/fr/basics/astro-pages/#page-partielle) pour une route individuelle en exportant une valeur pour `partial` à partir de ce fichier :
+Vous pouvez remplacer la valeur par défaut pour désigner le contenu comme une [partie de page](/fr/basics/astro-pages/#pages-partielles) pour une route individuelle en exportant une valeur pour `partial` à partir de ce fichier :
 
 ```astro title="src/pages/my-page-partial.astro" {2}
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Following https://github.com/withastro/docs/pull/11593, updates the remaining files in the `basics` directory with a lot of small changes:
* replace `layout` and `présentation` with `mise en page`
* replace `styliser` with `mettre en forme`
* replace `styles limités` with `styles à portée limitée`
* replace `construction` with `compilation` or `création`
* update capitalization in various places
* reword some sentences to match the English version
* translate untranslated words (endpoint, content collection, project)
* fix the `<FileTree />` component in project structure
* break a sentence that was hard to read 😅 

I also replaced the use of `partiels` as a noun with `pages partielles` because it seems, in France, `partiel` is only used as noun to refer to a midterm (examen) or in dentistery. When used as a noun in English, we use it as a noun followed by the adjective `partiel`. See [Wiktionary](https://fr.wiktionary.org/wiki/partial#Nom_commun) for example.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
