### PR TITLE
i18n(fr): update `guides/cms/contentful.mdx`

### DIFF
--- a/src/content/docs/fr/guides/cms/contentful.mdx
+++ b/src/content/docs/fr/guides/cms/contentful.mdx
@@ -37,7 +37,7 @@ Pour ajouter les identifiants de votre espace Contentful à Astro, créez un fic
 
 ```ini title=".env"
 CONTENTFUL_SPACE_ID=ID_DE_VOTRE_ESPACE
-CONTENTFUL_DELIVERY_TOKEN=VOTRE_JETON_DE_LIVRAISON
+CONTENTFUL_DELIVERY_TOKEN=VOTRE_JETON_DE_DIFFUSION
 CONTENTFUL_PREVIEW_TOKEN=VOTRE_JETON_DE_PREVISUALISATION
 ```
 
@@ -110,7 +110,7 @@ L'extrait de code ci-dessus crée un nouveau client Contentful, en lui passant l
 :::caution
 En mode développement, votre contenu sera récupéré à partir de l'**API de prévisualisation de Contentful**. Cela signifie que vous serez en mesure de voir le contenu non publié à partir de l'application web Contentful.
 
-Au moment de la compilation, votre contenu sera récupéré à partir de l'**API de livraison de Contentful**. Cela signifie que seul le contenu publié sera disponible au moment de la compilation.
+Au moment de la compilation, votre contenu sera récupéré à partir de l'**API de diffusion de Contentful**. Cela signifie que seul le contenu publié sera disponible au moment de la compilation.
 :::
 
 Enfin, votre répertoire racine devrait maintenant contenir ces nouveaux fichiers :

--- a/src/content/docs/fr/guides/cms/contentful.mdx
+++ b/src/content/docs/fr/guides/cms/contentful.mdx
@@ -15,30 +15,30 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## Intégration avec Astro
 
-Dans cette section, nous utiliserons le [Contentful SDK](https://github.com/contentful/contentful.js) pour connecter votre espace Contentful à Astro avec zéro JavaScript côté client.
+Dans cette section, nous utiliserons le [SDK Contentful](https://github.com/contentful/contentful.js) pour connecter votre espace Contentful à Astro avec zéro JavaScript côté client.
 
 ### Conditions préalables
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 
-2. **Un compte Contentful et un espace Contentful**. Si vous n'avez pas de compte, vous pouvez [vous inscrire](https://www.contentful.com/sign-up/) pour un compte gratuit et créer un nouvel espace Contentful. Vous pouvez également utiliser un espace existant si vous en avez un.
+2. **Un compte Contentful et un espace Contentful**. Si vous n'avez pas de compte, vous pouvez [vous inscrire](https://www.contentful.com/sign-up/) pour obtenir un compte gratuit et créer un nouvel espace Contentful. Vous pouvez également utiliser un espace existant si vous en avez un.
 
-3. **Crédentials Contentful** - Vous pouvez trouver les credentials suivants dans votre tableau de bord Contentful **Settings > API keys***. Si vous n'avez pas de clés API, créez-en une en sélectionnant **Add API key**.
+3. **Informations d'identification de Contentful** - Vous pouvez trouver les informations d'identification suivantes dans votre tableau de bord Contentful **Settings > API keys***. Si vous n'avez pas de clés API, créez-en une en sélectionnant **Add API key**.
 
  - **Contentful space ID** - L'ID de votre espace Contentful.
- - **Contentful delivery access token** - Le jeton d'accès pour consommer le contenu _publié_ de votre espace Contentful.
- - **Contentful preview access token** - Le jeton d'accès pour consommer le contenu _non publié_ de votre espace Contentful.
+ - **Contentful delivery access token** - Le jeton d'accès pour consommer le contenu _publié_ depuis votre espace Contentful.
+ - **Contentful preview access token** - Le jeton d'accès pour consommer le contenu _non publié_ depuis votre espace Contentful.
 
 ### Mise en place des informations d'identification
 
 Pour ajouter les identifiants de votre espace Contentful à Astro, créez un fichier `.env` à la racine de votre projet avec les variables suivantes :
 
 ```ini title=".env"
-CONTENTFUL_SPACE_ID=YOUR_SPACE_ID
-CONTENTFUL_DELIVERY_TOKEN=YOUR_DELIVERY_TOKEN
-CONTENTFUL_PREVIEW_TOKEN=YOUR_PREVIEW_TOKEN
+CONTENTFUL_SPACE_ID=ID_DE_VOTRE_ESPACE
+CONTENTFUL_DELIVERY_TOKEN=VOTRE_JETON_DE_LIVRAISON
+CONTENTFUL_PREVIEW_TOKEN=VOTRE_JETON_DE_PREVISUALISATION
 ```
 
 Vous pouvez maintenant utiliser ces variables d'environnement dans votre projet.
@@ -58,7 +58,7 @@ Pour en savoir plus sur [l'utilisation des variables d'environnement](/fr/guides
 
 Votre répertoire racine doit maintenant contenir ces nouveaux fichiers :
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - **env.d.ts**
 - **.env**
@@ -70,7 +70,7 @@ Votre répertoire racine doit maintenant contenir ces nouveaux fichiers :
 
 Pour vous connecter à votre espace Contentful, installez les deux éléments suivants à l'aide de la commande unique ci-dessous pour votre gestionnaire de paquets préféré :
 - [`contentful.js`](https://github.com/contentful/contentful.js), le SDK officiel de Contentful pour JavaScript
-- [`rich-text-html-renderer`](https://github.com/contentful/rich-text/tree/master/packages/rich-text-html-renderer), un paquetage pour rendre les champs de texte riche de Contentful en HTML.
+- [`rich-text-html-renderer`](https://github.com/contentful/rich-text/tree/master/packages/rich-text-html-renderer), un paquet pour générer les champs de texte riche de Contentful en HTML.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -108,14 +108,14 @@ export const contentfulClient = contentful.createClient({
 L'extrait de code ci-dessus crée un nouveau client Contentful, en lui passant les informations d'identification du fichier `.env`.
 
 :::caution
-En mode développement, votre contenu sera récupéré à partir de l'**API Contentful preview**. Cela signifie que vous serez en mesure de voir le contenu non publié à partir de l'application web Contentful.
+En mode développement, votre contenu sera récupéré à partir de l'**API de prévisualisation de Contentful**. Cela signifie que vous serez en mesure de voir le contenu non publié à partir de l'application web Contentful.
 
-Au moment de la construction, votre contenu sera récupéré à partir de l'**API Contentful delivery**. Cela signifie que seul le contenu publié sera disponible au moment de la construction.
+Au moment de la compilation, votre contenu sera récupéré à partir de l'**API de livraison de Contentful**. Cela signifie que seul le contenu publié sera disponible au moment de la compilation.
 :::
 
 Enfin, votre répertoire racine devrait maintenant contenir ces nouveaux fichiers :
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - env.d.ts
   - lib/
@@ -127,9 +127,9 @@ Enfin, votre répertoire racine devrait maintenant contenir ces nouveaux fichier
 
 ### Récupération de données
 
-Les composants Astro peuvent récupérer des données depuis votre compte Contentful en utilisant le `contentfulClient` et en spécifiant le `content_type`.
+Les composants Astro peuvent récupérer des données depuis votre compte Contentful en utilisant le client Contentful (`contentfulClient`) et en spécifiant le type de contenu (`content_type`).
 
-Par exemple, si vous avez un type de contenu "blogPost" qui a un champ texte pour le titre et un champ texte riche pour le contenu, votre composant pourrait ressembler à ceci :
+Par exemple, si vous avez un type de contenu « blogPost » qui a un champ texte pour le titre et un champ texte riche pour le contenu, votre composant pourrait ressembler à ceci :
 
 ```astro
 ---
@@ -160,10 +160,10 @@ const entries = await contentfulClient.getEntries<BlogPost>({
 ```
 
 :::tip
-Si vous disposez d'un espace Contentful vide, consultez [setting up a Contentful model](#mise-en-place-dun-modèle-contentful) pour apprendre à créer un modèle de blog de base pour votre contenu.
+Si vous disposez d'un espace Contentful vide, consultez [mise en place d'un modèle Contentful](#mise-en-place-dun-modèle-contentful) pour apprendre à créer un modèle de blog de base pour votre contenu.
 :::
 
-Vous trouverez d'autres options de recherche dans la [documentation Contentful](https://contentful.github.io/contentful.js/).
+Vous trouverez d'autres options de recherche dans la [documentation de Contentful](https://contentful.github.io/contentful.js/).
 
 ## Créer un blog avec Astro et Contentful
 
@@ -207,14 +207,14 @@ Cliquez sur **Save** pour enregistrer vos modifications.
 Dans la section **Content** de votre espace Contentful, créez une nouvelle entrée en cliquant sur le bouton **Add entry**. Remplissez ensuite les champs :
 
 - **Title:** `Astro est incroyable !`
-- **Slug:** `astro-is-amazing`
+- **Slug:** `astro-est-incroyable`
 - **Description:** `Astro est un nouveau générateur de sites statiques très rapide et facile à utiliser.`
 - **Date:** `2022-10-05`
 - **Content:** `C'est mon premier article de blog !`
 
 Cliquez sur **Publish** pour enregistrer votre entrée. Vous venez de créer votre premier article de blog.
 
-N'hésitez pas à ajouter autant d'articles de blog que vous le souhaitez, puis passez à votre éditeur de code préféré pour commencer à pirater avec Astro !
+N'hésitez pas à ajouter autant d'articles de blog que vous le souhaitez, puis passez à votre éditeur de code préféré pour commencer à bricoler avec Astro !
 
 ### Afficher une liste d'articles de blog
 
@@ -248,7 +248,7 @@ Ensuite, allez sur la page Astro où vous allez récupérer les données de Cont
 
 Importez l'interface `BlogPost` et `contentfulClient` depuis `src/lib/contentful.ts`.
 
-Récupérez toutes les entrées de Contentful avec un type de contenu `blogPost` tout en passant l'interface `BlogPost` pour saisir votre réponse.
+Récupérez toutes les entrées de Contentful avec un type de contenu `blogPost` tout en transmettant l'interface `BlogPost` pour ajouter des types à votre réponse.
 
 ```astro title="src/pages/index.astro"
 ---
@@ -335,7 +335,7 @@ Utilisez la même méthode que ci-dessus pour récupérer vos données auprès d
 
 #### Génération de sites statiques
 
-Si vous utilisez le mode statique par défaut d'Astro, vous utiliserez [dynamic routes](/fr/guides/routing/#routes-dynamiques) et la fonction `getStaticPaths()`. Cette fonction sera appelée au moment de la construction pour générer la liste des chemins qui deviendront des pages.
+Si vous utilisez le mode statique par défaut d'Astro, vous utiliserez les [routes dynamiques](/fr/guides/routing/#routes-dynamiques) et la fonction `getStaticPaths()`. Cette fonction sera appelée au moment de la compilation pour générer la liste des chemins qui deviendront des pages.
 
 Créez un nouveau fichier nommé `[slug].astro` dans `src/pages/posts/`.
 
@@ -356,7 +356,7 @@ export async function getStaticPaths() {
 ---
 ```
 
-Ensuite, mappez chaque élément à un objet possédant les propriétés `params` et `props`. La propriété `params` sera utilisée pour générer l'URL de la page et la propriété `props` sera passée au composant de la page en tant que props.
+Ensuite, associez chaque élément à un objet possédant les propriétés `params` et `props`. La propriété `params` sera utilisée pour générer l'URL de la page et la propriété `props` sera transmise au composant de la page en tant que props.
 
 ```astro title="src/pages/posts/[slug].astro" ins={3,11-19}
 ---
@@ -426,11 +426,11 @@ const { content, title, date } = Astro.props;
 </html>
 ```
 
-Allez sur http://localhost:4321/ et cliquez sur l'un de vos posts pour vérifier que votre route dynamique fonctionne !
+Allez sur http://localhost:4321/ et cliquez sur l'un de vos articles pour vérifier que votre route dynamique fonctionne !
 
-#### Rendu côté serveur
+#### Rendu à la demande
 
-Si vous avez [opté pour le mode SSR](/fr/guides/on-demand-rendering/), vous utiliserez une route dynamique qui utilise un paramètre `slug` pour récupérer les données de Contentful.
+Si vous avez [opté pour le rendu à la demande avec un adaptateur](/fr/guides/on-demand-rendering/), vous utiliserez une route dynamique qui utilise un paramètre `slug` pour récupérer les données de Contentful.
 
 Créez une page `[slug].astro` dans `src/pages/posts`. Utilisez [`Astro.params`](/fr/reference/api-reference/#params) pour récupérer le slug de l'URL, puis passez-le à `getEntries` :
 
@@ -450,7 +450,7 @@ const data = await contentfulClient.getEntries<BlogPost>({
 
 Si l'entrée n'est pas trouvée, vous pouvez rediriger l'utilisateur vers la page 404 en utilisant [`Astro.redirect`](/fr/guides/routing/#redirections-dynamiques).
 
-```astro title="src/pages/posts/[slug].astro" ins={7, 12-13}
+```astro title="src/pages/posts/[slug].astro" ins={7, 12-14}
 ---
 import { contentfulClient } from "../../lib/contentful";
 import type { BlogPost } from "../../lib/contentful";
@@ -467,7 +467,7 @@ try {
 }
 ---
 ```
-Pour passer les données du message à la section template, créez un objet `post` à l'extérieur du bloc `try/catch`.
+Pour transmettre les données de l'article à la section modèle, créez un objet `post` à l'extérieur du bloc `try/catch`.
 
 Utilisez `documentToHtmlString` pour convertir `content` d'un document en HTML, et utilisez le constructeur Date pour formater la date. `title` peut être laissé tel quel. Ensuite, ajoutez ces propriétés à votre objet `post`.
 
@@ -539,9 +539,9 @@ try {
 
 Pour déployer votre site web, consultez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions correspondant à votre hébergeur préféré.
 
-#### Reconstruction en cas de changements dans Contentful
+#### Recompiler en cas de changements dans Contentful
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle compilation à partir des événements Contentful.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle compilation à partir des événements Contentful.
 
 ##### Netlify
 
@@ -552,7 +552,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ##### Vercel
@@ -564,11 +564,11 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ##### Ajouter un webhook à Contentful
 
-Dans votre espace Contentful **settings**, cliquez sur l'onglet **Webhooks** et créez un nouveau webhook en cliquant sur le bouton **Add Webhook**. Donnez un nom à votre webhook et collez l'URL du webhook que vous avez copié dans la section précédente. Enfin, cliquez sur **Save** pour créer le webhook.
+Dans les **paramètres (Settings)** de votre espace Contentful, cliquez sur l'onglet **Webhooks** et créez un nouveau webhook en cliquant sur le bouton **Add Webhook**. Donnez un nom à votre webhook et collez l'URL du webhook que vous avez copié dans la section précédente. Enfin, cliquez sur **Save** pour créer le webhook.
 
-Maintenant, chaque fois que vous publiez un nouvel article de blog dans Contentful, un nouveau build sera déclenché et votre blog sera mis à jour.
+Maintenant, chaque fois que vous publiez un nouvel article de blog dans Contentful, une nouvelle compilation sera déclenchée et votre blog sera mis à jour.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/cms/contentful` with changes from:
* #11722 
* #11593
  * replace `construction` with `compilation`
  * replace `rendre` with `générer`
  * replace `template` with `modèle`
  * replace `paquetage` with `paquet`
  * fix some bad translations (e.g. type, hacking)
  * translate some untranslated parts
  * reword some sentences to make the reading easier

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
