### PR TITLE
i18n(ja): Add `guides/migrate-to-astro/from-vuepress.mdx`

### DIFF
--- a/src/content/docs/ja/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/ja/guides/migrate-to-astro/from-vuepress.mdx
@@ -1,0 +1,66 @@
+---
+title: VuePressからの移行
+description: 既存のVuePressプロジェクトをAstroに移行するためのヒント
+sidebar:
+  label: VuePress
+type: migration
+stub: true
+framework: VuePress
+i18nReady: true
+---
+
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+
+[VuePress](https://vuePress.vuejs.org)は、Vueをベースにしたオープンソースの静的サイトジェネレーターです。
+
+## VuePressとAstroの主な共通点
+
+VuePressとAstroには、移行時に役立ついくつかの共通点があります。
+
+- VuePressとAstroはどちらも最新のJavaScript静的サイトジェネレーターであり、似たようなプロジェクト構成を持ちます。どちらも[ファイルベースのルーティング用の特別な`src/pages/`フォルダー](/ja/basics/astro-pages/)を使用します。ページの作成や管理の方法は親しみやすいはずです。
+- AstroとVuePressはどちらも[コンテンツ駆動型のWebサイト](/ja/concepts/why-astro/#content-driven)に適しており、Markdownファイルの優れたサポートを提供します。Markdownでの執筆は馴染みがあり、既存コンテンツをそのまま利用できます。
+- Astroには[Vueコンポーネントを使用するための公式インテグレーション](/ja/guides/integrations-guide/vue/)があり、[Vue関連のNPMパッケージのインストール](/ja/guides/imports/#npm-packages)もサポートしています。Vueで書いたUIコンポーネントの一部またはすべてを再利用できる可能性があります。
+
+## VuePressとAstroの主な違い
+
+VuePressサイトをAstroで再構築する際には、いくつかの重要な違いに気付くはずです。
+
+- VuePressはVueベースのシングルページアプリケーション（SPA）です。Astroサイトは[`.astro`コンポーネント](/ja/basics/astro-components/)を用いたマルチページアプリケーション（MPA）ですが、[React、Preact、Vue、Svelte、Solid、AlpineJS](/ja/guides/framework-components/)などのフレームワークにも対応しています。
+- [レイアウトテンプレート](/ja/basics/layouts/)：VuePressではMarkdown（`.md`）とHTMLテンプレートを使ってページを構成します。Astroはコンポーネントベースであり、HTMLテンプレートとして使えるAstroコンポーネントを通じて、ページ・レイアウト・UI要素を組み立てます。Astroでは[MarkdownおよびMDXファイルからページを生成](/ja/guides/markdown-content/)できます。
+- VuePressはMarkdown中心のコンテンツ重視のドキュメントサイトを構築するために設計されており、組み込みのドキュメント機能が多数あります。Astroではそのような機能を[公式ドキュメントテーマ（Starlight）](https://starlight.astro.build)で補完できます。Starlightはこのサイトが元になっており、現在も使われています。[コミュニティによるドキュメントテーマ](https://astro.build/themes?search=&categories%5B%5D=docs)も多数用意されています。
+
+## VuePressからAstroへの移行方法
+
+VuePressのドキュメントサイトをAstroへ移行するには、公式の[Starlightドキュメントテーマスターター](https://starlight.astro.build)を使うか、[コミュニティ製ドキュメントテーマ一覧](https://astro.build/themes?search=&categories%5B%5D=docs)からテーマを選びましょう。
+
+`create astro`コマンドに `--template` オプションを付けてスターターテンプレートから新しいAstroプロジェクトを開始できます。または、[GitHubにあるAstroの既存リポジトリからプロジェクトを作成](/jainstall-and-setup/#install-from-the-cli-wizard)することも可能です。
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```shell
+  npm create astro@latest -- --template starlight
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```shell
+  pnpm create astro@latest --template starlight
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```shell
+  yarn create astro --template starlight
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+既存のMarkdownコンテンツファイルを[Markdownページとして追加](/ja/guides/markdown-content/)できます。VuePressの`docs`ディレクトリにあるドキュメントをAstroの`src/pages/`に移動すれば、[ファイルベースルーティング](/ja/guides/routing/)の利点を活かせます。既存のURL構造を維持したい場合は、同じ構成でフォルダを作成してください。
+
+VuePressやそのテーマは、レイアウトやメタデータの処理を多く担っていた可能性があります。[Markdown用ラッパーレイアウトの作成方法](/ja/basics/layouts/#markdown-layouts)を参照して、Astroでテンプレートや`<head>`の管理方法を確認しましょう。
+
+[astro.new](https://astro.new)では、Astroの公式ドキュメントスターターやその他テンプレートが見つかります。各プロジェクトのGitHubリポジトリのリンクや、IDX、StackBlitz、CodeSandbox、Gitpodといったオンライン開発環境ですぐに試せるリンクも用意されています。
+
+## コミュニティリソース
+
+:::note[共有したいリソースがありますか？]
+VuePressサイトをAstroに移行するための参考になる動画やブログ記事を見つけた・作成した場合は、[このリストに追加してください](https://github.com/withastro/docs/edit/main/src/content/docs/en/guides/migrate-to-astro/from-vuepress.mdx)！
+:::


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Add missing Japanese translation
This improves completeness of the Japanese docs and aligns them with the latest English source. 

original source: https://github.com/withastro/docs/blob/main/src/content/docs/ja/guides/migrate-to-astro/from-vuepress.mdx

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
Discord: jp-knj
<!-- https://astro.build/chat -->
