### PR TITLE
fix(link) Updates reference to glob patterns to go to proper library

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -343,7 +343,7 @@ Additionally, glob patterns must begin with one of the following:
 - `../` (to start in the parent directory)
 - `/` (to start at the root of the project)
  
-[Read more about the glob pattern syntax](https://github.com/mrmlnc/fast-glob#pattern-syntax).
+[Read more about the glob pattern syntax](https://github.com/micromatch/picomatch#globbing-features).
 
 ### `import.meta.glob()` vs `getCollection()`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Replaces [mrmlnc/fast-glob#pattern-syntax](https://github.com/mrmlnc/fast-glob#pattern-syntax) with [micromatch/picomatch#globbing-features](https://github.com/micromatch/picomatch#globbing-features) in guides/imports

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Related Issue: #11673 
- Suggested label: fix

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.7`.

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
