### PR TITLE
chore: clarifying relation between Astro sessions & cookies

### DIFF
--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -13,7 +13,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Sessions are used to share data between requests for [on-demand rendered pages](/en/guides/on-demand-rendering/). 
 
-Unlike traditional [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
+Unlike traditional [`cookies`](/en/guides/on-demand-rendering/#cookies), Astro sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
 
 They are useful for storing things like user data, shopping carts, and form state, and they work without any client-side JavaScript:
 

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -13,7 +13,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Sessions are used to share data between requests for [on-demand rendered pages](/en/guides/on-demand-rendering/). 
 
-Unlike [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
+Unlike traditional [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
 
 They are useful for storing things like user data, shopping carts, and form state, and they work without any client-side JavaScript:
 

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -13,7 +13,9 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Sessions are used to share data between requests for [on-demand rendered pages](/en/guides/on-demand-rendering/). 
 
-Unlike [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. They are useful for storing things like user data, shopping carts, and form state, and they work without any client-side JavaScript:
+Unlike [`cookies`](/en/guides/on-demand-rendering/#cookies), sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
+
+They are useful for storing things like user data, shopping carts, and form state, and they work without any client-side JavaScript:
 
 ```astro title="src/components/CartButton.astro" {3}
 ---

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -13,7 +13,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Sessions are used to share data between requests for [on-demand rendered pages](/en/guides/on-demand-rendering/). 
 
-Unlike traditional [`cookies`](/en/guides/on-demand-rendering/#cookies), Astro sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, the actual data remains server-side, meaning you don't have to worry about exposing sensitive information or hitting browser storage limits.
+Unlike traditional [`cookies`](/en/guides/on-demand-rendering/#cookies), Astro sessions are stored on the server, so you can store larger amounts of data without worrying about size limits or security issues. While Astro sessions do create a cookie to store the session ID in the browser, all actual data remains server-side.
 
 They are useful for storing things like user data, shopping carts, and form state, and they work without any client-side JavaScript:
 

--- a/src/content/docs/fr/guides/sessions.mdx
+++ b/src/content/docs/fr/guides/sessions.mdx
@@ -13,7 +13,9 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Les sessions sont utilisées pour partager des données entre les requêtes de [pages rendues à la demande](/fr/guides/on-demand-rendering/). 
 
-Contrairement aux [`cookies`](/fr/guides/on-demand-rendering/#cookies), les sessions sont stockées sur le serveur, ce qui vous permet de stocker de grandes quantités de données sans vous soucier des limites de taille ni des problèmes de sécurité. Elles sont utiles pour stocker des éléments tels que les données utilisateur, les paniers d'achat et l'état des formulaires, et fonctionnent sans JavaScript côté client :
+Contrairement aux [`cookies`](/fr/guides/on-demand-rendering/#cookies) classiques, les sessions sont stockées sur le serveur, ce qui vous permet de stocker de grandes quantités de données sans vous soucier des limites de taille ni des problèmes de sécurité. Bien que les sessions Astro créent un cookie pour stocker l'ID de session dans le navigateur, les données réelles restent côté serveur, ce qui signifie que vous n'avez pas à vous soucier d'exposer des informations sensibles ou d'atteindre les limites de stockage du navigateur.
+
+Elles sont utiles pour stocker des éléments tels que les données utilisateur, les paniers d'achat et l'état des formulaires, et fonctionnent sans JavaScript côté client :
 
 ```astro title="src/components/CartButton.astro" {3}
 ---

--- a/src/content/docs/fr/guides/sessions.mdx
+++ b/src/content/docs/fr/guides/sessions.mdx
@@ -13,9 +13,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 Les sessions sont utilisées pour partager des données entre les requêtes de [pages rendues à la demande](/fr/guides/on-demand-rendering/). 
 
-Contrairement aux [`cookies`](/fr/guides/on-demand-rendering/#cookies) classiques, les sessions sont stockées sur le serveur, ce qui vous permet de stocker de grandes quantités de données sans vous soucier des limites de taille ni des problèmes de sécurité. Bien que les sessions Astro créent un cookie pour stocker l'ID de session dans le navigateur, les données réelles restent côté serveur, ce qui signifie que vous n'avez pas à vous soucier d'exposer des informations sensibles ou d'atteindre les limites de stockage du navigateur.
-
-Elles sont utiles pour stocker des éléments tels que les données utilisateur, les paniers d'achat et l'état des formulaires, et fonctionnent sans JavaScript côté client :
+Contrairement aux [`cookies`](/fr/guides/on-demand-rendering/#cookies), les sessions sont stockées sur le serveur, ce qui vous permet de stocker de grandes quantités de données sans vous soucier des limites de taille ni des problèmes de sécurité. Elles sont utiles pour stocker des éléments tels que les données utilisateur, les paniers d'achat et l'état des formulaires, et fonctionnent sans JavaScript côté client :
 
 ```astro title="src/components/CartButton.astro" {3}
 ---


### PR DESCRIPTION
#### Description

The wording around Astro sessions can be a bit misleading, making you believe they work with 0 cookies.
This PR amends that, clarifying that a minimal cookie is created just to hold the session ID and that the actual data remains in the provider instead of the user’s browser.