### PR TITLE
fix(guides/cms): update some FileTree and code snippets

### DIFF
--- a/src/content/docs/en/guides/cms/contentful.mdx
+++ b/src/content/docs/en/guides/cms/contentful.mdx
@@ -428,9 +428,9 @@ const { content, title, date } = Astro.props;
 
 Navigate to http://localhost:4321/ and click on one of your posts to make sure your dynamic route is working!
 
-#### Server side rendering
+#### On-demand rendering
 
-If you've [opted in to SSR mode](/en/guides/on-demand-rendering/), you will use a dynamic route that uses a `slug` parameter to fetch the data from Contentful.
+If you've [opted into on-demand rendering with an adapter](/en/guides/on-demand-rendering/), you will use a dynamic route that uses a `slug` parameter to fetch the data from Contentful.
 
 Create a `[slug].astro` page in `src/pages/posts`. Use [`Astro.params`](/en/reference/api-reference/#params) to get the slug from the URL, then pass that to `getEntries`: 
 
@@ -450,7 +450,7 @@ const data = await contentfulClient.getEntries<BlogPost>({
 
 If the entry is not found, you can redirect the user to the 404 page using [`Astro.redirect`](/en/guides/routing/#dynamic-redirects).
 
-```astro title="src/pages/posts/[slug].astro" ins={7, 12-13}
+```astro title="src/pages/posts/[slug].astro" ins={7, 12-14}
 ---
 import { contentfulClient } from "../../lib/contentful";
 import type { BlogPost } from "../../lib/contentful";

--- a/src/content/docs/en/guides/cms/ghost.mdx
+++ b/src/content/docs/en/guides/cms/ghost.mdx
@@ -132,7 +132,7 @@ The page `src/pages/index.astro` will display a list of posts, each with a descr
 
 <FileTree title="Project Structure">
 - src/
- - lib/
+  - lib/
     - ghost.ts
   - pages/
     - **index.astro**
@@ -198,7 +198,7 @@ The page `src/pages/post/[slug].astro` [dynamically generates a page](/en/guides
 
 <FileTree title="Project Structure">
 - src/
- - lib/
+  - lib/
     -  ghost.ts
   - pages/
     - index.astro
@@ -301,5 +301,3 @@ To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow 
 :::note[Have a resource to share?]
 If you found (or made!) a helpful video or blog post about using Ghost with Astro, [add it to this list](https://github.com/withastro/docs/edit/main/src/content/docs/en/guides/cms/ghost.mdx)!
 :::
-
-

--- a/src/content/docs/en/guides/cms/hashnode.mdx
+++ b/src/content/docs/en/guides/cms/hashnode.mdx
@@ -280,7 +280,7 @@ const allPosts = data.publication.posts.edges;
 
     <FileTree title="Project Structure">
     - src/
-    - lib/
+      - lib/
         - client.ts
         - schema.ts
       - pages/
@@ -359,4 +359,3 @@ To deploy your site visit our [deployment guide](/en/guides/deploy/) and follow 
 ## Community Resources 
 
 - [`astro-hashnode`](https://github.com/matthiesenxyz/astro-hashnode) on GitHub
-

--- a/src/content/docs/en/guides/cms/preprcms.mdx
+++ b/src/content/docs/en/guides/cms/preprcms.mdx
@@ -63,9 +63,9 @@ export async function Prepr(query, variables) {
 Your root directory should now include these files:
 
 <FileTree title="Project Structure">
-- lib/
-    - **prepr.js**
 - src/
+  - lib/
+    - **prepr.js**
 - **.env**
 - astro.config.mjs
 - package.json
@@ -130,11 +130,13 @@ You will fetch your data from Prepr by writing queries to interact with its Grap
 Your root directory should include these new files:
 
 <FileTree title="Project Structure">
-- lib/
-    - prepr.js
-    - **queries**/
-        - **get-articles.js**
 - src/
+  - lib/
+    - prepr.js
+  - pages/
+    - index.astro
+  - **queries**/
+      - **get-articles.js**
 - .env
 - astro.config.mjs
 - package.json
@@ -142,7 +144,7 @@ Your root directory should include these new files:
 
 #### Creating individual blog post pages
 
-To create a page for each blog post, you will execute a new GraphQL query on a [dynamic routing](/en/guides/routing/#on-demand-dynamic-routes) server-ssr-mode) `.astro` page. This query will fetch a specific article by its slug and a new page will be created for each individual blog post.
+To create a page for each blog post, you will execute a new GraphQL query on a [dynamic routing](/en/guides/routing/#on-demand-dynamic-routes) `.astro` page. This query will fetch a specific article by its slug and a new page will be created for each individual blog post.
 
 <Steps>
 1. Create a file called `get-article-by-slug.js` in the `queries` folder and add the following to query a specific article by its slug and return data such as the article `title` and `content`:
@@ -213,15 +215,15 @@ To create a page for each blog post, you will execute a new GraphQL query on a [
 Your root directory should now include these new files:
 
 <FileTree title="Project Structure">
-- lib/
-    - prepr.js
-    - queries/
-        - get-articles.js
-        - **get-article-by-slug.js**
 - src/
-    - pages/
-      - index.astro
-      - **[…slug].astro**
+  - lib/
+    - prepr.js
+  - pages/
+    - index.astro
+    - **[…slug].astro**
+  - queries/
+      - get-articles.js
+      - **get-article-by-slug.js**
 - .env
 - astro.config.mjs
 - package.json
@@ -237,4 +239,3 @@ To deploy your Prepr blog, visit our [deployment guides](/en/guides/deploy/) and
 
 - Follow the [Prepr CMS Astro quickstart](https://github.com/preprio/astro-quick-start) guide to make a simple blog with Astro and Prepr CMS. 
 - Check out the [Connecting Prepr CMS to Astro](https://docs.prepr.io/connecting-front-end-apps/astro) for an overview of Astro and Prepr CMS resources.
-

--- a/src/content/docs/en/guides/cms/sitecore.mdx
+++ b/src/content/docs/en/guides/cms/sitecore.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 ## Getting started
 
 <Steps>
-1. [Create a Sitecore Headless website](https://doc.sitecore.com/xp/en/developers/sxa/103/sitecore-experience-accelerator/create-a-headless-tenant-and-site.html) following Sitcore's official documentation.
+1. [Create a Sitecore Headless website](https://doc.sitecore.com/xp/en/developers/sxa/103/sitecore-experience-accelerator/create-a-headless-tenant-and-site.html) following Sitecore's official documentation.
 
 2. Run the following project initialization command in your terminal: 
     ```shell

--- a/src/content/docs/en/guides/cms/statamic.mdx
+++ b/src/content/docs/en/guides/cms/statamic.mdx
@@ -43,7 +43,7 @@ Fetch your Statamic data from your site's REST API URL. By default, it's `https:
 
 For example, to display a list of titles and their content from a selected [collection](https://statamic.dev/collections):
 
-```astro title="src/pages/index.astro
+```astro title="src/pages/index.astro"
 ---
 const res = await fetch("https://[YOUR-SITE]/api/collections/posts/entries?sort=-date")
 const posts = await res.json()
@@ -63,7 +63,7 @@ Fetch your Statamic data with your site's GraphQL API URL. By default, it's `htt
 
 For example, to display a list of titles and their content from a selected [collection](https://statamic.dev/collections):
 
-```astro title="src/pages/index.astro
+```astro title="src/pages/index.astro"
 ---
 const graphqlQuery = {
   query: `

--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -245,7 +245,7 @@ Create the file `src/pages/blog/[slug].astro` to [dynamically generate a page](/
 
 In Astro's default static mode (SSG), use [`getStaticPaths()`](/en/reference/routing-reference/#getstaticpaths) to fetch your list of articles from Strapi.
 
-```astro title="src/pages/blog/[slug].astro
+```astro title="src/pages/blog/[slug].astro"
 ---
 import fetchApi from '../../lib/strapi';
 import type Article from '../../interfaces/article';
@@ -269,7 +269,7 @@ const article = Astro.props;
 
 Create the template for each page using the properties of each post object.
 
-```astro title="src/pages/blog/[slug].astro ins={21-43}
+```astro title="src/pages/blog/[slug].astro" ins={21-43}
 ---
 import fetchApi from '../../lib/strapi';
 import type Article from '../../interfaces/article';

--- a/src/content/docs/en/guides/cms/umbraco.mdx
+++ b/src/content/docs/en/guides/cms/umbraco.mdx
@@ -206,11 +206,11 @@ If you are using the Umbraco HTTPS endpoint locally, any `fetch` queries will re
 
 Alternatively, you can set `NODE_TLS_REJECT_UNAUTHORIZED=0` in an `env.development` file and update `astro.config.js` as shown:
 
-```sh title=".env.development"
+```ini title=".env.development"
 NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
 
-```astro title="astro.config.mjs"
+```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
 import { loadEnv } from "vite";
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates some `guides/cms` pages to fix:
* some indentation in `<FileTree />` components (files wasn't under `src/` because of that)
* some code snippets title (we had an extra `"` before the title because the closing quote was missing)
* some code snippets languages
* a line marker in a code snippet to include the closing brace
* a typo in `sitecore.mdx`

In addition:
* in `preprcms.mdx`: rewrite the file trees because they were a bit off compared to what is described in the guide (ie. none of the files were under `src/`) and remove a leftover from #11501
* in `contentful.mdx`: replace `Server side rendering` with `On demand rendering` reusing the same wording used in Strapi.

I also noticed that [Keystatic](https://docs.astro.build/en/guides/cms/keystatic/#displaying-a-single-entry) uses the legacy content collection API but I preferred not to update it. I don't know if the CMS is compatible with the Content Layer API; their docs is also outdated. It seemed like it needed bigger changes (adding a step for `content.config.ts`?).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
