### PR TITLE
fix(backend/turso): replace broken links to Turso Docs

### DIFF
--- a/src/content/docs/en/guides/backend/turso.mdx
+++ b/src/content/docs/en/guides/backend/turso.mdx
@@ -16,7 +16,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 ### Prerequisites
 
-- The [Turso CLI](https://docs.turso.tech/reference/turso-cli) installed and signed in
+- The [Turso CLI](https://docs.turso.tech/cli/introduction) installed and signed in
 - A [Turso](https://turso.tech) Database with schema
 - Your Database URL
 - An Access Token
@@ -83,7 +83,7 @@ export const turso = createClient({
 
 ## Querying your database
 
-To access information from your database, import `turso` and [execute a SQL query](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#execute-a-single-statement) inside any `.astro` component.
+To access information from your database, import `turso` and [execute a SQL query](https://docs.turso.tech/sdk/ts/reference#simple-query) inside any `.astro` component.
 
 The following example fetches all `posts` from your table, then displays a list of titles in a `<BlogIndex />` component:
 
@@ -103,7 +103,7 @@ const { rows } = await turso.execute('SELECT * FROM posts')
 
 ### SQL Placeholders
 
-The `execute()` method can take [an object to pass variables to the SQL statement](https://docs.turso.tech/libsql/client-access/javascript-typescript-sdk#positional-placeholders), such as `slug`, or pagination.
+The `execute()` method can take [an object to pass variables to the SQL statement](https://docs.turso.tech/sdk/ts/reference#placeholders), such as `slug`, or pagination.
 
 The following example fetches a single entry from the `posts` table `WHERE` the `slug` is the retrieved value from `Astro.params`, then displays the title of the post.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The structure of Turso Docs has changed since the backend guide was written. So I replaced 3 broken links (redirected to the homepage) with 3 equivalent links I think.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: typo/link/grammar - quick fix!

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
