### PR TITLE
i18n(fr): update `experimental-flags/fonts.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/fonts.mdx
@@ -20,7 +20,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Cette fonctionnalité expérimentale vous permet d'utiliser des polices de votre système de fichiers et de divers fournisseurs de polices (par exemple Google, Fontsource, Bunny) via une API unifiée, entièrement personnalisable et assurant la sûreté du typage.
 
-Les polices web peuvent impacter les performances des pages, aussi bien au moment du chargement qu'au moment du rendu. Cette API vous aide à maintenir les performances de votre site grâce à des [optimisations automatiques des polices web](https://web.dev/learn/performance/optimize-web-fonts) notamment des liens de préchargement, des solutions de repli optimisées et des valeurs par défaut pensées pour éviter les problèmes courants tels que le téléchargement inutiles de fichiers de polices.
+Les polices web peuvent impacter les performances des pages, aussi bien au moment du chargement qu'au moment du rendu. Cette API vous aide à maintenir les performances de votre site grâce à des [optimisations automatiques des polices web](https://web.dev/learn/performance/optimize-web-fonts) notamment des liens de préchargement, des solutions de repli optimisées et des valeurs par défaut opiniâtres. [Voir des exemples d'utilisation courante](#exemples-dutilisation).
 
 Pour activer cette fonctionnalité, configurez un objet `experimental.fonts` avec au moins une police :
 
@@ -215,6 +215,70 @@ provider: fontProviders.google({
 </Tabs>
 
 Vous pouvez également [créer un fournisseur de polices Astro personnalisé](#créer-votre-propre-fournisseur-de-polices) pour n'importe quel fournisseur unifont.
+
+## Exemples d'utilisation
+
+```js title="astro.config.mjs"
+import { defineConfig, fontProviders } from "astro/config";
+
+export default defineConfig({
+  experimental: {
+    fonts: [
+      {
+        name: "Roboto",
+        cssVariable: "--font-roboto"
+        provider: fontProviders.google(),
+        // Par défaut inclus :
+        // weights: [400] ,
+        // styles: ["normal", "italics"],
+        // subsets: ["cyrillic-ext", "cyrillic", "greek-ext", "greek", "vietnamese", "latin-ext", "latin"],
+        // fallbacks: ["sans-serif"], 
+      },
+      {
+        name: "Inter",
+        cssVariable: "--font-inter",
+        provider: fontProviders.fontsource(),
+        // Spécifier les graisses réellement utilisées
+        weights: [400, 500, 600, 700],
+        // Spécifier les styles réellement utilisés
+        styles: ["normal"],
+        // Télécharger uniquement les fichiers de polices pour les caractères utilisés sur la page
+        subsets: ["cyrillic"],
+      },
+      {
+        name: "JetBrains Mono",
+        cssVariable: "--font-jetbrains-mono",
+        provider: fontProviders.fontsource(),
+        // Télécharger uniquement les fichiers de polices pour les caractères utilisés sur la page
+        subsets: ["latin"],
+        // Utiliser une famille de polices de repli correspondant à l'apparence souhaitée
+        fallbacks: ["monospace"],
+      },
+      {
+        name: "Poppins",
+        cssVariable: "--font-poppins",
+        provider: "local",
+        // La graisse et le style ne sont pas spécifiés, donc Astro
+        // essaiera de les déduire pour chaque variante
+        variants: [
+          {
+            src: [
+              "./src/assets/fonts/Poppins-regular.woff2",
+              "./src/assets/fonts/Poppins-regular.woff",
+            ]
+          },
+          {
+            src: [
+              "./src/assets/fonts/Poppins-bold.woff2",
+              "./src/assets/fonts/Poppins-bold.woff",
+            ]
+          },
+        ]
+      }
+    ],
+  }
+});
+```
 
 ## Référence du composant `<Font />`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11643 to the French translation of `experimental-flags/fonts.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
