### PR TITLE
i18n(fr): update `guides/cms/strapi.mdx`

### DIFF
--- a/src/content/docs/fr/guides/cms/strapi.mdx
+++ b/src/content/docs/fr/guides/cms/strapi.mdx
@@ -1,6 +1,6 @@
 ---
 title: Strapi & Astro
-description: Ajouter du contenu à votre projet Astro en utilisant Strapi Headless CMS
+description: Ajouter du contenu à votre projet Astro en utilisant le CMS headless Strapi
 sidebar:
   label: Strapi
 type: cms
@@ -12,17 +12,17 @@ import { Steps } from '@astrojs/starlight/components';
 import { FileTree } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-[Strapi](https://strapi.io/) est un CMS Headless open-source et personnalisable.
+[Strapi](https://strapi.io/) est un CMS headless open-source et personnalisable.
 
 ## Intégration avec Astro
 
-Ce guide va construire une fonction wrapper pour connecter Strapi avec Astro.
+Ce guide va créer une fonction wrapper pour connecter Strapi avec Astro.
 
 ### Prérequis
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 2. **Un serveur CMS Strapi** - Vous pouvez [configurer un serveur Strapi dans un environnement local](https://docs.strapi.io/dev-docs/quick-start).
 
 ### Ajouter l'URL de Strapi dans `.env`
@@ -46,13 +46,13 @@ Votre répertoire racine devrait maintenant contenir le(s) nouveau(x) fichier(s)
 
 <FileTree title="Structure du projet">
   - src/
-  - **env.d.ts**
+    - **env.d.ts**
   - **.env**
   - astro.config.mjs
   - package.json
 </FileTree>
 
-### Création de l'API wrapper
+### Création du wrapper de l'API
 
 Créez un nouveau fichier `src/lib/strapi.ts` et ajoutez la fonction wrapper suivante pour interagir avec l'API Strapi :
 
@@ -68,8 +68,8 @@ interface Props {
  * Récupère les données de l'API Strapi
  * @param endpoint - Le point d'accès à partir duquel la recherche doit être effectuée
  * @param query - Les paramètres de requête à ajouter à l'URL
- * @param wrappedByKey - La clé pour décapsuler la réponse
- * @param wrappedByList - Si la réponse est une liste, déroulez-la.
+ * @param wrappedByKey - La clé pour désenvelopper la réponse
+ * @param wrappedByList - Si la réponse est une liste, la désenvelopper.
  * @returns
  */
 export default async function fetchApi<T>({
@@ -106,14 +106,14 @@ export default async function fetchApi<T>({
 
 Cette fonction nécessite un objet ayant les propriétés suivantes :
 
-1. `endpoint` - Le point d'accès que vous récupérez.
+1. `endpoint` - Le point de terminaison que vous interrogez.
 2. `query` - Les paramètres de requête à ajouter à la fin de l'URL
 3. `wrappedByKey` - La clé `data` dans l'objet qui enveloppe votre `Response`.
-4. `wrappedByList` - Un paramètre pour "déballer" la liste retournée par Strapi, et ne retourner que le premier élément.
+4. `wrappedByList` - Un paramètre pour « désenvelopper » la liste retournée par Strapi, et ne retourner que le premier élément.
 
 ### Facultatif : Création de l'interface Article
 
-Si vous utilisez TypeScript, créez l'interface Article suivante pour correspondre aux types de contenu Strapi dans `src/interfaces/article.ts` :
+Si vous utilisez TypeScript, créez l'interface Article suivante pour correspondre aux types de contenu de Strapi dans `src/interfaces/article.ts` :
 
 ```ts title="src/interfaces/article.ts"
 export default interface Article {
@@ -136,11 +136,11 @@ Vous pouvez modifier cette interface, ou en créer plusieurs, pour qu'elle corre
 
 <FileTree title="Structure du projet">
   - src/
-  - interfaces/
-  - **article.ts**
-  - lib/
-  - strapi.ts
-  - env.d.ts
+    - interfaces/
+      - **article.ts**
+    - lib/
+      - strapi.ts
+    - env.d.ts
   - .env
   - astro.config.mjs
   - package.json
@@ -152,7 +152,6 @@ Vous pouvez modifier cette interface, ou en créer plusieurs, pour qu'elle corre
 1. Mettez à jour votre page d'accueil `src/pages/index.astro` pour afficher une liste d'articles de blog, chacun avec une description et un lien vers sa propre page.
 
 2. Importez la fonction wrapper et l'interface. Ajoutez l'appel API suivant pour récupérer vos articles et renvoyer une liste :
-    
     ```astro title="src/pages/index.astro"
     ---
     import fetchApi from '../lib/strapi';
@@ -160,7 +159,7 @@ Vous pouvez modifier cette interface, ou en créer plusieurs, pour qu'elle corre
 
     const articles = await fetchApi<Article[]>({
       endpoint: 'articles', // le type de contenu à récupérer
-      wrappedByKey: 'data', // la clé pour décapsuler la réponse
+      wrappedByKey: 'data', // la clé pour désenvelopper la réponse
     });
     ---
     ```
@@ -186,7 +185,6 @@ Vous pouvez modifier cette interface, ou en créer plusieurs, pour qu'elle corre
     ```
 
 3. En utilisant les données du tableau `articles` renvoyé par l'API, affichez les articles de votre blog Strapi dans une liste. Ces articles seront liés à leur propre page individuelle, que vous allez créer à l'étape suivante.
-  
     ```astro title="src/pages/index.astro"
     ---
     import fetchApi from '../lib/strapi';
@@ -221,34 +219,33 @@ Vous pouvez modifier cette interface, ou en créer plusieurs, pour qu'elle corre
       </body>
     </html>
     ```
-
 </Steps>
 
 ### Générer des pages d'articles
 
 Créez le fichier `src/pages/blog/[slug].astro` pour [générer dynamiquement une page](/fr/guides/routing/#routes-dynamiques) pour chaque article.
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
   - src/
-  - interfaces/
-  - article.ts
-  - lib/
-  - strapi.ts
-  - pages/
-  - index.astro
-  - blog/
-  - **[slug].astro**
-  - env.d.ts
+    - interfaces/
+      - article.ts
+    - lib/
+      - strapi.ts
+    - pages/
+      - index.astro
+      - blog/
+        - **[slug].astro**
+    - env.d.ts
   - .env
   - astro.config.mjs
   - package.json
 </FileTree>
 
-#### Génération du site statique
+#### Génération de site statique
 
 Dans le mode statique par défaut d'Astro (SSG), utilisez [`getStaticPaths()`](/fr/reference/routing-reference/#getstaticpaths) pour récupérer votre liste d'articles à partir de Strapi.
 
-```astro title="src/pages/blog/[slug].astro
+```astro title="src/pages/blog/[slug].astro"
 ---
 import fetchApi from '../../lib/strapi';
 import type Article from '../../interfaces/article';
@@ -272,7 +269,7 @@ const article = Astro.props;
 
 Créer le modèle pour chaque page en utilisant les propriétés de chaque objet post.
 
-```astro title="src/pages/blog/[slug].astro ins={21-43}
+```astro title="src/pages/blog/[slug].astro" ins={21-43}
 ---
 import fetchApi from '../../lib/strapi';
 import type Article from '../../interfaces/article';
@@ -305,13 +302,13 @@ const article = Astro.props;
 
       <h1>{article.attributes.title}</h1>
 
-      <!-- Rendre du texte brut -->
+      <!-- Afficher du texte brut -->
       <p>{article.attributes.content}</p>
-      <!-- Rendre du markdown -->
+      <!-- Afficher du markdown -->
       <MyMarkdownComponent>
         {article.attributes.content}
       </MyMarkdownComponent>
-      <!-- Rendre du html -->
+      <!-- Restituer du html -->
       <Fragment set:html={article.attributes.content} />
     </main>
   </body>
@@ -362,20 +359,20 @@ try {
 
       <h1>{article.attributes.title}</h1>
 
-      <!-- Rendre du texte brut -->
+      <!-- Afficher du texte brut -->
       <p>{article.attributes.content}</p>
-      <!-- Rendre du markdown -->
+      <!-- Afficher du markdown -->
       <MyMarkdownComponent>
         {article.attributes.content}
       </MyMarkdownComponent>
-      <!-- Rendre du html -->
+      <!-- Restituer du html -->
       <Fragment set:html={article.attributes.content} />
     </main>
   </body>
 </html>
 ```
 
-Ce fichier va récupérer et rendre les données de la page de Strapi qui correspondent au paramètre dynamique `slug`.
+Ce fichier va récupérer et restituer les données de la page de Strapi qui correspondent au paramètre dynamique `slug`.
 
 Puisque vous utilisez une redirection vers `/404`, créez une page 404 dans `src/pages` :
 
@@ -397,9 +394,9 @@ Si l'article n'est pas trouvé, l'utilisateur sera redirigé vers cette page 404
 
 Pour déployer votre site, consultez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-#### Reconstruction en cas de modifications
+#### Recompiler lors de modifications
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité de webhook pour déclencher une nouvelle compilation à partir de Strapi.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité de webhook pour déclencher une nouvelle compilation à partir de Strapi.
 
 ##### Netlify
 
@@ -410,7 +407,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ##### Vercel
@@ -422,13 +419,13 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ##### Ajouter un webhook à Strapi
 
-Suivez [le guide Strapi webhooks](https://strapi.io/blog/webhooks) pour créer un webhook dans votre panneau d'administration Strapi.
+Suivez [le guide des webhooks de Strapi](https://strapi.io/blog/webhooks) pour créer un webhook dans votre panneau d'administration Strapi.
 
 ## Ressources officielles
 
-- [Strapi Blog Guide For React](https://strapi.io/blog/build-a-blog-with-next-react-js-strapi) par Strapi
+- [Guide de création de blog avec Strapi pour React](https://strapi.io/blog/build-a-blog-with-next-react-js-strapi) (Anglais) par Strapi


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/cms/strapi.mdx`:
* with changes from #11722 (code snippets titles)
* to fix indentation in `FileTree`
* with changes related to #11593
  * replace `construire` with other words when more appropriated
  * replace `construction` with `compilation`
  * replace `rendre` with more appropriate words
  * replace `point d'accès` with `point de terminaison`
  * use a consistent translation for `unwrap` (while we don't have an official translation for wrapper, this is commonly translated with `envelopper` - probably because of [Quebec recommandations](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/8871097/classe-enveloppante) - so `unwrap` would be `désenvelopper`)
  * translate community links and add language after

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
