### PR TITLE
i18n(fr): update `guides/cms/statamic.mdx`

### DIFF
--- a/src/content/docs/fr/guides/cms/statamic.mdx
+++ b/src/content/docs/fr/guides/cms/statamic.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import Grid from '~/components/FluidGrid.astro'
 import Card from '~/components/ShowcaseCard.astro'
 
-[Statamic](https://statamic.com/) est un système de gestion de contenu (CMS) moderne et uniforme. Il permet aux développeurs de créer facilement des sites web et des applications dynamiques tout en offrant aux éditeurs de contenu une interface intuitive et conviviale pour la gestion du contenu.
+[Statamic](https://statamic.com/) est un CMS moderne à fichiers plats. Il permet aux développeurs de créer facilement des sites web et des applications dynamiques tout en offrant aux éditeurs de contenu une interface intuitive et conviviale pour la gestion du contenu.
 
 ## Intégration avec Astro
 
@@ -22,12 +22,12 @@ Statamic est livré avec une [API REST](https://statamic.dev/rest-api) et une [A
 Pour commencer, vous devez disposer des éléments suivants :
 
 1. Les API REST et GraphQL ne sont disponibles que dans la version pro de Statamic. Vous pouvez essayer la version Pro gratuitement sur votre [machine locale](https://statamic.dev/tips/how-to-enable-statamic-pro#trial-mode).
-2. **Un projet Astro** - Si vous avez besoin d'un projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être rapidement opérationnel.
+2. **Un projet Astro** - Si vous avez besoin d'un projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être rapidement opérationnel.
 3. **Un site Statamic** - Si vous avez besoin d'un site Statamic, [ce guide](https://statamic.dev/quick-start-guide) vous aidera à démarrer.
 N'oubliez pas d'activer l'[API REST](https://statamic.dev/rest-api#enable-the-api) ou l'[API GraphQL](https://statamic.dev/graphql#enable-graphql) en ajoutant `STATAMIC_API_ENABLED=true` ou `STATAMIC_GRAPHQL_ENABLED=true` dans le fichier `.env` et d'activer les ressources nécessaires dans le fichier de configuration de l'API.
 
 :::caution
-Tous les exemples supposent que votre site web a une collection appelée `posts`, qui a un plan appelé `post`, et que ce plan a un champ title (fieldtype text) et un content (fieldtype markdown).
+Tous les exemples supposent que votre site web a une collection appelée `posts`, qui a un plan appelé `post`, et que ce plan a un champ titre (champs de type texte) et un contenu (champ de type Markdown).
 :::
 
 ### Récupération de données
@@ -39,13 +39,13 @@ Lors d'une requête sur le serveur Astro, `localhost` n'est pas résolu correcte
 
 #### API REST
 
-Récupérez vos données Statamic à partir de l'URL de l'API REST de votre site. Par défaut, c'est `https://[VOTRE-SITE]/api/`. Ensuite, vous pouvez rendre les propriétés de vos données en utilisant la directive Astro `set:html={}`. 
+Récupérez vos données Statamic à partir de l'URL de l'API REST de votre site. Par défaut, c'est `https://[VOTRE-SITE]/api/`. Ensuite, vous pouvez restituer les propriétés de vos données en utilisant la directive Astro `set:html={}`. 
 
 Par exemple, pour afficher une liste de titres et leur contenu à partir d'une [collection sélectionnée](https://statamic.dev/collections) :
 
-```astro title="src/pages/index.astro
+```astro title="src/pages/index.astro"
 ---
-const res = await fetch("https://[YOUR-SITE]/api/collections/posts/entries?sort=-date")
+const res = await fetch("https://[VOTRE-SITE]/api/collections/posts/entries?sort=-date")
 const posts = await res.json()
 ---
 <h1>Astro + Statamic 🚀</h1>
@@ -59,11 +59,11 @@ const posts = await res.json()
 
 #### GraphQL
 
-Récupérez vos données Statamic avec l'URL de l'API GraphQL de votre site. Par défaut, c'est `https://[VOTRE-SITE]/graphql/`. Ensuite, vous pouvez rendre les propriétés de vos données en utilisant la directive Astro `set:html={}`. 
+Récupérez vos données Statamic avec l'URL de l'API GraphQL de votre site. Par défaut, c'est `https://[VOTRE-SITE]/graphql/`. Ensuite, vous pouvez restituer les propriétés de vos données en utilisant la directive Astro `set:html={}`. 
 
 Par exemple, pour afficher une liste de titres et leur contenu à partir d'une [collection sélectionnée](https://statamic.dev/collections) :
 
-```astro title="src/pages/index.astro
+```astro title="src/pages/index.astro"
 ---
 const graphqlQuery = {
   query: `
@@ -116,8 +116,8 @@ Pour déployer votre site Astro, consultez nos [guides de déploiement](/fr/guid
 
 ## Ressources communautaires 
 
-- [Comment construire un site statique en utilisant Statamic comme headless CMS](https://buddy.works/guides/statamic-rest-api)
-- [Mise en œuvre des aperçus en direct Astro avec Statamic](https://maciekpalmowski.dev/implementing-live-previews-in-headless-statamic-when-using-astro/)
+- [Comment construire un site statique en utilisant Statamic comme CMS headless](https://buddy.works/guides/statamic-rest-api) (Anglais)
+- [Mise en œuvre des aperçus en direct Astro avec Statamic](https://maciekpalmowski.dev/implementing-live-previews-in-headless-statamic-when-using-astro/) (Anglais)
 
 ## Thèmes
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/cms/statamic.mdx` with changes from:
* #11722 (code snippet titles)
* #11593
  * replace `rendre` with `restituer`
  * add language after community links
  * I don't know when the first sentence was updated but it didn't match (and yes, it seems `fichiers plats` is the expected translation... See [Grand dictionnaire terminologique of Quebec](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/8373984/fichier-plat) and I also found this on French websites)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
