### PR TITLE
i18n(fr): update `guides/deploy/cloudflare.mdx`

### DIFF
--- a/src/content/docs/fr/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/fr/guides/deploy/cloudflare.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Cloudflare
+title: Déployer votre site Astro sur Cloudflare
 description: Comment déployer votre site Astro sur le web en utilisant Cloudflare
 sidebar:
   label: Cloudflare
@@ -24,7 +24,7 @@ Cloudflare recommande d'utiliser Cloudflare Workers pour les nouveaux projets. P
 :::
 
 <ReadMore>En savoir plus sur [l'utilisation de l'environnement d'exécution Cloudflare](/fr/guides/integrations-guide/cloudflare/) dans votre projet Astro.</ReadMore>
-## Pré-requis
+## Prérequis
 
 Pour commencer, vous aurez besoin :
 
@@ -111,7 +111,7 @@ Pour commencer, vous aurez besoin :
 
 Une fois vos ressources téléchargées, Wrangler vous donnera une URL de prévisualisation pour inspecter votre site.
 
-<ReadMore>En savoir plus sur l'utilisation des [API d'exécution de Cloudflare](/fr/guides/integrations-guide/cloudflare/) telles que les liaisons.</ReadMore>
+<ReadMore>En savoir plus sur l'utilisation des [API de l'environnement d'exécution Cloudflare](/fr/guides/integrations-guide/cloudflare/) telles que les liaisons.</ReadMore>
 
 ### Comment déployer avec CI/CD
 
@@ -174,12 +174,13 @@ Une fois vos ressources téléchargées, Wrangler vous fournira une URL d'aperç
 <Steps>
 1. Envoyez votre code vers votre dépôt Git (par exemple GitHub, GitLab).
 
-2. Connectez-vous au [tableau de bord Cloudflare](https://dash.cloudflare.com/) et accédez à `Workers & Pages`. Sélectionnez `Create`, puis l'onglet `Pages`. Connectez votre dépôt Git.
+2. Connectez-vous au [tableau de bord de Cloudflare](https://dash.cloudflare.com/) et accédez à **Compute (Workers) > Workers & Pages**. Sélectionnez **Create**, puis l'onglet **Pages**. Connectez votre dépôt Git.
 
 3. Configurez votre projet avec :
     - **Framework preset**: `Astro`
     - **Build command:** `npm run build`
     - **Build output directory:** `dist`
+    - **Environment variables:** Définissez la variable `NODE_VERSION` sur `20` ou `22`. Par défaut, Cloudflare Pages crée des sites en utilisant Node.js `v18.17.1`, qui n'est pas compatible avec la dernière version d'Astro.
 
 4. Cliquez sur le bouton **Save and deploy**.
 </Steps>
@@ -190,12 +191,12 @@ Une fois vos ressources téléchargées, Wrangler vous fournira une URL d'aperç
 
 L'hydratation côté client peut échouer à cause du paramètre Auto Minify de Cloudflare. Si vous voyez `Hydration completed but contains mismatches` dans la console, assurez-vous de désactiver Auto Minify dans les paramètres de Cloudflare.
 
-### API d'exécution Node.js
+### API de l'environnement d'exécution Node.js
 
 Si vous créez un projet qui utilise le rendu à la demande avec [l'adaptateur Cloudflare](/fr/guides/integrations-guide/cloudflare/) et que le serveur ne parvient pas à construire avec un message d'erreur tel que `[Error] Could not resolve "XXXX. The package "XXXX" wasn't found on the file system but is built into node.` :
 
-- Cela signifie qu'un paquet ou une importation que vous utilisez dans l'environnement côté serveur n'est pas compatible avec les [API d'exécution de Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/nodejs/). 
+- Cela signifie qu'un paquet ou une importation que vous utilisez dans l'environnement côté serveur n'est pas compatible avec les [API de l'environnement d'exécution Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/nodejs/). 
 
-- Si vous importez directement une API d'exécution Node.js, veuillez consulter la documentation Astro sur la [compatibilité Node.js](/fr/guides/integrations-guide/cloudflare/#compatibilité-nodejs) de Cloudflare pour savoir comment résoudre ce problème.
+- Si vous importez directement une API de l'environnement d'exécution Node.js, veuillez consulter la documentation Astro sur la [compatibilité Node.js](/fr/guides/integrations-guide/cloudflare/#compatibilité-nodejs) de Cloudflare pour savoir comment résoudre ce problème.
 
-- Si vous importez un paquet qui importe une API d'exécution Node.js, vérifiez avec l'auteur du paquet s'il supporte la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un autre paquet.
+- Si vous importez un paquet qui importe une API de l'environnement d'exécution Node.js, vérifiez avec l'auteur du paquet s'il supporte la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un autre paquet.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/deploy/cloudflare.mdx` with:
* changes from #11735
* some rewording:
  * use infinitive form for the page title
  * `prérequis` doesn't require an hyphen
  * replace `exécution` with `environnement d'exécution` (see [Nodejs](https://nodejs.org/fr) for example)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
