### PR TITLE
i18n(ja): Add `guides/migrate-to-astro/from-hugo.mdx`

### DIFF
--- a/src/content/docs/ja/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/content/docs/ja/guides/migrate-to-astro/from-hugo.mdx
@@ -1,0 +1,71 @@
+---
+title: Hugoからの移行
+description: HugoプロジェクトをAstroに移行するためのガイド
+sidebar:
+label: Hugo
+type: migration
+stub: false
+framework: Hugo
+i18nReady: true
+---
+
+import PackageManagerTabs from '\~/components/tabs/PackageManagerTabs.astro';
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+[Hugo](https://gohugo.io)は、Goで構築されたオープンソースの静的サイトジェネレーターです。
+
+## HugoとAstroの類似点
+
+HugoとAstroには、プロジェクト移行を容易にするいくつかの共通点があります：
+
+- HugoもAstroも、ブログのような[コンテンツ主導のウェブサイト](/ja/concepts/why-astro/#content-driven)に最適なモダンな静的サイトジェネレーターです。
+- どちらも[Markdownでコンテンツを作成](/ja/guides/markdown-content/)できます。HugoではYAML、TOML、JSONのいずれかでフロントマターを記述できます。AstroではYAMLとTOMLに対応しており、既存のMarkdownファイルやフロントマターの値をそのまま利用できます（ただしAstro側で「特別な」意味は持ちません）。
+- HugoとAstroはいずれも、多様な[インテグレーションや外部パッケージ](https://astro.build/integrations/)を組み込んで拡張できます。
+
+## HugoとAstroの主な相違点
+
+- HugoはページテンプレートにGoテンプレートを使用しますが、Astroは[JSX風のHTML構文](/ja/basics/astro-components/)を使います。
+- Astroは標準のMarkdownで動的コンテンツ向けにショートコードを使用しませんが、[MDXインテグレーション](/ja/guides/integrations-guide/mdx/)を追加すれば、JSXやコンポーネントのインポートが可能になります。
+- Hugoでは「パーシャル」でレイアウトの再利用を行いますが、Astroは完全に[コンポーネントベース](/ja/basics/astro-components/)です。`.astro`ファイルはコンポーネント、レイアウト、ページのいずれとしても使用可能で、他のAstroコンポーネントや[UIフレームワークのコンポーネント](/ja/guides/framework-components/)、[MarkdownやMDXファイル](/ja/guides/imports/)のメタデータやコンテンツも読み込めます。
+
+## HugoサイトをAstroに変換する
+
+HugoブログをAstroへ移行するには、まず[公式ブログテーマスターター](https://astro.build/themes/blog/)を使うか、[テーマショーケース](https://astro.build/themes/)でコミュニティ製テーマを探してください。
+
+`create astro`コマンドに`--template`を渡すと、公式スターターで新しいAstroプロジェクトを作成できます。また、[GitHub上の既存Astroリポジトリから新規プロジェクトを開始](/ja/install-and-setup/)することも可能です。
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro@latest -- --template blog
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro@latest --template blog
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn create astro --template blog
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Markdown（またはMDX）ファイルは、[AstroのMarkdown/MDXページ](/ja/guides/markdown-content/)として再利用できます。YAMLやTOMLのフロントマターはそのまま使用できますが、**JSONは変換が必要**です。
+
+Markdownファイル内で変数や表現、UIコンポーネントなど動的コンテンツを使用するには、AstroのMDXインテグレーションを追加して[MDXページ](/ja/guides/markdown-content/)へ変換してください。MDXはYAMLとTOMLのフロントマターをサポートしており、ショートコード構文は[MDX構文](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax)に置き換える必要があります（JSX表現やコンポーネントのインポートなど）。
+
+ポートフォリオサイトやドキュメントサイトなど別のタイプのサイトを移行したい場合は、[astro.new](https://astro.new)で他の公式スターターテンプレートを参照してください。GitHubリポジトリへのリンクや、IDX・StackBlitz・CodeSandbox・Gitpodで開発環境をすぐに立ち上げるためのリンクも用意されています。
+
+## コミュニティリソース
+
+<CardGrid>
+
+  <LinkCard title="Elio StruyfによるHugoからAstroへの移行ストーリー" href="https://www.eliostruyf.com/migration-story-hugo-astro/" />
+
+  <LinkCard title="HugoとAstroの比較（2023年版）" href="https://onebite.dev/hugo-vs-astro-which-static-site-generator-to-choose-in-2023/" />
+
+  <LinkCard title="AI支援によるAstroへの移行の教訓" href="https://bennet.org/blog/lessons-from-ai-assisted-migration-to-astro/" />
+
+</CardGrid>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Add missing Japanese translation
This improves completeness of the Japanese docs and aligns them with the latest English source. 

original source: https://github.com/withastro/docs/blob/main/src/content/docs/ja/guides/migrate-to-astro/from-hugo.mdx

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
Discord: jp-knj
<!-- https://astro.build/chat -->
