### PR TITLE
feat: add explanation for Prettier plugin order to Editor setup page

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -116,7 +116,7 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
     }
     ```
 
-3. Optionally, install other Prettier plugins for your project, and add them to the configuration file. These additional plugins may need to be listed in a specific order. For example, if you use Tailwind, `prettier-plugin-tailwindcss` must be the last Prettier plugin in the plugins array.
+3. Optionally, install other Prettier plugins for your project, and add them to the configuration file. These additional plugins may need to be listed in a specific order. For example, if you use Tailwind, `prettier-plugin-tailwindcss` must be [the last Prettier plugin in the plugins array](https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins).
 
     ```json title=".prettierrc"
     {

--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -116,7 +116,9 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
     }
     ```
 
-3. Run the following command in your terminal to format your files.
+3. Optionally, install other Prettier plugins for your project, and add them to the configuration file. These additional plugins may need to be listed in a specific order. For example, if you use Tailwind, `prettier-plugin-tailwindcss` must be the last Prettier plugin in the plugins array.
+
+4. Run the following command in your terminal to format your files.
 
     <PackageManagerTabs>
       <Fragment slot="npm">

--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -118,6 +118,23 @@ To add support for formatting `.astro` files outside of the editor (e.g. CLI) or
 
 3. Optionally, install other Prettier plugins for your project, and add them to the configuration file. These additional plugins may need to be listed in a specific order. For example, if you use Tailwind, `prettier-plugin-tailwindcss` must be the last Prettier plugin in the plugins array.
 
+    ```json title=".prettierrc"
+    {
+      "plugins": [
+        "prettier-plugin-astro",
+        "prettier-plugin-tailwindcss" // needs to appear after other Prettier plugins
+      ],
+      "overrides": [
+        {
+          "files": "*.astro",
+          "options": {
+            "parser": "astro"
+          }
+        }
+      ]
+    }
+    ```
+
 4. Run the following command in your terminal to format your files.
 
     <PackageManagerTabs>


### PR DESCRIPTION
#### Description

This change adds an extra step to the Prettier setup instructions of `editor-setup.mdx`. The extra step discusses adding other Prettier plugins, making sure to mention the importance of their order. There is an example that specifically shows `prettier-plugin-tailwindcss` as the last one.

I went with an extra step to avoid cluttering step 2, and to try keeping concepts separate. 

#### Related issues & labels

- Closes #10877.
- Suggested label: `improve or update documentation`
