### PR TITLE
i18n(fr): improve wording in remaining `guides/cms`

### DIFF
--- a/src/content/docs/fr/guides/cms/builderio.mdx
+++ b/src/content/docs/fr/guides/cms/builderio.mdx
@@ -29,14 +29,14 @@ Pour commencer, vous devez disposer des éléments suivants :
 Pour ajouter votre clé API Builder et votre nom de modèle Builder à Astro, créez un fichier `.env` à la racine de votre projet (s'il n'existe pas déjà) et ajoutez les variables suivantes :
 
 ```ini title=".env"
-BUILDER_API_PUBLIC_KEY=VOTRE_VLE_API
+BUILDER_API_PUBLIC_KEY=VOTRE_CLE_API
 BUILDER_BLOGPOST_MODEL='blogpost'
 ```
 
 Maintenant, vous devriez pouvoir utiliser cette clé API dans votre projet.
 
 :::note
-Au moment où nous écrivons ces lignes, [cette clé est publique](https://www.builder.io/c/docs/using-your-api-key#prerequisites), vous n'avez donc pas à vous soucier de la cacher ou de la crypter.
+Au moment de la rédaction, [cette clé est publique](https://www.builder.io/c/docs/using-your-api-key#prerequisites), vous n'avez donc pas à vous soucier de la cacher ou de la chiffrer.
 :::
 
 Si vous voulez avoir IntelliSense pour vos variables d'environnement, vous pouvez créer un fichier `env.d.ts` dans le répertoire `src/` et configurer `ImportMetaEnv` comme ceci :
@@ -49,7 +49,7 @@ interface ImportMetaEnv {
 
 Votre projet doit maintenant inclure ces fichiers :
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - **env.d.ts**
 - **.env**
@@ -60,7 +60,7 @@ Votre projet doit maintenant inclure ces fichiers :
 
 ## Créer un blog avec Astro et Builder
 
-### Création d'un modèle pour un billet de blog
+### Création d'un modèle pour un article de blog
 
 Les instructions ci-dessous créent un blog Astro en utilisant un modèle Builder (Type : "Section") appelé `blogpost` qui contient deux champs texte obligatoires : `title` et `slug`.
 
@@ -71,22 +71,22 @@ Vous pouvez trouver des vidéos montrant cette procédure dans l'un des [tutorie
 Dans l'application Builder, créez le modèle qui représentera un article de blog : allez dans l'onglet **Models** et cliquez sur le bouton **+ Create Model** pour créer un modèle avec les champs et valeurs suivants :
 
 - **Type:** Section
-- **Name:** "blogpost"
-- **Description:** "Ce modèle est destiné à un article de blog"
+- **Name:** « blogpost »
+- **Description:** « Ce modèle est destiné à un article de blog »
 
 Dans votre nouveau modèle, utilisez le bouton **+ New Custom Field** pour créer deux nouveaux champs :
 
 1. Champ texte
-    - **Name:** "title"
-    - **Requis:** Yes
-    - Valeur par défaut : "J'ai oublié de donner un titre à ce champ".
+    - **Name:** « title »
+    - **Required:** Yes
+    - **Default value** « J'ai oublié de donner un titre à ce champ »
 
     (laisser les autres paramètres par défaut)
 
 2. Champ texte
-    - Nom:** "slug"
-    - Obligatoire:** Yes
-    - **Default value** "certaines-limaces-prennent-leur-temps"
+    - **Name:** « slug »
+    - **Required:** Yes
+    - **Default value** « certaines-limaces-prennent-leur-temps »
 
     (laisser les autres paramètres par défaut)
 
@@ -102,9 +102,9 @@ Il y a quelques pièges avec le champ `slug` :
 
 ### Mise en place de la prévisualisation
 
-Pour utiliser l'éditeur visuel de Builder, créez la page `src/pages/builder-preview.astro` qui rendra le composant spécial `<builder-component>` :
+Pour utiliser l'éditeur visuel de Builder, créez la page `src/pages/builder-preview.astro` qui générera le composant spécial `<builder-component>` :
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - pages/
     - **builder-preview.astro**
@@ -174,14 +174,14 @@ Les choses peuvent parfois mal tourner lors de la mise en place de la prévisual
 * Assurez-vous qu'il s'agit de l'URL complète, y compris le protocole, par exemple `https://`.
 * Si vous travaillez dans un environnement virtuel comme [IDX](https://idx.dev), [StackBlitz](https://stackblitz.com/) ou [Gitpod](https://www.gitpod.io/), vous devrez peut-être copier et coller l'URL à nouveau lorsque vous redémarrez votre espace de travail, car cela génère généralement une nouvelle URL pour votre projet.
 
-Pour plus d'informations, lisez [Builder's troubleshooting guide](https://www.builder.io/c/docs/guides/preview-url-working).
+Pour plus d'informations, consultez [le guide de dépannage de Builder](https://www.builder.io/c/docs/guides/preview-url-working).
 :::
 
 ### Création d'un article de blog
 
 <Steps>
 1. Dans l'éditeur visuel de Builder, créez une nouvelle entrée de contenu avec les valeurs suivantes :
-    - **title:** 'premier article, woohoo !
+    - **title:** 'Premier article, woohoo !
     - **slug:** 'premier-article-woohoo'
 
 2. Complétez votre article à l'aide du bouton **Add Block** et ajoutez un champ de texte avec le contenu de l'article.
@@ -248,7 +248,7 @@ Allez sur votre route d'index et vous devriez pouvoir voir une liste de liens, c
 
 Créez la page `src/pages/posts/[slug].astro` qui [générera dynamiquement une page](/fr/guides/routing/#routes-dynamiques) pour chaque article.
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - pages/
     - index.astro
@@ -263,7 +263,7 @@ Créez la page `src/pages/posts/[slug].astro` qui [générera dynamiquement une 
 Ce fichier doit contenir :
 - Une fonction [`getStaticPaths()`](/fr/reference/routing-reference/#getstaticpaths) pour récupérer les informations `slug` de Builder et créer une route statique pour chaque article de blog.
 - Un `fetch()` vers l'API de Builder utilisant l'identifiant `slug` pour retourner le contenu de l'article et les métadonnées (par exemple un `title`).
-- Un `<Fragment />` dans le template pour rendre le contenu de l'article en HTML.
+- Un `<Fragment />` dans le modèle pour générer le contenu de l'article en HTML.
 
 Chacun de ces éléments est mis en évidence dans l'extrait de code suivant.
 
@@ -283,7 +283,7 @@ export async function getStaticPaths() {
   )
     .then((res) => res.json())
     .catch
-    // ...catch some errors...);
+    // ...détecter quelques erreurs...);
     ();
   return posts.map(({ data: { slug, title } }) => ({
     params: { slug },
@@ -331,9 +331,9 @@ Désormais, lorsque vous cliquez sur un lien de votre route d'indexation, vous �
 
 Pour déployer votre site web, visitez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-#### Reconstruire sur les changements du Builder
+#### Recompiler suite à des changements sur Builder
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme fournisseur d'hébergement, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle construction chaque fois que vous cliquez sur **Publish** dans l'éditeur Builder.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme fournisseur d'hébergement, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle compilation chaque fois que vous cliquez sur **Publish** dans l'éditeur Builder.
 
 ##### Netlify
 
@@ -342,7 +342,7 @@ Si votre projet utilise le mode statique par défaut d'Astro, vous devrez config
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ##### Vercel
@@ -352,13 +352,13 @@ Si votre projet utilise le mode statique par défaut d'Astro, vous devrez config
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ##### Ajouter un webhook à Builder
 
 :::tip[Ressource officielle]
-Voir [Builder's guide on adding webhooks](https://www.builder.io/c/docs/webhooks) pour plus d'informations.
+Consultez le [guide de Builder sur l'ajout de webhooks](https://www.builder.io/c/docs/webhooks) pour plus d'informations.
 :::
 
 <Steps>
@@ -375,9 +375,9 @@ Avec ce webhook en place, chaque fois que vous cliquez sur le bouton **Publish**
 ## Ressources officielles
 
 - Consultez [le projet de démarrage officiel de Builder.io](https://github.com/BuilderIO/builder/tree/main/examples/astro-solidjs), qui utilise Astro et SolidJS.
-- Le [guide officiel de démarrage rapide de Builder](https://www.builder.io/c/docs/quickstart#step-1-add-builder-as-a-dependency) couvre à la fois l'utilisation de l'API REST et la récupération de données par le biais d'une intégration avec un cadre JavaScript comme Qwik, React ou Vue.
+- Le [guide officiel de démarrage rapide de Builder](https://www.builder.io/c/docs/quickstart#step-1-add-builder-as-a-dependency) couvre à la fois l'utilisation de l'API REST et la récupération de données par le biais d'une intégration avec un framework JavaScript comme Qwik, React ou Vue.
 - L'[explorateur d'API de Builder](https://builder.io/api-explorer) peut vous aider à résoudre les problèmes liés à vos appels d'API.
 
 ## Ressources communautaires
 
-- Lire [Connecter le CMS visuel de Builder.io à Astro](https://www.hamatoyogi.dev/blog/astro-log/connecting-builderio-to-astro) par Yoav Ganbar.
+- Lire [Connecter le CMS visuel de Builder.io à Astro](https://www.hamatoyogi.dev/blog/astro-log/connecting-builderio-to-astro) (Anglais) par Yoav Ganbar.

--- a/src/content/docs/fr/guides/cms/buttercms.mdx
+++ b/src/content/docs/fr/guides/cms/buttercms.mdx
@@ -15,7 +15,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 ## Intégrer avec Astro
 :::note
-Pour un exemple de site de blog complet, voir le [Projet de démarrage Astro + ButterCMS](https://buttercms.com/starters/astro-starter-project/).
+Pour un exemple de site de blog complet, consultez le [projet de démarrage Astro + ButterCMS](https://buttercms.com/starters/astro-starter-project/).
 :::
 Dans cette section, nous allons utiliser le [SDK ButterCMS](https://www.npmjs.com/package/buttercms) pour intégrer vos données dans votre projet Astro.
 Pour démarrer, vous aurez besoin de ce qui suit :
@@ -25,7 +25,7 @@ Pour démarrer, vous aurez besoin de ce qui suit :
 
 2. **Un compte ButterCMS** - Si vous n'avez pas de compte, vous pouvez [vous inscrire](https://buttercms.com/join/) pour un essai gratuit.
 
-3. **Votre jeton d'API ButterCMS** - Vous pouvez trouver votre jeton d'API sur la page [Paramètres](https://buttercms.com/settings/).
+3. **Votre jeton d'API ButterCMS** - Vous pouvez trouver votre jeton d'API sur la page [Paramètres (« Settings »)](https://buttercms.com/settings/).
 
 ### Configuration
 
@@ -40,7 +40,7 @@ Pour démarrer, vous aurez besoin de ce qui suit :
     En savoir plus sur [l'utilisation des variables d'environnement](/fr/guides/environment-variables/) et les fichiers `.env` dans Astro.
     :::
 
-2. Installer le SDK ButterCMS en tant que dépendance :
+2. Installez le SDK ButterCMS en tant que dépendance :
     <PackageManagerTabs>
       <Fragment slot="npm">
         ```shell

--- a/src/content/docs/fr/guides/cms/caisy.mdx
+++ b/src/content/docs/fr/guides/cms/caisy.mdx
@@ -9,7 +9,7 @@ i18nReady: true
 stub: true
 ---
 
-[Caisy](https://caisy.io/) est un CMS sans tête qui expose une API GraphQL pour accéder au contenu.
+[Caisy](https://caisy.io/) est un CMS headless qui expose une API GraphQL pour accéder au contenu.
 
 ## Utiliser le CMS Caisy avec Astro
 
@@ -60,5 +60,5 @@ const post = gqlResponse?.allBlogArticle?.edges?.[0]?.node;
 
 - Consultez l'exemple Caisy + Astro sur [GitHub](https://github.com/caisy-io/caisy-example-astro) ou [StackBlitz](https://stackblitz.com/github/caisy-io/caisy-example-astro?file=src%2Fpages%2Fblog%2F%5B...slug%5D.astro)
 - Interrogez vos documents en [mode brouillon](https://caisy.io/developer/docs/external-api/localization-and-preview#preview-mode-15) et dans plusieurs [langues](https://caisy.io/developer/docs/external-api/localization-and-preview#localization-in-a-graphql-query-8).
-- Utilisez [pagination](https://caisy.io/developer/docs/external-api/queries-pagination) pour interroger un grand nombre de documents.
-- Utilisez [filter](https://caisy.io/developer/docs/external-api/external-filter-and-sorting) dans vos requêtes et [ordonner](https://caisy.io/developer/docs/external-api/external-filter-and-sorting#sorting-8) les résultats.
+- Utilisez la [pagination](https://caisy.io/developer/docs/external-api/queries-pagination) pour interroger un grand nombre de documents.
+- Utilisez les [filtres](https://caisy.io/developer/docs/external-api/external-filter-and-sorting) dans vos requêtes et [ordonner](https://caisy.io/developer/docs/external-api/external-filter-and-sorting#sorting-8) les résultats.

--- a/src/content/docs/fr/guides/cms/cloudcannon.mdx
+++ b/src/content/docs/fr/guides/cms/cloudcannon.mdx
@@ -19,7 +19,7 @@ import Card from '~/components/ShowcaseCard.astro'
 - [Modèle de démarrage Astro](https://cloudcannon.com/templates/astro-starter/)
 - [Modèle de démarrage multilingue Astro](https://cloudcannon.com/templates/astro-multilingual-starter/)
 - [Guide de démarrage Astro](https://cloudcannon.com/documentation/guides/astro-starter-guide/)
-- [Bookshop & Astro Guide](https://cloudcannon.com/documentation/guides/bookshop-astro-guide/)
+- [Guide Bookshop & Astro](https://cloudcannon.com/documentation/guides/bookshop-astro-guide/)
 - [Série de tutoriels Astro pour les débutants](https://cloudcannon.com/tutorials/astro-beginners-tutorial-series/)
 - Blog : [Comment l'édition en direct de CloudCannon fonctionne avec Astro et Bookshop](https://cloudcannon.com/blog/how-cloudcannons-live-editing-works-with-astro-and-bookshop/)
 - Blog : [Une assistance hors du commun pour tous les utilisateurs d'Astro](https://cloudcannon.com/blog/out-of-this-world-support-for-all-astro-users/)

--- a/src/content/docs/fr/guides/cms/cosmic.mdx
+++ b/src/content/docs/fr/guides/cms/cosmic.mdx
@@ -132,7 +132,7 @@ Les instructions suivantes supposent que vous disposez d'un **Object Type** dans
 
 ### Afficher une liste d'articles de blog dans Astro
 
-En utilisant la même [méthode de récupération de données](#récupérer-des-données-de-cosmic) que ci-dessus, importez la requête `getAllPosts()` de votre fichier script et attendez les données. Cette fonction fournit des métadonnées sur chaque article (`post`) qui peuvent être affichées dynamiquement.
+En utilisant la même [méthode de récupération de données](#récupérer-des-données-depuis-cosmic) que ci-dessus, importez la requête `getAllPosts()` de votre fichier script et attendez les données. Cette fonction fournit des métadonnées sur chaque article (`post`) qui peuvent être affichées dynamiquement.
 
 L'exemple ci-dessous transmet ces valeurs à un composant `<Card />` pour afficher une liste formatée d'articles de blog :
 

--- a/src/content/docs/fr/guides/cms/cosmic.mdx
+++ b/src/content/docs/fr/guides/cms/cosmic.mdx
@@ -16,7 +16,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## Prérequis
 
-1. **Un projet Astro**- Si vous souhaitez démarrer avec un nouveau projet Astro, lisez le [guide d'installation](/fr/install-and-setup/). Ce guide suit une version simplifiée du [Theme Astro Headless CMS](https://astro.build/themes/details/cosmic-cms-blog/) avec [Tailwind CSS](https://tailwindcss.com/) pour le style.
+1. **Un projet Astro**- Si vous souhaitez démarrer avec un nouveau projet Astro, lisez le [guide d'installation](/fr/install-and-setup/). Ce guide suit une version simplifiée du [thème Astro Headless CMS](https://astro.build/themes/details/cosmic-cms-blog/) avec [Tailwind CSS](https://tailwindcss.com/) pour la mise en forme.
 2. **Un compte Cosmic et un Bucket** - [Créez un compte Cosmic gratuitement](https://app.cosmicjs.com/signup) si vous n'en avez pas. Après avoir créé votre compte, vous serez invité à créer un nouveau projet vide. Il y a aussi un [modèle simple de Blog Astro](https://www.cosmicjs.com/marketplace/templates/simple-astro-blog) disponible (c'est le même modèle que le thème Astro Headless CMS) pour importer automatiquement tout le contenu utilisé dans ce guide.
 3. **Vos clés API Cosmic** - A partir de votre tableau de bord Cosmic, vous devrez localiser à la fois le **Bucket slug** et la **Bucket read key** afin de vous connecter à Cosmic.
 
@@ -24,7 +24,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 ### Installation des dépendances nécessaires
 
-Ajoutez le [SDK Javascript Cosmic](https://www.npmjs.com/package/@cosmicjs/sdk) pour récupérer les données de votre Cosmic Bucket.
+Ajoutez le [SDK Javascript de Cosmic](https://www.npmjs.com/package/@cosmicjs/sdk) pour récupérer les données de votre Cosmic Bucket.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -49,11 +49,11 @@ Ajoutez le [SDK Javascript Cosmic](https://www.npmjs.com/package/@cosmicjs/sdk) 
 Créez un fichier `.env` à la racine de votre projet Astro (s'il n'existe pas déjà). Ajoutez les **Bucket slug** et **Bucket read key** disponibles dans votre tableau de bord Cosmic comme variables d'environnement publiques.
 
 ```ini title=".env"
-PUBLIC_COSMIC_BUCKET_SLUG=YOUR_BUCKET_SLUG
-PUBLIC_COSMIC_READ_KEY=YOUR_READ_KEY
+PUBLIC_COSMIC_BUCKET_SLUG=VOTRE_SLUG_BUCKET
+PUBLIC_COSMIC_READ_KEY=VOTRE_CLE_DE_LECTURE
 ```
 
-## Récupérer des données de Cosmic
+## Récupérer des données depuis Cosmic
 
 <Steps>
 1. Créez un nouveau fichier appelé `cosmic.js`. Placez ce fichier dans le dossier `src/lib` de votre projet.
@@ -81,7 +81,7 @@ PUBLIC_COSMIC_READ_KEY=YOUR_READ_KEY
     }
     ```
 
-    Lire plus au sujet des [requêtes dans la documentation de Cosmic](https://www.cosmicjs.com/docs/api/queries).
+    En savoir plus sur les [requêtes dans la documentation de Cosmic](https://www.cosmicjs.com/docs/api/queries).
 
 3. Importez votre fonction de requête dans un composant `.astro`. Après avoir récupéré les données, les résultats de la requête peuvent être utilisés dans votre modèle Astro.
 
@@ -119,9 +119,9 @@ PUBLIC_COSMIC_READ_KEY=YOUR_READ_KEY
 
 Vous pouvez gérer le contenu de votre blog Astro à l'aide de Cosmic et créer des webhooks pour redéployer automatiquement votre site web lorsque vous mettez à jour ou ajoutez du nouveau contenu.
 
-### Objets de contenu Cosmic
+### Les objets de contenu de Cosmic
 
-Les instructions suivantes supposent que vous disposez d'un **Object Type** dans Cosmic appelé **posts**. Chaque article de blog individuel est un "post" qui est défini dans le tableau de bord de Cosmic avec les Metafields suivants :
+Les instructions suivantes supposent que vous disposez d'un **Object Type** dans Cosmic appelé **posts**. Chaque article de blog individuel est un `post` qui est défini dans le tableau de bord de Cosmic avec les métadonnées (Metafields) suivantes :
 
 1. **Text input** - Auteur
 2. **Image** - Image de couverture
@@ -132,7 +132,7 @@ Les instructions suivantes supposent que vous disposez d'un **Object Type** dans
 
 ### Afficher une liste d'articles de blog dans Astro
 
-En utilisant la même [méthode de récupération de données](#récupérer-des-données-de-cosmic) que ci-dessus, importez la requête `getAllPosts()` de votre fichier script et attendez les données. Cette fonction fournit des métadonnées sur chaque "post" qui peuvent être affichées dynamiquement.
+En utilisant la même [méthode de récupération de données](#récupérer-des-données-de-cosmic) que ci-dessus, importez la requête `getAllPosts()` de votre fichier script et attendez les données. Cette fonction fournit des métadonnées sur chaque article (`post`) qui peuvent être affichées dynamiquement.
 
 L'exemple ci-dessous transmet ces valeurs à un composant `<Card />` pour afficher une liste formatée d'articles de blog :
 
@@ -165,15 +165,15 @@ const data = await getAllPosts()
 
 Pour générer une page individuelle avec un contenu complet pour chaque article de blog, créez une [page de routage dynamique](/fr/guides/routing/#routes-dynamiques) dans `src/pages/blog/[slug].astro`.
 
-Cette page exportera une fonction `getStaticPaths()` pour générer une route de page au niveau du `slug` renvoyé par chaque objet `post`. Cette fonction est appelée au moment de la construction et génère et rend tous les articles de votre blog en une seule fois.
+Cette page exportera une fonction `getStaticPaths()` pour générer une route de page au niveau du `slug` renvoyé par chaque objet `post`. Cette fonction est appelée au moment de la compilation et génère et restitue tous les articles de votre blog en une seule fois.
 
 Pour accéder à vos données depuis Cosmic :
 
 - Interrogez Cosmic à l'intérieur de `getStaticPaths()` pour récupérer les données de chaque article et les fournir à la fonction.
 - Utilisez chaque `post.slug` comme paramètre de route, en créant les URLs pour chaque article de blog.
-- Retourner chaque `post` à l'intérieur de `Astro.props`, rendant les données du post disponibles pour le rendu de la partie du modèle HTML du composant de la page.
+- Retourner chaque `post` à l'intérieur de `Astro.props`, rendant les données de l'article disponibles pour le rendu de la partie du modèle HTML du composant de la page.
 
-Le balisage HTML ci-dessous utilise diverses données de Cosmic, telles que le titre de l'article, l'image de couverture et le **rich text content** (contenu complet de l'article de blog). Utilisez [set&colon;html](/fr/reference/directives-reference/#sethtml) sur l'élément affichant le contenu de l'article de Cosmic pour rendre les éléments HTML de la page exactement comme ils ont été récupérés de Cosmic.
+Le balisage HTML ci-dessous utilise diverses données de Cosmic, telles que le titre de l'article, l'image de couverture et le **rich text content** (contenu complet de l'article de blog). Utilisez [set&colon;html](/fr/reference/directives-reference/#sethtml) sur l'élément affichant le contenu de l'article de Cosmic pour générer les éléments HTML de la page exactement comme ils ont été récupérés de Cosmic.
 
 ```astro
 ---
@@ -210,7 +210,7 @@ const { post } = Astro.props
         height={675}
         aspectRatio={16 / 9}
         quality={50}
-        alt={`Cover image for the blog ${post.title}`}
+        alt={`Image de couverture pour l'article ${post.title}`}
         class={'my-12 rounded-md shadow-lg'}
       />
     )
@@ -223,11 +223,11 @@ const { post } = Astro.props
 
 Pour déployer votre site web, visitez les [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-#### Rebuild sur les mises à jour du contenu de Cosmic
+#### Recompiler lors de la mise à jour du contenu sur Cosmic
 
 Vous pouvez configurer un webhook dans Cosmic directement pour déclencher un redéploiement de votre site sur votre plateforme d'hébergement (par exemple Vercel) chaque fois que vous mettez à jour ou ajoutez des objets de contenu.
 
-Sous "Settings" > "webhooks", ajoutez le point de terminaison URL de Vercel et sélectionnez le type d'objet que vous souhaitez déclencher le webhook. Cliquez sur "Add webhook" pour le sauvegarder.
+Sous "Settings" > "webhooks", ajoutez l'URL du point de terminaison de Vercel et sélectionnez le type d'objet que vous souhaitez déclencher le webhook. Cliquez sur "Add webhook" pour le sauvegarder.
 
 #### Netlify
 
@@ -238,7 +238,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 #### Vercel
@@ -250,11 +250,11 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ## Thèmes
 
 <Grid>
-  <Card title="Astro Headless CMS Blog" href="https://astro.build/themes/details/cosmic-cms-blog/" thumbnail="simple-astro-blog.png" />
+  <Card title="Blog Astro avec CMS Headless" href="https://astro.build/themes/details/cosmic-cms-blog/" thumbnail="simple-astro-blog.png" />
 </Grid>

--- a/src/content/docs/fr/guides/cms/craft-cms.mdx
+++ b/src/content/docs/fr/guides/cms/craft-cms.mdx
@@ -9,7 +9,7 @@ i18nReady: true
 stub: true
 ---
 
-[Craft CMS](https://craftcms.com/) est un CMS open source flexible avec une expérience de création accessible. Il comprend son propre front-end, mais peut également être utilisé comme headless CMS pour fournir du contenu à votre projet Astro.
+[Craft CMS](https://craftcms.com/) est un CMS open source flexible avec une expérience de création accessible. Il comprend son propre front-end, mais peut également être utilisé comme CMS headless pour fournir du contenu à votre projet Astro.
 
 ## Ressources officielles
 
@@ -18,6 +18,6 @@ stub: true
 
 ## Ressources communautaires
 
-- [Astro SSG avec Craft CMS en mode headless : récupérer le contenu au moment de la construction](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time/) (en)
-- [Astro SSG avec Craft CMS en mode headless : utiliser du contenu récupéré au moment de la construction ou mis en cache à l'avance](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time-or-cached-in-advance/) (en)
-- [Astro SSR avec Craft CMS en mode headless](https://www.olets.dev/posts/ssr-astro-with-headless-craft-cms/) (en)
+- [Astro SSG avec Craft CMS en mode headless : récupérer le contenu au moment de la compilation](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time/) (Anglais)
+- [Astro SSG avec Craft CMS en mode headless : utiliser du contenu récupéré au moment de la compilation ou mis en cache à l'avance](https://www.olets.dev/posts/ssg-astro-with-headless-craft-cms-content-fetched-at-build-time-or-cached-in-advance/) (Anglais)
+- [Astro SSR avec Craft CMS en mode headless](https://www.olets.dev/posts/ssr-astro-with-headless-craft-cms/) (Anglais)

--- a/src/content/docs/fr/guides/cms/crystallize.mdx
+++ b/src/content/docs/fr/guides/cms/crystallize.mdx
@@ -8,8 +8,8 @@ stub: true
 service: Crystallize
 i18nReady: true
 ---
-[Crystallize](https://crystallize.com/) est un système de gestion de contenu sans tête pour le commerce électronique qui expose une API GraphQL.
-## Example
+[Crystallize](https://crystallize.com/) est un système de gestion de contenu headless pour le commerce électronique qui expose une API GraphQL.
+## Exemple
 
 ```astro title="src/pages/index.astro"
 ---

--- a/src/content/docs/fr/guides/cms/datocms.mdx
+++ b/src/content/docs/fr/guides/cms/datocms.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import { Steps } from '@astrojs/starlight/components';
 import { FileTree } from '@astrojs/starlight/components';
 
-[DatoCMS](https://datocms.com/) est un système de gestion de contenu (CMS) Headless, basé sur le web, qui permet de gérer le contenu numérique de vos sites et applications.
+[DatoCMS](https://datocms.com/) est un CMS headless, basé sur le web, qui permet de gérer le contenu numérique de vos sites et applications.
 
 ## Intégration avec Astro
 
@@ -21,7 +21,7 @@ Dans ce guide, vous allez récupérer les données de contenu de DatoCMS dans vo
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-- **Un projet Astro** - Si vous n'avez pas encore de projet Astro, vous pouvez suivre les instructions de notre [Guide d'installation](/fr/install-and-setup/).
+- **Un projet Astro** - Si vous n'avez pas encore de projet Astro, vous pouvez suivre les instructions de notre [guide d'installation](/fr/install-and-setup/).
 - **Un compte et un projet DatoCMS** - Si vous n'avez pas de compte, vous pouvez [créer un compte gratuit](https://dashboard.datocms.com/signup).
 - **La clé API en lecture seule de votre projet DatoCMS** - Vous pouvez la trouver dans le tableau de bord d'administration de votre projet, sous "Settings" > "API Tokens".
 
@@ -30,10 +30,10 @@ Pour commencer, vous devez disposer des éléments suivants :
 Créez un nouveau fichier (s'il n'existe pas déjà) nommé `.env` à la racine de votre projet Astro. Ajoutez une nouvelle variable d'environnement comme suit, en utilisant la clé API trouvée dans votre tableau de bord d'administration DatoCMS :
 
 ```ini title=".env"
-DATOCMS_API_KEY=YOUR_API_KEY
+DATOCMS_API_KEY=VOTRE_CLE_API
 ```
 
-Pour le support de TypeScript, déclarez le typage de cette variable d'environnement dans le fichier `env.d.ts` du dossier `src/`. Si ce fichier n'existe pas, vous pouvez le créer et ajouter ce qui suit :
+Pour la prise en charge de TypeScript, déclarez le type de cette variable d'environnement dans le fichier `env.d.ts` du dossier `src/`. Si ce fichier n'existe pas, vous pouvez le créer et ajouter ce qui suit :
 
 ```ts title="src/env.d.ts"
 interface ImportMetaEnv {
@@ -43,7 +43,7 @@ interface ImportMetaEnv {
 
 Votre répertoire racine doit maintenant contenir ces fichiers :
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - src/
   - **env.d.ts**
 - **.env**
@@ -59,7 +59,7 @@ Accédez à l'onglet "Content" de votre projet et cliquez sur la page d'accueil 
 
 ## Récupérer des données
 
-Dans votre projet Astro, naviguez jusqu'à la page qui récupérera et affichera le contenu de votre CMS. Ajoutez la requête suivante pour récupérer le contenu de `Accueil` en utilisant l'API GraphQL de DatoCMS.
+Dans votre projet Astro, naviguez jusqu'à la page qui récupérera et affichera le contenu de votre CMS. Ajoutez la requête suivante pour récupérer le contenu de l'accueil (`home`) en utilisant l'API GraphQL de DatoCMS.
 
 Cet exemple affiche le titre de la page de DatoCMS sur `src/pages/index.astro` :
 
@@ -89,13 +89,13 @@ const data = json.data.home;
 <h1>{data.title}</h1>
 ```
 
-Cette requête GraphQL va chercher le champ `title` dans la page `Accueil` de votre projet DatoCMS. Lorsque vous rafraîchissez votre navigateur, vous devriez voir le titre sur votre page.
+Cette requête GraphQL va récupérer le champ `title` dans la page accueil (`home`) de votre projet DatoCMS. Lorsque vous rafraîchissez votre navigateur, vous devriez voir le titre sur votre page.
 
 ## Ajouter des blocs de contenu modulaire dynamique
 
-Si votre projet DatosCMS inclut du [contenu modulaire](https://www.datocms.com/docs/content-modelling/modular-content), alors vous devrez construire un composant `.astro` correspondant pour chaque bloc de contenu (par exemple une section de texte, une vidéo, un bloc de citation, etc).
+Si votre projet DatosCMS inclut du [contenu modulaire](https://www.datocms.com/docs/content-modelling/modular-content), alors vous devrez créer un composant `.astro` correspondant pour chaque bloc de contenu (par exemple une section de texte, une vidéo, un bloc de citation, etc).
 
-L'exemple ci-dessous est un composant Astro `<Text />` pour l'affichage d'un bloc "Texte à paragraphes multiples" de DatoCMS.
+L'exemple ci-dessous est un composant Astro `<Text />` pour l'affichage d'un bloc de texte à paragraphes multiples (« Multiple-paragraph text ») de DatoCMS.
 
 ```astro title="src/components/Text.astro"
 ---
@@ -115,7 +115,7 @@ const { item } = Astro.props;
 ```
 Pour récupérer ces blocs, modifiez votre requête GraphQL pour inclure le bloc de contenu modulaire que vous avez créé dans DatoCMS.
 
-Dans cet exemple, le bloc de contenu modulaire est nommé **content** dans DatoCMS. Cette requête inclut également la `_modelApiKey` unique de chaque élément pour vérifier quel bloc doit être affiché dans le champ modulaire, en fonction du bloc choisi par l'auteur du contenu dans l'éditeur de DatoCMS. Utilisez une instruction switch dans le modèle Astro pour permettre un rendu dynamique basé sur les données reçues de la requête.
+Dans cet exemple, le bloc de contenu modulaire est nommé **content** dans DatoCMS. Cette requête inclut également la clé d'API unique du modèle (`_modelApiKey`) de chaque élément pour vérifier quel bloc doit être affiché dans le champ modulaire, en fonction du bloc choisi par l'auteur du contenu dans l'éditeur de DatoCMS. Utilisez une instruction switch dans le modèle Astro pour permettre un affichage dynamique basé sur les données reçues de la requête.
 
 L'exemple suivant représente un bloc de contenu modulaire DatoCMS qui permet à un auteur de choisir entre un champ de texte (`<Text />`) et une image (`<Image />`) affichée sur la page d'accueil :
 
@@ -176,9 +176,9 @@ const data = json.data.home;
 
 Pour déployer votre site web, visitez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-## Publier sur les changements de contenu de DatoCMS
+## Publier lors de changements de contenu dans DatoCMS
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme fournisseur d'hébergement, vous pouvez utiliser sa fonctionnalité webhook pour déclencher un nouveau build lorsque vous changez le contenu dans DatoCMS.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme fournisseur d'hébergement, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle compilation lorsque vous modifiez le contenu dans DatoCMS.
 
 ### Netlify
 
@@ -189,7 +189,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ### Vercel
@@ -201,12 +201,12 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ### Ajouter un webhook à DatoCMS
 
-Dans le tableau de bord d'administration de votre projet DatoCMS, naviguez jusqu'à l'onglet **Settings** et cliquez sur **Webhooks**. Cliquez sur l'icône plus pour créer un nouveau webhook et donnez-lui un nom. Dans le champ URL, collez l'URL générée par votre service d'hébergement préféré. Dans le champ Déclencheur, sélectionnez l'option qui vous convient le mieux. (Par exemple : construire chaque fois qu'un nouvel enregistrement est publié).
+Dans le tableau de bord d'administration de votre projet DatoCMS, naviguez jusqu'à l'onglet **Settings** et cliquez sur **Webhooks**. Cliquez sur l'icône plus pour créer un nouveau webhook et donnez-lui un nom. Dans le champ URL, collez l'URL générée par votre service d'hébergement préféré. En tant que déclencheur, sélectionnez l'option qui vous convient le mieux à vos besoins. (Par exemple : compiler chaque fois qu'un nouvel enregistrement est publié).
 
 ## Projet de démarrage
 Vous pouvez également consulter le [modèle de blog Astro](https://www.datocms.com/marketplace/starters/astro-template-blog) sur la place de marché DatoCMS pour apprendre à créer un blog avec Astro et DatoCMS

--- a/src/content/docs/fr/guides/cms/directus.mdx
+++ b/src/content/docs/fr/guides/cms/directus.mdx
@@ -14,13 +14,13 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## Ressources officielles
 
-- [Premiers pas avec Directus et Astro](https://docs.directus.io/blog/getting-started-directus-astro.html).
+- [Premiers pas avec Directus et Astro](https://docs.directus.io/blog/getting-started-directus-astro.html) (Anglais).
 
 
 ## Ressources communautaires
 
 <CardGrid>
-  <LinkCard title="Utiliser le CMS Directus avec Neon Postgres et Astro pour créer un blog (en)" href="https://neon.tech/guides/directus-cms" />
+  <LinkCard title="Utiliser le CMS Directus avec Neon Postgres et Astro pour créer un blog (Anglais)" href="https://neon.tech/guides/directus-cms" />
 </CardGrid>
 
 :::note[Vous avez une ressource à partager ?]

--- a/src/content/docs/fr/guides/cms/drupal.mdx
+++ b/src/content/docs/fr/guides/cms/drupal.mdx
@@ -109,7 +109,7 @@ La structure de base de l'URL est : `/jsonapi/{entity_type_id}/{bundle_id}`
 
 L'URL est toujours préfixée par `jsonapi`.
 - `entity_type_id` fait référence au type d'entité, tel qu'un nœud, un bloc, un utilisateur, etc.
-- `bundle_id` fait référence aux bundles d'entités. Dans le cas d'un type d'entité Node, le bundle peut être un article.
+- `bundle_id` fait référence aux regroupements d'entités. Dans le cas d'un type d'entité Node, le regroupement peut être un article.
 - Dans ce cas, pour obtenir la liste de tous les articles, l'URL sera `[DRUPAL_BASE_URL]/jsonapi/node/article`.
 
 Pour récupérer une entité individuelle, la structure de l'URL sera `/jsonapi/{entity_type_id}/{bundle_id}/{uuid}`, où l'uuid est l'UUID de l'entité. Par exemple, l'URL pour obtenir un article spécifique sera de la forme `/jsonapi/node/article/2ee9f0ef-1b25-4bbe-a00f-8649c68b1f7e`.
@@ -361,7 +361,7 @@ Avec la configuration ci-dessus, vous êtes désormais en mesure de créer un bl
 
     Cet appel de récupération utilisant getArticles() renverra un tableau typé d'entrées qui peuvent être utilisées dans votre modèle de page.
 
-    Votre répertoire `src/pages/` devrait maintenant inclure le nouveau fichier, si vous avez utilisé le même fichier d'échange :
+    Votre répertoire `src/pages/` devrait maintenant inclure le nouveau fichier, si vous avez utilisé le même fichier de page :
     <FileTree title="Structure du projet">
     - .env
     - astro.config.mjs
@@ -452,7 +452,7 @@ Cet exemple utilise le mode statique par défaut d'Astro et crée [un fichier de
       - types.ts
     </FileTree>
 
-2. Dans le même fichier, mappez chaque entrée Drupal à un objet avec une propriété `params` et `props`. La propriété `params` sera utilisée pour générer l'URL de la page et les valeurs `props` seront transmises au composant de page en tant que props.
+2. Dans le même fichier, associez chaque entrée Drupal à un objet avec une propriété `params` et `props`. La propriété `params` sera utilisée pour générer l'URL de la page et les valeurs `props` seront transmises au composant de page en tant que props.
 
     ```astro title="src/pages/articles/[path].astro" ins={12-33}
     ---
@@ -540,19 +540,19 @@ Cet exemple utilise le mode statique par défaut d'Astro et crée [un fichier de
     </html>
     ```
 
-4. Accédez à l’aperçu de votre serveur de développement et cliquez sur l’un de vos messages pour vous assurer que votre route dynamique fonctionne.
+4. Accédez à l’aperçu de votre serveur de développement et cliquez sur l’un de vos articles pour vous assurer que votre route dynamique fonctionne.
 
 </Steps>
 
 ### Publier votre site
 
-Pour déployer votre site Web, visitez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
+Pour déployer votre site web, visitez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
 ## Ressources communautaires
 
 <CardGrid>
 
-  <LinkCard title="Créer une application web avec Astro et Drupal (en)" href="https://www.linkedin.com/pulse/create-web-application-astrojs-website-generator-using-gambino-kx6cf"/>
+  <LinkCard title="Créer une application web avec Astro et Drupal (Anglais)" href="https://www.linkedin.com/pulse/create-web-application-astrojs-website-generator-using-gambino-kx6cf"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/cms/flotiq.mdx
+++ b/src/content/docs/fr/guides/cms/flotiq.mdx
@@ -30,7 +30,7 @@ Pour commencer, vous aurez besoin de :
 Ajoutez la clé API en lecture seule de votre compte Flotiq au fichier `.env` à la racine de votre projet Astro :
 
 ```ini title=".env"
-FLOTIQ_API_KEY=__YOUR_FLOTIQ_API_KEY__
+FLOTIQ_API_KEY=__VOTRE_CLE_API_FLOTIQ__
 ```
 
 ### Définir un type de contenu dans Flotiq
@@ -49,7 +49,7 @@ Ensuite, créez un ou plusieurs exemples d'[objets de contenu](https://flotiq.co
 
 ### Installation du SDK TypeScript de Flotiq
 
-Pour connecter votre projet à Flotiq, installez le [Flotiq SDK](https://github.com/flotiq/flotiq-api-ts) en utilisant le gestionnaire de paquets de votre choix :
+Pour connecter votre projet à Flotiq, installez le [SDK de Flotiq](https://github.com/flotiq/flotiq-api-ts) en utilisant le gestionnaire de paquets de votre choix :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -93,7 +93,7 @@ Cette configuration peut maintenant être utilisée dans l'ensemble de votre pro
     ---
     ```
 
-2. Affichez le contenu dans votre modèle Astro. Vous aurez accès au `title`, `slug`, et `content` de vos articles ainsi qu'à d'autres données internes de l'article :
+2. Affichez le contenu dans votre modèle Astro. Vous aurez accès au titre (`title`), `slug`, et contenu (`content`) de vos articles ainsi qu'à d'autres données internes de l'article :
 
     ```astro title="src/pages/index.astro" ins={6-21}
     ---
@@ -125,11 +125,11 @@ Cette configuration peut maintenant être utilisée dans l'ensemble de votre pro
 
 ### Générer des pages individuelles
 
-Astro prend en charge le pré-rendu de toutes vos pages à l'avance, ou la création d'itinéraires à la demande lorsqu'elles sont demandées. Suivez les instructions pour la [génération de site statique](#génération-de-sites-statiques) ou le [rendu à la demande](#rendu-à-la-demande) pour construire les routes de pages pour vos articles de blog.
+Astro prend en charge le pré-rendu de toutes vos pages à l'avance, ou la création de routes à la demande lorsqu'elles sont demandées. Suivez les instructions pour la [génération de site statique](#génération-de-sites-statiques) ou le [rendu à la demande](#rendu-à-la-demande) pour créer les routes de pages pour vos articles de blog.
 
 #### Génération de sites statiques
 
-En mode de génération de sites statiques (SSG), utilisez la méthode `getStaticPaths()` pour récupérer tous les chemins d'accès possibles aux articles de blog à partir de Flotiq.
+En mode génération de sites statiques (SSG), utilisez la méthode `getStaticPaths()` pour récupérer tous les chemins d'accès possibles aux articles de blog à partir de Flotiq.
 
 <Steps>
 
@@ -150,7 +150,7 @@ En mode de génération de sites statiques (SSG), utilisez la méthode `getStati
     ---
     ```
 
-2. Ajoutez le modèle pour afficher un message individuel :
+2. Ajoutez le modèle pour afficher un article individuel :
 
     ```astro title="src/pages/posts/[slug].astro" ins={12-20}
     ---
@@ -185,7 +185,7 @@ Si vous utilisez le mode [SSR](/fr/guides/on-demand-rendering/), vous devrez ré
 
 <Steps>
 
-1. Créer un nouveau fichier `[slug].astro` dans le répertoire `/src/pages/posts/`. Récupérer l'article par son champ `slug`, en incluant la logique pour afficher une page 404 si la route n'est pas trouvée :
+1. Créez un nouveau fichier `[slug].astro` dans le répertoire `/src/pages/posts/`. Récupérez l'article par son champ `slug`, en incluant la logique pour afficher une page 404 si la route n'est pas trouvée :
 
     ```astro title="src/pages/posts/[slug].astro"
     ---
@@ -213,7 +213,7 @@ Si vous utilisez le mode [SSR](/fr/guides/on-demand-rendering/), vous devrez ré
     ---
     ```
 
-2. Ajoutez le modèle pour afficher un message individuel :
+2. Ajoutez le modèle pour afficher un article individuel :
 
     ```astro title="src/pages/posts/[slug].astro" ins={24-30}
     ---
@@ -254,7 +254,7 @@ Si vous utilisez le mode [SSR](/fr/guides/on-demand-rendering/), vous devrez ré
 
 ### Actualiser le SDK après des changements de type de contenu
 
-Lorsque vous utilisez le SDK Flotiq TypeScript (`flotiq-api-ts`), tous vos types de données sont correctement mappés dans le projet Astro.
+Lorsque vous utilisez le SDK TypeScript de Flotiq (`flotiq-api-ts`), tous vos types de données sont correctement associés dans le projet Astro.
 
 Si vous apportez des modifications à la structure de vos types de contenu (comme l'ajout d'un nouveau champ ou la modification d'un champ existant), vous devrez actualiser le SDK pour vous assurer que votre projet reflète les dernières mises à jour du modèle.
 
@@ -288,7 +288,7 @@ Pour déployer votre site web, visitez les [guides de déploiement](/fr/guides/d
 
 ### Redéploiement en fonction des modifications apportées à Flotiq
 
-Pour mettre à jour votre site publié, configurez Flotiq pour qu'il envoie un webhook à votre hébergeur afin de déclencher une reconstruction chaque fois que votre contenu est modifié.
+Pour mettre à jour votre site publié, configurez Flotiq pour qu'il envoie un webhook à votre hébergeur afin de déclencher une nouvelle compilation chaque fois que votre contenu est modifié.
 
 Dans Flotiq, vous pouvez définir le type de contenu et les événements sur lesquels il doit se déclencher, et le configurer en conséquence. Voir la [documentation des Webhooks de Flotiq](https://flotiq.com/docs/panel/webhooks/async-co-webhook/?utm_campaign=flotiq_at_astro_headless_cms&utm_medium=referral&utm_source=astro) pour plus de détails.
 
@@ -297,4 +297,4 @@ Dans Flotiq, vous pouvez définir le type de contenu et les événements sur les
 - [Documentation de Flotiq](https://flotiq.com/docs/?utm_campaign=flotiq_at_astro_headless_cms&utm_medium=referral&utm_source=astro)
 
 ## Ressources communautaires
-- [Flotiq x Astro](https://maciekpalmowski.dev/blog/flotiq-cms-astro/) (en) par Maciek Palmowski
+- [Flotiq x Astro](https://maciekpalmowski.dev/blog/flotiq-cms-astro/) (Anglais) par Maciek Palmowski

--- a/src/content/docs/fr/guides/cms/frontmatter-cms.mdx
+++ b/src/content/docs/fr/guides/cms/frontmatter-cms.mdx
@@ -18,7 +18,7 @@ Dans cette section, nous allons voir comment ajouter Front Matter CMS à votre p
 ### Prérequis 
 
 - Visual Studio Code
-- Utilisez le [template Astro Blog](https://github.com/withastro/astro/tree/main/examples/blog) pour fournir la configuration de base et un exemple de contenu pour commencer avec Front Matter CMS.
+- Utilisez le [modèle Astro Blog](https://github.com/withastro/astro/tree/main/examples/blog) pour fournir la configuration de base et un exemple de contenu pour commencer avec Front Matter CMS.
 
 ### Installer l'extension Front Matter CMS
 
@@ -58,7 +58,7 @@ Une fois que Front Matter CMS est installé, vous obtiendrez une nouvelle icône
 
 Une fois le projet initialisé, vous obtiendrez un fichier de configuration `frontmatter.json` et un dossier `.frontmatter` à la racine de votre projet.
 
-<FileTree title="Project Structure">
+<FileTree title="Structure du projet">
 - .frontmatter/
   - database/
     - mediaDb.json
@@ -189,6 +189,6 @@ Pour permettre à votre contenu d'être créé en tant que Markdoc, spécifiez l
 
 ## Ressources officielles
 
-- [Front Matter CMS](https://frontmatter.codes/)
-- [Front Matter CMS - Documentation](https://frontmatter.codes/docs/)
-- [Démarrer avec Astro et Front Matter CMS](https://youtu.be/xb6pZiier_E)
+- [Front Matter CMS](https://frontmatter.codes/) (Anglais)
+- [Front Matter CMS - Documentation](https://frontmatter.codes/docs/) (Anglais)
+- [Démarrer avec Astro et Front Matter CMS](https://youtu.be/xb6pZiier_E) (Anglais)

--- a/src/content/docs/fr/guides/cms/gitcms.mdx
+++ b/src/content/docs/fr/guides/cms/gitcms.mdx
@@ -8,9 +8,9 @@ service: GitCMS
 i18nReady: true
 ---
 
-[GitCMS](https://gitcms.blog) transforme GitHub en un CMS sans-tête (ou « headless ») basé sur Git, offrant une expérience d'édition Markdown de type Notion directement dans votre navigateur.
+[GitCMS](https://gitcms.blog) transforme GitHub en un CMS headless basé sur Git, offrant une expérience d'édition Markdown de type Notion directement dans votre navigateur.
 
 ## Ressources officielles
-- [Présentation de GitCMS](https://gitcms.blog/posts/introducing-gitcms/) (en)
-- [Comment configurer GitCMS pour un site Astro](https://gitcms.blog/posts/how-to-configure-gitcms/) (en)
-- [Installer l'extension GitCMS pour Chrome](https://gitcms.blog/extension) (en)
+- [Présentation de GitCMS](https://gitcms.blog/posts/introducing-gitcms/) (Anglais)
+- [Comment configurer GitCMS pour un site Astro](https://gitcms.blog/posts/how-to-configure-gitcms/) (Anglais)
+- [Installer l'extension GitCMS pour Chrome](https://gitcms.blog/extension) (Anglais)

--- a/src/content/docs/fr/guides/cms/hygraph.mdx
+++ b/src/content/docs/fr/guides/cms/hygraph.mdx
@@ -14,7 +14,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 ## Intégration avec Astro
 
-Dans cette section, vous allez créer un point d'accès GraphQL [Hygraph](https://hygraph.com/) pour récupérer du contenu avec Astro.
+Dans cette section, vous allez créer un point de terminaison GraphQL [Hygraph](https://hygraph.com/) pour récupérer du contenu avec Astro.
 
 ### Prérequis
 
@@ -22,14 +22,14 @@ Pour commencer, vous devez disposer des éléments suivants :
 
 1. **Un compte Hygraph et un projet**. Si vous n'avez pas de compte, vous pouvez [vous inscrire gratuitement](https://app.hygraph.com/signup) et créer un nouveau projet.
 
-2. **Autorisation d'accès à Hygraph** - Dans `Project Settings > API Access`, configurez les permissions de l'API Public Content pour autoriser les requêtes en lecture sans authentification. Si vous n'avez pas défini de permissions, vous pouvez cliquer sur **Yes, initialize defaults** pour ajouter les permissions nécessaires à l'utilisation de "High Performance Content API".
+2. **Autorisation d'accès à Hygraph** - Dans `Project Settings > API Access`, configurez les permissions de l'API Public Content pour autoriser les requêtes en lecture sans authentification. Si vous n'avez pas défini de permissions, vous pouvez cliquer sur **Yes, initialize defaults** pour ajouter les permissions nécessaires à l'utilisation de « l'API de contenu à haute performance (High Performance Content API, en anglais) ».
 
 ### Configuration du point de terminaison
 
 Pour ajouter votre point de terminaison Hygraph à Astro, créez un fichier `.env` à la racine de votre projet avec la variable suivante :
 
 ```ini title=".env"
-HYGRAPH_ENDPOINT=YOUR_HIGH_PERFORMANCE_API
+HYGRAPH_ENDPOINT=VOTRE_API_HAUTE_PERFORMANCE
 ```
 
 Maintenant, vous devriez être capable d'utiliser cette variable d'environnement dans votre projet. 
@@ -58,7 +58,7 @@ Votre répertoire racine doit maintenant contenir ces nouveaux fichiers :
 
 ### Récupérer des données
 
-Récupérez les données de votre projet Hygraph en utilisant le `HYGRAPH_ENDPOINT`.
+Récupérez les données de votre projet Hygraph en utilisant le point de terminaison `HYGRAPH_ENDPOINT`.
 
 Par exemple, pour récupérer les entrées d'un type de contenu `blogPosts` qui a un champ de chaîne `title`, créez une requête GraphQL pour récupérer ce contenu. Ensuite, définissez le type du contenu, et définissez-le comme type de la réponse.
 
@@ -86,7 +86,7 @@ const json = await response.json();
 const posts: Post[] = json.data.blogPosts;
 ---
 
-<html lang="en">
+<html lang="fr">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -109,7 +109,7 @@ const posts: Post[] = json.data.blogPosts;
 
 ## Déployer
 
-### Configuration de Netlify Webhook
+### Configuration d'un webhook Netlify
 
 Pour configurer un webhook dans Netlify :
 
@@ -125,4 +125,4 @@ Pour configurer un webhook dans Netlify :
 
 ## Ressources communautaires
 
-- [Exemple Hygraph + Astro avec `marked` pour l'analyse markdown](https://github.com/camunoz2/example-astrowithhygraph)
+- [Exemple Hygraph + Astro avec `marked` pour l'analyse markdown](https://github.com/camunoz2/example-astrowithhygraph) (Anglais)

--- a/src/content/docs/fr/guides/cms/index.mdx
+++ b/src/content/docs/fr/guides/cms/index.mdx
@@ -9,7 +9,7 @@ import CMSGuidesNav from '~/components/CMSGuidesNav.astro';
 import ReadMore from '~/components/ReadMore.astro';
 import Badge from "~/components/Badge.astro"
 
-**Prêt pour connecter un Headless CMS à votre projet Astro ?** Suivez l'un de nos guides pour intégrer un CMS.
+**Prêt pour connecter un CMS headless à votre projet Astro ?** Suivez l'un de nos guides pour intégrer un CMS.
 
 :::tip
 Trouvez des [intégrations gérées par la communauté](https://astro.build/integrations/?search=cms) pour connecter un CMS à votre projet dans notre répertoire d'intégrations. 
@@ -23,13 +23,13 @@ Notez que plusieurs de ces pages sont des **ébauches** : ce sont des collection
 
 ## Pourquoi utiliser un CMS ?
 
-Un Système de Gestion de Contenu vous permet d'écrire du contenu et de gérer les actifs en dehors de votre projet Astro.
+Un système de gestion de contenu vous permet d'écrire du contenu et de gérer les ressources en dehors de votre projet Astro.
 
-Cela ouvre de nouvelles fonctionnalités pour travailler avec du contenu. La plupart des CMS vous donnent un éditeur de contenu visuel, la possibilité de spécifier des types de contenu standard et un moyen de collaborer avec d'autres.
+Cela ouvre de nouvelles fonctionnalités pour travailler avec du contenu. La plupart des CMS vous donnent un éditeur de contenu visuel, la possibilité de spécifier des types de contenu standard et un moyen de collaborer avec d'autres personnes.
 
-Un CMS peut être utile pour un contenu qui suit une structure particulière, vous donnant souvent une expérience similaire à un tableau de bord et des outils d'édition WYSIWYG. Vous pouvez utiliser un CMS pour écrire des billets de blog en utilisant l'éditeur de texte riche d'un CMS au lieu de fichiers Markdown. Ou vous pourriez utiliser un CMS pour maintenir les listes de produits pour une boutique en ligne, en rendant certains champs obligatoires pour éviter des annonces incomplètes.
+Un CMS peut être utile pour un contenu qui suit une structure particulière, vous donnant souvent une expérience similaire à un tableau de bord et des outils d'édition WYSIWYG. Vous pouvez utiliser un CMS pour écrire des articles de blog en utilisant l'éditeur de texte riche d'un CMS au lieu de fichiers Markdown. Ou vous pourriez utiliser un CMS pour maintenir les listes de produits pour une boutique en ligne, en rendant certains champs obligatoires pour éviter des annonces incomplètes.
 
-Votre projet Astro peut alors récupérer votre contenu de votre CMS et l'afficher, où et comment vous le souhaitez sur votre site.
+Votre projet Astro peut alors récupérer votre contenu depuis votre CMS et l'afficher, où et comment vous le souhaitez sur votre site.
 
 
 ## Quels CMS fonctionnent bien avec Astro ?

--- a/src/content/docs/fr/guides/cms/keystatic.mdx
+++ b/src/content/docs/fr/guides/cms/keystatic.mdx
@@ -14,7 +14,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 [Keystatic](https://keystatic.com/) est un système de gestion de contenu open source qui vous permet de structurer votre contenu et de le synchroniser avec GitHub.
 
 :::tip
-Si vous démarrez un **nouveau projet Astro + Keystatic à partir de zéro**, vous pouvez utiliser le [Keystatic CLI](https://keystatic.com/docs/quick-start#keystatic-cli) pour générer un nouveau projet en quelques secondes :
+Si vous démarrez un **nouveau projet Astro + Keystatic à partir de zéro**, vous pouvez utiliser la [CLI de Keystatic](https://keystatic.com/docs/quick-start#keystatic-cli) pour générer un nouveau projet en quelques secondes :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -123,14 +123,14 @@ export default config({
 
   collections: {
     posts: collection({
-      label: 'Posts',
+      label: 'Articles',
       slugField: 'title',
       path: 'src/content/posts/*',
       format: { contentField: 'content' },
       schema: {
-        title: fields.slug({ name: { label: 'Title' } }),
+        title: fields.slug({ name: { label: 'Titre' } }),
         content: fields.markdoc({
-          label: 'Content',
+          label: 'Contenu',
         }),
       },
     }),
@@ -146,7 +146,7 @@ Keystatic est maintenant configuré pour gérer votre contenu en fonction de vot
 
 ## Exécuter Keystatic localement
 
-Pour lancer le tableau de bord de l'interface d'administration de Keystatic, démarrez le serveur de développement d'Astro :
+Pour exécuter le tableau de bord de l'interface d'administration de Keystatic, démarrez le serveur de développement d'Astro :
 
     ```bash
     npm run dev
@@ -154,17 +154,17 @@ Pour lancer le tableau de bord de l'interface d'administration de Keystatic, dé
 
 Visitez `http://127.0.0.1:4321/keystatic` dans le navigateur pour voir l'interface d'administration de Keystatic fonctionner.
 
-## Créer un nouveau message
+## Créer un nouvel article
 
 <Steps>
-1. Dans le tableau de bord de l'interface d'administration Keystatic, cliquez sur la collection "Posts".
+1. Dans le tableau de bord de l'interface d'administration Keystatic, cliquez sur la collection « Articles ».
 
-2. Utilisez le bouton pour créer un nouveau message. Ajoutez le titre " Mon premier article " et un peu de contenu, puis enregistrez l'article.
+2. Utilisez le bouton pour créer un nouvel article. Ajoutez le titre « Mon premier article » et un peu de contenu, puis enregistrez l'article.
  
-3. Ce message devrait maintenant être visible dans votre collection " Posts ". Vous pouvez afficher et modifier vos messages individuels à partir de cette page du tableau de bord.
+3. Cet article devrait maintenant être visible dans votre collection « Articles ». Vous pouvez afficher et modifier vos articles individuels à partir de cette page du tableau de bord.
  
-4. Retournez voir vos fichiers de projet Astro. Vous trouverez maintenant un nouveau fichier `.mdoc` dans le répertoire `src/content/posts` pour ce nouvel article :
-		<FileTree title="Project Structure">
+4. Retournez voir les fichiers de votre projet Astro. Vous trouverez maintenant un nouveau fichier `.mdoc` dans le répertoire `src/content/posts` pour ce nouvel article :
+		<FileTree title="Structure du projet">
 		- src/
 		  - content/
 		    - posts/
@@ -174,16 +174,16 @@ Visitez `http://127.0.0.1:4321/keystatic` dans le navigateur pour voir l'interfa
 5. Naviguez vers ce fichier dans votre éditeur de code et vérifiez que vous pouvez voir le contenu Markdown que vous avez saisi. Par exemple, il est possible de voir le contenu Markdown que vous avez saisi :
 		```markdown
 		---
-		title: Mon premier billet
+		title: Mon premier article
 		---
 		
-		C'est mon tout premier message. Je suis **super** excitée !
+		C'est mon tout premier article. Je suis **super** excitée !
 		```
 </Steps>
 
 ## Rendu du contenu Keystatic
 
-Utilisez l'API Content Collections d'Astro pour [interroger et afficher vos articles et collections](/fr/guides/content-collections/#interroger-les-collections), comme vous le feriez dans n'importe quel projet Astro.
+Utilisez l'API des collections de contenu d'Astro pour [interroger et afficher vos articles et collections](/fr/guides/content-collections/#interroger-les-collections), comme vous le feriez dans n'importe quel projet Astro.
 
 ### Affichage d'une liste de collections
 
@@ -206,7 +206,7 @@ const posts = await getCollection('posts')
 
 ### Affichage d'un seul article
 
-Pour afficher le contenu d'un article individuel, vous pouvez importer et utiliser le composant `<Content />` pour [rendre votre contenu en HTML](/fr/guides/content-collections/#restitution-du-contenu) :
+Pour afficher le contenu d'un article individuel, vous pouvez importer et utiliser le composant `<Content />` pour [restituer votre contenu en HTML](/fr/guides/content-collections/#restitution-du-contenu) :
 
 ```tsx {4-5}
 ---
@@ -223,8 +223,7 @@ const { Content } = await post.render()
 
 ```
 
-Pour plus d'informations sur l'interrogation, le filtrage, l'affichage du contenu de vos collections et plus encore, consultez la [documentation sur les collections](/fr/guides/content-collections/).
-
+Pour plus d'informations sur l'interrogation, le filtrage, l'affichage du contenu de vos collections et plus encore, consultez la [documentation sur les collections de contenu](/fr/guides/content-collections/).
 ## Déploiement de Keystatic + Astro
 
 Pour déployer votre site web, consultez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
@@ -233,5 +232,5 @@ Vous voudrez probablement aussi [connecter Keystatic à GitHub](https://keystati
 
 ## Ressources officielles
 
-- Consultez [le guide officiel de Keystatic](https://keystatic.com/docs/installation-astro)
-- [Keystatic starter template](https://github.com/Thinkmill/keystatic/tree/main/templates/astro)
+- Consultez [le guide officiel de Keystatic](https://keystatic.com/docs/installation-astro) (Anglais)
+- [Modèle de démarrage Keystatic](https://github.com/Thinkmill/keystatic/tree/main/templates/astro) (Anglais)

--- a/src/content/docs/fr/guides/cms/keystonejs.mdx
+++ b/src/content/docs/fr/guides/cms/keystonejs.mdx
@@ -9,4 +9,4 @@ service: KeystoneJS
 i18nReady: true
 ---
 
-[KeystoneJS](https://keystonejs.com/) est un système de gestion de contenu sans tête, open source, qui vous permet de décrire la structure de votre schéma.
+[KeystoneJS](https://keystonejs.com/) est un système de gestion de contenu headless, open source, qui vous permet de décrire la structure de votre schéma.

--- a/src/content/docs/fr/guides/cms/kontent-ai.mdx
+++ b/src/content/docs/fr/guides/cms/kontent-ai.mdx
@@ -23,20 +23,20 @@ Pour commencer, vous aurez besoin des éléments suivants :
 
 1. **Projet Kontent.ai** - Si vous n'avez pas encore de compte Kontent.ai, [inscrivez-vous gratuitement](https://app.kontent.ai/sign-up) et créez un nouveau projet.
 
-2. **Clés API de livraison** - Vous aurez besoin de l'identifiant d'environnement pour le contenu publié et de la clé API de prévisualisation pour récupérer les brouillons (facultatif). Les deux clés sont situées dans l'onglet **Environment Settings -> API keys** dans Kontent.ai.
+2. **Clés API de diffusion** - Vous aurez besoin de l'identifiant d'environnement pour le contenu publié et de la clé API de prévisualisation pour récupérer les brouillons (facultatif). Les deux clés sont situées dans l'onglet **Environment Settings -> API keys** dans Kontent.ai.
 
 ### Configuration des informations d'identification
 
 Pour ajouter vos identifiants Kontent.ai à Astro, créez un fichier `.env` à la racine de votre projet avec les variables suivantes :
 
 ```ini title=".env"
-KONTENT_ENVIRONMENT_ID=YOUR_ENVIRONMENT_ID
-KONTENT_PREVIEW_API_KEY=YOUR_PREVIEW_API_KEY
+KONTENT_ENVIRONMENT_ID=VOTRE_ID_ENVIRONNEMENT
+KONTENT_PREVIEW_API_KEY=VOTRE_CLE_API_PREVISUALISATION
 ```
 
 Ces variables d'environnement peuvent maintenant être utilisées dans votre projet Astro.
 
-Si vous souhaitez obtenir [TypeScript IntelliSense pour ces variables d'environnement](/fr/guides/environment-variables/#autocomplétion-pour-typescript), vous pouvez créer un nouveau fichier `env.d.ts` dans le répertoire `src/` et configurer `ImportMetaEnv` comme ceci :
+Si vous souhaitez obtenir l'[IntelliSense TypeScript pour ces variables d'environnement](/fr/guides/environment-variables/#autocomplétion-pour-typescript), vous pouvez créer un nouveau fichier `env.d.ts` dans le répertoire `src/` et configurer `ImportMetaEnv` comme ceci :
 ```ts title="src/env.d.ts"
 interface ImportMetaEnv {
   readonly KONTENT_ENVIRONMENT_ID: string;
@@ -47,17 +47,17 @@ interface ImportMetaEnv {
 Votre répertoire racine doit maintenant contenir ces nouveaux fichiers :
 
 <FileTree title="Structure du projet">
-  - src/
+- src/
   - **env.d.ts**
-  - **.env**
-  - astro.config.mjs
-  - package.json
+- **.env**
+- astro.config.mjs
+- package.json
 </FileTree>
 
 
 ### Installation des dépendances
 
-Pour connecter Astro à votre projet Kontent.ai, installez le [Kontent.ai TypeScript SDK](https://github.com/kontent-ai/delivery-sdk-js) :
+Pour connecter Astro à votre projet Kontent.ai, installez le [SDK TypeScript de Kontent.ai](https://github.com/kontent-ai/delivery-sdk-js) :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -95,19 +95,19 @@ En savoir plus sur [l'obtention de variables d'environnement dans Astro](/fr/gui
 Cette implémentation crée un nouvel objet `DeliveryClient` en utilisant les informations d'identification du fichier `.env`.
 
 :::note[Prévisualisation]
-La clé `previewApiKey` est optionnelle. Lorsqu'elle est utilisée, vous pouvez [configurer chaque requête](https://github.com/kontent-ai/delivery-sdk-js#enable-preview-mode-per-query) vers le point de terminaison Delivery API pour qu'il renvoie les dernières versions des éléments de contenu, quel que soit leur état dans le flux de travail. Sinon, seuls les éléments publiés sont renvoyés.
+La clé `previewApiKey` est optionnelle. Lorsqu'elle est utilisée, vous pouvez [configurer chaque requête](https://github.com/kontent-ai/delivery-sdk-js#enable-preview-mode-per-query) vers le point de terminaison de l'API Delivery pour qu'il renvoie les dernières versions des éléments de contenu, quel que soit leur état dans le flux de travail. Sinon, seuls les éléments publiés sont renvoyés.
 :::
 
 Enfin, le répertoire racine de votre projet Astro devrait maintenant inclure ces nouveaux fichiers :
 
 <FileTree title="Structure du projet">
-  - src/
+- src/
   - lib/
-  - **kontent.ts**
+    - **kontent.ts**
   - env.d.ts
-  - .env
-  - astro.config.mjs
-  - package.json
+- .env
+- astro.config.mjs
+- package.json
 </FileTree>
 
 ### Récupération de données
@@ -184,8 +184,8 @@ Naviguez maintenant dans l'onglet **Content & assets** et créez un nouvel élé
 * **Title:** Astro est incroyable
 * **Teaser:** Astro est un framework tout-en-un pour construire des sites web rapides plus rapidement.
 * **Content:** Vous pouvez utiliser JavaScript pour mettre en œuvre la fonctionnalité du site web, mais aucun paquet client n'est nécessaire.
-* **Date & time:** Sélectionnez "today"
-* **URL slug:** astro-is-amazing
+* **Date & time:** Sélectionnez « today »
+* **URL slug:** astro-est-incroyable
 
 Lorsque vous avez terminé, publiez l'article de blog en utilisant le bouton **Publier** en haut de la page.
 
@@ -199,7 +199,7 @@ Ensuite, vous allez générer des types TypeScript à partir de votre modèle de
 Cette étape est facultative, mais elle offre une bien meilleure expérience au développeur et permet de découvrir des problèmes potentiels au moment de la construction plutôt qu'au moment de l'exécution.
 :::
 
-Tout d'abord, installez [Kontent.ai JS model generator](https://github.com/kontent-ai/model-generator-js), [ts-node](https://github.com/TypeStrong/ts-node), et [dotenv](https://github.com/motdotla/dotenv) :
+Tout d'abord, installez [le générateur de modèles JS de Kontent.ai](https://github.com/kontent-ai/model-generator-js), [ts-node](https://github.com/TypeStrong/ts-node), et [dotenv](https://github.com/motdotla/dotenv) :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -234,9 +234,9 @@ Ensuite, ajoutez le script suivant au fichier package.json :
 Comme les types nécessitent des informations structurelles sur votre projet qui ne sont pas disponibles dans l'API publique, vous devez également ajouter une clé API de gestion de contenu au fichier `.env`. Vous pouvez générer la clé sous **Environment settings -> API keys -> Management API**.
 
 ```ini title=".env" ins={3}
-KONTENT_ENVIRONMENT_ID=YOUR_ENVIRONMENT_ID
-KONTENT_PREVIEW_API_KEY=YOUR_PREVIEW_API_KEY
-KONTENT_MANAGEMENT_API_KEY=YOUR_MANAGEMENT_API_KEY
+KONTENT_ENVIRONMENT_ID=VOTRE_ID_ENVIRONNEMENT
+KONTENT_PREVIEW_API_KEY=VOTRE_CLE_API_PREVISUALISATION
+KONTENT_MANAGEMENT_API_KEY=VOTRE_CLE_API_GESTION
 ```
 
 Enfin, ajoutez le script `generate-models.ts` qui configure le générateur de modèles pour générer les modèles :
@@ -321,7 +321,7 @@ const blogPosts = await deliveryClient
     .toPromise()
 ```
 
-L'appel fetch renvoie un objet `response` qui contient une liste de tous les articles de blog dans `data.items`. Dans la section HTML de la page Astro, vous pouvez utiliser la fonction `map()` pour lister les articles du blog :
+L'appel de récupération renvoie un objet `response` qui contient une liste de tous les articles de blog dans `data.items`. Dans la section HTML de la page Astro, vous pouvez utiliser la fonction `map()` pour lister les articles du blog :
 
 ```astro title="src/pages/index.astro" ins={11-29}
 ---
@@ -341,7 +341,7 @@ const blogPosts = await deliveryClient
         <title>Astro</title>
     </head>
     <body>
-        <h1>Blog posts</h1>
+        <h1>Articles de blog</h1>
         <ul>
             {blogPosts.data.items.map(blogPost => (
                 <li>
@@ -361,7 +361,7 @@ La dernière étape du tutoriel consiste à générer des pages d'articles de bl
 
 #### Génération de sites statiques
 
-Dans cette section, vous allez utiliser le [Mode Static (SSG)](/fr/guides/routing/#mode-statique-ssg) avec Astro.
+Dans cette section, vous allez utiliser le [mode statique (SSG)](/fr/guides/routing/#mode-statique-ssg) avec Astro.
 
 Tout d'abord, créez un fichier `[slug].astro` dans `/src/pages/blog/` qui doit exporter une fonction `getStaticPaths` qui collecte toutes les données du CMS :
 
@@ -441,13 +441,13 @@ const blogPost: BlogPost = Astro.props.blogPost
 </html>
 ```
 
-Naviguez vers votre aperçu Astro (http://localhost:4321/blog/astro-is-amazing/ par défaut) pour voir le rendu de l'article de blog.
+Naviguez vers votre aperçu Astro (http://localhost:4321/blog/astro-est-incroyable/ par défaut) pour voir le rendu de l'article de blog.
 
 #### Rendu à la demande
 
 Si vos routes sont [rendues à la demande](/fr/guides/on-demand-rendering/), vous utiliserez des routes dynamiques pour récupérer les données de la page à partir de Kontent.ai.
 
-Créez un nouveau fichier `[slug].astro` dans `/src/pages/blog/` et ajoutez le code suivant. La récupération des données est très similaire aux cas d'utilisation précédents mais ajoute un `equalsFilter` qui nous permet de trouver le bon article de blog basé sur l'URL utilisée :
+Créez un nouveau fichier `[slug].astro` dans `/src/pages/blog/` et ajoutez le code suivant. La récupération des données est très similaire aux cas d'utilisation précédents mais ajoute un filtre `equalsFilter` qui nous permet de trouver le bon article de blog basé sur l'URL utilisée :
 
 ```astro title="src/pages/blog/[slug].astro"
 ---
@@ -524,9 +524,9 @@ try {
 
 Pour déployer votre site, visitez les [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-#### Reconstruction sur les changements de Kontent.ai
+#### Recompiler lors des modifications sur Kontent.ai
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle construction à partir des événements Kontent.ai.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonctionnalité webhook pour déclencher une nouvelle compilation à partir des événements Kontent.ai.
 
 ##### Netlify
 
@@ -537,7 +537,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ##### Vercel
@@ -549,11 +549,11 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy Hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ##### Ajouter un webhook à Kontent.ai
 
-Dans l'application [Kontent.ai app](https://kontent.ai/learn/docs/webhooks/javascript), allez dans **Environment settings -> Webhooks**. Cliquez sur **Create new webhook** et donnez un nom à votre nouveau webhook. Collez l'URL que vous avez copiée depuis Netlify ou Vercel et sélectionnez les événements qui doivent déclencher le webhook. Par défaut, pour reconstruire votre site lorsque le contenu publié change, vous n'avez besoin que des événements **Publish** et **Unpublish** sous **Delivery API triggers**. Lorsque vous avez terminé, cliquez sur Enregistrer.
+Dans l'[application Kontent.ai](https://kontent.ai/learn/docs/webhooks/javascript), allez dans **Environment settings -> Webhooks**. Cliquez sur **Create new webhook** et donnez un nom à votre nouveau webhook. Collez l'URL que vous avez copiée depuis Netlify ou Vercel et sélectionnez les événements qui doivent déclencher le webhook. Par défaut, pour recompiler votre site lorsque le contenu publié change, vous n'avez besoin que des événements **Publish** et **Unpublish** sous **Delivery API triggers**. Lorsque vous avez terminé, cliquez sur Enregistrer.
 
-Maintenant, chaque fois que vous publiez un nouvel article de blog dans Kontent.ai, une nouvelle construction sera déclenchée et votre blog sera mis à jour.
+Maintenant, chaque fois que vous publiez un nouvel article de blog dans Kontent.ai, une nouvelle compilation sera déclenchée et votre blog sera mis à jour.

--- a/src/content/docs/fr/guides/cms/microcms.mdx
+++ b/src/content/docs/fr/guides/cms/microcms.mdx
@@ -9,9 +9,9 @@ service: microCMS
 i18nReady: true
 ---
 
-[microCMS](https://microcms.io/en) est un CMS sans tête basé sur une API qui vous permet de définir le contenu à l'aide de schémas et de le gérer à l'aide du tableau de bord.
+[microCMS](https://microcms.io/en) est un CMS headless basé sur une API qui vous permet de définir le contenu à l'aide de schémas et de le gérer à l'aide du tableau de bord.
 
 ## Ressources officielles
 
-- Consultez [le document officiel de microCMS](https://document.microcms.io/tutorial/astro/astro-top)
-- Blog : [Créer un blog avec microCMS](https://blog.microcms.io/astro-microcms-introduction/)
+- Consultez [la documentation officielle de microCMS](https://document.microcms.io/tutorial/astro/astro-top) (Japonais)
+- Blog : [Créer un blog avec microCMS](https://blog.microcms.io/astro-microcms-introduction/) (Japonais)

--- a/src/content/docs/fr/guides/cms/payload.mdx
+++ b/src/content/docs/fr/guides/cms/payload.mdx
@@ -16,7 +16,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 ### Prérequis
 
-1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 2. **Une base de données MongoDB** - PayloadCMS vous demandera une chaîne de connexion MongoDB lors de la création d'un nouveau projet. Vous pouvez en installer une localement ou utiliser [MongoDBAtlas](https://www.mongodb.com/) pour héberger une base de données sur le web gratuitement.
 3. **Une API REST PayloadCMS** - Créez un projet [PayloadCMS](https://payloadcms.com/docs/getting-started/installation) et connectez-le à votre base de données MongoDB pendant l'installation.
 
@@ -126,7 +126,7 @@ Par défaut, Astro et PayloadCMS utilisent le port 4321. Vous pouvez changer le 
 
 Récupérez les données de PayloadCMS via l'URL unique de l'API REST de votre site et la route de votre contenu (par défaut, PayloadCMS monte toutes les routes via `/api`). Ensuite, vous pouvez rendre les propriétés de vos données en utilisant la directive Astro `set:html=""`.
 
-Avec votre message, PayloadCMS renverra des métadonnées de premier niveau. Les documents réels sont imbriqués dans le tableau `docs`.
+Avec votre article, PayloadCMS renverra des métadonnées de premier niveau. Les documents réels sont imbriqués dans le tableau `docs`.
 
 Par exemple, pour afficher une liste de titres d'articles et leur contenu :
 
@@ -183,7 +183,7 @@ const posts = await res.json()
 
 ### Utiliser l'API PayloadCMS pour générer des pages
 
-Créer une page `src/pages/posts/[slug].astro` pour [générer dynamiquement une page](/fr/guides/routing/#routes-dynamiques) pour chaque post.
+Créer une page `src/pages/posts/[slug].astro` pour [générer dynamiquement une page](/fr/guides/routing/#routes-dynamiques) pour chaque article.
 
 ```astro title="src/pages/posts/[slug].astro"
 ---

--- a/src/content/docs/fr/guides/cms/prismic.mdx
+++ b/src/content/docs/fr/guides/cms/prismic.mdx
@@ -9,8 +9,8 @@ service: Prismic
 i18nReady: true
 ---
 
-[Prismic](https://prismic.io/) est un système de gestion de contenu sans tête.
+[Prismic](https://prismic.io/) est un système de gestion de contenu headless.
 
 ## Ressources communautaires
 
-- [Construire avec Astro et Prismic - avec Nate Moore](https://www.youtube.com/watch?v=qFUfuDSLdxM) (livestream) et le [repo de l'émission](https://github.com/natemoo-re/miles-of-code).
+- [Construire avec Astro et Prismic - avec Nate Moore](https://www.youtube.com/watch?v=qFUfuDSLdxM) (livestream en Anglais) et le [repo de l'émission](https://github.com/natemoo-re/miles-of-code).

--- a/src/content/docs/fr/guides/cms/sanity.mdx
+++ b/src/content/docs/fr/guides/cms/sanity.mdx
@@ -12,15 +12,15 @@ i18nReady: true
 import Grid from '~/components/FluidGrid.astro'
 import Card from '~/components/ShowcaseCard.astro'
 
-[Sanity](http://sanity.io) est un système de gestion de contenu sans tête qui se concentre sur le [contenu structuré](https://www.sanity.io/structured-content-platform).
+[Sanity](http://sanity.io) est un système de gestion de contenu headless qui se concentre sur le [contenu structuré](https://www.sanity.io/structured-content-platform).
 
 ## Ressources officielles
 
-- [Intégration officielle de Sanity pour Astro](https://www.sanity.io/plugins/sanity-astro)
+- [Intégration officielle de Sanity pour Astro](https://www.sanity.io/plugins/sanity-astro) (Anglais)
 
-- [Construisez votre blog avec Astro et Sanity](https://www.sanity.io/guides/sanity-astro-blog)
+- [Construisez votre blog avec Astro et Sanity](https://www.sanity.io/guides/sanity-astro-blog) (Anglais)
 
-- [Un site Astro minimal avec un Sanity Studio](https://www.sanity.io/templates/astro-sanity-clean)
+- [Un site Astro minimal avec un Sanity Studio](https://www.sanity.io/templates/astro-sanity-clean) (Anglais)
 
 ## Thèmes
 

--- a/src/content/docs/fr/guides/cms/spinal.mdx
+++ b/src/content/docs/fr/guides/cms/spinal.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-[Spinal](https://spinalcms.com/cms-for-astro/) est un CMS commercial, SaaS, basé sur Git.
+[Spinal](https://spinalcms.com/cms-for-astro/) est un CMS commercial, centré sur les SaaS et basé sur Git.
 
 ## Pour commencer
 
@@ -25,9 +25,9 @@ import { Steps } from '@astrojs/starlight/components';
 Tout le contenu Markdown du dossier sélectionné sera importé dans votre compte Spinal et sera prêt à être édité.
 
 ## Ressources officielles
-- [Thème de documentation construit pour Astro avec Tailwind CSS](https://spinalcms.com/resources/astro-documentation-theme-with-tailwind-css/)
-## Sites de production
+- [Thème de documentation créé pour Astro avec Tailwind CSS](https://spinalcms.com/resources/astro-documentation-theme-with-tailwind-css/)
+## Sites en production
 
 Les sites suivants utilisent Astro + Spinal en production :
 
-- [spinalcms.com](https://spinalcms.com/) (tous les articles de blog, documentation, changelog, pages de fonctionnalités, etc.)
+- [spinalcms.com](https://spinalcms.com/) (tous les articles de blog, documentation, journal des modifications, pages de fonctionnalités, etc.)

--- a/src/content/docs/fr/guides/cms/storyblok.mdx
+++ b/src/content/docs/fr/guides/cms/storyblok.mdx
@@ -22,7 +22,7 @@ Dans cette section, vous utiliserez l'[intégration Storyblok](https://github.co
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 
 2. **Un compte Storyblok et un espace** - Si vous n'avez pas encore de compte, [inscrivez-vous gratuitement](https://app.storyblok.com/#/signup) et créez un nouvel espace.
 
@@ -33,7 +33,7 @@ Pour commencer, vous devez disposer des éléments suivants :
 Pour ajouter vos identifiants Storyblok à Astro, créez un fichier `.env` à la racine de votre projet avec la variable suivante :
 
 ```ini title=".env"
-STORYBLOK_TOKEN=YOUR_PREVIEW_TOKEN
+STORYBLOK_TOKEN=VOTRE_JETON_DE_PREVISUALISATION
 ```
 
 Vous devriez maintenant pouvoir utiliser ces variables d'environnement dans votre projet.
@@ -41,15 +41,15 @@ Vous devriez maintenant pouvoir utiliser ces variables d'environnement dans votr
 Votre répertoire racine doit maintenant contenir ce nouveau fichier :
 
 <FileTree title="Structure du projet">
-  - src/
-  - **.env**
-  - astro.config.mjs
-  - package.json
+- src/
+- **.env**
+- astro.config.mjs
+- package.json
 </FileTree>
 
 ### Installation des dépendances
 
-Pour connecter Astro à votre espace Storyblok, installez l'intégration officielle [Storyblok integration](https://github.com/storyblok/storyblok-astro) en utilisant la commande ci-dessous pour votre gestionnaire de paquets préféré :
+Pour connecter Astro à votre espace Storyblok, installez l'[intégration Storyblok](https://github.com/storyblok/storyblok-astro) officielle en utilisant la commande ci-dessous pour votre gestionnaire de paquets préféré :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -145,7 +145,7 @@ const content = renderRichText(blok.content)
 
 La propriété `blok` contient les données que vous recevrez de Storyblok. Elle contient également les champs qui ont été définis dans le type de contenu `blogPost` Blok dans Storyblok.
 
-Pour rendre notre contenu, l'intégration fournit des fonctions utilitaires telles que :
+Pour restituer notre contenu, l'intégration fournit des fonctions utilitaires telles que :
 
 - `storyblokEditable` - elle ajoute les attributs nécessaires aux éléments afin que vous puissiez les éditer dans Storyblok.
 - `renderRichText` - elle transforme le champ de texte riche en HTML.
@@ -153,12 +153,12 @@ Pour rendre notre contenu, l'intégration fournit des fonctions utilitaires tell
 Votre répertoire racine devrait inclure ce nouveau fichier :
 
 <FileTree title="Structure du projet">
-  - src/
+- src/
   - storyblok/
-  - **BlogPost.astro**
-  - .env
-  - astro.config.mjs
-  - package.json
+    - **BlogPost.astro**
+- .env
+- astro.config.mjs
+- package.json
 </FileTree>
 
 Enfin, pour connecter le Blok `blogPost` au composant `BlogPost`, ajoutez une nouvelle propriété à votre objet components dans votre fichier de configuration Astro.
@@ -215,7 +215,7 @@ const content = data.story.content;
 
 Pour interroger vos données, utilisez le hook `useStoryblokApi`. Cela initialisera une nouvelle instance de client en utilisant votre configuration d'intégration.
 
-Pour rendre votre contenu, passez la propriété `content` de la story au `StoryblokComponent` en tant que propriété `blok`. Ce composant rendra les Bloks définis dans la propriété `content`. Dans ce cas, il rendra le composant `BlogPost`.
+Pour restituer votre contenu, transmettez la propriété `content` de la story au `StoryblokComponent` en tant que propriété `blok`. Ce composant générera les Bloks définis dans la propriété `content`. Dans ce cas, il va générer le composant `BlogPost`.
 
 ## Créer un blog avec Astro et Storyblok
 
@@ -225,7 +225,7 @@ Avec l'intégration mise en place, vous pouvez maintenant créer un blog avec As
 
 1. **Un espace Storyblok** - Pour ce tutoriel, nous recommandons d'utiliser un nouvel espace. Si vous avez déjà un espace avec des Bloks, n'hésitez pas à les utiliser, mais vous devrez modifier le code pour qu'il corresponde aux noms et aux types de contenu des Bloks.
 
-2. **Un projet Astro intégré à Storyblok** - Voir [les intégrations avec Astro](#intégration-avec-astro) pour les instructions sur la façon de mettre en place l'intégration.
+2. **Un projet Astro intégré à Storyblok** - Consultez [intégration avec Astro](#intégration-avec-astro) pour les instructions sur la façon de mettre en place l'intégration.
 
 ### Création d'une bibliothèque de bloks
 
@@ -266,7 +266,7 @@ Maintenant que votre contenu est prêt, retournez à votre projet Astro et comme
 
 Pour connecter vos Bloks nouvellement créés aux composants Astro, créez un nouveau dossier nommé `storyblok` dans votre répertoire `src` et ajoutez les fichiers suivants :
 
-`Page.astro` est un composant de type Block emboîtable qui rendra récursivement tous les Bloks à l'intérieur de la propriété `body` du Blok `page`. Il ajoute également les attributs `storyblokEditable` à l'élément parent, ce qui nous permettra d'éditer la page dans Storyblok.
+`Page.astro` est un composant de type Block imbriquable qui restituera récursivement tous les Bloks à l'intérieur de la propriété `body` du Blok `page`. Il ajoute également les attributs `storyblokEditable` à l'élément parent, ce qui nous permettra d'éditer la page dans Storyblok.
 
 ```astro title="src/storyblok/Page.astro"
 ---
@@ -284,7 +284,7 @@ const { blok } = Astro.props
 </main>
 ```
 
-`BlogPost.astro` rendra les propriétés `title`, `description` et `content` du Blok `blogPost`.
+`BlogPost.astro` restituera les propriétés `title`, `description` et `content` du Blok `blogPost`.
 
 Pour transformer la propriété `content` d'un champ de texte riche en HTML, vous pouvez utiliser la fonction d'aide `renderRichText`.
 
@@ -301,7 +301,7 @@ const content = renderRichText(blok.content)
 </article>
 ```
 
-`BlogPostList.astro` est un composant de type Blok imbriquable qui rendra une liste d'aperçus d'articles de blogs.
+`BlogPostList.astro` est un composant de type Blok imbriquable qui affichera une liste d'aperçus d'articles de blogs.
 
 Il utilise le hook `useStoryblokApi` pour récupérer toutes les story avec le type de contenu `blogPost`. Il utilise le paramètre de requête `version` pour récupérer les versions préliminaires des articles lorsqu'il est en mode développement et les versions publiées lorsqu'il est en mode production.
 
@@ -371,7 +371,7 @@ export default defineConfig({
 
 Pour créer une route pour une `page` spécifique, vous pouvez récupérer son contenu directement à partir de l'API Storyblok et le passer au composant `StoryblokComponent`.  N'oubliez pas de vous assurer que vous avez ajouté le composant `Page` dans votre fichier astro.config.mjs.
 
-Créez un fichier `index.astro` dans `src/pages/` pour rendre la page `home` :
+Créez un fichier `index.astro` dans `src/pages/` pour générer la page `home` :
 
 ```astro title="src/pages/index.astro" {3,7,8,9,17} 
 ---
@@ -447,7 +447,7 @@ const story = data.story;
 Ce fichier générera une page pour chaque story, avec le slug et le contenu récupérés à partir de l'API Storyblok.
 
 :::note
-Lorsque vous ajoutez des dossiers à l'intérieur de Storyblok, incluez-les dans la balise lorsque vous interagissez avec l'API de Storyblok. Par exemple, dans la requête GET ci-dessus, nous pouvons utiliser **cdn/stories/blog**, avec un dossier de blog à l'intérieur plutôt que de les utiliser à la racine.
+Lorsque vous ajoutez des dossiers à l'intérieur de Storyblok, incluez-les dans le slug lorsque vous interagissez avec l'API de Storyblok. Par exemple, dans la requête GET ci-dessus, nous pouvons utiliser **cdn/stories/blog**, avec un dossier de blog à l'intérieur plutôt que de les utiliser à la racine.
 :::
 
 #### Rendu à la demande
@@ -482,7 +482,7 @@ try {
 </html>
 ```
 
-Ce fichier va chercher et rendre les données de la page de Storyblok qui correspondent au paramètre dynamique `slug`.
+Ce fichier va chercher et restituer les données de la page de Storyblok qui correspondent au paramètre dynamique `slug`.
 
 Puisque vous utilisez une redirection vers `/404`, créez une page 404 dans `src/pages` :
 
@@ -503,9 +503,9 @@ Si la story n'est pas trouvée, la demande sera redirigée vers la page 404.
 
 Pour déployer votre site, consultez nos [guides de déploiement](/fr/guides/deploy/) et suivez les instructions de votre hébergeur préféré.
 
-#### Reconstruction lors de changements sur Storyblok
+#### Recompiler lors de changements sur Storyblok
 
-Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle construction lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonction webhook pour déclencher une nouvelle compilation à partir des événements Storyblok.
+Si votre projet utilise le mode statique par défaut d'Astro, vous devrez configurer un webhook pour déclencher une nouvelle compilation lorsque votre contenu change. Si vous utilisez Netlify ou Vercel comme hébergeur, vous pouvez utiliser sa fonction webhook pour déclencher une nouvelle compilation à partir des événements Storyblok.
 
 ##### Netlify
 
@@ -516,7 +516,7 @@ Pour configurer un webhook dans Netlify :
 
 2. Sous l'onglet **Continuous Deployment**, trouvez la section **Build hooks** et cliquez sur **Add build hook**.
 
-3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Save** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et sélectionnez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Save** et copiez l'URL générée.
 </Steps>
 
 ##### Vercel
@@ -528,14 +528,14 @@ Pour configurer un webhook dans Vercel :
 
 2. Sous l'onglet **Git**, trouvez la section **Deploy hooks**.
 
-3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la construction. Cliquez sur **Add** et copiez l'URL générée.
+3. Donnez un nom à votre webhook et indiquez la branche sur laquelle vous souhaitez déclencher la compilation. Cliquez sur **Add** et copiez l'URL générée.
 </Steps>
 
 ##### Ajouter un webhook à Storyblok
 
 Dans votre espace Storyblok **Settings**, cliquez sur l'onglet **Webhooks**. Collez l'URL du webhook que vous avez copié dans le champ **Story published & unpublished** et cliquez sur <kbd>Save</kbd> pour créer un webhook.
 
-Désormais, chaque fois que vous publierez un nouvel article, une nouvelle construction sera déclenchée et votre blog sera mis à jour.
+Désormais, chaque fois que vous publierez un nouvel article, une nouvelle compilation sera déclenchée et votre blog sera mis à jour.
 
 ## Ressources officielles
 
@@ -543,6 +543,6 @@ Désormais, chaque fois que vous publierez un nouvel article, une nouvelle const
 
 ## Ressources communautaires
 
-- [Faire fonctionner l'éditeur visuel pour Storyblok + Astro](https://dev.to/sandrarodgers/getting-the-visual-editor-to-work-for-storyblok-astro-2gja) par Sandra Rodgers
-- [Astro + Storyblok : prévisualisation SSR pour une édition visuelle instantanée](https://dev.to/jgierer12/astro-storyblok-ssr-preview-for-instant-visual-editing-3g9m) par Jonas Gierer
-- [Astro-Storyblok prévisualise le site avec la fonctionnalité Branch Deploys de Netlify](https://dev.to/sandrarodgers/astro-storyblok-previews-site-with-netlifys-branch-deploys-feature-44dh) par Sandra Rodgers
+- [Faire fonctionner l'éditeur visuel pour Storyblok + Astro](https://dev.to/sandrarodgers/getting-the-visual-editor-to-work-for-storyblok-astro-2gja) (Anglais) par Sandra Rodgers
+- [Astro + Storyblok : prévisualisation SSR pour une édition visuelle instantanée](https://dev.to/jgierer12/astro-storyblok-ssr-preview-for-instant-visual-editing-3g9m) (Anglais) par Jonas Gierer
+- [Astro-Storyblok prévisualise le site avec la fonctionnalité Branch Deploys de Netlify](https://dev.to/sandrarodgers/astro-storyblok-previews-site-with-netlifys-branch-deploys-feature-44dh) (Anglais) par Sandra Rodgers

--- a/src/content/docs/fr/guides/cms/studiocms.mdx
+++ b/src/content/docs/fr/guides/cms/studiocms.mdx
@@ -8,11 +8,11 @@ service: StudioCMS
 i18nReady: true
 ---
 
-[StudioCMS](https://studiocms.dev/) est un CMS sans-tête (« headless ») pour Astro, construit avec Astro, qui fournit un tableau de bord convivial et configurable pour la gestion de contenu ainsi qu'un système de rendu personnalisé pour afficher vos composants Astro.
+[StudioCMS](https://studiocms.dev/) est un CMS headless pour Astro, construit avec Astro, qui fournit un tableau de bord convivial et configurable pour la gestion de contenu ainsi qu'un système de rendu personnalisé pour afficher vos composants Astro.
 
 
 ## Ressources officielles
 
 - [Documentation de StudioCMS](https://docs.studiocms.dev/fr/)
-- [Dépôt GitHub de StudioCMS](https://github.com/withstudiocms/studiocms) (en)
-- [Communauté Discord de StudioCMS](https://chat.studiocms.dev) (en)
+- [Dépôt GitHub de StudioCMS](https://github.com/withstudiocms/studiocms) (Anglais)
+- [Communauté Discord de StudioCMS](https://chat.studiocms.dev) (Anglais)

--- a/src/content/docs/fr/guides/cms/tina-cms.mdx
+++ b/src/content/docs/fr/guides/cms/tina-cms.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 [Tina CMS](https://tina.io/) est un système de gestion de contenu headless soutenu par Git.
 
-## Integration avec Astro
+## Intégration avec Astro
 
 Pour commencer, vous aurez besoin d'un projet Astro existant.
 
@@ -40,8 +40,8 @@ Pour commencer, vous aurez besoin d'un projet Astro existant.
       </Fragment>
     </PackageManagerTabs>
 
-    - Lorsqu'on vous demande un Cloud ID, appuyez sur <kbd>Enter</kbd> pour passer. Vous en générerez un plus tard si vous souhaitez utiliser Tina Cloud.
-    - A la question "What framework are you using", choisissez **Other**.
+    - Lorsqu'on vous demande un ID Cloud, appuyez sur <kbd>Enter</kbd> pour passer. Vous en générerez un plus tard si vous souhaitez utiliser Tina Cloud.
+    - A la question « What framework are you using », choisissez **Other**.
     - Lorsque l'on vous demande où sont stockées les ressources publiques, appuyez sur <kbd>Enter</kbd>.
 
     Une fois cette opération terminée, vous devriez avoir un dossier `.tina` à la racine de votre projet et un fichier `hello-world.md` généré dans `content/posts`.
@@ -86,11 +86,11 @@ Pour commencer, vous aurez besoin d'un projet Astro existant.
 
 3. TinaCMS est maintenant configuré en mode local. Testez-le en lançant le script `dev`, puis en naviguant vers `/admin/index.html#/collections/post`.
 
-    L'édition du post "Hello, World !" mettra à jour le fichier `content/posts/hello-world.md` dans le répertoire de votre projet.
+    L'édition du post « Hello, World! » mettra à jour le fichier `content/posts/hello-world.md` dans le répertoire de votre projet.
 
 4. Configurez vos collections Tina en éditant la propriété `schema.collections` dans `.tina/config.ts`.
 
-    Par exemple, vous pouvez ajouter une propriété frontmatter "date posted" à nos posts :
+    Par exemple, vous pouvez ajouter une propriété de frontmatter « date de publication » à nos articles :
 
     ```js title=".tina/config.ts" ins={35-40}
     import { defineConfig } from "tinacms";
@@ -123,20 +123,20 @@ Pour commencer, vous aurez besoin d'un projet Astro existant.
               {
                 type: "string",
                 name: "title",
-                label: "Title",
+                label: "Titre",
                 isTitle: true,
                 required: true,
               },
               {
                 type: "datetime",
                 name: "posted",
-                label: "Date Posted",
+                label: "Date de publication",
                 required: true,
               },
               {
                 type: "rich-text",
                 name: "body",
-                label: "Body",
+                label: "Corps",
                 isBody: true,
               },
             ],
@@ -146,20 +146,20 @@ Pour commencer, vous aurez besoin d'un projet Astro existant.
     });
     ```
 
-    En savoir plus sur les collections Tina dans la [documentation Tina](https://tina.io/docs/reference/collections/).
+    En savoir plus sur les collections Tina dans la [documentation de Tina](https://tina.io/docs/reference/collections/).
 
-5. En production, TinaCMS peut livrer des changements directement à votre dépôt GitHub. Pour configurer TinaCMS pour la production, vous pouvez choisir d'utiliser [Tina Cloud](https://tina.io/docs/tina-cloud/) ou d'auto-héberger la [couche de données Tina](https://tina.io/docs/self-hosted/overview/). Vous pouvez [en savoir plus sur l'inscription à Tina Cloud](https://app.tina.io/register) dans les Tina Docs.
+5. En production, TinaCMS peut valider les modifications directement dans votre dépôt GitHub. Pour configurer TinaCMS pour la production, vous pouvez choisir d'utiliser [Tina Cloud](https://tina.io/docs/tina-cloud/) ou d'auto-héberger la [couche de données Tina](https://tina.io/docs/self-hosted/overview/). Vous pouvez [en savoir plus sur l'inscription à Tina Cloud](https://app.tina.io/register) dans la documentation de Tina.
 </Steps>
 
 ## Ressources officielles
 
-- [Guide d'intégration de TinaCMS avec Astro](https://tina.io/docs/frameworks/astro/).
+- [Guide d'intégration de TinaCMS avec Astro](https://tina.io/docs/frameworks/astro/) (Anglais).
 
 ## Ressources communautaires
 
-- [Astro Tina Kit de démarrage avec une édition visuelle](https://github.com/dawaltconley/tina-astro) par Jeff See + Dylan Awalt-Conley
-- [Astro Tina Kit de démarrage avec une édition basique](https://github.com/tombennet/astro-tina-starter/tree/main) par Tom Bennet
-- [Utiliser les optimisations d'images Astro avec Tina](https://joschua.io/posts/2023/08/16/how-to-use-astro-assets-with-tina-cms/)
+- [Kit de démarrage Astro Tina avec une édition visuelle](https://github.com/dawaltconley/tina-astro) (Anglais) par Jeff See + Dylan Awalt-Conley
+- [Kit de démarrage Astro Tina avec une édition basique](https://github.com/tombennet/astro-tina-starter/tree/main) (Anglais) par Tom Bennet
+- [Utiliser les optimisations d'images d'Astro avec Tina](https://joschua.io/posts/2023/08/16/how-to-use-astro-assets-with-tina-cms/) (Anglais)
 
 ## Thèmes
 

--- a/src/content/docs/fr/guides/cms/wordpress.mdx
+++ b/src/content/docs/fr/guides/cms/wordpress.mdx
@@ -1,5 +1,5 @@
 ---
-title: Headless WordPress et Astro
+title: WordPress Headless & Astro
 description: Ajoutez du contenu à votre projet Astro en utilisant WordPress comme CMS
 sidebar:
   label: WordPress
@@ -13,17 +13,17 @@ import Grid from '~/components/FluidGrid.astro'
 import Card from '~/components/ShowcaseCard.astro'
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-[WordPress](https://wordpress.org/) est un système de gestion de contenu qui comprend son propre frontend, mais qui peut également être utilisé comme un CMS sans tête pour fournir du contenu à votre projet Astro.
+[WordPress](https://wordpress.org/) est un système de gestion de contenu qui comprend son propre frontend, mais qui peut également être utilisé comme un CMS headless pour fournir du contenu à votre projet Astro.
 
 ## Intégration avec Astro
 
-WordPress est doté d'un système intégré de l'[API REST WordPress](https://developer.wordpress.org/rest-api/) pour connecter vos données WordPress à Astro. Vous pouvez éventuellement installer [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) ou [Gato GraphQL](https://wordpress.org/plugins/gatographql/) sur votre site pour utiliser GraphQL.
+WordPress est livré avec une [API REST WordPress](https://developer.wordpress.org/rest-api/) intégrée pour connecter vos données WordPress à Astro. Vous pouvez éventuellement installer [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) ou [Gato GraphQL](https://wordpress.org/plugins/gatographql/) sur votre site pour utiliser GraphQL.
 
-### Pré-requis
+### Prérequis
 
 Pour commencer, vous devez disposer des éléments suivants :
 
-1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [Guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
+1. **Un projet Astro** - Si vous n'avez pas encore de projet Astro, notre [guide d'installation](/fr/install-and-setup/) vous permettra d'être opérationnel en un rien de temps.
 2. **Un site WordPress** - L'API REST de votre site est `[VOTRE_SITE]/wp-json/wp/v2/` et est disponible par défaut avec tout site WordPress. Il est également possible de [configurer WordPress dans un environnement local](https://wordpress.org/support/article/installing-wordpress-on-your-own-computer/).
 
 ### Mise en place des informations d'identification
@@ -34,13 +34,13 @@ Vous pouvez choisir de [demander une authentification](https://developer.wordpre
 
 ### Récupération de données
 
-Récupérez vos données WordPress via l'URL unique de l'API REST de votre site et la route de votre contenu (pour un blog, il s'agira généralement de `posts`). Ensuite, vous pouvez rendre les propriétés de vos données en utilisant la directive `set:html={}` d'Astro.
+Récupérez vos données WordPress via l'URL unique de l'API REST de votre site et la route de votre contenu (pour un blog, il s'agira généralement de `posts`). Ensuite, vous pouvez restituer les propriétés de vos données en utilisant la directive `set:html={}` d'Astro.
 
 Par exemple, pour afficher une liste de titres d'articles et leur contenu :
 
 ```astro title="src/pages/index.astro"
 ---
-const res = await fetch("https://[YOUR-SITE]/wp-json/wp/v2/posts");
+const res = await fetch("https://[VOTRE-SITE]/wp-json/wp/v2/posts");
 const posts = await res.json();
 ---
 <h1>Astro + WordPress 🚀</h1>
@@ -60,12 +60,12 @@ L'API peut également renvoyer du contenu lié à votre article, tel qu'un lien 
 
 ## Créer un blog avec WordPress et Astro
 
-Cet exemple récupère des données de l'API WordPress publique de [https://norian.studio/dinosaurs/](https://norian.studio/dinosaurs/). Ce site WordPress stocke des informations sur des dinosaures individuels sous la route `dinos`, de la même manière qu'un blog stockerait des articles individuels sous la route `posts`.
+Cet exemple récupère des données de l'API WordPress publique de [https://norian.studio/dinosaurs/](https://norian.studio/dinosaurs/). Ce site WordPress rassemble des informations sur des dinosaures individuels sous la route `dinos`, de la même manière qu'un blog rassemblerait des articles individuels sous la route `posts`.
 
 Cet exemple montre comment reproduire cette structure de site dans Astro : une page d'index qui répertorie les dinosaures avec des liens vers des pages individuelles de dinosaures générées dynamiquement.
 
 :::note
-Pour utiliser les [Custom Post Types (CPT)](https://learn.wordpress.org/lesson-plan/custom-post-types/) dans votre API WordPress (pas seulement `post` et `page`), vous devrez [les configurer dans votre tableau de bord WordPress](https://stackoverflow.com/questions/48536646/how-can-i-get-data-from-custom-post-type-using-wp-rest-api) ou [ajouter le support de l'API REST pour les types de contenu personnalisés](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-rest-api-support-for-custom-content-types/) dans WordPress.
+Pour utiliser les [Custom Post Types (CPT)](https://learn.wordpress.org/lesson-plan/custom-post-types/) dans votre API WordPress (pas seulement `post` et `page`), vous devrez [les configurer dans votre tableau de bord WordPress](https://stackoverflow.com/questions/48536646/how-can-i-get-data-from-custom-post-type-using-wp-rest-api) ou [ajouter la prise en charge de l'API REST pour les types de contenu personnalisés](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-rest-api-support-for-custom-content-types/) dans WordPress.
 
 Cet exemple récupère les données d'un site WordPress dont les types de contenu ont déjà été configurés et exposés à l'API REST.
 :::
@@ -147,7 +147,7 @@ export async function getStaticPaths() {
 </Layout>
 ```
 
-### Retour des ressources intégrées
+### Renvoyer les ressources intégrées
 
 Le paramètre de requête `_embed` demande au serveur de renvoyer des ressources connexes (intégrées).
 
@@ -178,10 +178,10 @@ Pour déployer votre site web, consultez nos [guides de déploiement](/fr/guides
 
 ## Ressources communautaires
 
-- [Construire un site Astro avec WordPress comme CMS sans tête](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/) par Chris Bongers.
-- [Construire avec Astro x WordPress](https://www.youtube.com/watch?v=Jstqgklvfnc) sur le flux de Ben Holmes.
-- [Construire un site WordPress sans tête avec Astro](https://developers.wpengine.com/blog/building-a-headless-wordpress-site-with-astro) par Jeff Everhart.
-- [Astro et WordPress en tant qu'API](https://darko.io/posts/wp-as-an-api/) par Darko Bozhinovski.
+- [Construire un site Astro avec WordPress comme CMS headless](https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/) (Anglais) par Chris Bongers.
+- [Construire avec Astro x WordPress](https://www.youtube.com/watch?v=Jstqgklvfnc) (Anglais) sur le flux de Ben Holmes.
+- [Construire un site WordPress headless avec Astro](https://developers.wpengine.com/blog/building-a-headless-wordpress-site-with-astro) (Anglais) par Jeff Everhart.
+- [Astro et WordPress en tant qu'API](https://darko.io/posts/wp-as-an-api/) (Anglais) par Darko Bozhinovski.
 
 ## Sites web en production
 
@@ -199,20 +199,20 @@ Les sites suivants utilisent Astro + WordPress en production :
 
 <CardGrid>
 
-  <LinkCard href="https://dev.to/bngmnn/leveraging-wordpress-as-a-headless-cms-for-your-astro-website-a-comprehensive-guide-a4d" title="Introduction à Astro + WordPress (en)"/>
-  <LinkCard title="Astro + WPGraphQL pour des sites WordPress plus sécurisés (en)" href="https://www.youtube.com/watch?v=fWxn-r83ygQ" />
-  <LinkCard title="Réduire les temps de construction de WordPress en mode sans tête grâce à l'API Content Layer d'Astro (en)" href="https://andrewkepson.com/blog/headless-wordpress/build-time-astro-content-layer-api/"/>
-  <LinkCard title="Comment configurer un site WordPress sans tête avec Astro (en)" href="https://dev.to/mathiasahlgren/how-to-set-up-a-headless-wordpress-site-with-astro-3a2h" />
-  <LinkCard title="Créer un site statique avec WordPress et Astro (en)" href="https://kinsta.com/blog/wordpress-astro/" />
-  <LinkCard title="Passer à WordPress headless avec Astro (en)" href="https://www.youtube.com/watch?v=MP2TR6Z_YTc" />
-  <LinkCard title="Tirer parti de WordPress comme CMS sans tête pour votre site Web Astro : configuration de l'API et récupération de données (en)" href="https://medium.com/@bangemann.dev/configure-wordpress-rest-api-setup-data-fetching-4af5161095f6" />
-  <LinkCard title="WordPress headless avec Astro : Installation d'Astro et récupération d'articles avec WP-GraphQL (en)" href="https://www.youtube.com/watch?v=2PSqABrME28" />
-  <LinkCard title="Créer un site WordPress sans tête avec Astro (en)" href="https://www.youtube.com/watch?v=54U7dVmhyxE" />
-  <LinkCard title="Démo de démarrage de WordPress sans tête avec Astro par WPEngine (en)" href="https://www.youtube.com/watch?v=BcoxZZIfESI" />
-  <LinkCard title="WordPress headless avec Astro – Créez un blog simple à partir de zéro avec Tailwind CSS (en)" href="https://fullstackdigital.io/blog/headless-wordpress-with-astro-build-a-simple-blog/" />
-  <LinkCard title="Créer un site e-commerce avec WordPress Headless et Astro (en)" href="https://shaxadd.medium.com/building-an-e-commerce-website-with-headless-wordpress-and-astro-2712d8c8b735" />
-   <LinkCard title="Créer un site WordPress sans tête avec Astro (en)" href="https://wpengine.com/builders/building-headless-wordpress-site-astro/" />
-  <LinkCard title="Créer un site web Astro avec WordPress en tant que CMS headless (en)" href="https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/" />
+  <LinkCard href="https://dev.to/bngmnn/leveraging-wordpress-as-a-headless-cms-for-your-astro-website-a-comprehensive-guide-a4d" title="Introduction à Astro + WordPress (Anglais)"/>
+  <LinkCard title="Astro + WPGraphQL pour des sites WordPress plus sécurisés (Anglais)" href="https://www.youtube.com/watch?v=fWxn-r83ygQ" />
+  <LinkCard title="Réduire les temps de compilation de WordPress en mode headless grâce à l'API couche de contenu d'Astro (Anglais)" href="https://andrewkepson.com/blog/headless-wordpress/build-time-astro-content-layer-api/"/>
+  <LinkCard title="Comment configurer un site WordPress headless avec Astro (Anglais)" href="https://dev.to/mathiasahlgren/how-to-set-up-a-headless-wordpress-site-with-astro-3a2h" />
+  <LinkCard title="Créer un site statique avec WordPress et Astro (Anglais)" href="https://kinsta.com/blog/wordpress-astro/" />
+  <LinkCard title="Passer à WordPress headless avec Astro (Anglais)" href="https://www.youtube.com/watch?v=MP2TR6Z_YTc" />
+  <LinkCard title="Tirer parti de WordPress comme CMS headless pour votre site Web Astro : configuration de l'API et récupération de données (Anglais)" href="https://medium.com/@bangemann.dev/configure-wordpress-rest-api-setup-data-fetching-4af5161095f6" />
+  <LinkCard title="WordPress headless avec Astro : Installation d'Astro et récupération d'articles avec WP-GraphQL (Anglais)" href="https://www.youtube.com/watch?v=2PSqABrME28" />
+  <LinkCard title="Créer un site WordPress headless avec Astro (Anglais)" href="https://www.youtube.com/watch?v=54U7dVmhyxE" />
+  <LinkCard title="Démo de démarrage de WordPress headless avec Astro par WPEngine (Anglais)" href="https://www.youtube.com/watch?v=BcoxZZIfESI" />
+  <LinkCard title="WordPress headless avec Astro – Créez un blog simple à partir de zéro avec Tailwind CSS (Anglais)" href="https://fullstackdigital.io/blog/headless-wordpress-with-astro-build-a-simple-blog/" />
+  <LinkCard title="Créer un site e-commerce avec WordPress Headless et Astro (Anglais)" href="https://shaxadd.medium.com/building-an-e-commerce-website-with-headless-wordpress-and-astro-2712d8c8b735" />
+   <LinkCard title="Créer un site WordPress headless avec Astro (Anglais)" href="https://wpengine.com/builders/building-headless-wordpress-site-astro/" />
+  <LinkCard title="Créer un site web Astro avec WordPress en tant que CMS headless (Anglais)" href="https://blog.openreplay.com/building-an-astro-website-with-wordpress-as-a-headless-cms/" />
  
 
 </CardGrid>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of `guides/cms` (see #11593):
* fix bad translations (e.g. `message` instead of `article`)
* fix indentation in some `FileTree`
* replace `sans tête` with `headless`
* replace `crypter` with `chiffrer`
* replace `rendre` with `générer` / `restituer`
* replace `template` with `modèle`
* replace `construction` with `compiler`
* replace `cadre` with `framework`
* replace `style` with `mise en forme`
* replace `support` with `prise en charge`
* replace `fetch` with `récupération`
* replace `bundle` with `regroupement`
* replace `en` with `Anglais` in community links
* translate untranslated parts
* use French quotes instead of double quotes
* reword some sentences to make the reading easier

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
