### PR TITLE
docs(cloudflare): custom entryfile

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -305,7 +305,7 @@ Provide any additional defined named exports of your [custom entry file](#creati
 
 #### Creating a custom Cloudflare Worker entry file
 
-The custom entry file must export the `createExports()` function, with a `default` export including all the handlers you need.
+The custom entry file must export the `createExports()` function with a `default` export including all the handlers you need.
 
 The following example entry file registers a Durable Object and a queue handler:
 


### PR DESCRIPTION
docs for https://github.com/withastro/astro/pull/13837

I'm not sure if we should a full section which explain the usage of this a bit more, or if it is enough to document the new options like I did? Also maybe the two options should be nested under one common prefix `entryfile.path` & `entryfile.exports`, however not to sure 🤔 