### PR TITLE
i18n(fr): improve the wording in `integrations-guide`

### DIFF
--- a/src/content/docs/fr/guides/astro-db.mdx
+++ b/src/content/docs/fr/guides/astro-db.mdx
@@ -684,7 +684,7 @@ export default async function () {
 
 <ReadMore>
 
-Voir la [référence CLI](/fr/guides/integrations-guide/db/#référence-cli-astro-db) pour une liste complète des commandes.
+Voir la [référence CLI](/fr/guides/integrations-guide/db/#référence-de-la-cli-dastro-db) pour une liste complète des commandes.
 
 </ReadMore>
 

--- a/src/content/docs/fr/guides/environment-variables.mdx
+++ b/src/content/docs/fr/guides/environment-variables.mdx
@@ -188,7 +188,7 @@ const data = await db(import.meta.env.DB_PASSWORD);
 const data = fetch(`${import.meta.env.PUBLIC_POKEAPI}/pokemon/squirtle`);
 ```
 
-Lorsque vous utilisez SSR, les variables d'environnement peuvent être accédées au moment de l'exécution en fonction de l'adaptateur SSR utilisé. Avec la plupart des adaptateurs, vous pouvez accéder aux variables d'environnement avec `process.env`, mais certains adaptateurs fonctionnent différemment. Pour l'adaptateur Deno, vous utiliserez `Deno.env.get()`. Voir comment [accéder au runtime Cloudflare](/fr/guides/integrations-guide/cloudflare/#moteur-dexécution-de-cloudflare) pour gérer les variables d'environnement lors de l'utilisation de l'adaptateur Cloudflare. Astro vérifiera d'abord l'environnement du serveur pour les variables, et si elles n'existent pas, Astro les cherchera dans les fichiers `.env`.
+Lorsque vous utilisez SSR, les variables d'environnement peuvent être accédées au moment de l'exécution en fonction de l'adaptateur SSR utilisé. Avec la plupart des adaptateurs, vous pouvez accéder aux variables d'environnement avec `process.env`, mais certains adaptateurs fonctionnent différemment. Pour l'adaptateur Deno, vous utiliserez `Deno.env.get()`. Voir comment [accéder au runtime Cloudflare](/fr/guides/integrations-guide/cloudflare/#environnement-dexécution-cloudflare) pour gérer les variables d'environnement lors de l'utilisation de l'adaptateur Cloudflare. Astro vérifiera d'abord l'environnement du serveur pour les variables, et si elles n'existent pas, Astro les cherchera dans les fichiers `.env`.
 
 ## Variables d'environnement avec sûreté du typage
 

--- a/src/content/docs/fr/guides/integrations-guide/alpinejs.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/alpinejs.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/alpinejs'
-description: Apprenez à utiliser l'intégration du framework @astrojs/alpinejs pour étendre le support des composants dans votre projet Astro.
+description: Apprenez à utiliser l'intégration de framework @astrojs/alpinejs pour étendre la prise en charge des composants dans votre projet Astro.
 sidebar:
   label: Alpine.js
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/alpinejs/'
@@ -92,13 +92,13 @@ export default defineConfig({
 });
 ```
 
-## Options de Configuration
+## Options de configuration
 
 ### `entrypoint`
 
-Vous pouvez étendre Alpine en mettant l'option `entrypoint` à un spécificateur d'importation relatif à la racine (par exemple `entrypoint : "/src/entrypoint"`).
+Vous pouvez étendre Alpine en définissant l'option `entrypoint` sur un spécificateur d'importation relatif à la racine (par exemple `entrypoint: "/src/entrypoint"`).
 
-L'exportation par défaut de ce fichier doit être une fonction qui accepte une instance Alpine avant de démarrer. Cela permet d'utiliser des directives personnalisées, des plugins et d'autres personnalisations pour des cas d'utilisation avancés.
+L'exportation par défaut de ce fichier doit être une fonction qui accepte une instance Alpine avant de démarrer. Cela permet d'utiliser des directives personnalisées, des modules d'extension et d'autres personnalisations pour des cas d'utilisation avancés.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -121,9 +121,9 @@ export default (Alpine: Alpine) => {
 
 ## Utilisation
 
-Une fois l'intégration installée, vous pouvez utiliser les directives et la syntaxe [Alpine.js](https://alpinejs.dev/) dans n'importe quel composant Astro. Le script Alpine.js est automatiquement ajouté et activé sur chaque page de votre site web, aucune directive client n'est donc nécessaire. Ajoutez les scripts du plugin à la page `<head>`.
+Une fois l'intégration installée, vous pouvez utiliser les directives et la syntaxe [Alpine.js](https://alpinejs.dev/) dans n'importe quel composant Astro. Le script Alpine.js est automatiquement ajouté et activé sur chaque page de votre site web, aucune directive client n'est donc nécessaire. Ajoutez les scripts du module d'extension dans la balise `<head>` de la page.
 
-L'exemple suivant ajoute le plugin [Alpine's Collapse](https://alpinejs.dev/plugins/collapse) pour développer et réduire le texte d'un paragraphe.
+L'exemple suivant ajoute le module d'extension [Collapse d'Alpine](https://alpinejs.dev/plugins/collapse) pour développer et réduire le texte d'un paragraphe.
 
 ```astro title="src/pages/index.astro" ins={6} ins="x-collapse"
 ---
@@ -136,7 +136,7 @@ L'exemple suivant ajoute le plugin [Alpine's Collapse](https://alpinejs.dev/plug
 	<body>
     <!-- ... -->
 		<div x-data="{ expanded: false }">
-			<button @click="expanded = ! expanded">Toggle Content</button>
+			<button @click="expanded = ! expanded">Afficher/Masquer le contenu</button>
 
 			<p id="foo" x-show="expanded" x-collapse>
         Lorem ipsum
@@ -158,8 +158,8 @@ interface Window {
 
 ## Exemples
 
-* L'exemple [Astro Alpine.js](https://github.com/withastro/astro/tree/main/examples/framework-alpine) montre comment utiliser Alpine.js dans un projet Astro.
+* L'[exemple Astro Alpine.js](https://github.com/withastro/astro/tree/main/examples/framework-alpine) montre comment utiliser Alpine.js dans un projet Astro.
 
 [astro-integration]: /fr/guides/integrations-guide/
 
-[astro-ui-frameworks]: /fr/guides/framework-components/#using-framework-components
+[astro-ui-frameworks]: /fr/guides/framework-components/#utilisation-des-composants-de-framework

--- a/src/content/docs/fr/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/cloudflare.mdx
@@ -15,7 +15,7 @@ import Since from '~/components/Since.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 
-Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Cloudflare](https://www.cloudflare.com/), y compris [les îles de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
+Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Cloudflare](https://www.cloudflare.com/), y compris [les îlots de serveur](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
 
 Si vous utilisez Astro comme générateur de site statique, vous n'avez pas besoin d'adaptateur.
 
@@ -23,7 +23,7 @@ Découvrez comment déployer votre site Astro dans notre [guide de déploiement 
 
 ## Pourquoi Astro Cloudflare
 
-La [plateforme de développement](https://developers.cloudflare.com/) de Cloudflare vous permet de développer des applications full-stack avec accès à des ressources telles que le stockage et l'IA, le tout déployé sur un réseau mondial. Cet adaptateur construit votre projet Astro pour le déploiement via Cloudflare.
+La [plateforme de développement](https://developers.cloudflare.com/) de Cloudflare vous permet de développer des applications full-stack avec accès à des ressources telles que le stockage et l'IA, le tout déployé sur un réseau mondial. Cet adaptateur compile votre projet Astro pour le déploiement via Cloudflare.
 
 
 ## Installation
@@ -50,7 +50,7 @@ Ajoutez l'adaptateur Cloudflare pour activer le rendu du serveur dans votre proj
   </Fragment>
 </PackageManagerTabs>
 
-Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre construction sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
+Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre compilation sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
 
 ### Installation manuelle
 
@@ -112,7 +112,7 @@ Détermine quel service d'image est utilisé par l'adaptateur. L'adaptateur util
 * **`cloudflare` :** Utilise le service de [redimensionnement d'image de Cloudflare](https://developers.cloudflare.com/images/image-resizing/).
 * **`passthrough` :** Utilise le service existant [`noop`](/fr/guides/images/#configurer-le-service-no-op-passthrough).
 * **`compile` :** Utilise le service par défaut d'Astro (sharp), mais seulement sur les routes pré-rendues au moment de la compilation. Pour les pages rendues à la demande, toutes les fonctionnalités de `astro:assets` sont désactivées.
-* **`custom` :** Utilise toujours le service d'image configuré dans les [options d'images](/fr/reference/configuration-reference/#options-dimages). **Cette option ne vérifiera pas si le service d'image configuré fonctionne dans le moteur d'exécution `workerd` de Cloudflare.**
+* **`custom` :** Utilise toujours le service d'image configuré dans les [options d'images](/fr/reference/configuration-reference/#options-dimages). **Cette option ne vérifiera pas si le service d'image configuré fonctionne dans l'environnemment d'exécution `workerd` de Cloudflare.**
 
 ```js title="astro.config.mjs" ins={6}
 import { defineConfig } from "astro/config";
@@ -127,7 +127,7 @@ export default defineConfig({
 
 ### `platformProxy`
 
-Détermine si et comment le moteur d'exécution Cloudflare est ajouté à `astro dev`. Il contient des proxys vers les liaisons `workerd` locales et des émulations de valeurs spécifiques à Cloudflare, permettant l'émulation du moteur d'exécution dans le processus de développement Node.js. En savoir plus sur le [moteur d'exécution de Cloudflare](#moteur-dexécution-de-cloudflare).
+Détermine si et comment l'environnemment d'exécution Cloudflare est ajouté à `astro dev`. Il contient des proxys vers les liaisons `workerd` locales et des émulations de valeurs spécifiques à Cloudflare, permettant l'émulation de l'environnemment d'exécution dans le processus de développement Node.js. En savoir plus sur l'[environnemment d'exécution Cloudflare](#environnement-dexécution-cloudflare).
 
 :::note
 Les proxys fournis par ce système constituent une émulation au mieux de la production réelle. Bien qu'ils soient conçus pour être aussi proches que possible de la réalité, il peut y avoir de légères différences et incohérences entre les deux.
@@ -139,7 +139,7 @@ Les proxys fournis par ce système constituent une émulation au mieux de la pro
 **Par défaut :** `true`
 </p>
 
-Détermine s'il faut activer le moteur d'exécution de Cloudflare en mode développement.
+Détermine s'il faut activer l'environnement d'exécution Cloudflare en mode développement.
 
 #### `platformProxy.configPath`
 <p>
@@ -165,15 +165,15 @@ Définit l'[environnement Cloudflare](https://developers.cloudflare.com/workers/
 
 Définit si et où enregistrer les données de liaison localement sur le système de fichiers.
 
-- Si définie avec `true`, les données de liaison sont stockées dans `.wrangler/state/v3/`. Ce paramètre est identique à celui par défaut de Wrangler.
-- Si définie avec `false`, les données de liaison ne sont pas stockées dans le système de fichiers.
+- Si définie sur `true`, les données de liaison sont stockées dans `.wrangler/state/v3/`. Ce paramètre est identique à celui par défaut de Wrangler.
+- Si définie sur `false`, les données de liaison ne sont pas stockées dans le système de fichiers.
 - Si définie avec `{ path: string }`, les données de liaison sont stockées dans le chemin spécifié.
 
 :::note
 L'option `--persist-to` de `wrangler` ajoute un sous-répertoire appelé `v3` sous le capot tandis que la propriété `persist` de `@astrojs/cloudflare` ne le fait pas. Par exemple, pour réutiliser le même emplacement qu'en lançant `wrangler dev --persist-to ./mon-dossier`, vous devez spécifier : `persist: { path: "./mon-dossier/v3" }`.
 :::
 
-La configuration suivante montre un exemple d'activation du moteur d'exécution de Cloudflare lors de l'exécution du serveur de développement, ainsi que l'utilisation d'un fichier de configuration `wrangler.json`. Elle spécifie également un emplacement personnalisé pour la persistance des données dans le système de fichiers :
+La configuration suivante montre un exemple d'activation de l'environnement d'exécution Cloudflare lors de l'exécution du serveur de développement, ainsi que l'utilisation d'un fichier de configuration `wrangler.json`. Elle spécifie également un emplacement personnalisé pour la persistance des données dans le système de fichiers :
 
 
 ```js
@@ -194,7 +194,7 @@ export default defineConfig({
 ```
 ### `routes.extend`
 
-Avec Cloudflare Workers, cette option n'est pas applicable. Consultez la section [Routage sur Cloudflare Workers](#routage-sur-cloudflare-workers) pour plus d'informations.
+Avec Cloudflare Workers, cette option n'est pas applicable. Consultez la section [routage sur Cloudflare Workers](#routage-sur-cloudflare-workers) pour plus d'informations.
 
 Avec Cloudflare Pages, cette option vous permet d'ajouter ou d'exclure des motifs personnalisés (par exemple `/fonts/*`) au fichier généré `_routes.json` qui détermine quelles routes sont générées à la demande. Cela peut être utile si vous avez besoin d'ajouter des modèles de route qui ne peuvent pas être générés automatiquement, ou d'exclure des routes pré-rendues.
 
@@ -224,7 +224,7 @@ export default defineConfig({
     routes: {
       extend: {
         include: [{ pattern: '/static' }], // Achemine une page pré-rendue vers la fonction serveur pour un rendu à la demande
-        exclude: [{ pattern: '/pagefind/*' }], // Utilise la recherche pagefind de Starlight, qui est générée statiquement au moment de la construction.
+        exclude: [{ pattern: '/pagefind/*' }], // Utilise la recherche pagefind de Starlight, qui est générée statiquement au moment de la compilation.
       }
     },
   }),
@@ -248,12 +248,12 @@ export default defineConfig({
 });
 ```
 
-## Moteur d'exécution de Cloudflare
+## Environnement d'exécution Cloudflare
 
 ### Utilisation
 
-Le moteur d'exécution de Cloudflare vous donne accès aux variables d'environnement et aux liaisons aux ressources Cloudflare.
-Le moteur d'exécution Cloudflare utilise les liaisons trouvées dans le fichier de configuration `wrangler.toml`/`wrangler.json`.
+L'environnement d'exécution Cloudflare vous donne accès aux variables d'environnement et aux liaisons aux ressources Cloudflare.
+L'environnement d'exécution Cloudflare utilise les liaisons trouvées dans le fichier de configuration `wrangler.toml`/`wrangler.json`.
 
 Vous pouvez accéder aux liaisons depuis `Astro.locals.runtime` :
 
@@ -262,7 +262,7 @@ Vous pouvez accéder aux liaisons depuis `Astro.locals.runtime` :
 const { env } = Astro.locals.runtime;
 ---
 ```
-Vous pouvez accéder au moteur d'exécution à partir des points de terminaison de l'API via `context.locals` :
+Vous pouvez accéder à l'environnement d'exécution à partir des points de terminaison de l'API via `context.locals` :
 
 ```js title="src/pages/api/someFile.js"
 export function GET(context) {
@@ -277,7 +277,7 @@ Voir la [liste de toutes les liaisons prises en charge](https://developers.cloud
 
 ### Variables d'environnement et secrets
 
-Le moteur d'exécution de Cloudflare traite les variables d'environnement comme un type de liaison.
+L'environnement d'exécution Cloudflare traite les variables d'environnement comme un type de liaison.
 
 Par exemple, vous pouvez définir une [variable d’environnement](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) dans `wrangler.json` comme suit :
 
@@ -357,21 +357,21 @@ declare namespace App {
 
 Vous pouvez attacher des [en-têtes personnalisés](https://developers.cloudflare.com/pages/platform/headers/) à vos réponses en ajoutant un fichier `_headers` dans le dossier `public/` de votre projet Astro. Ce fichier sera copié dans le répertoire de sortie de la compilation.
 
-Ceci est disponible sur Cloudflare Workers et Pages.
+Cette fonctionnalité est disponible sur Cloudflare Workers et Pages.
 
 ### Ressources
 Les ressources créées par Astro sont toutes nommées avec un hachage et peuvent donc se voir attribuer de longs en-têtes de cache. Par défaut, Astro sur Cloudflare ajoutera un tel en-tête pour ces fichiers.
 
 ### Redirections
 
-Vous pouvez déclarer des [redirections personnalisées](https://developers.cloudflare.com/pages/platform/redirects/) pour rediriger les requêtes vers une URL différente. Pour ce faire, ajoutez un fichier `_redirects` dans le dossier `public/` de votre projet Astro. Ce fichier sera copié dans votre répertoire de sortie de construction.
+Vous pouvez déclarer des [redirections personnalisées](https://developers.cloudflare.com/pages/platform/redirects/) pour rediriger les requêtes vers une URL différente. Pour ce faire, ajoutez un fichier `_redirects` dans le dossier `public/` de votre projet Astro. Ce fichier sera copié dans votre répertoire de sortie de compilation.
 
-Ceci est disponible sur Cloudflare Workers et Pages.
+Cette fonctionnalité est disponible sur Cloudflare Workers et Pages.
 
 ### Routes
 #### Routage sur Cloudflare Workers
 
-Le routage des ressources statiques est basé sur la structure des fichiers dans le répertoire de construction (par exemple, `./dist`). Si aucune correspondance n'est trouvée, le Worker sera utilisé pour le rendu à la demande. En savoir plus sur [le routage des ressources statiques avec Cloudflare Workers](https://developers.cloudflare.com/workers/static-assets/routing/).
+Le routage des ressources statiques est basé sur la structure des fichiers dans le répertoire de compilation (par exemple, `./dist`). Si aucune correspondance n'est trouvée, le Worker sera utilisé pour le rendu à la demande. En savoir plus sur [le routage des ressources statiques avec Cloudflare Workers](https://developers.cloudflare.com/workers/static-assets/routing/).
 
 Contrairement à [Cloudflare Pages](#routage-sur-cloudflare-pages), avec Workers, vous n'avez pas besoin d'un fichier `_routes.json`.
 
@@ -388,7 +388,7 @@ Pour Cloudflare Pages, [le routage](https://developers.cloudflare.com/pages/plat
 Vous pouvez [spécifier des modèles de routage supplémentaires à suivre](#routesextend) dans la configuration de votre adaptateur ou créer votre propre fichier `_routes.json` personnalisé pour remplacer complètement la génération automatique.
 
 
-La création d'un fichier `public/_routes.json` personnalisé annulera la génération automatique. Voir [la documentation de Cloudflare sur la création d'un `_routes.json` personnalisé](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file) pour plus de détails.
+La création d'un fichier `public/_routes.json` personnalisé annulera la génération automatique. Consultez [la documentation de Cloudflare sur la création d'un fichier `_routes.json` personnalisé](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file) pour plus de détails.
 
 ## Sessions
 
@@ -448,7 +448,7 @@ Les écritures dans Cloudflare KV sont [éventuellement cohérentes](https://dev
 
 ## Importations de modules Cloudflare
 
-Le moteur d'exécution `workerd` de Cloudflare prend en charge les importations de certains [types de modules non standard](https://developers.cloudflare.com/workers/wrangler/bundling/#including-non-javascript-modules). La plupart des types de fichiers supplémentaires sont également disponibles dans Astro :
+L'environnement d'exécution `workerd` de Cloudflare prend en charge les importations de certains [types de modules non standard](https://developers.cloudflare.com/workers/wrangler/bundling/#including-non-javascript-modules). La plupart des types de fichiers supplémentaires sont également disponibles dans Astro :
 
 - `.wasm` ou `.wasm?module` : exporte un [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) qui peut ensuite être instancié.
 - `.bin` : exporte un [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) du contenu binaire brut du fichier
@@ -476,7 +476,7 @@ Bien que cet exemple soit trivial, Wasm peut être utilisé pour accélérer des
 
 ## Compatibilité Node.js
 
-Cloudflare ne prend pas en charge les API d'exécution Node.js. Avec un peu de configuration, Cloudflare prend en charge un sous-ensemble des API d'exécution Node.js. Vous pouvez trouver les API d'exécution Node.js prises en charge dans la [documentation de Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/nodejs).
+Cloudflare ne prend pas en charge les API de l'environnement d'exécution Node.js. Avec un peu de configuration, Cloudflare peut prendre en charge un sous-ensemble de ces API. Vous pouvez trouver les API de l'environnement d'exécution Node.js prises en charge dans la [documentation de Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/nodejs).
 
 Pour utiliser ces API, votre page ou point de terminaison doit être rendu côté serveur (et non pré-rendu) et doit utiliser la syntaxe d'importation `import {} from 'node:*'`.
 
@@ -501,10 +501,10 @@ export default defineConfig({
 })
 ```
 
-En plus de cela, vous devrez suivre la documentation de Cloudflare sur la façon d'activer le support. Pour des conseils détaillés, veuillez vous référer à la [documentation Cloudflare sur l'activation de la compatibilité Node.js](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+En plus de cela, vous devrez suivre la documentation de Cloudflare sur la façon d'activer la prise en charge. Pour des conseils détaillés, veuillez vous référer à la [documentation Cloudflare sur l'activation de la compatibilité Node.js](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
 
 :::note[Implications de la compatibilité des paquets]
-Si un projet importe un paquet sur le serveur qui utilise les API d'exécution Node.js, cela peut entraîner des problèmes lors du déploiement sur Cloudflare. Ce problème survient avec les paquets qui n'utilisent pas la syntaxe d'importation `node:*`. Il est recommandé de contacter les auteurs du paquet pour déterminer s'il prend en charge la syntaxe d'importation ci-dessus. Si ce n'est pas le cas, vous devrez peut-être utiliser un autre paquet.
+Si un projet importe un paquet sur le serveur qui utilise les API de l'environnement d'exécution Node.js, cela peut entraîner des problèmes lors du déploiement sur Cloudflare. Ce problème survient avec les paquets qui n'utilisent pas la syntaxe d'importation `node:*`. Il est recommandé de contacter les auteurs du paquet pour déterminer s'il prend en charge la syntaxe d'importation ci-dessus. Si ce n'est pas le cas, vous devrez peut-être utiliser un autre paquet.
 :::
 
 ## Aperçu avec Wrangler
@@ -527,7 +527,7 @@ Développer avec [`wrangler`](https://developers.cloudflare.com/workers/wrangler
 
 ### Messages d'erreur significatifs
 
-Actuellement, les erreurs lors de l'exécution de votre application dans Wrangler ne sont pas très utiles, en raison de la minification de votre code. Pour un meilleur débogage, vous pouvez ajouter le paramètre `vite.build.minify = false` à votre `astro.config.mjs`.
+Actuellement, les erreurs lors de l'exécution de votre application dans Wrangler ne sont pas très utiles, en raison de la minification de votre code. Pour un meilleur débogage, vous pouvez ajouter le paramètre `vite.build.minify = false` à votre fichier `astro.config.mjs`.
 
 ```js title="astro.config.mjs" ins={3-7}
 export default defineConfig({

--- a/src/content/docs/fr/guides/integrations-guide/db.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/db.mdx
@@ -16,7 +16,7 @@ Astro DB est une base de données SQL entièrement gérée, conçue pour l'écos
 
 Avec Astro DB, vous disposez d'un outil puissant, local et sûr pour interroger et modéliser le contenu comme une base de données relationnelle.
 
-<ReadMore>Voir le [Guide Astro DB](/fr/guides/astro-db/) pour une utilisation complète et des exemples.</ReadMore>
+<ReadMore>Consultez le [guide Astro DB](/fr/guides/astro-db/) pour une utilisation complète et des exemples.</ReadMore>
 
 ## Installation
 
@@ -44,7 +44,7 @@ Exécutez l'une des commandes suivantes dans une nouvelle fenêtre de terminal.
 
 #### Installation manuelle
 
-Si vous préférez configurer les choses vous-même à partir de zéro, sautez `astro add` et suivez ces instructions pour installer Astro DB vous-même.
+Si vous préférez configurer les choses vous-même à partir de zéro, ignorez `astro add` et suivez ces instructions pour installer Astro DB vous-même.
 
 ##### 1. Installer l'intégration à partir de npm via un gestionnaire de paquets
 
@@ -79,7 +79,7 @@ Si vous préférez configurer les choses vous-même à partir de zéro, sautez `
     });
     ```
 
-##### 3. Configurez votre base de données
+##### 3. Configurer votre base de données
 
 Créez un fichier `db/config.ts` à la racine de votre projet. Il s'agit d'un fichier spécial qu'Astro chargera automatiquement et utilisera pour configurer les tables de votre base de données.
 
@@ -122,7 +122,7 @@ Les colonnes sont configurées en utilisant l'utilitaire `column`. `column` supp
 Quelques valeurs de configuration sont communes à toutes les colonnes :
 
 - `primaryKey` - Définit une colonne `number` ou `text` comme identifiant unique.
-- `optional` - Astro DB utilise `NOT NULL` pour toutes les colonnes par défaut. Mettez `optional` à `true` pour autoriser les valeurs nulles.
+- `optional` - Astro DB utilise `NOT NULL` pour toutes les colonnes par défaut. Définissez `optional` sur `true` pour autoriser les valeurs nulles.
 - `default` - Définit la valeur par défaut pour les entrées nouvellement insérées. Ceci accepte soit une valeur statique, soit une chaîne de `sql` pour les valeurs générées comme les timestamps.
 - `unique` - Marque une colonne comme unique. Cela permet d'éviter les valeurs dupliquées dans les entrées de la table.
 - `references` - Fait référence à une table liée par une colonne. Cela établit une contrainte de clé étrangère, ce qui signifie que chaque valeur de colonne doit avoir une valeur correspondante dans la table référencée.
@@ -151,8 +151,8 @@ Cela générera un index unique sur les colonnes `authorId` et `published` avec 
 Les options de configuration suivantes sont disponibles pour chaque index :
 
 - `on` : `string | string[]` - Une seule colonne ou un tableau de noms de colonnes à indexer.
-- `unique` : `boolean` - Fixé à `true` pour imposer des valeurs uniques à travers les colonnes indexées.
-- `name`: `string` (Optionnel) - Un nom personnalisé pour l'index unique. Il remplacera le nom généré par Astro basé sur les noms de la table et de la colonne indexée (par exemple `Comment_authorId_published_idx`). Les noms personnalisés sont globaux, il faut donc s'assurer que les noms d'index n'entrent pas en conflit entre les tables.
+- `unique` : `boolean` - Définir sur `true` pour imposer des valeurs uniques à travers les colonnes indexées.
+- `name` : `string` (Optionnel) - Un nom personnalisé pour l'index unique. Il remplacera le nom généré par Astro basé sur les noms de la table et de la colonne indexée (par exemple `Comment_authorId_published_idx`). Les noms personnalisés sont globaux, il faut donc s'assurer que les noms d'index n'entrent pas en conflit entre les tables.
 
 ### `foreignKeys`
 
@@ -191,22 +191,22 @@ const Comment = defineTable({
 
 Chaque objet de configuration de clé étrangère accepte les propriétés suivantes :
 
-- `columns`: `string[]` - Un tableau de noms de colonnes à associer à la table référencée.
-- `references`: `() => Column[]` - Une fonction qui renvoie un tableau de colonnes de la table référencée.
+- `columns` : `string[]` - Un tableau de noms de colonnes à associer à la table référencée.
+- `references` : `() => Column[]` - Une fonction qui renvoie un tableau de colonnes de la table référencée.
 
-## Référence CLI Astro DB
+## Référence de la CLI d'Astro DB
 
 Astro DB inclut un ensemble de commandes CLI pour interagir pour interagir avec votre base de données locale et compatible libSQL.
 
-Ces commandes sont appelées automatiquement lors de l'utilisation d'une action CI GitHub, et peuvent être appelées manuellement en utilisant le CLI `astro db`.
+Ces commandes sont appelées automatiquement lors de l'utilisation d'une action CI GitHub, et peuvent être appelées manuellement en utilisant la CLI `astro db`.
 
 ### `astro db push`
 
-**Flags :**
+**Options :**
 
-- `--force-reset` Réinitialiser toutes les données de production si une modification du schéma de rupture est nécessaire.
+- `--force-reset` Réinitialiser toutes les données de production si une modification du schéma avec rupture de compatibilité est nécessaire.
 
-Transférez en toute sécurité les modifications apportées à la configuration de la base de données dans la base de données de votre projet. Cela vérifiera tout risque de perte de données et vous guidera sur les étapes de migration recommandées. Si un changement radical de schéma doit être effectué, utilisez le drapeau `--force-reset` pour réinitialiser toutes les données de production.
+Transférez en toute sécurité les modifications apportées à la configuration de la base de données dans la base de données de votre projet. Cela vérifiera tout risque de perte de données et vous guidera sur les étapes de migration recommandées. Si un changement de schéma avec rupture de compatibilité doit être effectué, utilisez l'option `--force-reset` pour réinitialiser toutes les données de production.
 
 ### `astro db verify`
 
@@ -214,15 +214,15 @@ Vérifier s'il y a des différences entre la configuration de la base de donnée
 
 ### `astro db execute <file-path>`
 
-**Flags :**
+**Options :**
 
 - `--remote` Exécuter sur votre base de données compatible libSQL. L'omettre pour exécuter sur votre serveur de développement.
 
-Exécute un fichier `.ts` ou `.js` pour lire ou écrire dans votre base de données. Cette commande accepte un chemin de fichier comme argument, et supporte l'utilisation du module `astro:db` pour écrire des requêtes sûres. Utilisez l'option `--remote` pour exécuter sur votre base de données compatible libSQL, ou ignorez l'option pour lancer l'exécution sur votre serveur de développement. Voir comment utiliser les [données sur le développement des seeds](/fr/guides/astro-db/#alimentez-votre-base-de-données-pour-le-développement) pour un exemple de fichier.
+Exécute un fichier `.ts` ou `.js` pour lire ou écrire dans votre base de données. Cette commande accepte un chemin de fichier comme argument, et supporte l'utilisation du module `astro:db` pour écrire des requêtes sûres. Utilisez l'option `--remote` pour exécuter sur votre base de données compatible libSQL, ou ignorez l'option pour lancer l'exécution sur votre serveur de développement. Découvrez comment [amorcer les données de développement](/fr/guides/astro-db/#alimentez-votre-base-de-données-pour-le-développement) pour un exemple de fichier.
 
 ### `astro db shell --query <sql-string>`
 
-**Flags :**
+**Options :**
 
 - `--query` Requête SQL brute à exécuter.
 - `--remote` Exécuter sur votre base de données compatible libSQL. L'omettre pour exécuter sur votre serveur de développement.
@@ -247,9 +247,9 @@ export const POST: APIRoute = (ctx) => {
     });
   } catch (e) {
     if (isDbError(e)) {
-      return new Response(`Cannot insert comment with id ${id}\n\n${e.message}`, { status: 400 });
+      return new Response(`Impossible d'insérer un commentaire avec l'id ${id}\n\n${e.message}`, { status: 400 });
     }
-    return new Response('An unexpected error occurred', { status: 500 });
+    return new Response("Une erreur inattendue s'est produite", { status: 500 });
   }
 
   return new Response(null, { status: 201 });

--- a/src/content/docs/fr/guides/integrations-guide/deno.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/deno.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@deno/astro-adapter'
-description: L'adaptateur Deno Astro
+description: L'adaptateur Deno pour Astro
 sidebar:
   label: Deno
 i18nReady: true
@@ -8,6 +8,6 @@ i18nReady: true
 
 L'adaptateur Deno permet à Astro de déployer votre site SSR vers des cibles Deno, y compris Deno Deploy.
 
-L'adaptateur Deno était auparavant maintenu par Astro mais est maintenant maintenu par Deno directement. L'utilisation est désormais documentée [dans le référentiel de l'adaptateur Deno](https://github.com/denoland/deno-astro-adapter).
+L'adaptateur Deno était auparavant maintenu par Astro mais est maintenant maintenu par Deno directement. L'utilisation est désormais documentée [dans le dépôt de l'adaptateur Deno](https://github.com/denoland/deno-astro-adapter).
 
 Si vous utilisez actuellement cet adaptateur Astro, vous devrez migrer vers la nouvelle version de Deno ou [ajouter un autre adaptateur](/fr/guides/on-demand-rendering/) pour continuer à utiliser SSR dans votre projet.

--- a/src/content/docs/fr/guides/integrations-guide/index.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/index.mdx
@@ -11,7 +11,7 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { Steps } from '@astrojs/starlight/components';
 
 
-Les **intégrations Astro** permettent d'ajouter de nouvelles fonctionnalités et de nouveaux comportements à votre projet en quelques lignes de code. Vous pouvez utiliser une intégration officielle, [des intégrations créées par la communauté](#intégrations-officielles) ou même [créer vous-même une intégration personnalisée](#construire-votre-propre-intégration).
+Les **intégrations Astro** permettent d'ajouter de nouvelles fonctionnalités et de nouveaux comportements à votre projet en quelques lignes de code. Vous pouvez utiliser une intégration officielle, [des intégrations créées par la communauté](#intégrations-officielles) ou même [créer vous-même une intégration personnalisée](#créer-votre-propre-intégration).
 
 Les intégrations peuvent…
 

--- a/src/content/docs/fr/guides/integrations-guide/index.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/index.mdx
@@ -13,16 +13,16 @@ import { Steps } from '@astrojs/starlight/components';
 
 Les **intégrations Astro** permettent d'ajouter de nouvelles fonctionnalités et de nouveaux comportements à votre projet en quelques lignes de code. Vous pouvez utiliser une intégration officielle, [des intégrations créées par la communauté](#intégrations-officielles) ou même [créer vous-même une intégration personnalisée](#construire-votre-propre-intégration).
 
-Les intégrations peuvent...
+Les intégrations peuvent…
 
 - Débloquer React, Vue, Svelte, Solid et d'autres frameworks UI populaires.
 - Activer le rendu à la demande avec un [adaptateur SSR](/fr/guides/on-demand-rendering/).
 - Intégrer des outils comme MDX et Partytown avec quelques lignes de code.
 - Ajouter de nouvelles fonctionnalités à votre projet, comme la génération automatique de sitemap.
-- Écrire du code personnalisé qui s'accroche au processus de construction, au serveur de développement, et plus encore.
+- Écrire du code personnalisé qui se branche au processus de compilation, au serveur de développement, et plus encore.
 
 :::tip[Répertoire des intégrations]
-Parcourez ou recherchez des centaines d'intégrations officielles et communautaires dans notre [répertoire d'intégrations](https://astro.build/integrations/). Trouvez des packages à ajouter à votre projet Astro pour l'authentification, l'analyse, la performance, le référencement (SEO), l'accessibilité, l'interface utilisateur, les outils de développement, et plus encore.
+Parcourez ou recherchez des centaines d'intégrations officielles et communautaires dans notre [répertoire d'intégrations](https://astro.build/integrations/). Trouvez des paquets à ajouter à votre projet Astro pour l'authentification, l'analyse, la performance, le référencement (SEO), l'accessibilité, l'interface utilisateur, les outils de développement, et plus encore.
 :::
 
 ## Intégrations Officielles
@@ -33,7 +33,7 @@ Les intégrations suivantes sont gérées par Astro.
 
 ## Configuration automatique des intégrations
 
-Astro inclut une commande `astro add` pour automatiser la mise en place des intégrations officielles. Plusieurs plugins communautaires peuvent également être ajoutés en utilisant cette commande. Veuillez consulter la documentation de chaque intégration pour savoir si `astro add` est supporté, ou si vous devez [installer manuellement](#installation-manuelle).
+Astro inclut une commande `astro add` pour automatiser la mise en place des intégrations officielles. Plusieurs modules d'extension communautaires peuvent également être ajoutés en utilisant cette commande. Veuillez consulter la documentation de chaque intégration pour savoir si `astro add` est pris en charge, ou si vous devez [installer manuellement](#installation-manuelle).
 
 Exécutez la commande `astro add` en utilisant le gestionnaire de paquets de votre choix et notre assistant d'intégration automatique mettra à jour votre fichier de configuration et installera toutes les dépendances nécessaires.
 
@@ -125,7 +125,7 @@ export default defineConfig({
 })
 ```
 
-Consultez l'[API intégration](/fr/reference/integrations-reference/) de référence pour connaître les différentes façons d'écrire une intégration.
+Consultez la référence de l'[API des intégrations](/fr/reference/integrations-reference/) pour connaître les différentes façons d'écrire une intégration.
 
 #### Installation d'un paquet NPM
 
@@ -172,7 +172,7 @@ Par exemple, pour installer l'intégration `@astrojs/sitemap` :
 
 ### Options personnalisées
 
-Les intégrations sont presque toujours conçues comme des fonctions _"factory"_ qui renvoient l'objet d'intégration proprement dit. Cela vous permet de passer des arguments et des options à la fonction _"factory"_ afin de personnaliser l'intégration pour votre projet.
+Les intégrations sont presque toujours conçues comme des fonctions d'usine (ou « factory functions » en anglais) qui renvoient l'objet d'intégration réel. Cela vous permet de passer des arguments et des options à la fonction d'usine afin de personnaliser l'intégration pour votre projet.
 
 ```js
 integrations: [
@@ -183,18 +183,18 @@ integrations: [
 
 ### Activer/Désactiver une intégration
 
-Les intégrations Falsy sont ignorées, vous pouvez donc les activer et les désactiver sans vous soucier des valeurs `undefined` et booléennes laissées en suspens.
+Les intégrations évaluées comme fausses (« falsy » en anglais) sont ignorées, vous pouvez donc les activer et les désactiver sans vous soucier des valeurs `undefined` et booléennes laissées en suspens.
 
 ```js
 integrations: [
-  // Exemple : Sauter la construction d'un plan du site sous Windows
+  // Exemple : Sauter la génération d'un plan du site sous Windows
   process.platform !== 'win32' && sitemap()
 ]
 ```
 
 ## Mise à jour des intégrations
 
-Pour mettre à jour toutes les intégrations officielles en une seule fois, lancez la commande `@astrojs/upgrade`. Cela mettra à jour Astro et toutes les intégrations officielles vers leurs dernières versions.
+Pour mettre à jour toutes les intégrations officielles en une seule fois, exécuter la commande `@astrojs/upgrade`. Cela mettra à jour Astro et toutes les intégrations officielles vers leurs dernières versions.
 
 ### Mise à jour automatique
 
@@ -244,7 +244,7 @@ Pour mettre à jour manuellement une ou plusieurs intégrations, utilisez la com
   </Fragment>
 </PackageManagerTabs>
 
-## Supprimer une Intégration
+## Supprimer une intégration
 
 <Steps>
 1. Pour supprimer une intégration, désinstallez d'abord l'intégration de votre projet
@@ -286,8 +286,8 @@ Pour mettre à jour manuellement une ou plusieurs intégrations, utilisez la com
 
 Vous trouverez de nombreuses intégrations développées par la communauté dans le [répertoire des intégrations d'Astro](https://astro.build/integrations/). Suivez les liens pour obtenir des instructions détaillées d'utilisation et de configuration
 
-## Construire votre propre intégration
+## Créer votre propre intégration
 
-L'API d'intégration d'Astro s'inspire de Rollup et de Vite, et est conçue pour être familière à quiconque a déjà écrit un plugin Rollup ou Vite.
+L'API des intégrations d'Astro s'inspire de Rollup et de Vite, et est conçue pour être familière à quiconque a déjà écrit un module d'extension Rollup ou Vite.
 
-Consultez l'[API intégration](/fr/reference/integrations-reference/) de référence pour apprendre ce que les intégrations peuvent faire et comment en écrire une vous-même.
+Consultez la référence de l'[API des intégrations](/fr/reference/integrations-reference/) pour apprendre ce que les intégrations peuvent faire et comment en écrire une vous-même.

--- a/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
@@ -78,9 +78,9 @@ export default defineConfig({
 });
 ```
 
-### Intégration dans un éditeur VS Code
+### Intégration dans l'éditeur VS Code
 
-Si vous utilisez VS Code, il existe une [extension de langage Markdoc officielle](https://marketplace.visualstudio.com/items?itemName=Stripe.markdoc-language-support) qui inclut la coloration syntaxique et l'autocomplétion pour les balises configurées. [Voir le serveur de langue sur GitHub](https://github.com/markdoc/language-server.git) pour plus d'informations.
+Si vous utilisez VS Code, il existe une [extension de langage Markdoc officielle](https://marketplace.visualstudio.com/items?itemName=Stripe.markdoc-language-support) qui inclut la coloration syntaxique et l'autocomplétion pour les balises configurées. [Voir le serveur de langage sur GitHub](https://github.com/markdoc/language-server.git) pour plus d'informations.
 
 Pour configurer l'extension, créez un fichier `markdoc.config.json` à la racine du projet avec le contenu suivant :
 
@@ -106,14 +106,14 @@ Définissez `markdoc.config.mjs` comme fichier de configuration avec l'objet `sc
 Les fichiers Markdoc ne peuvent être utilisés que dans les collections de contenus. Ajoutez des entrées à n'importe quelle collection de contenus en utilisant l'extension `.mdoc` :
 
 <FileTree>
-  - src/
+- src/
   - content/
-  - docs/
-  - why-markdoc.mdoc
-  - quick-start.mdoc
+    - docs/
+      - why-markdoc.mdoc
+      - quick-start.mdoc
 </FileTree>
 
-Interrogez ensuite votre collection à l'aide des [API de Collections de contenus](/fr/guides/content-collections/#interroger-les-collections) :
+Interrogez ensuite votre collection à l'aide des [API de collections de contenus](/fr/guides/content-collections/#interroger-les-collections) :
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
@@ -129,11 +129,11 @@ const { Content } = await render(entry);
 <Content />
 ```
 
-<ReadMore>Voir les [docs de la collection de contenus Astro][astro-content-collections] pour plus d'informations.</ReadMore>
+<ReadMore>Consultez la [documentation des collections de contenu d'Astro][astro-content-collections] pour plus d'informations.</ReadMore>
 
-## Passer les variables Markdoc
+## Transmettre des variables Markdoc
 
-Vous pouvez avoir besoin de passer les [variables][markdoc-variables] à votre contenu. C'est utile pour passer des paramètres SSR comme les tests A/B.
+Vous pouvez avoir besoin de transmettre des [variables][markdoc-variables] à votre contenu. C'est utile pour passer des paramètres SSR comme les tests A/B.
 
 Les variables peuvent être transmises en tant que props via le composant `Content` :
 
@@ -188,15 +188,15 @@ const { Content } = await render(entry);
 
 Il est désormais accessible sous le nom de `$frontmatter` dans votre Markdoc.
 
-## Afficher les composants
+## Restituer les composants
 
 `@astrojs/markdoc` offre des options de configuration pour utiliser toutes les fonctionnalités de Markdoc et connecter des composants d'interface utilisateur à votre contenu.
 
 ### Utiliser les composants Astro comme balises Markdoc
 
-Vous pouvez configurer des [Markdoc tags][markdoc-tags] qui correspondent à des composants `.astro`. Vous pouvez ajouter une nouvelle balise en créant un fichier `markdoc.config.mjs|ts` à la racine de votre projet et en configurant l'attribut `tag`.
+Vous pouvez configurer des [balises Markdoc][markdoc-tags] qui correspondent à des composants `.astro`. Vous pouvez ajouter une nouvelle balise en créant un fichier `markdoc.config.mjs|ts` à la racine de votre projet et en configurant l'attribut `tag`.
 
-Cet exemple rend un composant `Aside`, et permet de passer une propriété `type` sous forme de chaîne de caractères :
+Cet exemple restitue un composant `Aside` et permet de transmettre une propriété `type` sous forme de chaîne de caractères :
 
 ```js title="markdoc.config.mjs"
 import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
@@ -208,7 +208,7 @@ export default defineMarkdocConfig({
       attributes: {
         // Markdoc exige des définitions de type pour chaque attribut.
         // Ceux-ci doivent refléter le type `Props` du composant
-        // que vous rendez.
+        // que vous restituez.
         // Voir la documentation de Markdoc sur la définition des attributs.
         // https://markdoc.dev/docs/attributes#defining-attributes
         type: { type: String },
@@ -225,7 +225,7 @@ Ce composant peut maintenant être utilisé dans vos fichiers Markdoc avec la ba
 
 {% aside type="tip" %}
 
-Utilisez des balises comme cette fantaisie "aside" pour ajouter un peu de _flair_ à vos documents.
+Utilisez des balises comme cet « encart » fantaisiste pour ajouter un peu de _d'originalité_ à vos documents.
 
 {% /aside %}
 ```
@@ -234,7 +234,7 @@ Utilisez des balises comme cette fantaisie "aside" pour ajouter un peu de _flair
 
 Les balises et les nœuds sont limités aux fichiers `.astro`. Pour intégrer des composants d'interface utilisateur côté client dans Markdoc, [utilisez un composant `.astro` enveloppant qui affiche un composant de framework](/fr/guides/framework-components/#imbriquer-des-composants-de-framework) avec la directive `client:` de votre choix.
 
-Cet exemple enveloppe un composant React `Aside.tsx` avec un composant `ClientAside.astro` :
+Cet exemple enveloppe un composant React `Aside.tsx` avec un composant `ClientAside.astro` :
 
 ```astro title="src/components/ClientAside.astro"
 ---
@@ -244,7 +244,7 @@ import Aside from './Aside';
 <Aside {...Astro.props} client:load />
 ```
 
-Ce composant Astro peut maintenant être passé à la propriété `render` pour n'importe quel [tag][markdoc-tags] ou [node][markdoc-nodes] dans votre configuration :
+Ce composant Astro peut maintenant être passé à la propriété `render` pour n'importe quel [balise][markdoc-tags] ou [nœud][markdoc-nodes] dans votre configuration :
 
 ```js title="markdoc.config.mjs"
 import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
@@ -285,17 +285,17 @@ Cela génère la déclaration d'importation suivante en interne :
 import { Tabs } from '@astrojs/starlight/components';
 ```
 
-### Partiels de Markdoc
+### Fichiers partiels de Markdoc
 
 La balise `{% partial /%}` vous permet d'afficher d'autres fichiers `.mdoc` dans votre contenu Markdoc.
 
 Cette fonction est utile pour réutiliser le contenu de plusieurs documents et permet d'avoir des fichiers de contenu `.mdoc` qui ne suivent pas le schéma de votre collection.
 
 :::tip
-Utilisez un préfixe `_` souligné pour les fichiers ou répertoires partiels. Cela permet d'exclure les fichiers partiels des requêtes de collecte de contenu.
+Utilisez un trait de soulignement `_` comme préfixe pour les fichiers ou répertoires partiels. Cela permet d'exclure les fichiers partiels des requêtes de collecte de contenu.
 :::
 
-Cet exemple montre une partie de Markdoc pour un pied de page à utiliser dans les entrées de la collection de blogs :
+Cet exemple montre un fichier Markdoc partiel pour un pied de page à utiliser dans les entrées de collection de blog :
 
 ```md title="src/content/blog/_footer.mdoc"
 Liens sociaux :
@@ -328,15 +328,15 @@ import shiki from '@astrojs/markdoc/shiki';
 export default defineMarkdocConfig({
   extends: [
     shiki({
-      // Choisissez parmi les thèmes intégrés de Shiki (ou ajoutez les vôtres)
-      // Défaut : 'github-dark'
+      // Choisir parmi les thèmes intégrés de Shiki (ou ajoutez les vôtres)
+      // Par défaut : 'github-dark'
       // https://shiki.style/themes
       theme: 'dracula',
       // Activer l'habillage des mots pour éviter le défilement horizontal
-      // Défaut : false
+      // Par défaut : false
       wrap: true,
-      // Passer des langues personnalisées
-      // Note : Shiki a d'innombrables langages intégrés, y compris `.astro` !
+      // Transmettre des langues personnalisées
+      // Remarque : Shiki a d'innombrables langages intégrés, y compris `.astro` !
       // https://shiki.style/languages
       langs: [],
     }),
@@ -382,7 +382,7 @@ export default defineMarkdocConfig({
 
 ### En-têtes personnalisés
 
-`@astrojs/markdoc` ajoute automatiquement des liens d'ancrage à vos titres, et [génère une liste de `titres` via l'API des Collections de contenu](/fr/guides/content-collections/#restitution-du-contenu). Pour personnaliser davantage le rendu des titres, vous pouvez appliquer un composant Astro [en tant que nœud Markdoc][markdoc-nodes].
+`@astrojs/markdoc` ajoute automatiquement des liens d'ancrage à vos titres, et [génère une liste de titres (`headings`) via l'API des collections de contenu](/fr/guides/content-collections/#restitution-du-contenu). Pour personnaliser davantage le rendu des titres, vous pouvez appliquer un composant Astro [en tant que nœud Markdoc][markdoc-nodes].
 
 Cet exemple rend un composant `Heading.astro` en utilisant la propriété `render` :
 
@@ -399,12 +399,12 @@ export default defineMarkdocConfig({
 });
 ```
 
-Tous les titres Markdown rendront le composant `Heading.astro` et passeront les `attributs` suivants en tant que props du composant :
+Tous les titres Markdown restitueront le composant `Heading.astro` et passeront les `attributs` suivants en tant que props du composant :
 
-* `level: number` Le niveau de la rubrique 1 - 6
-* `id: string` Un `id` généré à partir du contenu textuel de la rubrique. Cela correspond au `slug` généré par la fonction [content `render()`](/fr/guides/content-collections/#restitution-du-contenu).
+* `level: number` Le niveau de titre 1 - 6
+* `id: string` Un `id` généré à partir du contenu textuel du titre. Cela correspond au `slug` généré par la fonction [de restitution du contenu `render()`](/fr/guides/content-collections/#restitution-du-contenu).
 
-Par exemple, le titre `### Level 3 heading!` passera `level: 3` et `id: 'level-3-heading'` en tant qu'éléments du composant.
+Par exemple, le titre `### Titre de niveau 3 !` transmettra `level: 3` et `id: 'titre-de-niveau-3'` en tant que props du composant.
 
 ### Composants d'image personnalisés
 
@@ -538,7 +538,7 @@ Les étapes suivantes permettent de créer une balise image Markdoc personnalis�
 
 ## Configuration avancée de Markdoc
 
-Le fichier `markdoc.config.mjs|ts` accepte [toutes les options de configuration de Markdoc](https://markdoc.dev/docs/config), y compris [les tags](https://markdoc.dev/docs/tags) et [les fonctions](https://markdoc.dev/docs/functions).
+Le fichier `markdoc.config.mjs|ts` accepte [toutes les options de configuration de Markdoc](https://markdoc.dev/docs/config), y compris [les balises](https://markdoc.dev/docs/tags) et [les fonctions](https://markdoc.dev/docs/functions).
 
 Vous pouvez passer ces options à partir de l'exportation par défaut dans votre fichier `markdoc.config.mjs|ts` :
 
@@ -572,7 +572,7 @@ Vous pouvez désormais appeler cette fonction à partir de n'importe quelle entr
 
 ### Définir l'élément HTML racine
 
-Markdoc entoure les documents d'une balise `<article>` par défaut. Ce comportement peut être modifié à partir du noeud Markdoc `document`. Il accepte un nom d'élément HTML ou `null` si vous préférez supprimer l'élément enveloppant :
+Markdoc enveloppe les documents d'une balise `<article>` par défaut. Ce comportement peut être modifié à partir du noeud Markdoc `document`. Il accepte un nom d'élément HTML ou `null` si vous préférez supprimer l'élément enveloppant :
 
 ```js title="markdoc.config.mjs"
 import { defineMarkdocConfig, nodes } from '@astrojs/markdoc/config';
@@ -581,7 +581,7 @@ export default defineMarkdocConfig({
   nodes: {
     document: {
       ...nodes.document, // Application des valeurs par défaut pour les autres options
-      render: null, // défaut : 'article'
+      render: null, // par défaut : 'article'
     },
   },
 });

--- a/src/content/docs/fr/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/mdx.mdx
@@ -1,9 +1,9 @@
 ---
 type: integration
 title: '@astrojs/mdx'
+description: "Apprenez à utiliser l'intégration @astrojs/mdx dans votre projet Astro."
 sidebar:
   label: MDX
-description: "Apprenez à utiliser l'intégration @astrojs/mdx dans votre projet Astro."
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/mdx/'
 category: other
 i18nReady: true
@@ -86,7 +86,7 @@ Pour les autres éditeurs, utilisez le [serveur de langage MDX](https://github.c
 
 ## Utilisation
 
-Visitez le site [MDX docs](https://mdxjs.com/docs/what-is-mdx/) pour en savoir plus sur l'utilisation des fonctionnalités standard de MDX.
+Visitez la [documentation de MDX](https://mdxjs.com/docs/what-is-mdx/) pour en savoir plus sur l'utilisation des fonctionnalités standard de MDX.
 
 ## MDX dans Astro
 
@@ -123,7 +123,7 @@ MDX permet d'utiliser les instructions `export` pour ajouter des variables à vo
 Par exemple, vous pouvez exporter un champ `title` d'une page ou d'un composant MDX pour l'utiliser comme titre avec des `{expressions JSX}` :
 
 ```mdx title="/src/blog/posts/post-1.mdx"
-export const title = 'Mon tout premier post MDX';
+export const title = 'Mon tout premier article avec MDX';
 
 # {title}
 ```
@@ -146,17 +146,17 @@ Les propriétés suivantes sont disponibles pour un composant `.astro` lorsqu'il
 - **`file`** - Le chemin absolu du fichier (par exemple `/home/user/projects/.../file.mdx`).
 - **`url`** - L'URL de la page (par exemple `/fr/guides/markdown-content`).
 - **`frontmatter`** - Contient toutes les données spécifiées dans le frontmatter YAML/TOML du fichier.
-- **`getHeadings()`** - Une fonction asynchrone qui renvoie un tableau de tous les titres (`<h1>` à `<h6>`) dans le fichier avec le type : `{ depth: number ; slug: string ; text: string }[]`. Le `slug` de chaque titre correspond à l'ID généré pour un titre donné et peut être utilisé pour les liens d'ancrage.
+- **`getHeadings()`** - Une fonction asynchrone qui renvoie un tableau de tous les titres (`<h1>` à `<h6>`) dans le fichier avec le type : `{ depth: number; slug: string; text: string }[]`. Le `slug` de chaque titre correspond à l'ID généré pour un titre donné et peut être utilisé pour les liens d'ancrage.
 - **`<Content />`** - Un composant qui renvoie le contenu complet et affiché du fichier.
-- **(toute valeur `export`)** - Les fichiers MDX peuvent également exporter des données à l'aide d'une instruction `export`.
+- **(toute valeur exportée (`export`))** - Les fichiers MDX peuvent également exporter des données à l'aide d'une instruction `export`.
 
-### Utilisation de variables Frontmatter dans MDX
+### Utilisation des variables du frontmatter dans MDX
 
 L'intégration MDX d'Astro inclut la prise en charge de l'utilisation de frontmatter dans MDX par défaut. Ajoutez des propriétés frontmatter comme vous le feriez dans des fichiers Markdown, et ces variables pourront être utilisées aussi bien dans le modèle qu'en tant que propriétés nommées lorsque vous importez le fichier ailleurs.
 
 ```mdx title="/src/blog/posts/post-1.mdx"
 ---
-title: 'Mon premier post MDX'
+title: 'Mon premier article avec MDX'
 author: 'Houston'
 ---
 
@@ -167,11 +167,11 @@ author: 'Houston'
 
 ### Utilisation de composants dans MDX
 
-Après avoir installé l'intégration MDX, vous pouvez importer et utiliser les [composants Astro](/fr/basics/astro-components/) et les [composants du framework UI](/fr/guides/framework-components/#utilisation-des-composants-de-framework) dans les fichiers MDX (`.mdx`) comme vous le feriez avec n'importe quel autre composant Astro.
+Après avoir installé l'intégration MDX, vous pouvez importer et utiliser les [composants Astro](/fr/basics/astro-components/) et les [composants de framework UI](/fr/guides/framework-components/#utilisation-des-composants-de-framework) dans les fichiers MDX (`.mdx`) comme vous le feriez avec n'importe quel autre composant Astro.
 
 N'oubliez pas de transmettre `client:directive` aux composants de votre framework UI, si nécessaire !
 
-Vous trouverez d'autres exemples d'utilisation des instructions import et export dans la [documentation de MDX](https://mdxjs.com/docs/what-is-mdx/#esm).
+Vous trouverez d'autres exemples d'utilisation des instructions d'importation et d'exportation dans la [documentation de MDX](https://mdxjs.com/docs/what-is-mdx/#esm).
 
 ```mdx title="src/blog/post-1.mdx" {4,9}
 ---
@@ -181,7 +181,7 @@ import ReactCounter from '../components/ReactCounter.jsx';
 
 Je viens de commencer mon nouveau blog avec Astro !
 
-Voici mon composant compteur, fonctionnant en MDX :
+Voici mon composant compteur, fonctionnant dans MDX :
 <ReactCounter client:load />
 ```
 
@@ -240,7 +240,7 @@ Vous pouvez configurer le rendu de votre MDX à l'aide des options suivantes :
 
 ### Options héritées de la configuration Markdown
 
-Toutes les [options de configuration `markdown`](/fr/reference/configuration-reference/#options-de-markdown) peuvent être configurées séparément dans l'intégration MDX. Cela inclut les plugins remark et rehype, la coloration syntaxique, et plus encore. Les options seront par défaut celles de votre configuration Markdown ([voir l'option `extendMarkdownConfig`](#extendmarkdownconfig) pour les modifier).
+Toutes les [options de configuration `markdown`](/fr/reference/configuration-reference/#options-de-markdown) peuvent être configurées séparément dans l'intégration MDX. Cela inclut les modules d'extension remark et rehype, la coloration syntaxique, et plus encore. Les options seront par défaut celles de votre configuration Markdown ([voir l'option `extendMarkdownConfig`](#extendmarkdownconfig) pour les modifier).
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -256,7 +256,7 @@ export default defineConfig({
       shikiConfig: { theme: 'dracula' },
       remarkPlugins: [remarkToc],
       rehypePlugins: [rehypePresetMinify],
-      remarkRehype: { footnoteLabel: 'Footnotes' },
+      remarkRehype: { footnoteLabel: 'Notes de bas de page' },
       gfm: false,
     }),
   ],
@@ -264,7 +264,7 @@ export default defineConfig({
 ```
 
 :::caution
-MDX ne permet pas de fournir les plugins remark et rehype sous la forme d'une chaîne. Vous devez installer, importer et appliquer la fonction du plugin à la place.
+MDX ne prend pas en charge la transmission de modules d'extension remark et rehype sous la forme d'une chaîne de caractères. Vous devez installer, importer et appliquer la fonction du module d'extension à la place.
 :::
 
 <ReadMore>Voir la [référence des options Markdown](/fr/reference/configuration-reference/#options-de-markdown) pour une liste complète des options.</ReadMore>
@@ -272,11 +272,11 @@ MDX ne permet pas de fournir les plugins remark et rehype sous la forme d'une ch
 ### `extendMarkdownConfig`
 
 * **Type :** `boolean`
-* **Défaut :** `true`
+* **Par défaut :** `true`
 
 MDX étend par défaut [la configuration Markdown existante de votre projet](/fr/reference/configuration-reference/#options-de-markdown). Pour remplacer certaines options, vous pouvez spécifier leur équivalent dans votre configuration MDX.
 
-Par exemple, disons que vous avez besoin de désactiver GitHub-Flavored Markdown et d'appliquer un ensemble différent de plugins de remark pour les fichiers MDX. Vous pouvez appliquer ces options comme suit, avec `extendMarkdownConfig` activée par défaut :
+Par exemple, supposons que vous avez besoin de désactiver GitHub-Flavored Markdown et d'appliquer un ensemble différent de modules d'extension remark pour les fichiers MDX. Vous pouvez appliquer ces options comme suit, avec `extendMarkdownConfig` activée par défaut :
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -293,8 +293,8 @@ export default defineConfig({
     mdx({
       // `syntaxHighlight` héritée de Markdown
 
-      // Markdown `remarkPlugins` ignorée,
-      // seulement `remarkPlugin2` est appliquée.
+      // `remarkPlugins` de Markdown ignorés,
+      // seulement `remarkPlugin2` est appliqué.
       remarkPlugins: [remarkPlugin2],
       // `gfm` remplacée par `false`
       gfm: false,
@@ -303,7 +303,7 @@ export default defineConfig({
 });
 ```
 
-Vous pouvez également avoir besoin de désactiver l'extension de la configuration `markdown` dans MDX. Pour cela, mettez `extendMarkdownConfig` à `false` :
+Vous pouvez également avoir besoin de désactiver l'extension de la configuration `markdown` dans MDX. Pour cela, définissez `extendMarkdownConfig` sur `false` :
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -318,7 +318,7 @@ export default defineConfig({
     mdx({
       // La configuration Markdown est désormais ignorée
       extendMarkdownConfig: false,
-      // Pas de `remarkPlugins` appliquée
+      // aucun `remarkPlugins` n'est appliqué
     }),
   ],
 });
@@ -326,7 +326,7 @@ export default defineConfig({
 
 ### `recmaPlugins`
 
-Il s'agit de plugins qui modifient directement la sortie [estree](https://github.com/estree/estree). Ceci est utile pour modifier ou injecter des variables JavaScript dans vos fichiers MDX.
+Il s'agit de modules d'extension qui modifient directement la sortie [estree](https://github.com/estree/estree). Ceci est utile pour modifier ou injecter des variables JavaScript dans vos fichiers MDX.
 
 Nous vous suggérons [d'utiliser AST Explorer](https://astexplorer.net/) pour jouer avec les sorties d'estree, et d'essayer [`estree-util-visit`](https://unifiedjs.com/explore/package/estree-util-visit/) pour effectuer des recherches dans les nœuds JavaScript.
 
@@ -334,7 +334,7 @@ Nous vous suggérons [d'utiliser AST Explorer](https://astexplorer.net/) pour jo
 
 * **Type :** `boolean | { ignoreElementNames?: string[] }`
 
-Il s'agit d'un paramètre de configuration facultatif qui permet d'optimiser la sortie MDX pour une construction et un rendu plus rapides grâce à un plugin rehype interne. Cela peut être utile si vous avez beaucoup de fichiers MDX et que vous constatez des lenteurs dans la construction. Cependant, cette option peut générer du HTML non échappé, assurez-vous donc que les parties interactives de votre site fonctionnent toujours correctement après l'avoir activée.
+Il s'agit d'un paramètre de configuration facultatif qui permet d'optimiser la sortie MDX pour une compilation et un rendu plus rapides grâce à un module d'extension rehype interne. Cela peut être utile si vous avez beaucoup de fichiers MDX et que vous constatez des lenteurs lors de la compilation. Cependant, cette option peut générer du HTML non échappé, assurez-vous donc que les parties interactives de votre site fonctionnent toujours correctement après l'avoir activée.
 
 Cette option est désactivée par défaut. Pour activer l'optimisation MDX, ajoutez ce qui suit à votre configuration d'intégration MDX :
 

--- a/src/content/docs/fr/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/netlify.mdx
@@ -13,7 +13,7 @@ import Since from '~/components/Since.astro';
 
 Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Netlify](https://www.netlify.com/), y compris [les îlots de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
 
-Si vous utilisez Astro comme générateur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Netlify supplémentaires qui nécessitent un serveur (p. ex. [CDN d'images de Netlify](#support-du-cdn-dimages-netlify)). Sinon, vous n’avez pas besoin d’un adaptateur pour déployer votre site statique.
+Si vous utilisez Astro comme générateur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Netlify supplémentaires qui nécessitent un serveur (p. ex. [CDN d'images de Netlify](#prise-en-charge-du-cdn-image-de-netlify)). Sinon, vous n’avez pas besoin d’un adaptateur pour déployer votre site statique.
 
 Apprenez à déployer votre site Astro dans notre [guide de déploiement Netlify](/fr/guides/deploy/netlify/).
 

--- a/src/content/docs/fr/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/netlify.mdx
@@ -11,15 +11,15 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import Since from '~/components/Since.astro';
 
-Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Netlify](https://www.netlify.com/), y compris [les îles de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
+Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Netlify](https://www.netlify.com/), y compris [les îlots de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
 
-Si vous utilisez Astro comme constructeur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Netlify supplémentaires qui nécessitent un serveur (p. ex. [CDN d'images de Netlify](#support-du-cdn-dimages-netlify)). Sinon, vous n’avez pas besoin d’un adaptateur pour déployer votre site statique.
+Si vous utilisez Astro comme générateur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Netlify supplémentaires qui nécessitent un serveur (p. ex. [CDN d'images de Netlify](#support-du-cdn-dimages-netlify)). Sinon, vous n’avez pas besoin d’un adaptateur pour déployer votre site statique.
 
 Apprenez à déployer votre site Astro dans notre [guide de déploiement Netlify](/fr/guides/deploy/netlify/).
 
 ## Pourquoi Astro Netlify
 
-[Netlify](https://www.netlify.com/) est une plateforme de déploiement qui vous permet d'héberger votre site en vous connectant directement à votre dépôt GitHub. Cet adaptateur améliore le processus de construction d'Astro pour préparer votre projet à être déployé via Netlify.
+[Netlify](https://www.netlify.com/) est une plateforme de déploiement qui vous permet d'héberger votre site en vous connectant directement à votre dépôt GitHub. Cet adaptateur améliore le processus de compilation d'Astro pour préparer votre projet à être déployé via Netlify.
 
 ## Installation
 
@@ -46,7 +46,7 @@ Cela installera `@astrojs/netlify` et apportera les changements appropriés à v
   </Fragment>
 </PackageManagerTabs>
 
-Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre construction sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
+Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre compilation sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
 
 ### Installation manuelle
 
@@ -84,21 +84,21 @@ Ensuite, ajoutez l'adaptateur à votre fichier `astro.config.*` :
 
 ## Utilisation
 
-[Lisez le guide de déploiement complet ici](/fr/guides/deploy/netlify/)
+[Lisez le guide de déploiement complet ici.](/fr/guides/deploy/netlify/)
 
-Suivez les instructions pour [construire votre site localement](/fr/guides/deploy/#compiler-votre-site-localement). Après la construction, vous aurez un dossier `.netlify/` contenant à la fois [Netlify Functions](https://docs.netlify.com/functions/overview/) dans le dossier `.netlify/functions-internal/` et [Netlify Edge Functions](https://docs.netlify.com/edge-functions/overview/) dans le dossier `.netlify/edge-functions/`.
+Suivez les instructions pour [compiler votre site localement](/fr/guides/deploy/#compiler-votre-site-localement). Après la compilation, vous aurez un dossier `.netlify/` contenant à la fois [les fonctions de Netlify](https://docs.netlify.com/functions/overview/) dans le dossier `.netlify/functions-internal/` et [les fonctions Edge de Netlify](https://docs.netlify.com/edge-functions/overview/) dans le dossier `.netlify/edge-functions/`.
 
-Pour déployer votre site, installez le [Netlify CLI](https://docs.netlify.com/cli/get-started/) et exécutez-le :
+Pour déployer votre site, installez la [CLI de Netlify](https://docs.netlify.com/cli/get-started/) et exécutez :
 
 ```sh
 netlify deploy
 ```
 
-Le [blog de Netlify sur Astro](https://www.netlify.com/blog/how-to-deploy-astro/) et la [documentation de Netlify](https://docs.netlify.com/integrations/frameworks/astro/) fournissent plus d'informations sur la manière d'utiliser cette intégration pour déployer vers Netlify.
+L'[article de blog de Netlify sur Astro](https://www.netlify.com/blog/how-to-deploy-astro/) et la [documentation de Netlify](https://docs.netlify.com/integrations/frameworks/astro/) fournissent plus d'informations sur la manière d'utiliser cette intégration pour déployer vers Netlify.
 
-### Exécution du middleware Astro sur les fonctions Netlify Edge
+### Exécution du middleware Astro sur les fonctions Edge de Netlify
 
-Tout middleware Astro est appliqué aux pages pré-rendues au moment de la création, et aux pages pré-rendues au moment de l'exécution.
+Tout middleware Astro est appliqué aux pages pré-rendues au moment de la compilation, et aux pages pré-rendues au moment de l'exécution.
 
 Pour implémenter des redirections, des contrôles d'accès ou des en-têtes de réponse personnalisés pour les pages pré-rendues, exécutez votre middleware sur les fonctions Edge de Netlify en activant l'option [`edgeMiddleware`](/fr/reference/adapter-reference/#edgemiddleware) :
 
@@ -114,13 +114,13 @@ export default defineConfig({
 });
 ```
 
-Lorsque `edgeMiddleware` est activé, une fonction edge exécutera votre code middleware pour toutes les requêtes, y compris les actifs statiques, les pages pré-rendues et les pages rendues à la demande.
+Lorsque `edgeMiddleware` est activé, une fonction edge exécutera votre code middleware pour toutes les requêtes, y compris les ressources statiques, les pages pré-rendues et les pages rendues à la demande.
 
 Pour les pages rendues à la demande, l'objet `context.locals` est sérialisé en utilisant du JSON et envoyé dans un en-tête pour la fonction serverless, qui effectue le rendu. Comme mesure de sécurité, la fonction serverless refusera de servir les requêtes avec une réponse `403 Forbidden` à moins qu'elles ne proviennent de la fonction edge générée.
 
 ### Accès au contexte Edge depuis votre site
 
-Les fonctions Netlify Edge fournissent un [objet de contexte](https://docs.netlify.com/edge-functions/api/#netlify-specific-context-object) qui comprend des métadonnées sur la demande, telles que l'IP de l'utilisateur, les données de géolocalisation et les cookies.
+Les fonctions Edge de Netlify fournissent un [objet de contexte](https://docs.netlify.com/edge-functions/api/#netlify-specific-context-object) qui comprend des métadonnées sur la demande, telles que l'IP de l'utilisateur, les données de géolocalisation et les cookies.
 
 Cet objet est accessible via l'objet `Astro.locals.netlify.context` :
 
@@ -148,10 +148,10 @@ declare namespace App {
 
 Ceci n'est pas disponible sur les pages pré-rendues.
 
-### Support du CDN d'images Netlify
+### Prise en charge du CDN Image de Netlify
 
-Cet adaptateur utilise par défaut le [Netlify Image CDN](https://docs.netlify.com/image-cdn/overview/) pour transformer les images à la volée sans impacter sur les temps de construction.
-Il est implémenté en utilisant un [Astro Image Service](/fr/reference/image-service-reference/) sous le capot.
+Cet adaptateur utilise par défaut le [CDN Image de Netlify](https://docs.netlify.com/image-cdn/overview/) pour transformer les images à la volée sans impacter sur les temps de compilation.
+Il est implémenté en utilisant un [service d'images d'Astro](/fr/reference/image-service-reference/) sous le capot.
 
 Pour ne pas utiliser l'optimisation d'image à distance du CDN de Netlify, utilisez l'option `imageCDN` :
 
@@ -185,9 +185,9 @@ Pour plus d'informations, voir [le guide d'autorisation des images distantes](/f
 
 ### Sites statiques avec l'adaptateur Netlify
 
-Pour les sites statiques (`output : 'static'`) hébergés sur Netlify, vous n'avez généralement pas besoin d'adaptateur. Cependant, certaines fonctionnalités de déploiement ne sont disponibles qu'à travers un adaptateur.
+Pour les sites statiques (`output: 'static'`) hébergés sur Netlify, vous n'avez généralement pas besoin d'adaptateur. Cependant, certaines fonctionnalités de déploiement ne sont disponibles qu'à travers un adaptateur.
 
-Les sites statiques devront installer cet adaptateur pour utiliser et configurer le [service d'image de Netlify](#support-du-cdn-dimages-netlify).
+Les sites statiques devront installer cet adaptateur pour utiliser et configurer le [service d'image de Netlify](#prise-en-charge-du-cdn-image-de-netlify).
 
 Si vous utilisez la configuration `redirects` dans votre configuration Astro, l'adaptateur Netlify peut être utilisé pour traduire cette configuration au format `_redirects` approprié.
 
@@ -199,12 +199,12 @@ export default defineConfig({
   // ...
   adapter: netlify(),
   redirects: {
-    '/blog/old-post': '/blog/new-post',
+    '/blog/ancien-article': '/blog/nouvel-article',
   },
 });
 ```
 
-Une fois que vous avez lancé `astro build`, il y aura un fichier `dist/_redirects`. Netlify l'utilisera pour router correctement les pages en production.
+Une fois que vous avez exécuté `astro build`, il y aura un fichier `dist/_redirects`. Netlify l'utilisera pour router correctement les pages en production.
 
 :::note
 Vous pouvez toujours inclure un fichier `public/_redirects` pour les redirections manuelles. Toutes les redirections que vous spécifiez dans la configuration des redirections sont ajoutées à la fin de la vôtre.
@@ -244,7 +244,7 @@ Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=45, must-revali
 </Layout>
 ```
 
-Avec [fine-grained cache control](https://www.netlify.com/blog/swr-and-fine-grained-cache-control/), Netlify prend en charge
+Grâce au [contrôle précis du cache](https://www.netlify.com/blog/swr-and-fine-grained-cache-control/), Netlify prend en charge
 les en-têtes de cache standard comme `CDN-Cache-Control` ou `Vary`.
 Reportez-vous à la documentation pour en savoir plus sur la mise en place, par exemple, de la mise en cache TTL (time to live) ou SWR (stale while revalidate) : https://docs.netlify.com/platform/caching
 
@@ -274,7 +274,7 @@ import netlify from '@astrojs/netlify';
 export default defineConfig({
   // ...
   adapter: netlify({
-    includeFiles: ['./my-data.json'], // chemin relatif à `root`
+    includeFiles: ['./mes-donnees.json'], // chemin relatif à `root`
   }),
 });
 ```
@@ -288,7 +288,7 @@ export default defineConfig({
 </p>
 
 Vous pouvez utiliser la propriété `excludeFiles` pour empêcher le regroupement de fichiers spécifiques qui seraient autrement inclus. Cela est utile pour :
-- Réduire la taille du bundle
+- Réduire la taille du regroupement
 - Exclure des binaires volumineux
 - Empêcher le déploiement de fichiers indésirables
 
@@ -301,14 +301,14 @@ import netlify from '@astrojs/netlify';
 export default defineConfig({
   // ...
   adapter: netlify({
-    excludeFiles: ['./src/some_big_file.jpg'], // chemin relatif à `root`
+    excludeFiles: ['./src/un_gros_fichier.jpg'], // chemin relatif à `root`
   }),
 });
 ```
 
-#### Utilisation des modèles glob
+#### Utilisation des motifs glob
 
-`includeFiles` et `excludeFiles` prennent en charge les [modèles glob](/fr/guides/imports/#patterns-globaux) pour faire correspondre plusieurs fichiers :
+`includeFiles` et `excludeFiles` prennent en charge les [motifs glob](/fr/guides/imports/#patterns-globaux) pour faire correspondre plusieurs fichiers :
 
 ```js title="astro.config.mjs" ins={7, 10-11}
 import { defineConfig } from 'astro/config';
@@ -329,7 +329,7 @@ export default defineConfig({
 
 ## Exemples
 
-* Le [modèle de démarrage Astro avec Edge](https://github.com/sarahetter/astro-netlify-edge-starter) fournit un exemple et un guide dans le README.
+* Le [modèle de démarrage Astro avec Netlify Edge](https://github.com/sarahetter/astro-netlify-edge-starter) fournit un exemple et un guide dans le fichier README.
 
 * [Parcourir les projets Astro Netlify sur GitHub](https://github.com/search?q=path%3A**%2Fastro.config.mjs+%40astrojs%2Fnetlify\&type=code) pour plus d'exemples !
 

--- a/src/content/docs/fr/guides/integrations-guide/node.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/node.mdx
@@ -11,13 +11,13 @@ i18nReady: true
 
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) vers des cibles Node, y compris [les îles de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
+Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) vers des cibles Node, y compris [les îlots de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
 
-Si vous utilisez Astro comme constructeur de site statique, vous n'avez pas besoin d'adaptateur.
+Si vous utilisez Astro comme générateur de site statique, vous n'avez pas besoin d'adaptateur.
 
 ## Pourquoi Astro Node.js
 
-[Node.js](https://nodejs.org/fr/) est un moteur d'exécution JavaScript pour le code côté serveur. `@astrojs/node` peut être utilisé soit en mode standalone, soit comme middleware pour d'autres serveurs http, tels que [Express](https://expressjs.com/).
+[Node.js](https://nodejs.org/fr/) est un environnement d'exécution JavaScript pour le code côté serveur. `@astrojs/node` peut être utilisé soit en mode standalone, soit comme middleware pour d'autres serveurs http, tels que [Express](https://expressjs.com/).
 
 ## Installation
 
@@ -44,7 +44,7 @@ Cela installera `@astrojs/node` et apportera les changements appropriés à votr
   </Fragment>
 </PackageManagerTabs>
 
-Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre construction sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
+Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre compilation sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
 
 ### Installation manuelle
 
@@ -92,7 +92,7 @@ export default defineConfig({
 
 Contrôle si l'adaptateur se construit en mode `middleware` ou `standalone`.
 
-* Le mode `middleware` permet à la sortie construite d'être utilisée comme middleware pour un autre serveur Node.js, comme Express.js ou Fastify.
+* Le mode `middleware` permet à la sortie de compilation d'être utilisée comme middleware pour un autre serveur Node.js, comme Express.js ou Fastify.
 * Le mode `standalone` crée un serveur qui démarre automatiquement lorsque le module d'entrée est exécuté. Cela vous permet de déployer plus facilement votre compilation sur un hôte sans avoir besoin de code supplémentaire.
 
 ```js title="astro.config.mjs" {6}
@@ -108,11 +108,11 @@ export default defineConfig({
 
 ## Utilisation
 
-Tout d'abord, [effectuer un build](/fr/guides/deploy/#compiler-votre-site-localement). En fonction du `mode` sélectionné (voir ci-dessus), suivez les étapes appropriées ci-dessous :
+Tout d'abord, [effectuer une compilation](/fr/guides/deploy/#compiler-votre-site-localement). En fonction du `mode` sélectionné (voir ci-dessus), suivez les étapes appropriées ci-dessous :
 
 ### Middleware
 
-Le point d'entrée du serveur est construit dans `./dist/server/entry.mjs` par défaut. Ce module exporte une fonction `handler` qui peut être utilisée avec n'importe quel framework qui supporte les objets Node `request` et `response`.
+Le point d'entrée du serveur est compilé dans `./dist/server/entry.mjs` par défaut. Ce module exporte une fonction `handler` qui peut être utilisée avec n'importe quel framework qui supporte les objets Node `request` et `response`.
 
 Par exemple, avec Express :
 
@@ -121,7 +121,7 @@ import express from 'express';
 import { handler as ssrHandler } from './dist/server/entry.mjs';
 
 const app = express();
-// Changez ceci en fonction de votre astro.config.mjs, option `base`.
+// Changez ceci en fonction de votre option `base` dans astro.config.mjs.
 // Ils doivent correspondre. La valeur par défaut est "/".
 const base = '/';
 app.use(base, express.static('dist/client/'));
@@ -174,7 +174,7 @@ Notez que le mode middleware ne permet pas de servir des fichiers. Vous devrez c
 
 ### Standalone
 
-En mode standalone, un serveur démarre lorsque le point d'entrée du serveur est exécuté. Par défaut, il est construit dans `./dist/server/entry.mjs`. Vous pouvez le lancer avec :
+En mode standalone, un serveur démarre lorsque le point d'entrée du serveur est exécuté. Par défaut, il est compilé dans `./dist/server/entry.mjs`. Vous pouvez le lancer avec :
 
 ```sh
 node ./dist/server/entry.mjs
@@ -194,29 +194,29 @@ HOST=0.0.0.0 PORT=4321 node ./dist/server/entry.mjs
 
 Par défaut, le serveur standalone utilise le protocole HTTP. Cela fonctionne bien si vous avez un serveur proxy en face de lui qui utilise HTTPS. Si vous avez besoin que le serveur standalone utilise HTTPS lui-même, vous devez fournir votre clé et votre certificat SSL.
 
-Vous pouvez passer le chemin vers votre clé et votre certificat via les variables d'environnement `SERVER_CERT_PATH` et `SERVER_KEY_PATH`. Voici comment vous pouvez les passer en bash :
+Vous pouvez passer le chemin vers votre clé et votre certificat via les variables d'environnement `SERVER_CERT_PATH` et `SERVER_KEY_PATH`. Voici comment vous pouvez les transmettre avec Bash :
 
 ```bash
 SERVER_KEY_PATH=./private/key.pem SERVER_CERT_PATH=./private/cert.pem node ./dist/server/entry.mjs
 ```
 
-#### Variables d'environnement d'exécution
+#### Variables de l'environnement d'exécution
 
-Si un fichier `.env` contenant des variables d'environnement est présent lors de l'exécution du processus de construction, ces valeurs seront codées en dur dans la sortie, tout comme lors de la génération d'un site web statique.
+Si un fichier `.env` contenant des variables d'environnement est présent lors de l'exécution du processus de compilation, ces valeurs seront codées en dur dans la sortie, tout comme lors de la génération d'un site web statique.
 
-Pendant la construction, les variables d'exécution doivent être absentes du fichier `.env`, et vous devez fournir à Astro toutes les variables d'environnement à attendre à l'exécution : `VARIABLE_1=placeholder astro build`. Ceci signale à Astro que la valeur réelle sera disponible lors de l'exécution de l'application construite. La valeur de l'espace réservé sera ignorée par le processus de construction, et Astro utilisera la valeur fournie à l'exécution.
+Pendant la compilation, les variables d'exécution doivent être absentes du fichier `.env`, et vous devez fournir à Astro toutes les variables d'environnement attendues au moment de l'exécution : `VARIABLE_1=valeur-fictive astro build`. Ceci signale à Astro que la valeur réelle sera disponible lors de l'exécution de l'application compilée. La valeur fictive sera ignorée par le processus de compilation, et Astro utilisera la valeur fournie à l'exécution.
 
-Dans le cas multiple exécution de variables, stockez-les dans un fichier séparé (par exemple `.env.runtime`) de `.env`. Lancez la compilation avec la commande suivante :
+Dans le cas de multiples variables d'environnement, stockez-les dans un fichier séparé (par exemple `.env.runtime`) de `.env`. Lancez la compilation avec la commande suivante :
 
 ```sh
 export $(cat .env.runtime) && astro build
 ```
 
-#### Assets
+#### Ressources
 
 En mode standalone, les ressources de votre dossier `dist/client/` sont servies par le serveur standalone. Vous pouvez déployer ces ressources sur un CDN, auquel cas le serveur ne les servira jamais. Mais dans certains cas, comme les sites intranet, il est possible de servir les ressources statiques directement depuis le serveur d'application.
 
-Les assets dans le dossier `dist/client/_astro/` sont ceux qu'Astro a construits. Ces ressources sont toutes nommées avec un hachage et peuvent donc recevoir de longs en-têtes de cache. En interne, l'adaptateur ajoute cet en-tête pour ces ressources :
+Les ressources dans le dossier `dist/client/_astro/` sont celles générées par Astro. Celles-ci sont toutes nommées avec un hachage et peuvent donc recevoir de longs en-têtes de cache. En interne, l'adaptateur ajoute cet en-tête pour ces ressources :
 
 ```
 Cache-Control: public, max-age=31536000, immutable

--- a/src/content/docs/fr/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/partytown.mdx
@@ -12,9 +12,9 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
 Cette **[intégration Astro][astro-integration]** active [Partytown](https://partytown.builder.io/) dans votre projet Astro.
 
-## Why Astro Partytown
+## Pourquoi Astro Partytown
 
-Partytown est une bibliothèque lazy-loaded qui permet de relocaliser les scripts gourmands en ressources dans un [web worker](https://developer.mozilla.org/fr/docs/Web/API/Web_Workers_API) et hors du [main thread](https://developer.mozilla.org/fr/docs/Glossary/Main_thread).
+Partytown est une bibliothèque à chargement différé qui permet de déplacer les scripts gourmands en ressources dans un [web worker](https://developer.mozilla.org/fr/docs/Web/API/Web_Workers_API) et hors du [thread principal](https://developer.mozilla.org/fr/docs/Glossary/Main_thread).
 
 Si vous utilisez des scripts tiers à des fins d'analyse ou de publicité, Partytown est un excellent moyen de vous assurer qu'ils ne ralentissent pas votre site.
 
@@ -88,7 +88,7 @@ Partytown devrait être prêt à fonctionner sans aucune configuration. Si vous 
 <script type="text/partytown" src="fancy-analytics.js"></script>
 ```
 
-Si vous ouvrez l'onglet "Réseau" depuis [les outils de développement de votre navigateur](https://developer.chrome.com/docs/devtools/open/), vous devriez voir le proxy `partytown` intercepter cette requête.
+Si vous ouvrez l'onglet « Réseau » depuis [les outils de développement de votre navigateur](https://developer.chrome.com/docs/devtools/open/), vous devriez voir le proxy `partytown` intercepter cette requête.
 
 ## Configuration
 
@@ -107,7 +107,7 @@ export default defineConfig({
 });
 ```
 
-Cela correspond à l'objet de configuration [Partytown config object](https://partytown.builder.io/configuration).
+Cela reflète l'[objet de configuration Partytown](https://partytown.builder.io/configuration).
 
 ### config.debug
 
@@ -131,7 +131,7 @@ export default defineConfig({
 
 Les scripts tiers ajoutent généralement des variables à l'objet `window` afin que vous puissiez communiquer avec eux à travers votre site. Mais lorsqu'un script est chargé dans un web-worker, il n'a pas accès à l'objet global `window`.
 
-Pour résoudre ce problème, Partytown peut "patcher" des variables sur l'objet fenêtre global et les transmettre au script approprié.
+Pour résoudre ce problème, Partytown peut « patcher » les variables de l'objet de fenêtre globale et les transmettre au script approprié.
 
 Vous pouvez spécifier les variables à transférer avec l'option `config.forward`. [Pour en savoir plus, consultez la documentation de Partytown](https://partytown.builder.io/forwarding-events)
 

--- a/src/content/docs/fr/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/preact.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/preact'
-description: "Apprenez à utiliser l'intégration du framework @astrojs/preact pour étendre la prise en charge des composants dans votre projet Astro."
+description: "Apprenez à utiliser l'intégration de framework @astrojs/preact pour étendre la prise en charge des composants dans votre projet Astro."
 sidebar:
   label: Preact
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/preact/'
@@ -21,7 +21,7 @@ Preact est une bibliothèque qui vous permet de créer des composants d'interfac
 Preact est également un excellent choix si vous avez déjà utilisé React. Preact fournit la même API que React, mais dans un format beaucoup plus petit de 3 Ko. Il supporte même le rendu de nombreux composants React en utilisant l'option de configuration `compat` (voir ci-dessous).
 
 **Vous souhaitez en savoir plus sur Preact avant d'utiliser cette intégration ?**
-Consultez ["Learn Preact" (EN)](https://preactjs.com/tutorial), un tutoriel interactif sur leur site web.
+Consultez ["Learn Preact" (Anglais)](https://preactjs.com/tutorial), un tutoriel interactif sur leur site web.
 
 ## Installation
 
@@ -125,7 +125,7 @@ Pour utiliser votre premier composant Preact dans Astro, consultez notre [docume
 * 💧 les options d'hydratation côté client, et
 * 🤝 les possibilités de mélanger et d'imbriquer les frameworks.
 
-Consultez également notre [Documentation sur l'intégration Astro][astro-integration] pour en savoir plus sur les intégrations.
+Consultez également notre [documentation sur les intégrations Astro][astro-integration] pour en savoir plus sur les intégrations.
 
 ## Configuration
 
@@ -135,9 +135,9 @@ Pour une utilisation basique, vous n'avez pas besoin de configurer l'intégratio
 
 ### compat
 
-Vous pouvez activer `preact/compat`, la couche de compatibilité de Preact pour rendre les composants React sans avoir besoin d'installer ou de livrer les grandes bibliothèques de React aux navigateurs web de vos utilisateurs.
+Vous pouvez activer `preact/compat`, la couche de compatibilité de Preact pour le rendu des composants React sans avoir besoin d'installer ou de livrer les grandes bibliothèques de React aux navigateurs web de vos utilisateurs.
 
-Pour ce faire, passez un objet à l'intégration Preact et mettez `compat : true`.
+Pour ce faire, passez un objet à l'intégration Preact et mettez `compat: true`.
 
 ```js title="astro.config.mjs" "compat: true"
 import { defineConfig } from 'astro/config';
@@ -148,7 +148,7 @@ export default defineConfig({
 });
 ```
 
-Avec l'option `compat` activée, l'intégration Preact rendra les composants React ainsi que les composants Preact dans votre projet et vous permettra également d'importer des composants React à l'intérieur des composants Preact. Pour en savoir plus, consultez ["Switching to Preact (from React)"](https://preactjs.com/guide/v10/switching-to-preact) sur le site web de Preact.
+Avec l'option `compat` activée, l'intégration Preact effectuera le rendu des composants React ainsi que des composants Preact dans votre projet et vous permettra également d'importer des composants React à l'intérieur des composants Preact. Pour en savoir plus, consultez ["Switching to Preact (from React)"](https://preactjs.com/guide/v10/switching-to-preact) sur le site web de Preact.
 
 Lorsque vous importez des bibliothèques de composants React, afin de remplacer les dépendances `react` et `react-dom` par `preact/compat`, vous pouvez utiliser [`overrides`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) pour le faire.
 
@@ -161,17 +161,17 @@ Lorsque vous importez des bibliothèques de composants React, afin de remplacer 
 }
 ```
 
-Consultez les documents [`pnpm` overrides](https://pnpm.io/package_json#pnpmoverrides) et [`yarn` resolutions](https://yarnpkg.com/configuration/manifest#resolutions) pour leurs fonctionnalités respectives.
+Consultez la documentation [des remplacements `pnpm`](https://pnpm.io/package_json#pnpmoverrides) et celle des [résolutions `yarn`](https://yarnpkg.com/configuration/manifest#resolutions) pour leurs fonctionnalités de remplacement respectives.
 
 :::note
-Actuellement, l'option `compat` ne fonctionne que pour les bibliothèques React qui exportent du code en tant qu'ESM. Si une erreur survient lors de la compilation, essayez d'ajouter la bibliothèque à `vite.ssr.noExternal : ['the-react-library']` dans votre fichier `astro.config.mjs`.
+Actuellement, l'option `compat` ne fonctionne que pour les bibliothèques React qui exportent du code en tant qu'ESM. Si une erreur survient lors de la compilation, essayez d'ajouter la bibliothèque à `vite.ssr.noExternal: ['la-bibliotheque-react']` dans votre fichier `astro.config.mjs`.
 :::
 
 ### devtools
 
 <p><Since pkg="@astrojs/preact" v="3.3.0" /></p>
 
-Vous pouvez activer [Preact devtools](https://preactjs.github.io/preact-devtools/) durant le développement en passant un objet avec `devtools : true` à votre configuration d'intégration `preact()` :
+Vous pouvez activer les [outils de développement Preact](https://preactjs.github.io/preact-devtools/) durant le développement en passant un objet avec `devtools: true` à votre configuration d'intégration `preact()` :
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/fr/guides/integrations-guide/react.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/react.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/react'
-description: "Apprenez à utiliser l'intégration du framework @astrojs/react pour étendre la prise en charge des composants dans votre projet Astro."
+description: "Apprenez à utiliser l'intégration de framework @astrojs/react pour étendre la prise en charge des composants dans votre projet Astro."
 sidebar:
   label: React
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/react/'
@@ -110,9 +110,9 @@ Et ajoutez le code suivant au fichier `tsconfig.json`.
 
 Pour utiliser votre premier composant React dans Astro, dirigez-vous vers notre [documentation sur les frameworks UI][astro-ui-frameworks]. Vous y découvrirez :
 
-* 📦 comment les composants du cadre sont chargés,
+* 📦 comment les composants de framework sont chargés,
 * 💧 les options d'hydratation côté client, et
-* 🤝 les possibilités de mélanger et d'imbriquer les cadres.
+* 🤝 les possibilités de mélanger et d'imbriquer les frameworks.
 
 ## Options
 
@@ -149,11 +149,11 @@ export default defineConfig({
 });
 ```
 
-### Traitement des éléments enfants (Children parsing)
+### Analyse syntaxique des éléments enfants
 
-Les enfants passés dans un composant React depuis un composant Astro sont analysés comme des chaînes simples, et non comme des nœuds React.
+Les enfants transmis dans un composant React depuis un composant Astro sont analysés comme des chaînes de caractères simples, et non comme des nœuds React.
 
-Par exemple, le `<ReactComponent />` ci-dessous ne recevra qu'un seul élément enfant :
+Par exemple, le composant `<ReactComponent />` ci-dessous ne recevra qu'un seul élément enfant :
 
 ```astro
 ---
@@ -168,7 +168,7 @@ import ReactComponent from './ReactComponent';
 
 Si vous utilisez une bibliothèque qui *attend* que plus d'un élément enfant soit passé, par exemple pour qu'elle puisse placer certains éléments à différents endroits, vous pourriez trouver cela bloquant.
 
-Vous pouvez définir le drapeau expérimental `experimentalReactChildren` pour dire à Astro de toujours passer les enfants à React en tant que nœuds DOM virtuels React. Il y a un coût d'exécution à cela, mais cela peut aider à la compatibilité.
+Vous pouvez utiliser l'option expérimentale `experimentalReactChildren` pour dire à Astro de toujours passer les enfants à React en tant que nœuds DOM virtuels React. Il y a un coût d'exécution à cela, mais cela peut aider à la compatibilité.
 
 Vous pouvez activer cette option dans la configuration de l'intégration de React :
 

--- a/src/content/docs/fr/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/sitemap.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Cette **[intégration Astro][astro-integration]** génère un sitemap basé sur vos pages lorsque vous construisez votre projet Astro.
+Cette **[intégration Astro][astro-integration]** génère un sitemap basé sur vos pages lorsque vous compilez votre projet Astro.
 
 ## Pourquoi Astro Sitemap ?
 
@@ -99,7 +99,7 @@ export default defineConfig({
 });
 ```
 
-Avec l'intégration du sitemap configurée, les fichiers `sitemap-index.xml` et `sitemap-0.xml` seront ajoutés à votre répertoire de sortie lors de la construction de votre site.
+Avec l'intégration du sitemap configurée, les fichiers `sitemap-index.xml` et `sitemap-0.xml` seront ajoutés à votre répertoire de sortie lors de la compilation de votre site.
 
 `sitemap-index.xml` renvoie à tous les fichiers sitemap numérotés.
 `sitemap-0.xml` liste les pages de votre site.
@@ -204,7 +204,7 @@ export default defineConfig({
   site: 'https://stargazers.club',
   integrations: [
     sitemap({
-      filter: (page) => page !== 'https://stargazers.club/secret-vip-lounge/',
+      filter: (page) => page !== 'https://stargazers.club/salon-prive-secret/',
     }),
   ],
 });
@@ -223,10 +223,10 @@ export default defineConfig({
   integrations: [
     sitemap({
       filter: (page) =>
-        page !== 'https://stargazers.club/secret-vip-lounge-1/' &&
-        page !== 'https://stargazers.club/secret-vip-lounge-2/' &&
-        page !== 'https://stargazers.club/secret-vip-lounge-3/' &&
-        page !== 'https://stargazers.club/secret-vip-lounge-4/',
+        page !== 'https://stargazers.club/salon-prive-secret-1/' &&
+        page !== 'https://stargazers.club/salon-prive-secret-2/' &&
+        page !== 'https://stargazers.club/salon-prive-secret-3/' &&
+        page !== 'https://stargazers.club/salon-prive-secret-4/',
     }),
   ],
 });
@@ -244,7 +244,7 @@ export default defineConfig({
   site: 'https://stargazers.club',
   integrations: [
     sitemap({
-      customPages: ['https://stargazers.club/external-page', 'https://stargazers.club/external-page2'],
+      customPages: ['https://stargazers.club/page-externe', 'https://stargazers.club/page-externe2'],
     }),
   ],
 });
@@ -252,7 +252,7 @@ export default defineConfig({
 
 ### entryLimit
 
-Nombre maximal d'entrées par fichier sitemap. La valeur par défaut est 45000. Un index sitemap et plusieurs sitemaps sont créés si vous avez plus d'entrées. Voir cette [explication de la division d'un grand sitemap](https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps).
+Nombre maximal d'entrées par fichier sitemap. La valeur par défaut est 45000. Un index de sitemap et plusieurs sitemaps sont créés si vous avez plus d'entrées. Voir cette [explication de la division d'un grand sitemap](https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps).
 
 ```js title="astro.config.mjs" ins={8}
 import { defineConfig } from 'astro/config';
@@ -275,7 +275,7 @@ Ces options correspondent aux balises `<changefreq>`, `<lastmod>` et `<priority>
 Notez que `changefreq` et `priority` sont ignorés par Google.
 
 :::note
-En raison des limitations de l'[API d'intégration d'Astro](/fr/reference/integrations-reference/), cette intégration ne peut pas analyser le code source d'une page donnée. Cette option de configuration peut définir `changefreq`, `lastmod` et `priority` sur une base *site-wide* ; voir l'option suivante **serialize** pour savoir comment définir ces valeurs sur une base par page.
+En raison des limitations de l'[API des intégrations d'Astro](/fr/reference/integrations-reference/), cette intégration ne peut pas analyser le code source d'une page donnée. Cette option de configuration peut définir `changefreq`, `lastmod` et `priority` *à l'échelle du site* ; voir l'option suivante **serialize** pour savoir comment définir ces valeurs page par page.
 :::
 
 ```js title="astro.config.mjs" ins={8-10}
@@ -302,7 +302,7 @@ Elle reçoit en paramètre un objet `SitemapItem` qui peut avoir ces propriété
 
 * `url` (URL absolue de la page). C'est la seule propriété dont la présence est garantie sur `SitemapItem`.
 * `changefreq`
-* `lastmod` (date formatée ISO, type `String`)
+* `lastmod` (date au format ISO, type `String`)
 * `priority`
 * `links`.
 
@@ -323,10 +323,10 @@ export default defineConfig({
   integrations: [
     sitemap({
       serialize(item) {
-        if (/exclude-from-sitemap/.test(item.url)) {
+        if (/exclure-du-sitemap/.test(item.url)) {
           return undefined;
         }
-        if (/your-special-page/.test(item.url)) {
+        if (/votre-page-speciale/.test(item.url)) {
           item.changefreq = 'daily';
           item.lastmod = new Date();
           item.priority = 0.9;
@@ -340,7 +340,7 @@ export default defineConfig({
 
 ### i18n
 
-Pour traduire un sitemap, passez un objet à cette option `i18n`.
+Pour localiser un sitemap, passez un objet à cette option `i18n`.
 
 Cet objet a deux propriétés obligatoires :
 
@@ -360,7 +360,7 @@ export default defineConfig({
   integrations: [
     sitemap({
       i18n: {
-        defaultLocale: 'en', // Tous les urls qui ne contiennent pas `es` ou `fr` après `https://stargazers.club/` seront traités comme la locale par défaut, c'est-à-dire `en`
+        defaultLocale: 'en', // Toutes les URL qui ne contiennent pas `es` ou `fr` après `https://stargazers.club/` seront traitées comme le paramètre régional par défaut, c'est-à-dire `en`
         locales: {
           en: 'en-US', // La valeur `defaultLocale` doit être présente dans les clés `locales`.
           es: 'es-ES',
@@ -405,7 +405,7 @@ Le plan du site qui en résulte ressemble à ceci :
 
 ### xslURL
 
-L'URL d'une feuille de style XSL pour styliser et embellir votre sitemap.
+L'URL d'une feuille de style XSL pour mettre en forme et embellir votre sitemap.
 
 La valeur définie peut être soit un chemin relatif à l'URL configurée pour votre `site` dans le cas d'une feuille de style locale, soit une URL absolue vers une feuille de style externe.
 

--- a/src/content/docs/fr/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/solid-js.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/solid-js'
-description: "Apprenez à utiliser l'intégration du framework @astrojs/solid-js pour étendre la prise en charge des composants dans votre projet Astro."
+description: "Apprenez à utiliser l'intégration de framework @astrojs/solid-js pour étendre la prise en charge des composants dans votre projet Astro."
 sidebar:
   label: SolidJS
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/solid/'
@@ -113,7 +113,7 @@ Pour utiliser votre premier composant SolidJS dans Astro, consultez notre [docum
 
 * 📦 comment les composants du framework sont chargés,
 * 💧 les options d'hydratation côté client, et
-* 🤝 les possibilités de mélanger et d'imbriquer les Frameworks.
+* 🤝 les possibilités de mélanger et d'imbriquer les frameworks.
 
 ## Configuration
 
@@ -121,7 +121,7 @@ Pour utiliser votre premier composant SolidJS dans Astro, consultez notre [docum
 
 <p><Since pkg="@astrojs/solid-js" v="4.2.0" /></p>
 
-Vous pouvez activer [Solid DevTools](https://github.com/thetarnav/solid-devtools) durant le développement en passant un objet avec `devtools : true` à votre configuration d'intégration `solid()` et en ajoutant `solid-devtools` aux dépendances de votre projet :
+Vous pouvez activer les [outils de développement de Solid](https://github.com/thetarnav/solid-devtools) durant le développement en transmettant un objet avec `devtools: true` à votre configuration d'intégration `solid()` et en ajoutant `solid-devtools` aux dépendances de votre projet :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -188,11 +188,11 @@ export default defineConfig({
 
 ## Utilisation
 
-Utilisez un composant SolidJS comme vous le feriez avec n'importe quel [composant UI framework](/fr/guides/framework-components/).
+Utilisez un composant SolidJS comme vous le feriez avec n'importe quel [composant de framework UI](/fr/guides/framework-components/).
 
 ### Limites de Suspense
 
-Afin de prendre en charge les ressources Solid et les composants Lazy sans configuration excessive, les composants réservés au serveur et les composants d'hydratation sont automatiquement englobés dans les limites de Suspense de niveau supérieur et rendu sur le serveur à l'aide de la fonction [`renderToStringAsync`][solid-render-to-string-async]. Par conséquent, il n'est pas nécessaire d'ajouter une limite de suspension de haut niveau autour des composants asynchrones.
+Afin de prendre en charge les ressources Solid et les composants chargés à la demande sans configuration excessive, les composants réservés au serveur et les composants d'hydratation sont automatiquement englobés dans les limites de Suspense de niveau supérieur et rendu sur le serveur à l'aide de la fonction [`renderToStringAsync`][solid-render-to-string-async]. Par conséquent, il n'est pas nécessaire d'ajouter une limite de Suspense de niveau supérieur autour des composants asynchrones.
 
 Par exemple, vous pouvez utiliser la fonction [`createResource`][solid-create-resource] de Solid pour récupérer des données distantes asynchrones sur le serveur. Les données distantes seront incluses dans le HTML initial rendu par le serveur à partir d'Astro :
 
@@ -207,7 +207,7 @@ function CharacterName() {
 
   return (
     <>
-      <h2>Name:</h2>
+      <h2>Nom :</h2>
       {/* Luke Skywalker */}
       <div>{name()}</div>
     </>
@@ -215,7 +215,7 @@ function CharacterName() {
 }
 ```
 
-De même, les [Lazy Components][solid-lazy-components] de Solid seront également résolus et leur HTML sera inclus dans la page initiale rendue par le serveur.
+De même, les [composants chargés à la demande][solid-lazy-components] de Solid seront également résolus et leur HTML sera inclus dans la page initiale rendue par le serveur.
 
 Les composants non hydratants [`client:only`][astro-client-only] ne sont pas automatiquement englobés dans les limites de Suspense.
 

--- a/src/content/docs/fr/guides/integrations-guide/svelte.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/svelte.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/svelte'
-description: "Apprenez à utiliser l'intégration du framework @astrojs/svelte pour étendre la prise en charge des composants dans votre projet Astro."
+description: "Apprenez à utiliser l'intégration de framework @astrojs/svelte pour étendre la prise en charge des composants dans votre projet Astro."
 sidebar:
   label: Svelte
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/svelte/'
@@ -11,7 +11,7 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Since from '~/components/Since.astro';
 
-Cette **[intégration Astro][astro-integration]** permet le rendu et l'hydratation côté client pour vos 5 composants [Svelte](https://svelte.dev/). Pour le support de Svelte 3 et 4, installez `@astrojs/svelte@5` à la place.
+Cette **[intégration Astro][astro-integration]** permet le rendu et l'hydratation côté client pour vos composants [Svelte](https://svelte.dev/) 5. Pour la prise en charge de Svelte 3 et 4, installez `@astrojs/svelte@5` à la place.
 
 ## Installation
 
@@ -61,7 +61,7 @@ Tout d'abord, installez le paquet `@astrojs/svelte` :
   </Fragment>
 </PackageManagerTabs>
 
-La plupart des gestionnaires de paquets installent également les dépendances associées. Si vous voyez un avertissement "Cannot find package 'svelte'" (ou similaire) lorsque vous démarrez Astro, vous devez installer Svelte et Typescript :
+La plupart des gestionnaires de paquets installent également les dépendances associées. Si vous voyez un avertissement `Cannot find package 'svelte'` (ou similaire) lorsque vous démarrez Astro, vous devez installer Svelte et Typescript :
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -113,7 +113,7 @@ Pour utiliser votre premier composant Svelte dans Astro, consultez notre [docume
 
 ## Options
 
-Cette intégration est alimentée par `@sveltejs/vite-plugin-svelte`. Pour personnaliser le compilateur Svelte, des options peuvent être fournies à l'intégration. Voir [`@sveltejs/vite-plugin-svelte` docs](https://github.com/sveltejs/vite-plugin-svelte/blob/HEAD/docs/config.md) pour plus de détails.
+Cette intégration est alimentée par `@sveltejs/vite-plugin-svelte`. Pour personnaliser le compilateur Svelte, des options peuvent être fournies à l'intégration. Voir la [documentation de `@sveltejs/vite-plugin-svelte`](https://github.com/sveltejs/vite-plugin-svelte/blob/HEAD/docs/config.md) pour plus de détails.
 
 Vous pouvez définir des options soit en les passant à l'intégration `svelte` dans `astro.config.mjs`, soit dans `svelte.config.js`. Les options dans `astro.config.mjs` auront la priorité sur les options dans `svelte.config.js` si les deux sont présentes :
 
@@ -136,7 +136,7 @@ export default {
 
 <Since v="2.0.0" pkg="@astrojs/svelte" />
 
-Si vous utilisez SCSS ou Stylus dans vos fichiers Svelte, vous pouvez créer un fichier `svelte.config.js` afin qu'ils soient préalablement traités par Svelte, et que l'extension Svelte IDE puisse analyser correctement les fichiers Svelte.
+Si vous utilisez SCSS ou Stylus dans vos fichiers Svelte, vous pouvez créer un fichier `svelte.config.js` afin qu'ils soient préalablement traités par Svelte, et que l'extension Svelte pour les IDE puisse analyser correctement les fichiers Svelte.
 
 ```js title="svelte.config.js"
 import { vitePreprocess } from '@astrojs/svelte';

--- a/src/content/docs/fr/guides/integrations-guide/tailwind.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/tailwind.mdx
@@ -5,7 +5,7 @@ i18nReady: true
 ---
 
 :::caution[Obsolète]
-Tailwind CSS propose désormais un plugin Vite qui constitue le moyen privilégié d'utiliser Tailwind 4 dans Astro.
+Tailwind CSS propose désormais un module d'extension pour Vite qui constitue le moyen privilégié d'utiliser Tailwind 4 dans Astro.
 :::
 
 Pour utiliser Tailwind dans Astro, suivez le [guide de mise en forme pour Tailwind](/fr/guides/styling/#tailwind).

--- a/src/content/docs/fr/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/vercel.mdx
@@ -13,15 +13,15 @@ import ReadMore from '~/components/ReadMore.astro';
 import Since from '~/components/Since.astro'
 import { Steps } from '@astrojs/starlight/components';
 
-Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Vercel](https://www.vercel.com/), y compris [les îles de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
+Cet adaptateur permet à Astro de déployer vos [routes et fonctionnalités rendues à la demande](/fr/guides/on-demand-rendering/) sur [Vercel](https://www.vercel.com/), y compris [les îlots de serveurs](/fr/guides/server-islands/), les [actions](/fr/guides/actions/) et les [sessions](/fr/guides/sessions/).
 
-Si vous utilisez Astro comme constructeur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Vercel supplémentaires (par exemple [Vercel Web Analytics](https://vercel.com/docs/analytics), [Vercel Image Optimization](https://vercel.com/docs/image-optimization)). Sinon, vous n'avez pas besoin d'adaptateur pour déployer votre site statique.
+Si vous utilisez Astro comme générateur de site statique, vous n'avez besoin de cet adaptateur que si vous utilisez des services Vercel supplémentaires (par exemple [Vercel Web Analytics](https://vercel.com/docs/analytics), [Vercel Image Optimization](https://vercel.com/docs/image-optimization)). Sinon, vous n'avez pas besoin d'adaptateur pour déployer votre site statique.
 
 Apprenez à déployer votre site Astro dans notre [guide de déploiement Vercel](/fr/guides/deploy/vercel/).
 
 ## Pourquoi Astro Vercel ?
 
-[Vercel](https://www.vercel.com/) est une plateforme de déploiement qui vous permet d'héberger votre site en vous connectant directement à votre dépôt GitHub. Cet adaptateur améliore le processus de construction d'Astro pour préparer votre projet à être déployé via Vercel.
+[Vercel](https://www.vercel.com/) est une plateforme de déploiement qui vous permet d'héberger votre site en vous connectant directement à votre dépôt GitHub. Cet adaptateur améliore le processus de compilation d'Astro pour préparer votre projet à être déployé via Vercel.
 
 ## Installation
 
@@ -48,7 +48,7 @@ Ajoutez l'adaptateur Vercel pour activer le rendu à la demande dans votre proje
 </PackageManagerTabs>
 
 
-Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre construction sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
+Désormais, vous pouvez activer [le rendu à la demande par page](/fr/guides/on-demand-rendering/#activation-du-rendu-à-la-demande) ou définir la configuration de sortie de votre compilation sur `output: 'server'` pour [restituer toutes vos pages par défaut sur le serveur](/fr/guides/on-demand-rendering/#mode-server).
 
 ### Installation manuelle
 
@@ -88,7 +88,7 @@ export default defineConfig({
 
 <ReadMore>En savoir plus sur [le déploiement de votre projet sur Vercel](/fr/guides/deploy/vercel/)</ReadMore>
 
-Vous pouvez déployer par CLI (`vercel deploy`) ou en connectant votre nouveau repo dans le [tableau de bord de Vercel](https://vercel.com/). Vous pouvez également créer une version de production localement :
+Vous pouvez déployer par CLI (`vercel deploy`) ou en connectant votre nouveau dépôt dans le [tableau de bord de Vercel](https://vercel.com/). Vous pouvez également créer une version de production localement :
 
 ```sh
 astro build
@@ -129,7 +129,7 @@ export default defineConfig({
 **Disponible pour :** Serverless, Static
 <Since v="3.3.0" pkg="@astrojs/vercel" />
 
-Options de configuration pour [Image Optimization API de Vercel](https://vercel.com/docs/concepts/image-optimization). Voir [la documentation sur la configuration des images de Vercel](https://vercel.com/docs/build-output-api/v3/configuration#images) pour une liste complète des paramètres pris en charge.
+Options de configuration pour l'[API Image Optimization de Vercel](https://vercel.com/docs/concepts/image-optimization). Voir [la documentation sur la configuration des images de Vercel](https://vercel.com/docs/build-output-api/v3/configuration#images) pour une liste complète des paramètres pris en charge.
 
 Les propriétés `domains` et `remotePatterns` seront automatiquement remplies en utilisant [les paramètres `image` correspondants d'Astro](/fr/reference/configuration-reference/#options-dimages).
 
@@ -154,7 +154,7 @@ export default defineConfig({
 **Disponible pour :** Serverless, Static
 <Since v="3.3.0" pkg="@astrojs/vercel" />
 
-Lorsque cette option est activée, un [Service d'images](/fr/reference/image-service-reference/) alimenté par l'API Vercel Image Optimization sera automatiquement configuré et utilisé en production. En développement, le service d'image spécifié par [`devImageService`](#devimageservice) sera utilisé à la place.
+Lorsque cette option est activée, un [service d'images](/fr/reference/image-service-reference/) alimenté par l'API Image Optimization de Vercel sera automatiquement configuré et utilisé en production. En développement, le service d'image spécifié par [`devImageService`](#devimageservice) sera utilisé à la place.
 
 ```js title="astro.config.mjs" ins={8}
 import { defineConfig } from 'astro/config';
@@ -196,7 +196,7 @@ import astroLogo from '../assets/logo.png';
 <Since v="3.8.0" pkg="@astrojs/vercel" />
 **Par défaut :** `sharp`
 
-Permet de configurer le service d'images à utiliser pour le développement lorsque [imageService](#imageservice) est activé. Cela peut être utile si vous ne pouvez pas installer les dépendances de Sharp sur votre machine de développement, mais que l'utilisation d'un autre service d'image comme Squoosh vous permet de prévisualiser les images dans votre environnement de développement. La construction n'est pas affectée et utilisera toujours l'optimisation d'image de Vercel.
+Permet de configurer le service d'images à utiliser pour le développement lorsque [imageService](#imageservice) est activé. Cela peut être utile si vous ne pouvez pas installer les dépendances de Sharp sur votre machine de développement, mais que l'utilisation d'un autre service d'image comme Squoosh vous permet de prévisualiser les images dans votre environnement de développement. La compilation n'est pas affectée et utilisera toujours l'optimisation d'image de Vercel.
 
 Il peut également être défini à une valeur arbitraire afin d'utiliser un service d'images personnalisé au lieu des services intégrés d'Astro.
 
@@ -240,7 +240,7 @@ Notez que les demandes de fonctions de l'ISR ne comprennent pas de paramètres d
 
 #### Invalidation du cache de l'ISR
 
-Par défaut, une fonction ISR est mise en cache pour la durée de votre déploiement. Vous pouvez contrôler davantage la mise en cache en définissant un délai d'expiration ou en excluant complètement certains itinéraires de la mise en cache.
+Par défaut, une fonction ISR est mise en cache pour la durée de votre déploiement. Vous pouvez contrôler davantage la mise en cache en définissant un délai d'expiration ou en excluant complètement certaines routes de la mise en cache.
 
 ##### Invalidation basée sur le temps
 
@@ -299,7 +299,7 @@ import vercel from '@astrojs/vercel';
 export default defineConfig({
   // ...
   adapter: vercel({
-    includeFiles: ['./my-data.json'],
+    includeFiles: ['./mes-donnees.json'],
   }),
 });
 ```
@@ -318,7 +318,7 @@ import vercel from '@astrojs/vercel';
 export default defineConfig({
   // ...
   adapter: vercel({
-    excludeFiles: ['./src/some_big_file.jpg'],
+    excludeFiles: ['./src/un_gros_fichier.jpg'],
   }),
 });
 ```
@@ -362,7 +362,7 @@ export default defineConfig({
 });
 ```
 
-### Le middleware Vercel Edge avec le middleware Astro
+### Exécution du middleware Astro sur les fonctions Vercel Edge
 
 L’adaptateur `@astrojs/vercel` peut créer une [fonction edge](https://vercel.com/docs/functions/edge-functions) à partir d’un middleware Astro dans votre base de code. Lorsque `edgeMiddleware` est activé, une fonction edge exécute votre code middleware pour toutes les demandes, y compris les ressources statiques, les pages pré-rendues et les pages rendues à la demande.
 
@@ -394,9 +394,9 @@ declare namespace App {
 }
 ```
 
-### Support des versions de Node.js
+### Prise en charge des versions de Node.js
 
-L'adaptateur `@astrojs/vercel` supporte des versions spécifiques de Node.js pour déployer votre projet Astro sur Vercel. Pour voir les versions de Node.js supportées sur Vercel, cliquez sur l'onglet des paramètres d'un projet et descendez jusqu'à la section "Node.js Version".
+L'adaptateur `@astrojs/vercel` prend en charge des versions spécifiques de Node.js pour déployer votre projet Astro sur Vercel. Pour voir les versions de Node.js prises en charge sur Vercel, cliquez sur l'onglet des paramètres d'un projet et descendez jusqu'à la section « Node.js Version ».
 
 Consultez la [documentation de Vercel](https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#default-and-available-versions) pour en savoir plus.
 

--- a/src/content/docs/fr/guides/integrations-guide/vue.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/vue.mdx
@@ -1,7 +1,7 @@
 ---
 type: integration
 title: '@astrojs/vue'
-description: "Apprenez à utiliser l'intégration du framework @astrojs/vue pour étendre la prise en charge des composants dans votre projet Astro."
+description: "Apprenez à utiliser l'intégration de framework @astrojs/vue pour étendre la prise en charge des composants dans votre projet Astro."
 sidebar:
   label: Vue
 githubIntegrationURL: 'https://github.com/withastro/astro/tree/main/packages/integrations/vue/'
@@ -110,7 +110,7 @@ Vous pouvez également consulter notre [Documentation d'intégration Astro][astr
 
 ## Contribution
 
-Ce paquet est maintenu par l'équipe Core d'Astro. Vous êtes les bienvenus pour soumettre un problème ou un PR !
+Ce paquet est maintenu par l'équipe Core d'Astro. N'hésitez pas à ouvrir un ticket ou à envoyer une PR !
 
 [astro-integration]: /fr/guides/integrations-guide/
 
@@ -142,9 +142,9 @@ export default defineConfig({
 
 ### appEntrypoint
 
-Vous pouvez étendre l'instance Vue `app` en fixant l'option `appEntrypoint` à un spécificateur d'importation relatif à la racine (par exemple, `appEntrypoint : "/src/pages/_app"`).
+Vous pouvez étendre l'instance d'`app` Vue en fixant l'option `appEntrypoint` à un spécificateur d'importation relatif à la racine (par exemple, `appEntrypoint: "/src/pages/_app"`).
 
-L'exportation par défaut de ce fichier devrait être une fonction qui accepte une instance Vue `App` avant le rendu, permettant l'utilisation de [custom Vue plugins](https://vuejs.org/guide/reusability/plugins.html), `app.use`, et d'autres personnalisations pour des cas d'utilisation avancés.
+L'exportation par défaut de ce fichier devrait être une fonction qui accepte une instance d'`App` Vue avant le rendu, permettant l'utilisation de [modules d'extension Vue personnalisés](https://vuejs.org/guide/reusability/plugins.html), `app.use`, et d'autres personnalisations pour des cas d'utilisation avancés.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -167,7 +167,7 @@ export default (app: App) => {
 
 ### jsx
 
-Vous pouvez utiliser Vue JSX en définissant `jsx : true`.
+Vous pouvez utiliser Vue JSX en définissant `jsx: true`.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -202,7 +202,7 @@ export default defineConfig({
 
 <p><Since pkg="@astrojs/vue" v="4.2.0" /></p>
 
-Vous pouvez activer [Vue DevTools](https://devtools-next.vuejs.org/) durant le développement en passant un objet avec `devtools : true` à votre configuration d'intégration `vue()` :
+Vous pouvez activer les [outils de développement de Vue](https://devtools-next.vuejs.org/) durant le développement en passant un objet avec `devtools: true` à votre configuration d'intégration `vue()` :
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -214,13 +214,13 @@ export default defineConfig({
 });
 ```
 
-#### Personnaliser Vue DevTools
+#### Personnaliser les outils de développement de Vue
 
 <p><Since pkg="@astrojs/vue" v="4.3.0" /></p>
 
-Pour plus de personnalisation, vous pouvez passer des options que [le plugin Vue DevTools Vite](https://devtools-next.vuejs.org/guide/vite-plugin#options) supporte. (Note : `appendTo` n'est pas supporté).
+Pour plus de personnalisation, vous pouvez à la place transmettre des options prises en charge par [le module d'extension Vue DevTools pour Vite](https://devtools-next.vuejs.org/guide/vite-plugin#options). (À noter : `appendTo` n'est pas pris en charge).
 
-Par exemple, vous pouvez définir `launchEditor` à votre éditeur préféré si vous n'utilisez pas Visual Studio Code :
+Par exemple, vous pouvez définir `launchEditor` avec votre éditeur préféré si vous n'utilisez pas Visual Studio Code :
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations in `integrations-guide` to improve the wording (see #11593):
* replace `île` with `îlot`
* replace `plugin` with `module d'extension`
* replace `le CLI` with `la CLI`
* replace `construction` with `compilation` ou `génération`
* replace `référentiel`/`repo` with `dépôt`
* replace `rendre` with `effectuer le rendu`
* replace `cadre` with `framework`
* replace `styliser` with `mettre en forme`
* replace `support` with `prise en charge`
* replace the translation of `breaking` (change, schema) with `avec rupture de compatibilité`
* replace `drapeau`/`flags` with `option` (see [Wikipedia](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande#Option))
* use infinitive form in headings
* reword some sentences to make the reading easier
* translate some examples
* add some non breaking space to prevent the punctuation from being on a new line alone
* add some missing spaces before colons
* fix some typo (like spaces before colons in inline code)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
