### PR TITLE
i18n(fr): update `guides/cms/apostrophecms.mdx`

### DIFF
--- a/src/content/docs/fr/guides/cms/apostrophecms.mdx
+++ b/src/content/docs/fr/guides/cms/apostrophecms.mdx
@@ -21,7 +21,7 @@ Dans cette section, vous utiliserez l'[intégration Apostrophe](https://apostrop
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-1. **Un projet Astro affiché à la demande** avec l'[adaptateur Node.js](/fr/guides/integrations-guide/node/) installé et `output : 'server'` configuré - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro affiché à la demande** avec l'[adaptateur Node.js](/fr/guides/integrations-guide/node/) installé et `output: 'server'` configuré - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 
 2. **Un projet ApostropheCMS avec une variable d'environnement configurée appelée `APOS_EXTERNAL_FRONT_KEY`** - Cette variable d'environnement peut être configurée avec n'importe quelle chaîne de caractères aléatoire. Si vous n'avez pas encore de projet ApostropheCMS, le [guide d'installation](https://docs.apostrophecms.org/guide/development-setup.html) vous permettra de l'installer rapidement. Nous recommandons fortement l'utilisation de l'[outil CLI d'Apostrophe](https://apostrophecms.com/extensions/apos-cli) pour faciliter cette opération.
 
@@ -33,16 +33,16 @@ Votre projet Astro doit avoir une variable d'environnement `APOS_EXTERNAL_FRONT_
 Créez un fichier `.env` à la racine de votre projet Astro avec la variable suivante :
 
 ```ini title=".env"
-APOS_EXTERNAL_FRONT_KEY='RandomStrongString'
+APOS_EXTERNAL_FRONT_KEY='ChaîneDeCaractèresForteEtAléatoire'
 ```
 
 Votre répertoire racine doit maintenant contenir ce nouveau fichier :
 
 <FileTree title="Structure du projet">
-  - src/
-  - **.env**
-  - astro.config.mjs
-  - package.json
+- src/
+- **.env**
+- astro.config.mjs
+- package.json
 </FileTree>
 
 ### Installation des dépendances
@@ -70,7 +70,7 @@ Pour connecter Astro à votre projet ApostropheCMS, installez l'intégration off
 
 Configurez l'intégration `apostrophe-astro` et `vite` dans votre fichier `astro.config.mjs`.
 
-L'exemple suivant fournit l'URL de base de votre instance d'Apostrophe et les chemins vers les dossiers de votre projet pour établir une correspondance entre les types [widgets](https://docs.apostrophecms.org/guide/core-widgets.html) et les [templates de page](https://docs.apostrophecms.org/guide/pages.html) d'ApostropheCMS et votre projet Astro. Il configure également l'affichage côté serveur de Vite.
+L'exemple suivant fournit l'URL de base de votre instance d'Apostrophe et les chemins d'accès aux dossiers de votre projet pour établir une correspondance entre les [widgets](https://docs.apostrophecms.org/guide/core-widgets.html) et les [modèles de page](https://docs.apostrophecms.org/guide/pages.html) d'ApostropheCMS et votre projet Astro. Il configure également le rendu côté serveur de Vite.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -94,8 +94,8 @@ export default defineConfig({
   ],
   vite: {
     ssr: {
-      // Ne pas externaliser le plugin @apostrophecms/apostrophe-astro, nous avons besoin
-      // pour pouvoir y utiliser des URL virtuels :.
+      // Ne pas externaliser le module d'extension @apostrophecms/apostrophe-astro
+      // nous devons être capable d'y utiliser des URL virtuelles (`virtual:`)
       noExternal: [ '@apostrophecms/apostrophe-astro' ],
     },
     define: {
@@ -125,7 +125,7 @@ const { content } = widget;
 <Fragment set:html={ content }></Fragment>
 ```
 
-Certains widgets standards d'Apostrophe, tels que les images et les vidéos, nécessitent des **placeholders** car ils ne contiennent pas de contenu éditable par défaut. L'exemple suivant crée un composant standard `ImageWidget.astro` qui définit la valeur `src` conditionnellement à la valeur de l'image `aposPlaceholder` passée par le widget, à une image de repli du projet Astro, ou à l'image sélectionnée par le gestionnaire de contenu en utilisant l'aide `attachment` d'Apostrophe :
+Certains widgets standards d'Apostrophe, tels que les images et les vidéos, nécessitent des **valeurs de repli** car ils ne contiennent pas de contenu éditable par défaut. L'exemple suivant crée un composant standard `ImageWidget.astro` qui définit la valeur `src` conditionnellement à la valeur de l'image `aposPlaceholder` transmise par le widget, à une image de repli du projet Astro, ou à l'image sélectionnée par le gestionnaire de contenu en utilisant l'assistant `attachment` d'Apostrophe :
 
 ```js title="src/widgets/ImageWidget.astro"
 ---
@@ -166,14 +166,14 @@ Voir [la documentation d'ApostropheCMS](https://apostrophecms.com/extensions/ast
 Le répertoire du projet devrait maintenant ressembler à ceci :
 
 <FileTree title="Structure du projet">
-  - src/
+- src/
   - widgets/
-  - **index.js**
-  - **ImageWidget.astro**
-  - **RichTextWidget.astro**
-  - .env
-  - astro.config.mjs
-  - package.json
+    - **index.js**
+    - **ImageWidget.astro**
+    - **RichTextWidget.astro**
+- .env
+- astro.config.mjs
+- package.json
 </FileTree>
 
 ### Ajouter des types de pages
@@ -211,22 +211,22 @@ const templateComponents = {
 export default templateComponents;
 ```
 
-Consultez [la documentation d'ApostropheCMS](https://apostrophecms.com/extensions/astro-integration/#how-apostrophe-template-names-work) pour connaître les conventions de nommage des modèles, y compris des pages spéciales et des types de morceaux de pages.
+Consultez [la documentation d'ApostropheCMS](https://apostrophecms.com/extensions/astro-integration/#how-apostrophe-template-names-work) pour connaître les conventions de nommage des modèles, y compris des pages spéciales et des types de pièces de pages.
 
 Le répertoire du projet devrait maintenant ressembler à ceci :
 
 <FileTree title="Structure du projet">
-  - src/
+- src/
   - widgets/
-  - index.js
-  - ImageWidget.astro
-  - RichTextWidget.astro
+    - index.js
+    - ImageWidget.astro
+    - RichTextWidget.astro
   - templates/
-  - **HomePage.astro**
-  - **index.js**
-  - .env
-  - astro.config.mjs
-  - package.json
+    - **HomePage.astro**
+    - **index.js**
+- .env
+- astro.config.mjs
+- package.json
 </FileTree>
 
 ### Création du composant [...slug.astro] et récupération des données d'Apostrophe
@@ -260,7 +260,7 @@ if (aposData.notFound) {
     <AposTemplate {aposData} slot="main"/>
 </AposLayout>
 ```
-Voir [la documentation d'ApostropheCMS](https://apostrophecms.com/extensions/astro-integration#creating-the-slugastro-component-and-fetching-apostrophe-data) pour des options de modélisation supplémentaires, y compris les emplacements disponibles dans le composant `AposTemplate`.
+Consultez [la documentation d'ApostropheCMS](https://apostrophecms.com/extensions/astro-integration#creating-the-slugastro-component-and-fetching-apostrophe-data) pour découvrir des options de création de modèles supplémentaires, y compris les emplacements disponibles dans le composant `AposTemplate`.
 
 ## Créer un blog avec Astro et ApostropheCMS
 
@@ -268,18 +268,18 @@ Avec l'intégration mise en place, vous pouvez maintenant créer un blog avec As
 
 ### Prérequis
 
-1. **Un projet ApostropheCMS avec l'outil CLI d'Apostrophe installée** - Vous pouvez créer un nouveau projet ou utiliser un projet existant. Cependant, ce tutoriel ne montrera que la création d'un article de blog et d'un type de page d'article. Vous devrez intégrer le code de tout autre projet existant de manière indépendante. Si vous n'avez pas installé l'outil CLI, consulter les [instructions d'installation de l'Apostrophe CLI](https://docs.apostrophecms.org/guide/setting-up.html#the-apostrophe-cli-tool).
-2. **Un projet Astro intégré à ApostropheCMS** - Pour créer un projet à partir de zéro, voir [integrating with Astro](#intégration-avec-astro) pour les instructions sur la façon de configurer l'intégration, ou utiliser le projet de démarrage [astro-frontend](https://github.com/apostrophecms/astro-frontend).
+1. **Un projet ApostropheCMS avec l'outil CLI d'Apostrophe installé** - Vous pouvez créer un nouveau projet ou utiliser un projet existant. Cependant, ce tutoriel ne montrera que la création d'un article de blog et d'un type de page d'article. Vous devrez intégrer le code de tout autre projet existant de manière indépendante. Si vous n'avez pas installé l'outil CLI, consulter les [instructions d'installation de l'Apostrophe CLI](https://docs.apostrophecms.org/guide/setting-up.html#the-apostrophe-cli-tool).
+2. **Un projet Astro intégré à ApostropheCMS** - Pour créer un projet à partir de zéro, consultez [intégration avec Astro](#intégration-avec-astro) pour les instructions sur la façon de configurer l'intégration, ou utiliser le projet de démarrage [astro-frontend](https://github.com/apostrophecms/astro-frontend).
 
 ### Création d'un article de blog et d'un type de page d'article
 
-Pour créer votre pièce de blog et votre type de page de pièce pour leur affichage, naviguez vers la racine de votre projet ApostropheCMS dans votre terminal. Utilisez l'outil CLI d'ApostropheCMS pour créer le nouveau morceau et le nouveau type de page du morceau à l'aide de la commande suivante :
+Pour créer votre pièce de blog et votre pièce de type de page pour leur affichage, naviguez vers la racine de votre projet ApostropheCMS dans votre terminal. Utilisez l'outil CLI d'ApostropheCMS pour créer la nouvelle pièce et la nouvelle pièce de type de page à l'aide de la commande suivante :
 
 ```sh
 apos add piece blog --page
 ```
 
-Cela créera deux nouveaux modules dans votre projet, un pour le type de pièce du blog et un pour le type de page de la pièce correspondante. Ensuite, ouvrez le fichier `app.js` à la racine de votre projet ApostropheCMS dans votre éditeur de code et ajoutez vos nouveaux modules.
+Cela créera deux nouveaux modules dans votre projet, un pour le type de pièce du blog et un pour la pièce de type de page correspondante. Ensuite, ouvrez le fichier `app.js` à la racine de votre projet ApostropheCMS dans votre éditeur de code et ajoutez vos nouveaux modules.
 
 ```js title="app.js"
 require('apostrophe')({
@@ -314,7 +314,7 @@ module.exports = {
 
 ### Création du schéma du blog
 
-Dans un projet ApostropheCMS, les éditeurs disposent d'un ensemble de champs de saisie pour ajouter du contenu. Voici un exemple de billet de blog simple qui ajoute trois champs de saisie, un `authorName`, un `publicationDate` et une zone de `content` où les gestionnaires de contenu peuvent ajouter plusieurs instances de widgets. Dans ce cas, nous spécifions qu'ils peuvent ajouter les widgets image et texte riche que nous avons créés pendant la [configuration de l'intégration](#connecter-les-widgets-dapostrophecms-aux-composants-astro).
+Dans un projet ApostropheCMS, les éditeurs disposent d'un ensemble de champs de saisie pour ajouter du contenu. Voici un exemple de billet de blog simple qui ajoute trois champs de saisie, un nom d'auteur (`authorName`), une date de publication (`publicationDate`) et une zone de contenu (`content`) où les gestionnaires de contenu peuvent ajouter plusieurs instances de widgets. Dans ce cas, nous spécifions qu'ils peuvent ajouter les widgets image et texte riche que nous avons créés pendant la [configuration de l'intégration](#connecter-les-widgets-dapostrophecms-aux-composants-astro).
 
 ```js title="modules/blog/index.js"
 module.exports = {
@@ -357,7 +357,7 @@ module.exports = {
 À ce stade, tous les composants provenant du projet ApostropheCMS sont installés. Démarrez le site local à partir de la ligne de commande en utilisant `npm run dev`, en vous assurant de passer la variable d'environnement `APOS_EXTERNAL_FRONT_KEY` à votre chaîne de caractères sélectionnée :
 
 ```bash
-APOS_EXTERNAL_FRONT_KEY='MyRandomString' npm run dev
+APOS_EXTERNAL_FRONT_KEY='MaChaîneDeCaractèresAléatoire' npm run dev
 ```
 
 ### Affichage des articles de blog
@@ -412,7 +412,7 @@ const { main } = piece;
 </section>
 ```
 
-Enfin, ces composants Astro doivent être mappés aux types de pages ApostropheCMS correspondants. Ouvrez le fichier `src/templates/index.js` du projet Astro et modifiez-le pour qu'il contienne le code suivant :
+Enfin, ces composants Astro doivent être associés aux types de pages ApostropheCMS correspondants. Ouvrez le fichier `src/templates/index.js` du projet Astro et modifiez-le pour qu'il contienne le code suivant :
 
 ```js title="src/templates/index.js"
 import HomePage from './HomePage.astro';
@@ -432,19 +432,19 @@ export default templateComponents;
 
 Pour ajouter des articles de blog à votre site, vous devez utiliser les outils de gestion et de contenu d'ApostropheCMS pour créer ces articles et publier au moins une page d'index pour les afficher.
 
-Lorsque le serveur Astro dev est en cours d'exécution, accédez à la page de connexion située à l'adresse [http://localhost:4321/login](http://localhost:4321/login) dans l'aperçu de votre navigateur. Utilisez les identifiants qui ont été ajoutés lors de la [création du projet ApostropheCMS](https://docs.apostrophecms.org/guide/development-setup.html#creating-a-project) pour vous connecter en tant qu'administrateur. Votre projet ApostropheCMS doit toujours être en cours d'exécution.
+Lorsque le serveur de développement d'Astro est en cours d'exécution, accédez à la page de connexion située à l'adresse [http://localhost:4321/login](http://localhost:4321/login) dans l'aperçu de votre navigateur. Utilisez les identifiants qui ont été ajoutés lors de la [création du projet ApostropheCMS](https://docs.apostrophecms.org/guide/development-setup.html#creating-a-project) pour vous connecter en tant qu'administrateur. Votre projet ApostropheCMS doit toujours être en cours d'exécution.
 
 Une fois connecté, votre navigateur sera redirigé vers la page d'accueil de votre projet et affichera une barre d'administration en haut pour éditer le contenu et gérer votre projet.
 
 Pour ajouter votre premier article de blog, cliquez sur le bouton `Blogs` dans la barre d'administration pour ouvrir la fenêtre de création d'un article de blog. En cliquant sur le bouton `New Blog` en haut à droite, vous ouvrirez une fenêtre d'édition dans laquelle vous pourrez ajouter du contenu. Le champ `content` vous permettra d'ajouter autant d'images et de textes enrichis que vous le souhaitez.
 
-Vous pouvez répéter cette étape et ajouter autant de messages que vous le souhaitez. Vous suivrez également ces étapes chaque fois que vous voudrez ajouter un nouveau message.
+Vous pouvez répéter cette étape et ajouter autant d'articles que vous le souhaitez. Vous suivrez également ces étapes chaque fois que vous voudrez ajouter un nouvel article.
 
-Pour publier une page pour afficher tous vos messages, cliquez sur le bouton `Pages` dans la barre d'administration. Dans la fenêtre de l'arbre des pages, cliquez sur le bouton `New Page`. Dans le menu déroulant `Type` dans la colonne de droite, sélectionnez `Blog`. Ajoutez un titre à la page et cliquez sur `Publish and View`. Vous n'aurez à le faire qu'une seule fois.
+Pour publier une page pour afficher tous vos articles, cliquez sur le bouton `Pages` dans la barre d'administration. Dans la fenêtre de l'arbre des pages, cliquez sur le bouton `New Page`. Dans le menu déroulant `Type` dans la colonne de droite, sélectionnez `Blog`. Ajoutez un titre à la page et cliquez sur `Publish and View`. Vous n'aurez à le faire qu'une seule fois.
 
 Tout nouvel article de blog créé sera automatiquement affiché sur cette page. Les articles de blog individuels peuvent être affichés en cliquant sur le lien créé sur la page d'index.
 
-Le `content` des articles individuels peut être modifié directement sur la page en naviguant jusqu'à l'article et en cliquant sur `edit` dans la barre d'administration. D'autres champs peuvent être édités en utilisant la modale d'édition ouverte en cliquant sur l'élément de menu `Blogs` dans la barre d'administration.
+La zone de contenu (`content`) des articles individuels peut être modifiée directement sur la page en naviguant jusqu'à l'article et en cliquant sur `edit` dans la barre d'administration. D'autres champs peuvent être édités en utilisant la modale d'édition ouverte en cliquant sur l'élément de menu `Blogs` dans la barre d'administration.
 
 ### Déployer votre site
 Pour déployer votre site, vous devez héberger vos projets Astro et ApostropheCMS.
@@ -455,11 +455,11 @@ Pour le projet ApostropheCMS, suivez les instructions pour votre type d'héberge
 
 ## Ressources officielles
 
-- [Astro integration for ApostropheCMS](https://apostrophecms.com/extensions/astro-integration) - Plugin Astro d'ApostropheCMS, guide d'intégration et projets de démarrage pour Apostrophe et Astro.
-- [Exemple de projet Astro à utiliser avec ApostropheCMS](https://github.com/apostrophecms/astro-frontend) - Un projet Astro simple avec plusieurs pages et des widgets Apostrophe déjà créés.
-- [Exemple de kit de démarrage ApostropheCMS à utiliser avec Astro](https://apostrophecms.com/starter-kits/astro-integration-starter-kit) - Un projet ApostropheCMS avec des modifications de pages de base pour une utilisation avec Astro.
+- [Intégration Astro pour ApostropheCMS](https://apostrophecms.com/extensions/astro-integration) (Anglais) - Module d'extension pour Astro d'ApostropheCMS, guide d'intégration et projets de démarrage pour Apostrophe et Astro.
+- [Exemple de projet Astro à utiliser avec ApostropheCMS](https://github.com/apostrophecms/astro-frontend) (Anglais) - Un projet Astro simple avec plusieurs pages et des widgets Apostrophe déjà créés.
+- [Exemple de kit de démarrage ApostropheCMS à utiliser avec Astro](https://apostrophecms.com/starter-kits/astro-integration-starter-kit) (Anglais) - Un projet ApostropheCMS avec des modifications de pages de base pour une utilisation avec Astro.
 
 ## Ressources communautaires
-- [Intégrer ApostropheCMS avec Astro, Pt. 1](https://apostrophecms.com/blog/how-to-integrate-astro-with-apostrophecms-pt-1) par Antonello Zaini
-- [Intégration d'ApostropheCMS avec Astro, Partie 2](https://apostrophecms.com/blog/how-to-integrate-astro-with-apostrophecms-pt-2) par Antonello Zaini
-- [Show & Tell Live | Astro & Apostrophe](https://youtu.be/cwJhtJhAhwA?si=6iUU9EjidfdnOdCh)
+- [Intégrer ApostropheCMS à Astro, Partie 1](https://apostrophecms.com/blog/how-to-integrate-astro-with-apostrophecms-pt-1) (Anglais) par Antonello Zaini
+- [Intégrer ApostropheCMS à Astro, Partie 2](https://apostrophecms.com/blog/how-to-integrate-astro-with-apostrophecms-pt-2) (Anglais) par Antonello Zaini
+- [Show & Tell Live | Astro & Apostrophe](https://youtu.be/cwJhtJhAhwA?si=6iUU9EjidfdnOdCh) (Anglais)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/cms/apostrophecms.mdx` to:
* fix some typo / indentation
* fix some bad translation (`message` instead of `article` for `posts`)
* translate `piece` consistently (we had both `pièce` and `morceau`... while the later sounds better, `piece` is an ApostropheCMS concept also used in the CLI... so I guess using `pièce` would be less confusing)
* rewords some parts (related to #11593)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
