### PR TITLE
fix(migrate-to-astro): replace `getEntryBySlug` with `getEntry`

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-create-react-app.mdx
@@ -326,7 +326,7 @@ See more about [specific `<slot />` usage in Astro](/en/basics/astro-components/
 
 Fetching data in a Create React App component is similar to Astro, with some slight differences.
 
-You will need to remove any instances of a side effect hook (`useEffect`) for either `import.meta.glob()` or `getCollection()`/`getEntryBySlug()` to access data from other files in your project source.
+You will need to remove any instances of a side effect hook (`useEffect`) for either `import.meta.glob()` or `getCollection()`/`getEntry()` to access data from other files in your project source.
 
 To [fetch remote data](/en/guides/data-fetching/), use `fetch()`.
 

--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -385,7 +385,7 @@ See more about [specific `<slot />` usage in Astro](/en/basics/astro-components/
 
 ### Next Data Fetching to Astro
 
-Convert any instances of `getStaticProps()` to either `import.meta.glob()` or `getCollection()`/`getEntryBySlug()` in order to access data from other files in your project source. To [fetch remote data](/en/guides/data-fetching/), use `fetch()`.
+Convert any instances of `getStaticProps()` to either `import.meta.glob()` or `getCollection()`/`getEntry()` in order to access data from other files in your project source. To [fetch remote data](/en/guides/data-fetching/), use `fetch()`.
 
 These data requests are made in the frontmatter of the Astro component and use top-level await.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We had migration guides still referring to `getEntryBySlug` instead of `getEntry`, so I replaced the two references.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `typo/link/grammar - quick fix!` (not really a typo but certainly a quick fix!)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
