### PR TITLE
i18n(fr): improve the wording in the remaining `guides/deploy`

### DIFF
--- a/src/content/docs/fr/guides/deploy/aws.mdx
+++ b/src/content/docs/fr/guides/deploy/aws.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur AWS
+title: Déployer votre site Astro sur AWS
 description: Comment déployer votre site Astro sur le web en utilisant AWS.
 sidebar:
   label: AWS
@@ -12,7 +12,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 [AWS](https://aws.amazon.com/) est une plateforme d'hébergement d'applications web complète qui peut être utilisée pour déployer un site Astro.
 
-Pour déployer votre projet sur AWS, vous devez utiliser la [console AWS](https://aws.amazon.com/console/). (La plupart de ces actions peuvent également être effectuées à l'aide de [AWS CLI](https://aws.amazon.com/cli/)). Ce guide vous conduira à travers les étapes du déploiement de votre site sur AWS en utilisant [AWS Amplify](https://aws.amazon.com/amplify/), [Hébergement de sites web statiques S3](https://aws.amazon.com/s3/), et [CloudFront](https://aws.amazon.com/cloudfront/).
+Pour déployer votre projet sur AWS, vous devez utiliser la [console AWS](https://aws.amazon.com/console/). (La plupart de ces actions peuvent également être effectuées à l'aide de la [CLI d'AWS](https://aws.amazon.com/cli/)). Ce guide vous conduira à travers les étapes du déploiement de votre site sur AWS en utilisant [AWS Amplify](https://aws.amazon.com/amplify/), [Hébergement de sites web statiques S3](https://aws.amazon.com/s3/), et [CloudFront](https://aws.amazon.com/cloudfront/).
 
 ## AWS Amplify
 
@@ -218,9 +218,9 @@ Amplify déploiera automatiquement votre site web et le mettra à jour lorsque v
   Consultez [le guide de déploiement Astro d'AWS](https://docs.aws.amazon.com/fr_fr/amplify/latest/userguide/get-started-astro.html) pour plus d'informations.
 </ReadMore>
 
-## Hébergement de sites web statiques S3
+## Hébergement de sites web statiques sur S3
 
-S3 est le point de départ de toute application. C'est là que sont stockés les fichiers de votre projet et d'autres ressources. S3 facture le stockage des fichiers et le nombre de requêtes. Vous trouverez plus d'informations sur S3 dans la [documentation AWS](https://aws.amazon.com/s3/).
+S3 est le point de départ de toute application. C'est là que sont stockés les fichiers de votre projet et d'autres ressources. S3 facture le stockage des fichiers et le nombre de requêtes. Vous trouverez plus d'informations sur S3 dans la [documentation d'AWS](https://aws.amazon.com/s3/).
 
 <Steps>
 1. Créez un panier S3 avec le nom de votre projet.
@@ -229,9 +229,9 @@ S3 est le point de départ de toute application. C'est là que sont stockés les
     Le nom du bucket doit être globalement unique. Nous recommandons une combinaison du nom de votre projet et du nom de domaine de votre site.
     :::
 
-2. Désactivez **"Block all public access"**. Par défaut, AWS définit tous les buckets comme étant privés. Pour le rendre public, vous devez décocher la case "Bloquer l'accès public" dans les propriétés du bucket.
+2. Désactivez **« Block all public access »**. Par défaut, AWS définit tous les buckets comme étant privés. Pour le rendre public, vous devez décocher la case « Bloquer l'accès public » dans les propriétés du bucket.
 
-3. Téléchargez vos fichiers construits situés dans `dist` sur S3. Vous pouvez le faire manuellement dans la console ou utiliser le CLI AWS. Si vous utilisez la CLI AWS, vous pouvez utiliser la commande suivante après [l'authentification avec vos identifiants AWS](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) :
+3. Téléchargez vos fichiers compilés situés dans `dist` sur S3. Vous pouvez le faire manuellement dans la console ou utiliser la CLI d'AWS. Si vous utilisez la CLI d'AWS, vous pouvez utiliser la commande suivante après [l'authentification avec vos identifiants AWS](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) :
 
     ```
     aws s3 cp dist/ s3://<BUCKET_NAME>/ --recursive
@@ -270,13 +270,13 @@ S3 est le point de départ de toute application. C'est là que sont stockés les
 CloudFront est un service web qui offre des capacités de réseau de diffusion de contenu (CDN). Il est utilisé pour mettre en cache le contenu d'un serveur web et le distribuer aux utilisateurs finaux. CloudFront facture la quantité de données transférées. L'ajout de CloudFront à votre bucket S3 est plus rentable et permet une diffusion plus rapide.
 
 Pour connecter S3 à CloudFront, créez une distribution CloudFront avec les valeurs suivantes :
-  - **Domaine d'origine:** Point d'arrivée de votre site web statique dans le bucket S3. Vous pouvez trouver votre point de terminaison dans les **Propriétés > Hébergement de site web statique** de votre bucket S3. Vous pouvez également sélectionner votre bucket S3 et cliquer sur l'appel pour remplacer l'adresse de votre bucket par le point de terminaison statique de votre bucket.
-  - **Politique de protocole de visualisation:** « Redirect to HTTPS » (Redirection vers HTTPS)
+  - **Domaine d'origine :** Point d'arrivée de votre site web statique dans le bucket S3. Vous pouvez trouver votre point de terminaison dans les **Propriétés > Hébergement de site web statique** de votre bucket S3. Vous pouvez également sélectionner votre bucket S3 et cliquer sur l'appel pour remplacer l'adresse de votre bucket par le point de terminaison statique de votre bucket.
+  - **Politique de protocole de visualisation :** « Redirection vers HTTPS »
 
 Cette configuration servira votre site en utilisant le réseau CDN Cloudfront. Vous pouvez trouver l'URL de votre distribution CloudFront dans les **Distributions > Nom de domaine** du bucket.
 
 :::note
-Lorsque vous connectez CloudFront à un point d'extrémité de site web statique S3, vous vous appuyez sur les politiques de S3 Bucket pour le contrôle d'accès. Voir la section [Hébergement de sites web statiques S3](/fr/guides/deploy/aws/#hébergement-de-sites-web-statiques-s3) pour plus d'informations sur les politiques des Bucket.
+Lorsque vous connectez CloudFront à un point de terminaison de site web statique S3, vous vous appuyez sur les stratégies du Bucket S3 pour le contrôle d'accès. Voir la section [Hébergement de sites web statiques sur S3](/fr/guides/deploy/aws/#hébergement-de-sites-web-statiques-sur-s3) pour plus d'informations sur les stratégies du Bucket.
 :::
 
 ## Déploiement continu avec GitHub Actions
@@ -284,7 +284,7 @@ Lorsque vous connectez CloudFront à un point d'extrémité de site web statique
 Il existe de nombreuses façons de mettre en place un déploiement continu pour AWS. Une possibilité pour le code hébergé sur GitHub est d'utiliser [GitHub Actions](https://github.com/features/actions) pour déployer votre site web à chaque fois que vous poussez un commit.
 
 <Steps>
-1. Créez une nouvelle politique dans votre compte AWS en utilisant [IAM](https://aws.amazon.com/iam/) avec les permissions suivantes. Cette politique vous permettra de télécharger des fichiers construits dans votre bucket S3 et d'invalider les fichiers de distribution CloudFront lorsque vous poussez un commit.
+1. Créez une nouvelle stratégie dans votre compte AWS en utilisant [IAM](https://aws.amazon.com/iam/) avec les permissions suivantes. Cette stratégie vous permettra de télécharger des fichiers compilés dans votre bucket S3 et d'invalider les fichiers de distribution CloudFront lorsque vous poussez un commit.
   
      ```json
      {
@@ -315,7 +315,7 @@ Il existe de nombreuses façons de mettre en place un déploiement continu pour 
 
 2. Créez un nouvel utilisateur IAM et attachez la règle à l'utilisateur. Cela fournira votre `AWS_SECRET_ACCESS_KEY` et `AWS_ACCESS_KEY_ID`.
 
-3. Ajoutez cet exemple de flux de travail à votre référentiel à l'adresse suivante `.github/workflows/deploy.yml` et pousser-le sur GitHub. Vous devrez ajouter `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BUCKET_ID`, et `DISTRIBUTION_ID` en tant que “secrets” dans votre dépôt sur GitHub dans **Settings** > **Secrets** > **Actions**. Cliquez sur <kbd>New repository secret</kbd> pour ajouter chacun d'entre eux.
+3. Ajoutez cet exemple de flux de travail à votre dépôt à l'adresse suivante `.github/workflows/deploy.yml` et pousser-le sur GitHub. Vous devrez ajouter `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BUCKET_ID`, et `DISTRIBUTION_ID` en tant que « secrets » dans votre dépôt sur GitHub dans **Settings** > **Secrets** > **Actions**. Cliquez sur <kbd>New repository secret</kbd> pour ajouter chacun d'entre eux.
 
      ```yaml
      name: Déployer le site web
@@ -331,7 +331,7 @@ Il existe de nombreuses façons de mettre en place un déploiement continu pour 
          steps:
            - name: Checkout
              uses: actions/checkout@v4
-           - name: Configure AWS Credentials
+           - name: Configurer les informations d'identification AWS
              uses: aws-actions/configure-aws-credentials@v1
              with:
                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -339,7 +339,7 @@ Il existe de nombreuses façons de mettre en place un déploiement continu pour 
                aws-region: us-east-1
            - name: Installation des modules
              run: npm ci
-           - name: Construction de l'application
+           - name: Compilation de l'application
              run: npm run build
            - name: Déploiement sur S3
              run: aws s3 sync --delete ./dist/ s3://${{ secrets.BUCKET_ID }}
@@ -354,7 +354,7 @@ Il existe de nombreuses façons de mettre en place un déploiement continu pour 
 
 ## Ressources communautaires
 
-- [Déployer Astro sur AWS Amplify](https://www.launchfa.st/blog/deploy-astro-aws-amplify)
-- [Déployer Astro sur AWS Elastic Beanstalk](https://www.launchfa.st/blog/deploy-astro-aws-elastic-beanstalk)
-- [Déployer Astro sur Amazon ECS sur AWS Fargate](https://www.launchfa.st/blog/deploy-astro-aws-fargate)
+- [Déployer Astro sur AWS Amplify](https://www.launchfa.st/blog/deploy-astro-aws-amplify) (Anglais)
+- [Déployer Astro sur AWS Elastic Beanstalk](https://www.launchfa.st/blog/deploy-astro-aws-elastic-beanstalk) (Anglais)
+- [Déployer Astro sur Amazon ECS sur AWS Fargate](https://www.launchfa.st/blog/deploy-astro-aws-fargate) (Anglais)
 - [Dépanner les déploiements SSR Amplify](https://docs.aws.amazon.com/fr_fr/amplify/latest/userguide/troubleshooting-ssr-deployment.html)

--- a/src/content/docs/fr/guides/deploy/azion.mdx
+++ b/src/content/docs/fr/guides/deploy/azion.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Azion
+title: Déployer votre site Astro sur Azion
 description: Comment déployer votre site Astro sur le Web à l'aide d'Azion.
 sidebar:
   label: Azion
@@ -16,11 +16,11 @@ Pour commencer, vous aurez besoin de :
 
 - Un [compte Azion](https://www.azion.com/). Si vous n’en avez pas, vous pouvez créer un compte gratuit.
 - Le code de votre application stocké dans un dépôt [GitHub](https://github.com/).
-- le [CLI d'Azion](https://www.azion.com/en/documentation/products/azion-cli/overview/) installé pour une configuration et un déploiement de projet plus rapides.
+- la [CLI d'Azion](https://www.azion.com/en/documentation/products/azion-cli/overview/) installée pour une configuration et un déploiement de projet plus rapides.
 
 ## Comment déployer via le tableau de bord de la console Azion
 
-Pour commencer à construire, suivez ces étapes :
+Pour commencer à compiler, suivez ces étapes :
 
 <Steps>
 1. Accédez à [la console d'Azion](https://console.azion.com).
@@ -31,10 +31,10 @@ Pour commencer à construire, suivez ces étapes :
 4. Connectez votre compte Azion à GitHub.
    - Une fenêtre contextuelle apparaîtra demandant une autorisation.
 5. Choisissez le dépôt que vous souhaitez importer depuis GitHub.
-6. Configurez les paramètres de construction :
+6. Configurez les paramètres de compilation :
    - **Framework preset:** Sélectionnez le framework approprié (par exemple, `Astro`).  
    - **Root Directory:** Il s'agit du répertoire dans lequel se trouve votre code. Votre code doit se trouver dans le répertoire racine, et non dans un sous-répertoire. Un symbole `./` apparaît dans ce champ, indiquant qu'il s'agit d'un répertoire racine.
-   - **Install Command:** la commande qui compile vos paramètres pour la création en production. Les commandes de création sont exécutées via des scripts. Par exemple : `npm run build` ou `npm install` pour un package NPM.
+   - **Install Command:** la commande qui réunit vos paramètres pour la compilation en production. Les commandes de compilation ou d'installation sont exécutées via des scripts. Par exemple : `npm run build` ou `npm install` pour un paquet NPM.
 7. Cliquez sur **Save and Deploy**.  
 8. Surveillez le déploiement à l’aide d'**Azion Real-Time Metrics** et vérifiez que votre site est en ligne sur le périphérique.
 </Steps>
@@ -43,12 +43,12 @@ Pour commencer à construire, suivez ces étapes :
 
 <Steps>
 
-1. **Installez le CLI d'Azion :**  
+1. **Installez la CLI d'Azion :**  
      
-   - Téléchargez et installez le [CLI d'Azion](https://www.azion.com/en/documentation/products/azion-cli/overview/) pour faciliter la gestion et le déploiement.
+   - Téléchargez et installez la [CLI d'Azion](https://www.azion.com/en/documentation/products/azion-cli/overview/) pour faciliter la gestion et le déploiement.
 
    :::caution
-   Le CLI d'Azion ne prend actuellement pas en charge les environnements Windows natifs. Cependant, vous pouvez l'utiliser sous Windows via le sous-système Windows pour Linux (WSL). Suivez le [guide d’installation WSL](https://docs.microsoft.com/en-us/windows/wsl/install) pour configurer un environnement Linux sur votre machine Windows.
+   La CLI d'Azion ne prend actuellement pas en charge les environnements Windows natifs. Cependant, vous pouvez l'utiliser sous Windows via le sous-système Windows pour Linux (WSL). Suivez le [guide d’installation WSL](https://docs.microsoft.com/en-us/windows/wsl/install) pour configurer un environnement Linux sur votre machine Windows.
    :::
 
 2. **Authentifiez l'interface CLI :**  
@@ -67,9 +67,9 @@ Pour commencer à construire, suivez ces étapes :
    azion init
    ```  
 
-4. **Construisez votre projet Astro :**  
+4. **Compilez votre projet Astro :**  
      
-   - Exécutez votre commande de construction localement :
+   - Exécutez votre commande de compilation localement :
 
    ```bash
    azion build
@@ -77,7 +77,7 @@ Pour commencer à construire, suivez ces étapes :
 
 5. **Déployez vos fichiers statiques :**  
      
-   - Déployez vos fichiers statiques à l'aide du CLI d'Azion :
+   - Déployez vos fichiers statiques à l'aide de la CLI d'Azion :
 
    ```bash
    azion deploy
@@ -86,7 +86,7 @@ Pour commencer à construire, suivez ces étapes :
 
 Ce guide fournit une vue d'ensemble du déploiement d'applications statiques.
 
-## Activation du développement local à l'aide du CLI d'Azion
+## Activation du développement local à l'aide de la CLI d'Azion
 
 Pour que l'aperçu fonctionne, vous devez exécuter la commande suivante :
 
@@ -94,7 +94,7 @@ Pour que l'aperçu fonctionne, vous devez exécuter la commande suivante :
 azion dev
 ```
 
-Une fois le serveur de développement local initialisé, l'application passe par le processus de `build`.
+Une fois le serveur de développement local initialisé, l'application passe par le processus de compilation (`build`).
 
 ```bash 
 Building your Edge Application. This process may take a few minutes
@@ -102,7 +102,7 @@ Running build step command:
 ...
 ```
 
-Ensuite, lorsque la construction est terminée, l'accès à l'application est demandé :
+Ensuite, lorsque la compilation est terminée, l'adresse d'accès à l'application est affichée :
 
 ```bash
 [Azion Bundler] [Server] › ✔  success   Function running on port http://localhost:3000 
@@ -111,12 +111,12 @@ Ensuite, lorsque la construction est terminée, l'accès à l'application est de
 ## Dépannage
 
 
-### API d'exécution Node.js
+### API de l'environnement d'exécution Node.js
 
-Un projet utilisant un paquet NPM ne parvient pas à se construire avec un message d'erreur tel que `[Error] Could not resolve "XXXX. The package "XXXX" wasn't found on the file system but is built into node.`:
+Un projet utilisant un paquet NPM ne parvient pas à compiler avec un message d'erreur tel que `[Error] Could not resolve "XXXX. The package "XXXX" wasn't found on the file system but is built into node.`:
 
-Cela signifie qu’un paquet ou une importation que vous utilisez n’est pas compatible avec les API d’exécution d’Azion.
+Cela signifie qu’un paquet ou une importation que vous utilisez n’est pas compatible avec les API de l'environnement d’exécution Azion.
 
-Si vous importez directement une API d'exécution Node.js, veuillez vous référer à la [compatibilité de Node.js avec Azion](https://www.azion.com/en/documentation/products/azion-edge-runtime/compatibility/node/) pour obtenir des étapes supplémentaires sur la façon de résoudre ce problème.
+Si vous importez directement une API de l'environnement d'exécution Node.js, veuillez vous référer à la [compatibilité de Node.js avec Azion](https://www.azion.com/en/documentation/products/azion-edge-runtime/compatibility/node/) pour obtenir des étapes supplémentaires sur la façon de résoudre ce problème.
 
-Si vous importez un paquet qui importe une API d'exécution Node.js, vérifiez auprès de l'auteur du paquet s'il prend en charge la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un paquet alternatif.
+Si vous importez un paquet qui importe une API de l'environnement d'exécution Node.js, vérifiez auprès de l'auteur du paquet s'il prend en charge la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un paquet alternatif.

--- a/src/content/docs/fr/guides/deploy/buddy.mdx
+++ b/src/content/docs/fr/guides/deploy/buddy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro avec Buddy
+title: Déployer votre site Astro avec Buddy
 description: Comment déployer votre site Astro sur le web en utilisant Buddy.
 sidebar:
   label: Buddy
@@ -8,16 +8,16 @@ i18nReady: true
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-Vous pouvez déployer votre projet Astro en utilisant [Buddy](https://buddy.works/), une solution CI/CD qui peut construire votre site et le pousser vers de nombreuses cibles de déploiement différentes, y compris les serveurs FTP et les fournisseurs d'hébergement dans le cloud.
+Vous pouvez déployer votre projet Astro en utilisant [Buddy](https://buddy.works/), une solution CI/CD qui peut compiler votre site et le pousser vers de nombreuses cibles de déploiement différentes, y compris les serveurs FTP et les fournisseurs d'hébergement dans le cloud.
 
 :::note
-Buddy ne hébergera pas votre site lui-même. Au lieu de cela, il vous aide à gérer le processus de compilation et à livrer le résultat à une plate-forme de déploiement de votre choix.
+Buddy n'hébergera pas votre site lui-même. Au lieu de cela, il vous aide à gérer le processus de compilation et à diffuser le résultat vers une plate-forme de déploiement de votre choix.
 :::
 
 ## Comment déployer
 
 <Steps>
-1. [Creéz un compte](https://buddy.works/sign-up).
+1. [Creéz un compte **Buddy**](https://buddy.works/sign-up).
 
 2. Créez un nouveau projet et connectez-le avec un dépôt git (GitHub, GitLab, BitBucket, n'importe quel dépôt Git privé ou vous pouvez utiliser l'hébergement Git de Buddy).
 
@@ -25,14 +25,14 @@ Buddy ne hébergera pas votre site lui-même. Au lieu de cela, il vous aide à g
 
 4. Dans le nouveau pipeline, ajoutez une action **[Node.js](https://buddy.works/actions/node-js)**.
 
-5. Dans cette action, ajoutez:
+5. Dans cette action, ajoutez :
 
    ```bash
    npm install
    npm run build
    ```
 
-6. Ajoutez une action de déploiement - il y en a beaucoup à choisir, vous pouvez les parcourir dans le [catalogue d'actions de Buddy](https://buddy.works/actions). Bien que leurs paramètres puissent différer, n'oubliez pas de définir le **Chemin source** à `dist`.
+6. Ajoutez une action de déploiement — il y a beaucoup de choix, vous pouvez les parcourir dans le [catalogue d'actions de Buddy](https://buddy.works/actions). Bien que leurs paramètres puissent différer, n'oubliez pas de définir le **Chemin source** à `dist`.
 
 7. Appuyez sur le bouton **Run**.
 </Steps>

--- a/src/content/docs/fr/guides/deploy/cleavr.mdx
+++ b/src/content/docs/fr/guides/deploy/cleavr.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro avec Cleavr
+title: Déployer votre site Astro avec Cleavr
 description: Comment déployer votre site Astro sur votre serveur VPS en utilisant Cleavr.
 sidebar:
   label: Cleavr

--- a/src/content/docs/fr/guides/deploy/clever-cloud.mdx
+++ b/src/content/docs/fr/guides/deploy/clever-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Clever Cloud
+title: Déployer votre site Astro sur Clever Cloud
 description: Comment déployer votre site Astro sur le web avec Clever Cloud.
 sidebar:
   label: Clever Cloud
@@ -12,7 +12,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 ## Configuration du projet
 
-Vous pouvez déployer à la fois des projets Astro entièrement statiques ou rendus à la demande sur Clever Cloud. Quel que soit votre mode de sortie ([pré-rendu ou à la demande](/fr/guides/on-demand-rendering/)), vous pouvez choisir de déployer en tant qu'**application statique** qui s'exécute à l'aide d'un hook de post-construction, ou en tant qu'application **Node.js**, ce qui nécessite une configuration manuelle dans votre `package.json`.
+Vous pouvez déployer à la fois des projets Astro entièrement statiques ou rendus à la demande sur Clever Cloud. Quel que soit votre mode de sortie (pré-rendu ou [à la demande](/fr/guides/on-demand-rendering/)), vous pouvez choisir de déployer en tant qu'**application statique** qui s'exécute à l'aide d'un hook de post-compilation, ou en tant qu'application **Node.js**, ce qui nécessite une configuration manuelle dans votre `package.json`.
 
 ### Scripts
 
@@ -102,5 +102,5 @@ Par exemple, si vous souhaitez déployer votre branche locale `main` sans la ren
 
 
 ## Ressources officielles
-- [Documentation Clever Cloud pour déployer une application Node.js](https://www.clever-cloud.com/developers/doc/applications/javascript/nodejs/)
-- [Documentation Clever Cloud pour le déploiement d'Astro en tant qu'application statique](https://www.clever-cloud.com/developers/guides/astro/)
+- [Documentation Clever Cloud pour déployer une application Node.js](https://www.clever-cloud.com/developers/doc/applications/javascript/nodejs/) (Anglais)
+- [Documentation Clever Cloud pour le déploiement d'Astro en tant qu'application statique](https://www.clever-cloud.com/developers/guides/astro/) (Anglais)

--- a/src/content/docs/fr/guides/deploy/deno.mdx
+++ b/src/content/docs/fr/guides/deploy/deno.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro avec Deno
+title: Déployer votre site Astro avec Deno
 description: Comment déployer votre site Astro sur le web en utilisant Deno.
 sidebar:
   label: Deno
@@ -31,7 +31,7 @@ Votre projet Astro est un site statique par défaut. Aucune configuration suppl�
 Pour activer le rendu à la demande dans votre projet Astro à l'aide de Deno et pour déployer sur Deno Deploy :
 
 <Steps>
-1. Installez [l'adaptateur `@deno/astro-adapter`][Deno adapter] aux dépendances de votre projet en utilisant votre gestionnaire de paquets préféré:
+1. Installez [l'adaptateur `@deno/astro-adapter`][Deno adapter] dans les dépendances de votre projet en utilisant votre gestionnaire de paquets préféré :
 
    <PackageManagerTabs>
      <Fragment slot="npm">
@@ -51,7 +51,7 @@ Pour activer le rendu à la demande dans votre projet Astro à l'aide de Deno et
      </Fragment>
    </PackageManagerTabs>
 
-2. Mettez à jour votre fichier de configuration du projet `astro.config.mjs` avec les changements ci-dessous.
+2. Mettez à jour le fichier de configuration de votre projet `astro.config.mjs` avec les changements ci-dessous.
 
      ```js ins={3,6-7}
     // astro.config.mjs
@@ -64,7 +64,7 @@ Pour activer le rendu à la demande dans votre projet Astro à l'aide de Deno et
     });
     ```
 
-3. Mettez à jour votre script `preview` dans `package.json` avec la modification ci-dessous.
+3. Mettez à jour le script `preview` dans votre fichier `package.json` avec la modification ci-dessous.
 
     ```json del={8} ins={9}
     // package.json
@@ -130,7 +130,7 @@ Vous pouvez déployer Deno Deploy via les actions GitHub ou en utilisant l'inter
      </Fragment>
    </PackageManagerTabs>
 
-3. Créez votre site Astro avec votre gestionnaire de paquets préféré :
+3. Compilez votre site Astro avec votre gestionnaire de paquets préféré :
 
    <PackageManagerTabs>
      <Fragment slot="npm">
@@ -263,7 +263,7 @@ Si votre projet est stocké sur GitHub, le [site Deno Deploy](https://dash.deno.
 ### Déploiement CLI
 
 <Steps>
-1. Installez le [CLI de Deno Deploy](https://docs.deno.com/deploy/manual/deployctl).
+1. Installez la [CLI de Deno Deploy](https://docs.deno.com/deploy/manual/deployctl).
 
     ```bash
     deno install -gArf jsr:@deno/deployctl
@@ -307,7 +307,7 @@ Si votre projet est stocké sur GitHub, le [site Deno Deploy](https://dash.deno.
 
     Vous pouvez suivre tous vos déploiements sur [Deno Deploy](https://dash.deno.com).
 
-4. (Optionnel) Pour simplifier la construction et le déploiement en une seule commande, ajoutez un script `deploy-deno` dans `package.json`.
+4. (Optionnel) Pour simplifier la compilation et le déploiement en une seule commande, ajoutez un script `deploy-deno` dans `package.json`.
 
     <StaticSsrTabs>
       <Fragment slot="static">
@@ -342,7 +342,7 @@ Si votre projet est stocké sur GitHub, le [site Deno Deploy](https://dash.deno.
       </Fragment>
     </StaticSsrTabs>
 
-    Vous pouvez alors utiliser cette commande pour construire et déployer votre site Astro en une seule étape.
+    Vous pouvez alors utiliser cette commande pour compiler et déployer votre site Astro en une seule étape.
 
     ```bash
     npm run deno-deploy

--- a/src/content/docs/fr/guides/deploy/edgio.mdx
+++ b/src/content/docs/fr/guides/deploy/edgio.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Edgio
+title: Déployer votre site Astro sur Edgio
 description: Comment déployer votre site Astro sur le web en utilisant Edgio.
 sidebar:
   label: Edgio
@@ -11,13 +11,13 @@ import { Steps } from '@astrojs/starlight/components';
 Vous pouvez déployer votre projet Astro sur [Edgio](https://www.edg.io/), une plateforme de services et de CDN pour déployer, protéger et accélérer les sites web et les API.
 
 :::tip
-Consultez [le guide Astro dans les documents d'Edgio](https://docs.edg.io/guides/astro) !
+Consultez [le guide Astro dans la documentation d'Edgio](https://docs.edg.io/guides/astro) !
 :::
 
 ## Comment déployer
 
 <Steps>
-1. Installez [le CLI Edgio](https://docs.edg.io/guides/cli) globalement depuis le Terminal, si ce n'est pas déjà fait.
+1. Installez [la CLI d'Edgio](https://docs.edg.io/guides/cli) globalement depuis le Terminal, si ce n'est pas déjà fait.
 
     ```bash
     npm install -g @edgio/cli
@@ -29,7 +29,7 @@ Consultez [le guide Astro dans les documents d'Edgio](https://docs.edg.io/guides
     edgio init
     ```
 
-3. (Optionnel) Activer le rendu côté serveur
+3. (Optionnel) Activez le rendu côté serveur
 
     Après avoir configuré [@astrojs/node with Astro](/fr/guides/integrations-guide/node/), spécifiez le chemin du fichier serveur dans `edgio.config.js` comme ci-dessous :
 
@@ -46,7 +46,7 @@ Consultez [le guide Astro dans les documents d'Edgio](https://docs.edg.io/guides
     };
     ```
 
-4. Déployer vers Edgio
+4. Déployez vers Edgio
 
     ```bash
     edgio deploy

--- a/src/content/docs/fr/guides/deploy/fleek.mdx
+++ b/src/content/docs/fr/guides/deploy/fleek.mdx
@@ -20,7 +20,7 @@ Votre projet Astro peut être déployé sur Fleek en tant que site statique.
 
 ## Comment déployer
 
-Vous pouvez déployer vers Fleek via l’interface utilisateur du site web ou en utilisant le CLI (interface en ligne de commande) de Fleek.
+Vous pouvez déployer vers Fleek via l’interface utilisateur du site web ou en utilisant la CLI (interface en ligne de commande) de Fleek.
 
 ### Déploiement de l'interface utilisateur de la plateforme
 
@@ -40,7 +40,7 @@ Vous pouvez déployer vers Fleek via l’interface utilisateur du site web ou en
 ### CLI de Fleek
 
 <Steps>
-1. Installez le CLI de Fleek.
+1. Installez la CLI de Fleek.
 
     ```bash
     # Vous devez utiliser Nodejs >= 18.18.2
@@ -76,5 +76,5 @@ Vous pouvez déployer vers Fleek via l’interface utilisateur du site web ou en
 
 ## En savoir plus
 
-<ReadMore>[Déployer votre site depuis l'interface utilisateur Fleek](https://fleek.xyz/docs/platform/deployments/)</ReadMore>
-<ReadMore>[Déployer votre site depuis Fleek CLI](https://fleek.xyz/docs/cli/hosting/)</ReadMore>
+<ReadMore>[Déployer votre site depuis l'interface utilisateur de Fleek](https://fleek.xyz/docs/platform/deployments/)</ReadMore>
+<ReadMore>[Déployer votre site depuis la CLI de Fleek](https://fleek.xyz/docs/cli/hosting/)</ReadMore>

--- a/src/content/docs/fr/guides/deploy/flightcontrol.mdx
+++ b/src/content/docs/fr/guides/deploy/flightcontrol.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur AWS avec Flightcontrol
+title: Déployer votre site Astro sur AWS avec Flightcontrol
 description: Comment déployer votre site Astro sur AWS avec Flightcontrol
 sidebar:
   label: Flightcontrol
@@ -19,17 +19,17 @@ Prend en charge les sites Astro statiques et SSR.
 
 2. Allez sur [app.flightcontrol.dev/projects/new/1](https://app.flightcontrol.dev/projects/new/1)
 
-3. Connectez votre compte GitHub et sélectionnez votre repo
+3. Connectez votre compte GitHub et sélectionnez votre dépôt
 
-4. Sélectionnez votre "Config Type" :
-    - `GUI` (toute la configuration est gérée par le tableau de bord de flightcontrol) où vous sélectionnerez le preset `Astro Static` ou `Astro SSR`.
-    - `flightcontrol.json` (option "infrastructure as code" où toute la configuration est dans votre repo) où vous sélectionnerez un exemple de configuration Astro, puis l'ajouterez à votre base de code en tant que `flightcontrol.json`.
+4. Sélectionnez le type de configuration (« Config Type ») souhaité :
+    - `GUI` (toute la configuration est gérée par le tableau de bord de flightcontrol) où vous sélectionnerez le préréglage `Astro Static` ou `Astro SSR`.
+    - `flightcontrol.json` (option « infrastructure as code » où toute la configuration est dans votre dépôt) où vous sélectionnerez un exemple de configuration Astro, puis l'ajouterez à votre base de code en tant que `flightcontrol.json`.
 
 5. Ajustez la configuration si nécessaire
 
-6. Cliquez sur "Create Project" et complétez toutes les étapes requises (comme lier votre compte AWS).
+6. Cliquez sur « Create Project » et complétez toutes les étapes requises (comme lier votre compte AWS).
 </Steps>
 
 ### Configuration du SSR
 
-Pour déployer avec le support SSR, assurez-vous d'abord de configurer l'adaptateur [`@astrojs/node`](/fr/guides/integrations-guide/node/). Ensuite, suivez les étapes ci-dessus, en choisissant les configurations appropriées pour Astro SSR.
+Pour déployer avec la prise en charge du SSR, assurez-vous d'abord de configurer l'adaptateur [`@astrojs/node`](/fr/guides/integrations-guide/node/). Ensuite, suivez les étapes ci-dessus, en choisissant les configurations appropriées pour Astro SSR.

--- a/src/content/docs/fr/guides/deploy/flyio.mdx
+++ b/src/content/docs/fr/guides/deploy/flyio.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Fly.io
+title: Déployer votre site Astro sur Fly.io
 description: Comment déployer votre site Astro sur le web en utilisant Fly.io.
 sidebar:
   label: Fly.io
@@ -26,7 +26,7 @@ Pour activer le rendu à la demande dans votre projet Astro et déployer sur Fly
 ## Comment déployer
 
 <Steps>
-1. [S'inscrire à Fly.io](https://fly.io/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) si ce n'est pas déjà fait.
+1. [Inscrivez-vous sur Fly.io](https://fly.io/docs/getting-started/log-in-to-fly/#first-time-or-no-fly-account-sign-up-for-fly) si ce n'est pas déjà fait.
 
 2. [Installez `flyctl`](https://fly.io/docs/hands-on/install-flyctl/), le centre de commande de votre application Fly.io.
 
@@ -36,10 +36,10 @@ Pour activer le rendu à la demande dans votre projet Astro et déployer sur Fly
     fly launch
     ```
 
-    `flyctl` détectera automatiquement Astro, configurera les paramètres corrects, construira votre image et la déploiera sur la plateforme Fly.io.
+    `flyctl` détectera automatiquement Astro, configurera les paramètres corrects, compilera votre image et la déploiera sur la plateforme Fly.io.
 </Steps>
 
-## Générer votre fichier Astro Dockerfile
+## Générer votre fichier Dockerfile pour Astro
 
 Si vous n'avez pas encore de Dockerfile, `fly launch` va en générer un pour vous, ainsi que préparer un fichier `fly.toml`. Pour les pages rendues à la demande, ce Dockerfile inclura la commande de démarrage appropriée et les variables d'environnement.
 

--- a/src/content/docs/fr/guides/deploy/github.mdx
+++ b/src/content/docs/fr/guides/deploy/github.mdx
@@ -1,6 +1,6 @@
 ---
 title: Déployer votre site Astro sur GitHub Pages
-description: Comment déployer votre site Astro sur le Web à l'aide des GitHub Pages.
+description: Comment déployer votre site Astro sur le Web à l'aide de GitHub Pages.
 sidebar:
   label: GitHub Pages
 type: deploy
@@ -12,11 +12,11 @@ Vous pouvez utiliser [GitHub Pages](https://pages.github.com/) pour héberger un
 
 ## Comment déployer
 
-Vous pouvez déployer un site Astro sur les GitHub Pages en utilisant une [GitHub Actions](https://github.com/features/actions) pour construire (Build) et déployer automatiquement votre site. Pour ce faire, votre code source doit être hébergé sur GitHub.
+Vous pouvez déployer un site Astro sur GitHub Pages en utilisant [GitHub Actions](https://github.com/features/actions) pour compiler et déployer automatiquement votre site. Pour ce faire, votre code source doit être hébergé sur GitHub.
 
-Astro maintient l'action officielle `withastro/action` pour déployer vos projets avec très peu de configuration. Suivez les instructions ci-dessous pour déployer votre site Astro sur GitHub Pages, et consultez [le README du GitHub Action Astro](https://github.com/withastro/action) pour plus d'informations.
+Astro maintient l'action officielle `withastro/action` pour déployer vos projets avec très peu de configuration. Suivez les instructions ci-dessous pour déployer votre site Astro sur GitHub Pages, et consultez [le fichier README du paquet](https://github.com/withastro/action) pour plus d'informations.
 
-## Configurer Astro pour les pages GitHub
+## Configurer Astro pour GitHub Pages
 
 ### Déployer vers une URL `github.io`
 
@@ -27,7 +27,7 @@ import { defineConfig } from 'astro/config'
 
 export default defineConfig({
   site: 'https://astronaut.github.io',
-  base: 'my-repo',
+  base: 'mon-depot',
 })
 ```
 
@@ -35,18 +35,18 @@ export default defineConfig({
 
 La valeur de `site` doit être l'une des suivantes :
 
-- L'URL suivante en fonction de votre nom d'utilisateur : `https://<username>.github.io`
-- L'URL aléatoire autogénérée pour une [page privée de l'organisation GitHub](https://docs.github.com/en/enterprise-cloud@latest/pages/getting-started-with-github-pages/changing-the-visibility-of-your-github-pages-site) : `https://<random-string>.pages.github.io/`
+- L'URL suivante en fonction de votre nom d'utilisateur : `https://<nom-utilisateur>.github.io`
+- L'URL aléatoire autogénérée pour une [page privée d'une organisation GitHub](https://docs.github.com/fr/enterprise-cloud@latest/pages/getting-started-with-github-pages/changing-the-visibility-of-your-github-pages-site) : `https://<chaine-aleatoire>.pages.github.io/`
 
 #### `base`
 
-Une valeur pour `base` peut être requise pour qu'Astro considère le nom de votre dépôt (par exemple `/my-repo`) comme la racine de votre site web.
+Une valeur pour `base` peut être requise pour qu'Astro considère le nom de votre dépôt (par exemple `/mon-depot`) comme la racine de votre site web.
 
 :::note
   Ne mettez pas de paramètre `base` si :
 
 - Votre page est servie depuis le dossier racine.
-- Votre référentiel est situé à `https://github.com/<USERNAME>/<USERNAME>.github.io`.
+- Votre dépôt est situé à l'adresse `https://github.com/<NOM-UTILISATEUR>/<NOM-UTILISATEUR>.github.io`.
 :::
 
 La valeur de `base` doit être le nom de votre dépôt commençant par un slash, par exemple `/mon-blog`. Ceci afin qu'Astro comprenne que la racine de votre site web est `/mon-repo`, plutôt que le `/` par défaut.
@@ -54,14 +54,14 @@ La valeur de `base` doit être le nom de votre dépôt commençant par un slash,
 :::caution
     Lorsque cette valeur est configurée, tous les liens internes de votre page doivent être préfixés par votre valeur `base` :
 
-```astro ins="/my-repo"
-<a href="/my-repo/about">About</a>
+```astro ins="/mon-depot"
+<a href="/mon-depot/a-propos">À propos</a>
 ```
 
-En savoir plus sur [configurer une valeur `base`](/fr/reference/configuration-reference/#base)
+En savoir plus sur la [configuration d'une valeur pour `base`](/fr/reference/configuration-reference/#base)
 :::
 
-### Utiliser les pages GitHub avec un domaine personnalisé
+### Utiliser GitHub Pages avec un domaine personnalisé
 
 :::tip[Configurer un domaine personnalisé]
 Vous pouvez mettre en place un domaine personnalisé en ajoutant le fichier `./public/CNAME` suivant à votre projet :
@@ -70,10 +70,10 @@ Vous pouvez mettre en place un domaine personnalisé en ajoutant le fichier `./p
 sub.mydomain.com
 ```
 
-Ceci déploiera votre site sur votre domaine personnalisé au lieu de `user.github.io`. N'oubliez pas de [configurer les DNS pour votre fournisseur de domaine](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
+Ceci déploiera votre site sur votre domaine personnalisé au lieu de `utilisateur.github.io`. N'oubliez pas de [configurer les DNS pour votre fournisseur de domaine](https://docs.github.com/fr/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain).   
 :::
 
-Pour configurer Astro afin d'utiliser les pages GitHub avec un domaine personnalisé, définissez votre domaine comme valeur pour `site`. Ne définissez pas de valeur pour `base` :
+Pour configurer Astro afin d'utiliser GitHub Pages avec un domaine personnalisé, définissez votre domaine comme valeur pour `site`. Ne définissez pas de valeur pour `base` :
 
 ```js title="astro.config.mjs" ins={4}
 import { defineConfig } from 'astro/config'
@@ -89,7 +89,7 @@ export default defineConfig({
 1. Créez un nouveau fichier dans votre projet à `.github/workflows/deploy.yml` et collez le YAML ci-dessous.
 
     ```yaml title="deploy.yml"
-    name: Deploy to GitHub Pages
+    name: Déployer sur GitHub Pages
 
     on:
       # Déclenchez le workflow chaque fois que vous poussez vers la branche `main`
@@ -109,14 +109,14 @@ export default defineConfig({
       build:
         runs-on: ubuntu-latest
         steps:
-          - name: Checkout your repository using git
+          - name: Extraire votre dépôt à l'aide de git
             uses: actions/checkout@v4          
-          - name: Install, build, and upload your site
+          - name: Installer, compiler et télécharger votre site
             uses: withastro/action@v3
             with:
                 # path: . # L'emplacement racine de votre projet Astro dans le dépôt. (facultatif)
-                # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (facultatif)
-                # package-manager: yarn # Le gestionnaire de paquets Node qui doit être utilisé pour installer les dépendances et build votre site. Détecté automatiquement en fonction de votre lockfile. (facultatif)
+                # node-version: 20 # Version spécifique de Node à utiliser pour compiler votre site. La valeur par défaut est 20. (facultatif)
+                # package-manager: yarn # Le gestionnaire de paquets Node qui doit être utilisé pour installer les dépendances et compiler votre site. Détecté automatiquement en fonction de votre lockfile. (facultatif)
 
       deploy:
         needs: build
@@ -125,17 +125,17 @@ export default defineConfig({
           name: github-pages
           url: ${{ steps.deployment.outputs.page_url }}
         steps:
-          - name: Deploy to GitHub Pages
+          - name: Déployer sur GitHub Pages
             id: deployment
             uses: actions/deploy-pages@v4
     ```
 
     :::note
-    L'action astro prend quelques entrées optionnelles. Celles-ci peuvent être fournies en décommentant la ligne `with:` et l'entrée que vous voulez utiliser.
+    L'action Astro prend quelques entrées optionnelles. Celles-ci peuvent être fournies en décommentant la ligne `with:` et l'entrée que vous voulez utiliser.
     :::
 
     :::caution
-   La [GitHub Action](https://github.com/withastro/action) officielle Astro recherche un lockfile pour détecter votre gestionnaire de paquets préféré (`npm`, `yarn`, `pnpm`, ou `bun`). Vous devez commit le fichier `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, ou `bun.lockb` généré automatiquement par votre gestionnaire de paquets dans votre référentiel.
+   L'[Action](https://github.com/withastro/action) officielle d'Astro recherche un lockfile pour détecter votre gestionnaire de paquets préféré (`npm`, `yarn`, `pnpm`, ou `bun`). Vous devez envoyer le fichier `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, ou `bun.lockb` généré automatiquement par votre gestionnaire de paquets dans votre dépôt.
     :::
 
 2. Sur GitHub, allez dans l'onglet **Settings** (Paramètres) de votre dépôt et trouvez la section **Pages** des paramètres.  

--- a/src/content/docs/fr/guides/deploy/gitlab.mdx
+++ b/src/content/docs/fr/guides/deploy/gitlab.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur GitLab Pages
+title: Déployer votre site Astro sur GitLab Pages
 description: Comment déployer votre site Astro sur le web en utilisant GitLab Pages.
 sidebar:
   label: GitLab Pages
@@ -11,12 +11,12 @@ import { Steps } from '@astrojs/starlight/components';
 Vous pouvez utiliser [GitLab Pages](https://docs.gitlab.com/ee/user/project/pages/) pour héberger un site Astro pour vos projets, vos groupes ou votre compte utilisateur [GitLab](https://about.gitlab.com/).
 
 :::tip[Vous cherchez un exemple ?]
-Consultez [le projet d'exemple officiel GitLab Pages Astro](https://gitlab.com/pages/astro) !
+Consultez [l'exemple de projet officiel GitLab Pages avec Astro](https://gitlab.com/pages/astro) !
 :::
 
 ## Comment déployer
 
-Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD pour créer et déployer automatiquement votre site. Pour ce faire, votre code source doit être hébergé sur GitLab et vous devez apporter les modifications suivantes à votre projet Astro :
+Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD pour compiler et déployer automatiquement votre site. Pour ce faire, votre code source doit être hébergé sur GitLab et vous devez apporter les modifications suivantes à votre projet Astro :
 
 <Steps>
 
@@ -26,8 +26,8 @@ Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD p
     import { defineConfig } from 'astro/config';
 
     export default defineConfig({
-      site: 'https://<username>.gitlab.io',
-      base: '/<my-repo>',
+      site: 'https://<nom-utilisateur>.gitlab.io',
+      base: '/<mon-depot>',
       outDir: 'public',
       publicDir: 'static',
     });
@@ -37,27 +37,27 @@ Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD p
 
     La valeur de `site` doit être l'une des valeurs suivantes :
 
-    - L'URL suivante basée sur votre nom d'utilisateur : `https://<username>.gitlab.io`
-    - L'URL suivante basée sur le nom de votre groupe : `https://<groupname>.gitlab.io`
+    - L'URL suivante basée sur votre nom d'utilisateur : `https://<nom-utilisateur>.gitlab.io`
+    - L'URL suivante basée sur le nom de votre groupe : `https://<nom-du-groupe>.gitlab.io`
     - Votre nom de domaine personnalisé si vous l'avez configuré dans les paramètres de votre projet Gitlab : `https://example.com`
 
     Pour les instances autogérées GitLab, remplacez `gitlab.io` par le domaine Pages de votre instance.
 
     `base`
 
-    Une valeur pour `base` peut être requise pour qu'Astro traite le nom de votre dépôt (par exemple `/my-repo`) comme racine de votre site web.
+    Une valeur pour `base` peut être requise pour qu'Astro traite le nom de votre dépôt (par exemple `/mon-depot`) comme racine de votre site web.
 
     :::note
       Ne définissez pas de paramètre `base` si votre page est servie à partir du dossier racine.
     :::
 
-    La valeur de `base` doit être le nom de votre dépôt commençant par une barre oblique, par exemple `/my-blog`. Cela permet à Astro de comprendre que la racine de votre site Web est `/my-repo`, plutôt que le `/` par défaut.
+    La valeur de `base` doit être le nom de votre dépôt commençant par une barre oblique, par exemple `/my-blog`. Cela permet à Astro de comprendre que la racine de votre site Web est `/mon-depot`, plutôt que le `/` par défaut.
 
     :::caution
         Lorsque cette valeur est configurée, tous vos liens de page internes doivent être préfixés par la valeur que vous avez définie dans `base` :
 
-      ```astro ins="/my-repo"
-      <a href="/my-repo/about">About</a>
+      ```astro ins="/mon-depot"
+      <a href="/mon-depot/a-propos">À propos</a>
       ```
 
     En savoir plus sur [la configuration d'une valeur pour `base`](/fr/reference/configuration-reference/#base)
@@ -66,7 +66,7 @@ Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD p
 
 2. Renommez le répertoire `public/` en `static/`.
 
-3. Mettez `outDir: 'public'` dans `astro.config.mjs`. Ce paramètre indique à Astro de placer la sortie statique de la compilation dans un dossier appelé `public`, qui est le dossier requis par GitLab Pages pour les fichiers exposés.
+3. Définissez `outDir: 'public'` dans `astro.config.mjs`. Ce paramètre indique à Astro de placer la sortie statique de la compilation dans un dossier appelé `public`, qui est le dossier requis par GitLab Pages pour les fichiers exposés.
 
     Si vous utilisiez le répertoire [`public/`](/fr/basics/project-structure/#public) comme source de fichiers statiques dans votre projet Astro, renommez-le et utilisez ce nouveau nom de dossier dans `astro.config.mjs` pour la valeur de `publicDir`.
 
@@ -81,7 +81,7 @@ Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD p
     });
     ```
 
-4. Modifiez la sortie de construction dans `.gitignore`. Dans notre exemple, nous devons remplacer `dist/` par `public/` :
+4. Modifiez la sortie de compilation dans `.gitignore`. Dans notre exemple, nous devons remplacer `dist/` par `public/` :
 
     ```diff  title=".gitignore"
     # build output
@@ -89,35 +89,35 @@ Vous pouvez déployer un site Astro sur GitLab Pages en utilisant GitLab CI/CD p
     +public/
     ```
 
-5. Créez un fichier appelé `.gitlab-ci.yml` à la racine de votre projet avec le contenu ci-dessous. Cela permettra de construire et de déployer votre site à chaque fois que vous apporterez des modifications à votre contenu :
+5. Créez un fichier appelé `.gitlab-ci.yml` à la racine de votre projet avec le contenu ci-dessous. Cela permettra de compiler et de déployer votre site à chaque fois que vous apporterez des modifications à votre contenu :
 
    ```yaml
    pages:
-     # L'image Docker qui sera utilisée pour construire votre application
+     # L'image Docker qui sera utilisée pour compiler votre application
      image: node:lts
 
      before_script:
        - npm ci
 
      script:
-       # Précisez ici les étapes de la construction de votre application
+       # Précisez ici les étapes de la compilation de votre application
        - npm run build
 
      artifacts:
        paths:
-         # Le dossier qui contient les fichiers construits à publier.
-         # Il doit être appelé "public".
+         # Le dossier qui contient les fichiers compilés à publier.
+         # Il doit être appelé « public ».
          - public
 
      only:
-       # Déclencher un nouveau build et déployer uniquement lorsqu'il y a un push sur
-       # la(les) branche(s) ci-dessous
+       # Déclencher une nouvelle compilation et déployer uniquement lorsqu'il y
+       # a un push sur la(les) branche(s) ci-dessous
        - main
    ```
 
 6. Validez vos modifications et transférez-les vers GitLab.
 
-7. Sur Gitlab, accédez au menu **Déployer** de votre dépôt et sélectionnez **Pages**. Ici, vous verrez l'URL complète de votre site GitLab Pages. Pour vous assurer que vous utilisez le format d'URL `https://username.gitlab.io/my-repo`, décochez le paramètre **Utiliser un domaine unique** sur cette page.
+7. Sur Gitlab, accédez au menu **Déployer** de votre dépôt et sélectionnez **Pages**. Ici, vous verrez l'URL complète de votre site GitLab Pages. Pour vous assurer que vous utilisez le format d'URL `https://nom-utilisateur.gitlab.io/mon-depot`, décochez le paramètre **Utiliser un domaine unique** sur cette page.
 
 </Steps>
 

--- a/src/content/docs/fr/guides/deploy/google-cloud.mdx
+++ b/src/content/docs/fr/guides/deploy/google-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Google Cloud
+title: Déployer votre site Astro sur Google Cloud
 description: Comment déployer votre site Astro sur le web en utilisant Google Cloud.
 sidebar:
   label: Google Cloud
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 ### Cloud Storage (statique uniquement)
 
 <Steps>
-1. [Créer un nouveau projet GCP](https://console.cloud.google.com/projectcreate), ou sélectionnez un projet existant.
+1. [Créez un nouveau projet GCP](https://console.cloud.google.com/projectcreate), ou sélectionnez un projet existant.
 
 2. Créez un nouveau bucket sous [Cloud Storage](https://cloud.google.com/storage).
 
@@ -35,25 +35,25 @@ Cloud Run est une plateforme sans serveur qui vous permet d'exécuter un contene
 #### Préparer le service
 
 <Steps>
-1. [Créer un nouveau projet GCP](https://console.cloud.google.com/projectcreate), ou sélectionnez un projet existant.
+1. [Créez un nouveau projet GCP](https://console.cloud.google.com/projectcreate), ou sélectionnez un projet existant.
 
-2. Assurez-vous que [Cloud Run API](https://console.cloud.google.com/apis/library/run.googleapis.com) est activé.
+2. Assurez-vous que l'[API Cloud Run](https://console.cloud.google.com/apis/library/run.googleapis.com) est activée.
 
 3. Créez un nouveau service.
 </Steps>
 
-#### Créer un fichier Dockerfile et composer le Container
+#### Créer un fichier Dockerfile et créer le conteneur
 
-Avant de pouvoir déployer votre site Astro sur Cloud Run, vous devez créer un Dockerfile qui sera utilisé pour composer le Container. Vous trouverez plus d'informations sur [comment utiliser Docker avec Astro](/fr/recipes/docker/#création-dun-dockerfile) dans notre section des méthodes.
+Avant de pouvoir déployer votre site Astro sur Cloud Run, vous devez créer un fichier Dockerfile qui sera utilisé pour créer le conteneur. Vous trouverez plus d'informations sur [comment utiliser Docker avec Astro](/fr/recipes/docker/#création-dun-dockerfile) dans notre section des recettes.
 
-Une fois le fichier Docker créé, créez une image et envoyez-la sur Google Cloud. Il existe plusieurs façons d'y parvenir :
+Une fois le fichier Docker créé, utilisez le pour créer une image et envoyez-la sur Google Cloud. Il existe plusieurs façons d'y parvenir :
 
-**Composer localement en utilisant Docker** :
+**Créer localement en utilisant Docker** :
 
-Utilisez la commande `docker build` pour composer l'image, `docker tag` pour lui donner un tag, puis `docker push` pour la pousser vers un registre. Dans le cas de Google Cloud, [`Artifact Registry`](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling) est l'option la plus facile, mais vous pouvez aussi utiliser [Docker Hub](https://hub.docker.com/).
+Utilisez la commande `docker build` pour créer l'image, `docker tag` pour lui donner une étiquette, puis `docker push` pour l'envoyer vers un registre. Dans le cas de Google Cloud, [`Artifact Registry`](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling) est l'option la plus facile, mais vous pouvez aussi utiliser [Docker Hub](https://hub.docker.com/).
 
 ```bash
-# composez votre conteneur
+# créer votre conteneur
 docker build .
 
 docker tag SOURCE_IMAGE HOSTNAME/PROJECT-ID/TARGET-IMAGE:TAG
@@ -66,19 +66,19 @@ Modifiez les valeurs suivantes dans les commandes ci-dessus pour qu'elles corres
 
 - `SOURCE_IMAGE` : le nom ou l'ID de l'image locale.
 - `HOSTNAME` : l'hôte du registre (`gcr.io`, `eu.gcr.io`, `asia.gcr.io`, `us.gcr.io`, `docker.io`).
-- `PROJECT` : votre ID de projet Google Cloud.
+- `PROJECT` : l'ID de votre projet Google Cloud.
 - `TARGET-IMAGE` : le nom de l'image lorsqu'elle est stockée dans le registre.
 - `TAG` est la version associée à l'image.
 
-[Pour plus d'informations, consultez la documentation Google Cloud](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling)
+[Pour plus d'informations, consultez la documentation de Google Cloud](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling)
 
 **Utiliser un autre outil** :
 
 Vous pouvez utiliser un outil CI/CD qui prend en charge Docker, comme [GitHub Actions](https://github.com/marketplace/actions/push-to-gcr-github-action).
 
-**Construction à l'aide de [Cloud Build](https://cloud.google.com/build)** :
+**Créer à l'aide de [Cloud Build](https://cloud.google.com/build)** :
 
-Au lieu de composer le fichier Docker localement, vous pouvez demander à Google Cloud de composer l'image à distance. Voir la [documentation Google Cloud Build ici](https://cloud.google.com/build/docs/build-push-docker-image).
+Au lieu de créer le fichier Dockerfile localement, vous pouvez demander à Google Cloud de créer l'image à distance. Voir la [documentation Google Cloud Build ici](https://cloud.google.com/build/docs/build-push-docker-image).
 
 #### Déployer le conteneur
 

--- a/src/content/docs/fr/guides/deploy/google-firebase.mdx
+++ b/src/content/docs/fr/guides/deploy/google-firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur l'hébergement Firebase de Google
+title: Déployer votre site Astro sur l'hébergement Firebase de Google
 description: Comment déployer votre site Astro sur le web en utilisant l'hébergement Firebase de Google.
 sidebar:
   label: Google Firebase
@@ -32,7 +32,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
 ## Comment déployer
 
 <Steps>
-1. Installez le [Firebase CLI](https://github.com/firebase/firebase-tools). Il s'agit d'un outil de ligne de commande qui vous permet d'interagir avec Firebase à partir du terminal.
+1. Installez la [CLI de Firebase](https://github.com/firebase/firebase-tools). Il s'agit d'un outil en ligne de commande qui vous permet d'interagir avec Firebase à partir du terminal.
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -52,7 +52,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
       </Fragment>
     </PackageManagerTabs>
 
-2. Authentifiez le CLI Firebase avec votre compte Google. Cela ouvrira une fenêtre de navigateur dans laquelle vous pourrez vous connecter à votre compte Google.
+2. Authentifiez la CLI de Firebase avec votre compte Google. Cela ouvrira une fenêtre de navigateur dans laquelle vous pourrez vous connecter à votre compte Google.
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -72,7 +72,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
       </Fragment>
     </PackageManagerTabs>
 
-3. Activer le support expérimental des frameworks web. Il s'agit d'une fonctionnalité expérimentale qui permet au CLI Firebase de détecter et de configurer vos paramètres de déploiement pour Astro.
+3. Activez la prise en charge expérimentale des frameworks web. Il s'agit d'une fonctionnalité expérimentale qui permet à la CLI de Firebase de détecter et de configurer vos paramètres de déploiement pour Astro.
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -92,7 +92,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
       </Fragment>
     </PackageManagerTabs>
 
-4. Initialiser Firebase Hosting dans votre projet. Cela créera un fichier `firebase.json` et `.firebaserc` à la racine de votre projet.
+4. Initialisez Firebase Hosting dans votre projet. Cela créera un fichier `firebase.json` et `.firebaserc` à la racine de votre projet.
 
     <PackageManagerTabs>
       <Fragment slot="npm">
@@ -112,7 +112,7 @@ Le déploiement d'un site Astro SSR sur Firebase nécessite le [plan Blaze](http
       </Fragment>
     </PackageManagerTabs>
 
-5. Déployez votre site sur Firebase Hosting. Cela va construire votre site Astro et le déployer sur Firebase.
+5. Déployez votre site sur Firebase Hosting. Cela va compiler votre site Astro et le déployer sur Firebase.
 
     <PackageManagerTabs>
       <Fragment slot="npm">

--- a/src/content/docs/fr/guides/deploy/heroku.mdx
+++ b/src/content/docs/fr/guides/deploy/heroku.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur Heroku
+title: Déployer votre site Astro sur Heroku
 description: Comment déployer votre site Astro sur le web en utilisant Heroku.
 sidebar:
   label: Heroku
@@ -17,7 +17,7 @@ Les instructions suivantes utilisent [l'ancien `heroku-static-buildpack`](https:
 ## Comment déployer
 
 <Steps>
-1. Installez [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
+1. Installez [la CLI de Heroku](https://devcenter.heroku.com/articles/heroku-cli).
 
 2. Créez un compte Heroku en vous [inscrivant](https://signup.heroku.com/).
 
@@ -37,7 +37,7 @@ Les instructions suivantes utilisent [l'ancien `heroku-static-buildpack`](https:
 
     C'est la configuration de votre site ; lisez-en plus sur [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static).
 
-5. Configurez votre Heroku git remote :
+5. Configurez votre dépôt Git distant Heroku :
 
     ```bash
     # changement de version
@@ -55,7 +55,7 @@ Les instructions suivantes utilisent [l'ancien `heroku-static-buildpack`](https:
 6. Déployez votre site :
 
     ```bash
-    # publish site
+    # publier le site
     $ git push heroku master
 
     # ouvre un navigateur pour voir la version Dashboard de Heroku CI

--- a/src/content/docs/fr/guides/deploy/index.mdx
+++ b/src/content/docs/fr/guides/deploy/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: Déployer votre Site Astro
+title: Déployer votre site Astro
 description: Comment déployer votre site Astro sur le web.
 sidebar:
-  label: Aperçu des déploiements
+  label: Vue d'ensemble du déploiement
 i18nReady: true
 ---
 
@@ -10,7 +10,7 @@ import DeployGuidesNav from '~/components/DeployGuidesNav.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import { Steps } from '@astrojs/starlight/components'
 
-**Prêt à construire et déployer votre site Astro ?** Suivez un de nos guides sur différents services de déploiement, ou scrollez plus bas pour avoir des orientations générales sur comment déployer un site Astro.
+**Prêt à compiler et déployer votre site Astro ?** Suivez l'un de nos guides sur les différents services de déploiement, ou faites défiler vers le bas pour avoir des conseils généraux sur comment le déploiement d'un site Astro.
 
 ## Guide de déploiement
 
@@ -18,34 +18,34 @@ import { Steps } from '@astrojs/starlight/components'
 
 ## Options de déploiement rapide
 
-Vous pouvez construire et déployer rapidement un site Astro vers de nombreux hébergeurs, via l'interface de leur site internet ou une CLI.
+Vous pouvez compiler et déployer rapidement un site Astro vers de nombreux hébergeurs à l'aide de l'interface utilisateur du tableau de bord de leur site web ou d'une CLI.
 
-### Interface d'un hébergeur
+### Interface utilisateur du site web
 
-Une façon rapide de déployer votre site internet est de connecter le dépôt Git (ex. GitHub, GitLab, Bitbucket) de votre projet Astro à un hébergeur, afin de profiter du déploiement continu en utilisant Git.
+Une façon rapide de déployer votre site web est de connecter le dépôt Git (p. ex. GitHub, GitLab, Bitbucket) de votre projet Astro à un hébergeur, afin de profiter du déploiement continu en utilisant Git.
 
-Ces hébergeurs détectent automatiquement les push sur le dépôt de votre projet Astro, build votre site et le déploient sur le web sur une URL personnalisée ou sur votre nom de domaine personnel. La plupart du temps, mettre en place le déploiement sur ces plateformes suivra les étapes suivantes :
+Ces hébergeurs détectent automatiquement les push sur le dépôt de votre projet Astro, compilent votre site et le déploient sur le web sur une URL personnalisée ou sur votre nom de domaine personnel. Souvent, la configuration d’un déploiement sur ces plateformes suivra des étapes similaires à celles-ci :
 
 <Steps>
-1. Ajoutez votre dépôt à un provider Git (ex. sur GitHub, GitLab, Bitbucket)
+1. Ajoutez votre dépôt à un provider Git (p. ex. sur GitHub, GitLab, Bitbucket)
 
-2. Choisissez un hébergeur qui supporte le *déploiement continu* (ex. [Netlify](/fr/guides/deploy/netlify/) ou [Vercel](/fr/guides/deploy/vercel/)) et importez votre dépôt Git en tant que nouveau projet / site.
+2. Choisissez un hébergeur qui supporte le *déploiement continu* (p. ex. [Netlify](/fr/guides/deploy/netlify/) ou [Vercel](/fr/guides/deploy/vercel/)) et importez votre dépôt Git en tant que nouveau projet / site.
 
-    De nombreux hébergeurs vont reconnaître votre projet en tant que site Astro, et devraient automatiquement appliquer la configuration appropriée pour construire et déployer votre site comme montré ci-dessous. (Dans le cas contraire, ces paramètres peuvent être modifiés.)
+    De nombreux hébergeurs vont reconnaître votre projet en tant que site Astro, et devraient automatiquement appliquer la configuration appropriée pour compiler et déployer votre site comme montré ci-dessous. (Dans le cas contraire, ces paramètres peuvent être modifiés.)
 
     :::note[Paramètres de déploiement]
-    - **Commande de build:** `astro build` ou `npm run build`
-    - **Dossier de publication:** `dist`
+    - **Commande de compilation :** `astro build` ou `npm run build`
+    - **Dossier de publication :** `dist`
     :::
 
-3. Cliquez sur "Déployer" et votre nouveau site internet sera créé avec une URL unique (ex. `new-astro-site.netlify.app`).
+3. Cliquez sur « Déployer » et votre nouveau site web sera créé avec une URL unique (p. ex. `nouveau-site-astro.netlify.app`).
 </Steps>
 
-L'hébergeur va automatiquement inspecter votre branche main de votre dépôt, et dès que des changements seront détectés, va reconstruire et republier votre site. Ces paramètres peuvent typiquement être modifiés dans l'interface de votre hébergeur.
+L'hébergeur sera automatiquement configuré pour surveiller les modifications apportées à la branche principale de votre fournisseur Git, et pour recompiler et republier votre site à chaque nouveau commit. Ces paramètres peuvent généralement être configurés dans l'interface utilisateur du tableau de bord de votre hébergeur.
 
 ### Déploiement via une CLI
 
-Certains hébergeurs proposent leur propre interface de ligne de commande (CLI) que vous pouvez installer globalement sur votre machine en utilisant npm. Souvent, utiliser une CLI pour déployer ressemble à ceci :
+Certains hébergeurs proposent leur propre interface en ligne de commande (CLI) que vous pouvez installer globalement sur votre machine en utilisant npm. Souvent, utiliser une CLI pour déployer ressemble à ceci :
 
 <Steps>
 1. Installez globalement la CLI de votre hébergeur, par exemple :
@@ -70,26 +70,26 @@ Certains hébergeurs proposent leur propre interface de ligne de commande (CLI) 
 
 2. Exécutez la CLI et suivez les instructions de connexion, mise en place etc.
 
-3. Construisez votre site et déployez-le sur votre hébergeur
+3. Compilez votre site et déployez-le sur votre hébergeur
 
-    De nombreux hébergeurs vont reconnaître votre projet en tant que site Astro, et devraient automatiquement appliquer la configuration appropriée pour construire et déployer votre site comme montré ci-dessous. (Dans le cas contraire, ces paramètres peuvent être modifiés.)
+    De nombreux hébergeurs vont reconnaître votre projet en tant que site Astro, et devraient automatiquement appliquer la configuration appropriée pour compiler et déployer votre site comme montré ci-dessous. (Dans le cas contraire, ces paramètres peuvent être modifiés.)
 
     :::note[Paramètres de déploiement]
-    - **Commande de build:** `astro build` ou `npm run build`
-    - **Dossier de publication:** `dist`
+    - **Commande de build :** `astro build` ou `npm run build`
+    - **Dossier de publication :** `dist`
     :::
 
 
-    D'autres hébergeurs vont vous demander de [construire votre site localement](#construire-votre-site-localement) et déployer en utilisant la CLI.
+    D'autres hébergeurs vont vous demander de [compiler votre site localement](#compiler-votre-site-localement) et déployer en utilisant la CLI.
 </Steps>
 
-## Construire votre site localement
+## Compiler votre site localement
 
-De nombreux hébergeurs comme Netlify ou Vercel vont construire votre site pour vous puis le publier. Mais, certains sites vous demanderont de construire localement puis d'exécuter une commande de déploiement.
+De nombreux hébergeurs comme Netlify ou Vercel vont compiler votre site pour vous puis le publier. Mais, certains sites vous demanderont de compiler localement puis d'exécuter une commande de déploiement.
 
-Vous pouvez aussi vouloir construire votre site localement pour le prévisualiser, ou détecter des potentielles erreurs et avertissement dans votre propre environnement.
+Vous souhaiterez peut-être également compiler votre site localement pour le prévisualiser ou pour détecter d'éventuelles erreurs et avertissement dans votre propre environnement.
 
-Exécutez la commande `npm run build` pour construire votre site Astro.
+Exécutez la commande `npm run build` pour compiler votre site Astro.
 
 <PackageManagerTabs>
       <Fragment slot="npm">
@@ -109,13 +109,13 @@ Exécutez la commande `npm run build` pour construire votre site Astro.
       </Fragment>
   </PackageManagerTabs>
 
-Par défaut, le dossier de build sera placé à `dist/`. Ce dossier peut être changé en utilisant [l'option `outDir`](/fr/reference/configuration-reference/#outdir).
+Par défaut, la sortie de compilation sera placée dans `dist/`. Ce dossier peut être modifié en utilisant [l'option de configuration `outDir`](/fr/reference/configuration-reference/#outdir).
 
-## Ajouter un Adaptateur pour un rendu à la demande
+## Ajouter un adaptateur pour le rendu à la demande
 
 :::note
-Avant de déployer votre site Astro avec un [rendu à la demande](/fr/guides/on-demand-rendering/) activé, vérifiez que vous avez :
+Avant de déployer votre site Astro avec le [rendu à la demande](/fr/guides/on-demand-rendering/) activé, vérifiez que vous avez :
 
-- Installé [l'adaptateur approprié](/fr/guides/on-demand-rendering/) en tant que dépendance de votre projet (que ça soit manuellement, ou en utilisant la commande de l'adaptateur `astro add`, ex. `npx astro add netlify`).
+- Installé [l'adaptateur approprié](/fr/guides/on-demand-rendering/) en tant que dépendance de votre projet (que ça soit manuellement, ou en utilisant la commande de l'adaptateur `astro add`, p. ex. `npx astro add netlify`).
 - [Ajouté l'adaptateur](/fr/reference/configuration-reference/#integrations) à votre fichier `astro.config.mjs` si vous installez manuellement. (La commande `astro add` fera cette étape automatiquement !)
 :::

--- a/src/content/docs/fr/guides/deploy/kinsta.mdx
+++ b/src/content/docs/fr/guides/deploy/kinsta.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro vers l'hébergement d'applications Kinsta
+title: Déployer votre site Astro vers l'hébergement d'applications Kinsta
 description: Comment déployer votre site Astro sur le web avec Kinsta Application Hosting.
 sidebar:
   label: Kinsta
@@ -16,17 +16,17 @@ Vous pouvez utiliser [Kinsta Application Hosting](https://kinsta.com/application
 
 :::tip[Vous cherchez un exemple ?]
 Consultez [le projet officiel Kinsta Application Hosting Starter pour Astro](https://github.com/kinsta/hello-world-astro) !
-:: :
+:::
 
 Pour héberger votre projet sur **Kinsta Application Hosting**, vous devez :
 - Inclure un champ `name` dans votre `package.json`. (Cela peut être n'importe quoi, et n'affectera pas votre déploiement).
 - Inclure un script `build` dans votre `package.json`. (Votre projet Astro devrait déjà l'inclure).
-- Installez le paquet [`serve`](https://www.npmjs.com/package/serve) et définissez le script `start` comme `serve dist/`.
+- Installer le paquet [`serve`](https://www.npmjs.com/package/serve) et définir le script `start` sur `serve dist/`.
 
 Voici les lignes nécessaires dans votre fichier `package.json` :
 ```json title="package.json" {2,5,6} ins={12} "serv dist/"
 {
-  "name": "anything", // C'est obligatoire, mais sa valeur n'a pas d'importance.
+  "name": "ce-que-vous-voulez", // C'est obligatoire, mais sa valeur n'a pas d'importance.
   "scripts": {
     "dev": "astro dev",
     "start": "serve dist/",
@@ -45,18 +45,18 @@ Voici les lignes nécessaires dans votre fichier `package.json` :
 
 :::tip[Vous cherchez un exemple ?]
 Consultez [le projet officiel Kinsta Application Hosting Starter pour Astro SSR](https://github.com/kinsta/hello-world-astro-ssr) !
-:: :
+:::
 
 Pour héberger votre projet sur **Kinsta Application Hosting**, vous devez :
 - Inclure un champ `name` dans votre `package.json`. (Cela peut être n'importe quoi, et n'affectera pas votre déploiement).
 - Inclure un script `build` dans votre `package.json`. (Votre projet Astro devrait déjà l'inclure).
-- Installez le paquet [`@astrojs/node`](https://www.npmjs.com/package/@astrojs/node) et définissez le script `start` à `node ./dist/server/entry.mjs`.
-- Définissez `astro.config.mjs` pour utiliser `@astrojs/node` et pour utiliser `host : true`.
+- Installer le paquet [`@astrojs/node`](https://www.npmjs.com/package/@astrojs/node) et définir le script `start` sur `node ./dist/server/entry.mjs`.
+- Modifier `astro.config.mjs` pour utiliser `@astrojs/node` et pour utiliser `host: true`.
 
 Voici les lignes nécessaires dans votre fichier `package.json` :
 ```json title="package.json" {2,5,6} ins={12} "node ./dist/server/entry.mjs"
 {
-  "name": "anything", // C'est obligatoire, mais sa valeur n'a pas d'importance.
+  "name": "ce-que-vous-voulez", // C'est obligatoire, mais sa valeur n'a pas d'importance.
   "scripts": {
     "dev": "astro dev",
     "start": "node ./dist/server/entry.mjs",

--- a/src/content/docs/fr/guides/deploy/microsoft-azure.mdx
+++ b/src/content/docs/fr/guides/deploy/microsoft-azure.mdx
@@ -17,7 +17,7 @@ Ce guide vous explique comment déployer votre site Astro stocké dans GitHub à
 Pour suivre ce guide, vous aurez besoin de :
 
 - Un compte Azure et une clé d'abonnement. Vous pouvez créer un [compte Azure gratuit ici](https://azure.microsoft.com/free).
-- Le code de votre application poussé sur [GitHub](https://github.com/).
+- Le code de votre application transféré sur [GitHub](https://github.com/).
 - L'[extension SWA](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) dans [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Comment déployer
@@ -27,14 +27,14 @@ Pour suivre ce guide, vous aurez besoin de :
 
 2. Ouvrez l'extension Static Web Apps, connectez-vous à Azure et cliquez sur le bouton **+** pour créer une nouvelle Static Web App. Vous serez invité à désigner la clé d'abonnement à utiliser.
 
-3. Suivez l'assistant lancé par l'extension pour donner un nom à votre application, choisir un préréglage de cadre et désigner la racine de l'application (généralement `/`) et l'emplacement du fichier construit (utilisez `/dist`). Astro n'est pas listé dans les modèles intégrés dans Azure, vous devrez donc sélectionner `custom`. L'assistant s'exécutera et créera une [Action GitHub](https://github.com/features/actions) dans le dossier `.github` de votre dépôt. (Ce dossier sera automatiquement créé s'il n'existe pas déjà.)
+3. Suivez l'assistant lancé par l'extension pour donner un nom à votre application, choisir un préréglage de framework et désigner la racine de l'application (généralement `/`) et l'emplacement des fichiers compilés (généralement `/dist`). Astro n'est pas listé dans les modèles intégrés dans Azure, vous devrez donc sélectionner `custom`. L'assistant s'exécutera et créera une [Action GitHub](https://github.com/features/actions) dans le dossier `.github` de votre dépôt. (Ce dossier sera automatiquement créé s'il n'existe pas déjà.)
 </Steps>
 
-L'action GitHub va déployer votre application (vous pouvez voir sa progression dans l'onglet Actions de votre repo sur GitHub). Une fois le déploiement terminé, vous pouvez visualiser votre application à l'adresse indiquée dans la fenêtre de progression de l'extension SWA en cliquant sur le bouton **Browse Website** (qui apparaîtra après l'exécution de l'action GitHub).
+L'action GitHub va déployer votre application (vous pouvez voir sa progression dans l'onglet Actions de votre dépôt sur GitHub). Une fois le déploiement terminé, vous pouvez visualiser votre application à l'adresse indiquée dans la fenêtre de progression de l'extension SWA en cliquant sur le bouton **Browse Website** (qui apparaîtra après l'exécution de l'action GitHub).
 
 ## Problèmes connus
 
-L'action GitHub yaml qui est créée pour vous, suppose l'utilisation de node 14. Cela signifie que la construction d'Astro échoue. Pour résoudre ce problème, mettez à jour le fichier package.json de votre projet avec cet extrait.
+Le fichier YAML de l'action GitHub qui est créé pour vous suppose l'utilisation de Node 14. Cela signifie que la compilation d'Astro échoue. Pour résoudre ce problème, mettez à jour le fichier package.json de votre projet avec cet extrait.
 
 ```
   "engines": {
@@ -44,10 +44,10 @@ L'action GitHub yaml qui est créée pour vous, suppose l'utilisation de node 14
 
 ## Ressources officielles
 
-- [Documentation de Microsoft Azure Static Web Apps](https://learn.microsoft.com/fr-fr/azure/static-web-apps/
+- [Documentation de Microsoft Azure Static Web Apps](https://learn.microsoft.com/fr-fr/azure/static-web-apps/)
 
 ## Ressources de la communauté 
 
-- [Déploiement d'un site web Astro vers Azure Static Web Apps](https://www.blueboxes.co.uk/deploying-an-astro-website-to-azure-static-web-apps) (en)
-- [Déployer un site statique Astro vers Azure Static Web Apps à l'aide d'actions GitHub](https://agramont.net/blog/create-static-site-astro-azure-ssg/#automate-deployment-with-github-actions) (en)
-- [Déploiement d'un site Astro sur Azure Static Web Apps en utilisant le CLI depuis GitHub Actions](https://www.eliostruyf.com/deploy-astro-azure-static-web-apps-github-cli/) (en)
+- [Déploiement d'un site web Astro vers Azure Static Web Apps](https://www.blueboxes.co.uk/deploying-an-astro-website-to-azure-static-web-apps) (Anglais)
+- [Déployer un site statique Astro vers Azure Static Web Apps à l'aide d'actions GitHub](https://agramont.net/blog/create-static-site-astro-azure-ssg/#automate-deployment-with-github-actions) (Anglais)
+- [Déploiement d'un site Astro sur Azure Static Web Apps en utilisant la CLI depuis GitHub Actions](https://www.eliostruyf.com/deploy-astro-azure-static-web-apps-github-cli/) (Anglais)

--- a/src/content/docs/fr/guides/deploy/render.mdx
+++ b/src/content/docs/fr/guides/deploy/render.mdx
@@ -19,9 +19,9 @@ Vous pouvez déployer votre projet Astro sur [Render](https://render.com/), un s
 
 3. Connectez votre dépôt [GitHub](https://github.com/) ou [GitLab](https://about.gitlab.com/) ou entrez l'URL publique d'un dépôt public.
 
-4. Donnez un nom à votre site web, sélectionnez la branche et spécifiez la commande de construction et le répertoire de publication
+4. Donnez un nom à votre site web, sélectionnez la branche et spécifiez la commande de compilation et le répertoire de publication
   
-   - **Build Command:** `npm run build` (Commande de construction)
+   - **Build Command:** `npm run build`
    - **Publish Directory:** `dist` pour les sites statiques ; `dist/client` si vous avez des pages rendues à la demande.
 
 5. Cliquez sur le bouton **Create Static Site**

--- a/src/content/docs/fr/guides/deploy/sst.mdx
+++ b/src/content/docs/fr/guides/deploy/sst.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro sur AWS avec SST
+title: Déployer votre site Astro sur AWS avec SST
 description: Comment déployer votre site Astro sur AWS avec SST
 sidebar:
   label: SST
@@ -15,7 +15,7 @@ Vous pouvez également utiliser des composants SST supplémentaires comme les Cr
 ## Démarrage rapide
 
 <Steps>
-1. Créer un projet Astro.
+1. Créez un projet Astro.
 
 2. Exécutez `npx sst@latest init`.
 
@@ -50,4 +50,4 @@ console.log(Resource.MyBucket.name)
 
 Consultez la [documentation SST sur les liens vers les ressources](https://sst.dev/docs/linking) pour en savoir plus.
 
-Si vous avez des questions, vous pouvez [les poser dans le Discord SST](https://discord.gg/sst).
+Si vous avez des questions, vous pouvez [les poser dans le Discord de SST](https://discord.gg/sst).

--- a/src/content/docs/fr/guides/deploy/stormkit.mdx
+++ b/src/content/docs/fr/guides/deploy/stormkit.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro depuis Stormkit
+title: Déployer votre site Astro depuis Stormkit
 description: Déployez votre site Astro depuis Stormkit
 sidebar:
   label: Stormkit
@@ -20,9 +20,9 @@ Vous pouvez déployer votre projet Astro depuis [Stormkit](https://stormkit.io/)
 
   3. Accédez à l'environnement de production du projet dans Stormkit ou créez un nouvel environnement si nécessaire.
 
-  4. Vérifiez la commande de build dans votre [configuration Stormkit](https://stormkit.io/docs/deployments/configuration). Par défaut, Stormkit CI exécutera `npm run build` mais vous pouvez spécifier une commande de build personnalisée sur cette page.
+  4. Vérifiez la commande de compilation dans votre [configuration Stormkit](https://stormkit.io/docs/deployments/configuration). Par défaut, Stormkit CI exécutera `npm run build` mais vous pouvez spécifier une commande de compilation personnalisée sur cette page.
 
-  5. Cliquez sur le bouton "Deploy Now" pour déployer votre site.
+  5. Cliquez sur le bouton « Deploy Now » pour déployer votre site.
 </Steps>
 
-<ReadMore>En savoir plus dans la [documentation Stormkit](https://stormkit.io/docs).</ReadMore>
+<ReadMore>En savoir plus dans la [documentation de Stormkit](https://stormkit.io/docs).</ReadMore>

--- a/src/content/docs/fr/guides/deploy/surge.mdx
+++ b/src/content/docs/fr/guides/deploy/surge.mdx
@@ -13,13 +13,13 @@ Vous pouvez déployer votre projet Astro sur [Surge](https://surge.sh/), une pla
 ## Comment déployer
 
 <Steps>
-1. Installez la [CLI Surge](https://www.npmjs.com/package/surge) globalement depuis le Terminal, si ce n'est pas déjà fait.
+1. Installez la [CLI de Surge](https://www.npmjs.com/package/surge) globalement depuis le terminal, si ce n'est pas déjà fait.
 
     ```shell
     npm install -g surge
     ```
 
-2. Buildez votre site Astro à partir du répertoire racine de votre projet.
+2. Compilez votre site Astro à partir du répertoire racine de votre projet.
 
     ```shell
     npm run build
@@ -31,5 +31,5 @@ Vous pouvez déployer votre projet Astro sur [Surge](https://surge.sh/), une pla
     surge dist
     ```
 
-    Vous pouvez utiliser un [domaine personnalisé avec Surge](http://surge.sh/help/adding-a-custom-domain) lors du déploiement en exécutant `surge dist yourdomain.com`.
+    Vous pouvez utiliser un [domaine personnalisé avec Surge](http://surge.sh/help/adding-a-custom-domain) lors du déploiement en exécutant `surge dist votredomaine.com`.
 </Steps>

--- a/src/content/docs/fr/guides/deploy/vercel.mdx
+++ b/src/content/docs/fr/guides/deploy/vercel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployer votre Site Astro avec Vercel
+title: Déployer votre site Astro avec Vercel
 description: Comment déployer votre site Astro vers le web sur Vercel.
 sidebar:
   label: Vercel
@@ -10,13 +10,13 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Vous pouvez utiliser [Vercel](http://vercel.com/) pour déployer un site Astro vers son global edge network (réseau périphérique mondial) sans aucune configuration.
+Vous pouvez utiliser [Vercel](http://vercel.com/) pour déployer un site Astro vers son réseau périphérique mondial (ou « global edge network » en anglais) sans aucune configuration.
 
-Ce guide comprend des instructions pour le déploiement vers Vercel via l'interface utilisateur du site web ou le CLI de Vercel.
+Ce guide comprend des instructions pour le déploiement vers Vercel via l'interface utilisateur du site web ou la CLI de Vercel.
 
 ## Configuration du projet
 
-Votre projet Astro peut être déployé sur Vercel en tant que site statique, ou en tant que site rendu côté serveur (SSR).
+Votre projet Astro peut être déployé sur Vercel en tant que site statique, ou en tant que site rendu côté serveur.
 
 ### Site statique
 
@@ -59,12 +59,12 @@ Vous pouvez déployer Vercel via l'interface utilisateur du site web ou en utili
 
 3. Vercel détectera automatiquement Astro et configurera les bons paramètres.
 
-4. Votre application est déployée ! (ex : [astro.vercel.app](https://astro.vercel.app/))
+4. Votre application est déployée ! (p. ex. [astro.vercel.app](https://astro.vercel.app/))
 </Steps>
 
-Une fois que votre projet a été importé et déployé, tous les pushes ultérieures vers les branches généreront des [Déploiements de prévisualisation (EN)](https://vercel.com/docs/concepts/deployments/environments#preview), et toutes les modifications apportées à la branche de production (communément appelée "main") donneront lieu à un [Déploiement de production (EN)](https://vercel.com/docs/concepts/deployments/environments#production).
+Une fois que votre projet a été importé et déployé, tous les transferts ultérieures vers les branches généreront des [déploiements de prévisualisation (Anglais)](https://vercel.com/docs/concepts/deployments/environments#preview), et toutes les modifications apportées à la branche de production (communément appelée « main ») donneront lieu à un [déploiement de production (Anglais)](https://vercel.com/docs/concepts/deployments/environments#production).
 
-<ReadMore>Apprenez-en plus sur l'[Intégration Git de Vercel (EN)](https://vercel.com/docs/concepts/git).</ReadMore>
+<ReadMore>Apprenez-en plus sur l'[intégration Git de Vercel (Anglais)](https://vercel.com/docs/concepts/git).</ReadMore>
 
 ### Déploiement via CLI
 
@@ -96,11 +96,11 @@ Une fois que votre projet a été importé et déployé, tous les pushes ultéri
 
 3. Lorsqu'il sera demandé `Want to override the settings? [y/N]` (Souhaitez-vous annuler les réglages), sélectionner `N`.
 
-4. Votre application est déployée ! (ex : [astro.vercel.app](https://astro.vercel.app/))
+4. Votre application est déployée ! (p. ex. [astro.vercel.app](https://astro.vercel.app/))
 </Steps>
 
 ### Configuration du projet avec `vercel.json`
 
 Vous pouvez utiliser `vercel.json` pour remplacer le comportement par défaut de Vercel et pour configurer des paramètres supplémentaires. Par exemple, vous pouvez souhaiter attacher des en-têtes aux réponses HTTP de vos déploiements. 
 
-<ReadMore>En savoir plus sur [la configuration du projet Vercel (EN)](https://vercel.com/docs/project-configuration).</ReadMore>
+<ReadMore>En savoir plus sur [la configuration d'un projet Vercel (Anglais)](https://vercel.com/docs/project-configuration).</ReadMore>

--- a/src/content/docs/fr/guides/deploy/zeabur.mdx
+++ b/src/content/docs/fr/guides/deploy/zeabur.mdx
@@ -18,7 +18,7 @@ Ce guide comprend des instructions pour le déploiement sur Zeabur via l'interfa
 
 Astro produit un site statique par défaut. Il n'y a pas besoin de configuration supplémentaire pour déployer un site Astro statique sur Zeabur. 
 
-### Site rendu par le serveur
+### Adaptateur SSR
 
 Pour activer SSR dans votre projet Astro et le déployer sur Zeabur :
 
@@ -49,13 +49,13 @@ Vous pouvez déployer votre site Astro sur Zeabur si le projet est stocké sur G
 <Steps>
 1. Cliquez sur <kbd>Create new project</kbd> dans le [tableau de bord de Zeabur](https://dash.zeabur.com).
 
-2. Configurer l'installation de GitHub et importer le dépôt.
+2. Configurez l'installation de GitHub et importez le dépôt.
 
-3. Zeabur détectera automatiquement que votre projet est un projet Astro et le construira en utilisant la commande `astro build`.
+3. Zeabur détectera automatiquement que votre projet est un projet Astro et le compilera en utilisant la commande `astro build`.
 
-4. Une fois la construction terminée, vous pouvez lier un domaine à votre site et le visiter.
+4. Une fois la compilation terminée, vous pouvez lier un domaine à votre site et le visiter.
 </Steps>
 
 Une fois que votre projet a été importé et déployé, toutes les poussées ultérieures vers les branches génèreront de nouvelles versions.
 
-En savoir plus sur le [Guide de déploiement de Zeabur](https://zeabur.com/docs/get-started/).
+En savoir plus sur le [guide de déploiement](https://zeabur.com/docs/get-started/) de Zeabur.

--- a/src/content/docs/fr/guides/deploy/zerops.mdx
+++ b/src/content/docs/fr/guides/deploy/zerops.mdx
@@ -1,5 +1,5 @@
 ---
-title: Déployez votre site Astro depuis Zerops
+title: Déployer votre site Astro depuis Zerops
 description: Comment déployer votre site Astro sur le web en utilisant Zerops.
 sidebar:
   label: Zerops
@@ -21,8 +21,8 @@ Vous voulez tester Astro sur Zerops sans rien installer ni configurer ? En utili
 :::
 
 L'exécution d'applications sur Zerops nécessite deux étapes :
-1. Créer un projet
-2. Déclenchement du pipeline de construction et de déploiement
+1. Création d'un projet
+2. Déclenchement du pipeline de compilation et de déploiement
 
 :::note
 Un projet Zerops peut contenir plusieurs sites Astro.
@@ -99,12 +99,12 @@ Pour indiquer à Zerops comment construire et exécuter votre site, ajoutez un `
   </Fragment>
 </PackageManagerTabs>
 
-Maintenant, vous pouvez [déclencher le pipeline de construction et de déploiement en utilisant le CLI Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
+Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
 
 
 ## Site Astro SSR sur Zerops
 
-### Update scripts
+### Mettre à jour les scripts
 
 Mettez à jour votre script `start` pour exécuter la sortie serveur de l'adaptateur Node.
 
@@ -130,7 +130,7 @@ Cela créera un projet appelé `recipe-astro` avec un service Node.js Zerops app
 
 ### Déploiement de votre site Astro SSR
 
-Pour indiquer à Zerops comment construire et exécuter votre site en utilisant l'adaptateur officiel [Astro Node.js](/fr/guides/integrations-guide/node/) en mode `standalone`, ajoutez un fichier `zerops.yml` à votre dépôt :
+Pour indiquer à Zerops comment compiler et exécuter votre site en utilisant l'adaptateur officiel [Node.js d'Astro](/fr/guides/integrations-guide/node/) en mode `standalone`, ajoutez un fichier `zerops.yml` à votre dépôt :
 
 
 <PackageManagerTabs>
@@ -211,19 +211,19 @@ Pour indiquer à Zerops comment construire et exécuter votre site en utilisant 
   </Fragment>
 </PackageManagerTabs>
 
-Maintenant, vous pouvez [déclencher le pipeline de construction et de déploiement en utilisant le CLI Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
+Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
 
-## Déclencher le pipeline en utilisant Zerops CLI (zcli)
+## Déclencher le pipeline en utilisant la CLI de Zerops (zcli)
 
 <Steps>
-  1. Installez le CLI Zerops.
+  1. Installez la CLI de Zerops.
       ```shell
       # Pour télécharger le binaire zcli directement,
       # utilisez https://github.com/zeropsio/zcli/releases
       npm i -g @zerops/zcli
       ```
 
-  2. Ouvrez [̀Settings > Access Token Management](https://app.zerops.io/settings/token-management) dans l'application Zerops et générez un nouveau jeton d'accès.
+  2. Ouvrez [`Settings > Access Token Management`](https://app.zerops.io/settings/token-management) dans l'application Zerops et générez un nouveau jeton d'accès.
 
   3. Connectez-vous en utilisant votre jeton d'accès avec la commande suivante :
       ```shell
@@ -239,11 +239,11 @@ Maintenant, vous pouvez [déclencher le pipeline de construction et de déploiem
 ## Ressources
 ### Officielles
 
-- [Créer un Zerops](https://app.zerops.io/registration)
+- [Créer un compte Zerops](https://app.zerops.io/registration)
 - [Documentation de Zerops](https://docs.zerops.io)
-- [Recette de Zerops Astro](https://app.zerops.io/recipe/astro)
+- [Recette Astro de Zerops](https://app.zerops.io/recipe/astro)
 
 ### Communautaires
-- [Déployer Astro depuis Zerops en 3 minutes](https://medium.com/@arjunaditya/how-to-deploy-astro-to-zerops-4230816a62b4) (en)
-- [Déployer Astro SSG avec Node.js sur Zerops avec One Click Deploy](https://youtu.be/-4KTa4VWtBE) (en)
-- [Deployer Astro SSR avec Node.js sur Zerops avec One Click Deploy](https://youtu.be/eR6b_JnDH6g) (en)
+- [Déployer Astro depuis Zerops en 3 minutes](https://medium.com/@arjunaditya/how-to-deploy-astro-to-zerops-4230816a62b4) (Anglais)
+- [Déployer Astro SSG avec Node.js sur Zerops avec One Click Deploy](https://youtu.be/-4KTa4VWtBE) (Anglais)
+- [Deployer Astro SSR avec Node.js sur Zerops avec One Click Deploy](https://youtu.be/eR6b_JnDH6g) (Anglais)

--- a/src/content/docs/fr/guides/deploy/zerops.mdx
+++ b/src/content/docs/fr/guides/deploy/zerops.mdx
@@ -99,7 +99,7 @@ Pour indiquer à Zerops comment construire et exécuter votre site, ajoutez un `
   </Fragment>
 </PackageManagerTabs>
 
-Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
+Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-la-cli-de-zerops-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
 
 
 ## Site Astro SSR sur Zerops
@@ -211,7 +211,7 @@ Pour indiquer à Zerops comment compiler et exécuter votre site en utilisant l'
   </Fragment>
 </PackageManagerTabs>
 
-Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-zerops-cli-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
+Maintenant, vous pouvez [déclencher le pipeline de compilation et de déploiement en utilisant la CLI de Zerops](#déclencher-le-pipeline-en-utilisant-la-cli-de-zerops-zcli) ou en connectant le service `app` à votre dépôt [GitHub](https://docs.zerops.io/references/github-integration/) / [GitLab](https://docs.zerops.io/references/gitlab-integration) depuis le détail du service.
 
 ## Déclencher le pipeline en utilisant la CLI de Zerops (zcli)
 

--- a/src/content/docs/fr/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/netlify.mdx
@@ -86,7 +86,7 @@ Ensuite, ajoutez l'adaptateur à votre fichier `astro.config.*` :
 
 [Lisez le guide de déploiement complet ici](/fr/guides/deploy/netlify/)
 
-Suivez les instructions pour [construire votre site localement](/fr/guides/deploy/#construire-votre-site-localement). Après la construction, vous aurez un dossier `.netlify/` contenant à la fois [Netlify Functions](https://docs.netlify.com/functions/overview/) dans le dossier `.netlify/functions-internal/` et [Netlify Edge Functions](https://docs.netlify.com/edge-functions/overview/) dans le dossier `.netlify/edge-functions/`.
+Suivez les instructions pour [construire votre site localement](/fr/guides/deploy/#compiler-votre-site-localement). Après la construction, vous aurez un dossier `.netlify/` contenant à la fois [Netlify Functions](https://docs.netlify.com/functions/overview/) dans le dossier `.netlify/functions-internal/` et [Netlify Edge Functions](https://docs.netlify.com/edge-functions/overview/) dans le dossier `.netlify/edge-functions/`.
 
 Pour déployer votre site, installez le [Netlify CLI](https://docs.netlify.com/cli/get-started/) et exécutez-le :
 

--- a/src/content/docs/fr/guides/integrations-guide/node.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/node.mdx
@@ -108,7 +108,7 @@ export default defineConfig({
 
 ## Utilisation
 
-Tout d'abord, [effectuer un build](/fr/guides/deploy/#construire-votre-site-localement). En fonction du `mode` sélectionné (voir ci-dessus), suivez les étapes appropriées ci-dessous :
+Tout d'abord, [effectuer un build](/fr/guides/deploy/#compiler-votre-site-localement). En fonction du `mode` sélectionné (voir ci-dessus), suivez les étapes appropriées ci-dessous :
 
 ### Middleware
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of the remaining `guides/deploy` (see #11593):
* use infinitive form in title/headings
* replace `construction` with `compilation`
* `le CLI` > `la CLI`
* `endpoint` > `point de terminaison` (instead of `extrémité/accès`)
* `policy` > `stratégie`
* `package` > `paquet`
* `delivery` > `diffusion` instead of `livraison`
* replace `référentiel` with `dépôt`
* add or replace community links language
* `Node.js runtime` > `environnement d'exécution Node.js` (see [Node.js](https://nodejs.org/fr))
* translate some examples
* consistent use of imperative form in steps
* small rewording to make the reading easier
* update some parts to match the English version (ie. missing words or sentence parts)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
