### PR TITLE
Clarify usage of fs storage in Sessions with Cloudflare adapter

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -394,7 +394,9 @@ Creating a custom `public/_routes.json` will override the automatic generation. 
 
 The Astro [Sessions API](/en/guides/sessions/) allows you to easily store user data between requests. This can be used for things like user data and preferences, shopping carts, and authentication credentials. Unlike cookie storage, there are no size limits on the data, and it can be restored on different devices. 
 
-Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv/) for session storage when using the Cloudflare adapter. Before using sessions, you need to create a KV namespace to store the data and configure a KV binding in your Wrangler config file. By default, Astro expects the KV binding to be named `SESSION`, but you can choose a different name if you prefer by setting the [`sessionKVBindingName`](#sessionkvbindingname) option in the adapter config.
+Astro automatically configures [Workers KV](https://developers.cloudflare.com/kv/) for session storage when using the Cloudflare adapter in production. To avoid mistakes that could compromise your data or cause unexpected bills, the filesystem storage will be used during local development by default.
+
+Before deploying, you need to create a KV namespace to store the data and configure a KV binding in your Wrangler config file. By default, Astro expects the KV binding to be named `SESSION`, but you can choose a different name if you prefer by setting the [`sessionKVBindingName`](#sessionkvbindingname) option in the adapter config.
 
 <Steps>
 


### PR DESCRIPTION
#### Description (required)

When using the dev server with the Cloudflare adapter, you actually don't end up using the Cloudflare KV storage for sessions, but instead the filesystem storage.

#### Related issues & labels (optional)
Sibling core PR: https://github.com/withastro/astro/pull/13817 (it doesn't depend on it to be merged!)