### PR TITLE
i18n(fr): improve the wording in `guides/migrate-to-astro`

### DIFF
--- a/src/content/docs/fr/guides/media/cloudinary.mdx
+++ b/src/content/docs/fr/guides/media/cloudinary.mdx
@@ -10,9 +10,9 @@ i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-[Cloudinary](https://cloudinary.com) est une plateforme d'images et de vidéos et un gestionnaire de ressources numériques (DAM) sans tête qui vous permet d'héberger des ressources et de les diffuser à partir de leur réseau de diffusion de contenu (CDN).
+[Cloudinary](https://cloudinary.com) est une plateforme d'images et de vidéos et un gestionnaire de ressources numériques (DAM) headless qui vous permet d'héberger des ressources et de les diffuser à partir de leur réseau de diffusion de contenu (CDN).
 
-Lors de la livraison depuis Cloudinary, vous bénéficiez également d'un accès à leur API de transformation, vous donnant la possibilité de modifier vos ressources avec des outils tels que la suppression d'arrière-plan, le recadrage et le redimensionnement dynamiques et l'IA générative.
+Lors de la diffusion depuis Cloudinary, vous bénéficiez également d'un accès à leur API de transformation, vous donnant la possibilité de modifier vos ressources avec des outils tels que la suppression d'arrière-plan, le recadrage et le redimensionnement dynamiques et l'IA générative.
 
 ## Utilisation de Cloudinary dans Astro
 
@@ -192,12 +192,12 @@ Installez le SDK Node.js de Cloudinary en exécutant la commande appropriée pou
 Ajoutez les variables d'environnement suivantes dans votre fichier `.env` :
 
 ```shell title=".env"
-PUBLIC_CLOUDINARY_CLOUD_NAME="<Votre nom de cloud>"
+PUBLIC_CLOUDINARY_CLOUD_NAME="<Le nom de votre cloud>"
 PUBLIC_CLOUDINARY_API_KEY="<Votre clé API>"
 CLOUDINARY_API_SECRET="<Votre secret API>"
 ```
 
-Configurez votre compte avec une nouvelle instance Cloudinary en ajoutant le code suivant entre les barrières de code de votre composant Astro :
+Configurez votre compte avec une nouvelle instance Cloudinary en ajoutant le code suivant entre les délimitateurs de code de votre composant Astro :
 
 ```js title="Component.astro"
 ---
@@ -222,7 +222,7 @@ Découvrez comment [transférer des fichiers à l'aide du SDK Node.js de Cloudin
 
 ## Ressources officielles
 
-- [SDK Astro de Cloudinary](https://astro.cloudinary.dev/) (en)
-- [SDK Node.js de Cloudinary](https://cloudinary.com/documentation/node_integration) (en)
-- [Utiliser Cloudinary avec Astro (YouTube)](https://www.youtube.com/playlist?list=PL8dVGjLA2oMqnpf2tShn1exf5GkSWuu5-) (en)
-- [Exemples de code utilisant le SDK Astro de Cloudinary (GitHub)](https://github.com/cloudinary-community/cloudinary-examples/tree/main/examples/astro-cloudinary) (en)
+- [SDK Astro de Cloudinary](https://astro.cloudinary.dev/) (Anglais)
+- [SDK Node.js de Cloudinary](https://cloudinary.com/documentation/node_integration) (Anglais)
+- [Utiliser Cloudinary avec Astro (YouTube)](https://www.youtube.com/playlist?list=PL8dVGjLA2oMqnpf2tShn1exf5GkSWuu5-) (Anglais)
+- [Exemples de code utilisant le SDK Astro de Cloudinary (GitHub)](https://github.com/cloudinary-community/cloudinary-examples/tree/main/examples/astro-cloudinary) (Anglais)

--- a/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
@@ -26,7 +26,7 @@ import App from '../cra-project/App.jsx';
 <App client:load />
 ```
 
-<ReadMore>Voir comment [Construire une application à page unique (SPA) avec Astro](https://logsnag.com/blog/react-spa-with-astro) <Badge text="Externe" /> en utilisant React Router.</ReadMore>
+<ReadMore>Découvrez comment [créer une application à page unique (SPA) avec Astro](https://logsnag.com/blog/react-spa-with-astro) <Badge text="Externe" /> en utilisant React Router.</ReadMore>
 
 De nombreuses applications fonctionneront comme des applications React complètes si vous les ajoutez directement à votre projet Astro avec l'intégration React installée. C'est un excellent moyen de rendre votre projet opérationnel immédiatement et de maintenir votre application fonctionnelle pendant que vous migrez vers Astro.
 
@@ -36,33 +36,33 @@ Voici quelques concepts clés et stratégies de migration pour vous aider à dé
 
 ## Principales similitudes entre CRA et Astro
 
-- La [syntaxe des fichiers `.astro` est similaire à celle de JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx). L'écriture d'Astro devrait vous sembler familière.
+- La [syntaxe des fichiers `.astro` est similaire à celle de JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx). Écrire avec Astro devrait vous sembler familier.
 
 - Astro utilise un routage basé sur les fichiers et [permet à des pages spécialement nommées de créer des routes dynamiques](/fr/guides/routing/#routes-dynamiques).
 
 - Astro est [basé sur des composants](/fr/basics/astro-components/), et votre structure de balisage sera similaire avant et après votre migration.
 
-- Astro a [des intégrations officielles pour React, Preact, et Solid](/fr/guides/integrations-guide/react/) pour que vous puissiez utiliser vos composants JSX existants. Notez que dans Astro, ces fichiers **doivent** avoir une extension `.jsx` ou `.tsx`.
+- Astro a [des intégrations officielles pour React, Preact, et Solid](/fr/guides/integrations-guide/react/) pour que vous puissiez utiliser vos composants JSX existants. Notez qu'avec Astro, ces fichiers **doivent** avoir une extension `.jsx` ou `.tsx`.
 
-- Astro supporte [l'installation de paquets NPM](/fr/guides/imports/#paquets-npm), y compris les bibliothèques React. La plupart de vos dépendances existantes fonctionneront dans Astro.
+- Astro prend en charge [l'installation de paquets NPM](/fr/guides/imports/#paquets-npm), y compris les bibliothèques React. La plupart de vos dépendances existantes fonctionneront avec Astro.
 
 ## Principales différences entre CRA et Astro
 
-Lorsque vous reconstruisez votre site CRA dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site CRA avec Astro, vous remarquerez quelques différences importantes :
 
 - CRA est une application à page unique qui utilise `index.js` comme racine de votre projet. Astro est un site multi-pages, et `index.astro` est votre page d'accueil.
 
-- Les composants [`.astro`](/fr/basics/astro-components/) ne sont pas écrits comme des fonctions exportées qui renvoient un modèle de page. Au lieu de cela, vous diviserez votre code en une « barrière de code » pour votre JavaScript et un corps exclusivement pour le HTML que vous générez.
+- Les composants [`.astro`](/fr/basics/astro-components/) ne sont pas écrits en tant que fonctions exportées qui renvoient un modèle de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et un corps exclusivement pour le HTML que vous générez.
 
-- [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour mettre en valeur votre contenu et vous permettre d'opter pour l'interactivité uniquement en cas de besoin. Une application CRA existante peut être construite pour une grande interactivité côté client et peut nécessiter des techniques Astro avancées pour inclure des éléments qui sont plus difficiles à reproduire en utilisant des composants `.astro`, tels que des tableaux de bord.
+- [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour mettre en valeur votre contenu et vous permettre d'opter pour l'interactivité uniquement en cas de besoin. Une application CRA existante peut être conçue pour une interactivité élevée côté client et peut nécessiter des techniques Astro avancées pour inclure des éléments plus difficiles à reproduire en utilisant des composants `.astro`, tels que des tableaux de bord.
 
-## Ajouter votre CRA à Astro
+## Intégrer votre application CRA à Astro
 
-Votre application existante peut être affichée directement dans un nouveau projet Astro, souvent sans modification du code de votre application.
+Votre application existante peut être générée directement dans un nouveau projet Astro, souvent sans aucune modification du code de votre application.
 
 ### Créer un nouveau projet Astro
 
-Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro et sélectionner un nouveau projet Astro « vide ».
+Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro et sélectionnez un nouveau projet Astro « vide ».
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -82,7 +82,7 @@ Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer
   </Fragment>
 </PackageManagerTabs>
 
-### Ajouter les intégrations et les dépendances
+### Ajouter des intégrations et des dépendances
 Ajoutez l'intégration React en utilisant la commande `astro add` pour votre gestionnaire de paquets. Si votre application utilise d'autres paquets pris en charge par la commande `astro add`, comme Tailwind et MDX, vous pouvez tous les ajouter avec une seule commande :
 
 <PackageManagerTabs>
@@ -106,7 +106,7 @@ Ajoutez l'intégration React en utilisant la commande `astro add` pour votre ges
   </Fragment>
 </PackageManagerTabs>
 
-Si votre CRA nécessite des dépendances (par exemple des paquets NPM), installez-les individuellement en utilisant la ligne de commande ou en les ajoutant manuellement au `package.json` de votre nouveau projet Astro, puis en lançant une commande d'installation. Notez que beaucoup de dépendances React, mais pas toutes, fonctionneront dans Astro.
+Si votre application CRA nécessite des dépendances (par exemple des paquets NPM), installez-les individuellement en utilisant la ligne de commande ou en les ajoutant manuellement au `package.json` de votre nouveau projet Astro, puis en lançant une commande d'installation. Notez que beaucoup de dépendances React, mais pas toutes, fonctionneront dans Astro.
 
 ### Ajouter vos fichiers d'application existants
 
@@ -114,7 +114,7 @@ Copiez les fichiers sources et les dossiers de votre projet Create React App (CR
 
 N'incluez aucun fichier de configuration. Vous utiliserez les propres fichiers d'Astro `astro.config.mjs`, `package.json`, et `tsconfig.json`.
 
-Déplacez le contenu du dossier `public/` de votre application (par exemple les actifs statiques) dans le dossier `public/` d'Astro.
+Déplacez le contenu du dossier `public/` de votre application (par exemple les ressources statiques) dans le dossier `public/` d'Astro.
 
 <FileTree>
 - public/
@@ -132,7 +132,7 @@ Déplacez le contenu du dossier `public/` de votre application (par exemple les 
 - tsconfig.json
 </FileTree>
 
-### Afficher votre application
+### Effectuer le rendu de votre application
 
 Importez le composant racine de votre application dans la section frontmatter de `index.astro`, puis affichez le composant `<App />` dans votre modèle de page :
 
@@ -144,18 +144,18 @@ import App from '../cra-project/App.jsx';
 ```
 
 :::note[Directives client]
-Votre application a besoin d'une [directive client](/fr/reference/directives-reference/#directives-client) pour l'interactivité. Astro affichera votre application React en HTML statique jusqu'à ce que vous optiez pour le JavaScript côté client.
+Votre application a besoin d'une [directive client](/fr/reference/directives-reference/#directives-client) pour l'interactivité. Astro effectuera le rendu de votre application React sous forme de HTML statique jusqu'à ce que vous optiez pour l'ajout de JavaScript côté client.
 
 Utilisez `client:load` pour vous assurer que votre application se charge immédiatement depuis le serveur, ou `client:only="react"` pour ignorer le rendu sur le serveur et exécuter votre application entièrement côté client.
 :::
 
-## Convertir votre CRA en Astro
+## Convertir votre application CRA en application Astro
 
-Après avoir [ajouté votre application existante à Astro](#ajouter-votre-cra-à-astro), vous voudrez probablement convertir votre application elle-même à Astro !
+Après avoir [intégré votre application existante dans Astro](#intégrer-votre-application-cra-à-astro), vous voudrez probablement convertir votre application elle-même en Astro !
 
 Vous reproduirez un schéma similaire basé sur des composants [en utilisant une mise en page HTML dans des composants Astro pour votre structure de base](/fr/basics/astro-components/) tout en important et en incluant des composants React individuels (qui peuvent eux-mêmes être des applications entières !) pour des îlots d'interactivité.
 
-Chaque migration sera différente et peut être effectuée de manière incrémentale sans perturber votre application de travail. Transformez des éléments individuels à votre propre rythme afin que de plus en plus de votre application soit alimentée par des composants Astro au fil du temps.
+Chaque migration sera différente et peut être effectuée progressivement sans perturber le fonctionnement de votre application. Convertissez des éléments individuels à votre rythme afin qu'une part croissante de votre application soit alimentée par des composants Astro au fil du temps.
 
 Lors de la conversion de votre application React, vous déciderez quels composants React vous allez [réécrire en composants Astro](#conversion-des-fichiers-jsx-en-fichiers-astro). La seule restriction est que les composants Astro peuvent importer des composants React, alors que les composants React ne peuvent importer que d'autres composants React :
 
@@ -187,7 +187,7 @@ import MyReactButton from '../components/MyReactButton.jsx';
 ```
 
 
-Il peut être utile de se familiariser avec les [îles Astro](/fr/concepts/islands/) et les [composants Astro](/fr/basics/astro-components/) avant de restructurer votre CRA en projet Astro.
+Il peut être utile de se familiariser avec les [îlots Astro](/fr/concepts/islands/) et les [composants Astro](/fr/basics/astro-components/) avant de restructurer votre application CRA en projet Astro.
 
 
 ### Comparaison : JSX vs Astro
@@ -225,7 +225,7 @@ Comparez le composant CRA suivant et le composant Astro correspondant :
                     padding: `1em 1.5em`,
                     textAlign: `center`,
                     marginBottom: `1em`
-                }}>Astro has {stars} 🧑‍🚀</p>
+                }}>Astro possède {stars} 🧑‍🚀</p>
                 <Footer />
             </>
         )
@@ -246,7 +246,7 @@ Comparez le composant CRA suivant et le composant Astro correspondant :
         const stars = json.stargazers_count || 0;
         ---
         <Header />
-        <p class="banner">Astro has {stars} 🧑‍🚀</p>
+        <p class="banner">Astro possède {stars} 🧑‍🚀</p>
         <Footer />
         <style>
           .banner {
@@ -265,11 +265,11 @@ Comparez le composant CRA suivant et le composant Astro correspondant :
 
 Voici quelques conseils pour convertir un composant CRA `.js` en un composant `.astro` :
 
-1. Utilisez le JSX renvoyé de la fonction du composant CRA existant comme base de votre modèle HTML.
+1. Utilisez le JSX renvoyé par la fonction du composant CRA existant comme base de votre modèle HTML.
 
-2. Changez toute [syntaxe CRA ou JSX en Astro](#référence--convertir-la-syntaxe-cra-en-astro) ou aux standards web HTML. Cela inclut `{children}` et `className`, par exemple.
+2. Modifiez toute [syntaxe CRA ou JSX en Astro](#référence--convertir-la-syntaxe-cra-en-astro) ou selon les normes web HTML. Cela inclut `{children}` et `className`, par exemple.
 
-3. Déplacez tout JavaScript nécessaire, y compris les instructions d'importation, dans une [« barrière de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit à l'intérieur du modèle HTML directement dans Astro.
+3. Déplacez tout JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement à l'intérieur du modèle HTML avec Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires qui ont été précédemment transmises à votre fonction CRA.
 
@@ -277,9 +277,9 @@ Voici quelques conseils pour convertir un composant CRA `.js` en un composant `.
 
 6. Remplacez `useEffect()` par des déclarations d'importation ou [`import.meta.glob()`](/fr/guides/imports/#importmetaglob) pour interroger vos fichiers locaux. Utilisez `fetch()` pour récupérer des données externes.
 
-### Tests de migration
+### Migration des tests
 
-Comme Astro produit du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant le résultat de l'étape de construction. Tous les tests de bout en bout écrits précédemment peuvent fonctionner prêts à l'emploi si vous avez été en mesure de faire correspondre le balisage de votre site avec CRA. Les bibliothèques de test telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
+Comme Astro produit du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant le résultat de l'étape de compilation. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez été en mesure de faire correspondre le balisage de votre site CRA. Les bibliothèques de test telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
 
 Voir le [guide des tests](/fr/guides/testing/) d'Astro pour plus d'informations.
 
@@ -287,7 +287,7 @@ Voir le [guide des tests](/fr/guides/testing/) d'Astro pour plus d'informations.
 
 ### Importations CRA vers Astro
 
-Mettez à jour tous les [imports de fichiers](/fr/guides/imports/) pour qu'ils fassent exactement référence à des chemins d'accès relatifs. Cela peut être fait en utilisant [des alias d'importation](/fr/guides/typescript/#alias-dimportation), ou en écrivant un chemin relatif en entier.
+Mettez à jour toutes les [importations de fichiers](/fr/guides/imports/) pour qu'ils fassent exactement référence à des chemins d'accès relatifs. Cela peut être fait en utilisant [des alias d'importation](/fr/guides/typescript/#alias-dimportation), ou en écrivant un chemin relatif en entier.
 
 Notez que `.astro` et plusieurs autres types de fichiers doivent être importés avec leur extension complète.
 
@@ -300,7 +300,7 @@ import Card from '../../components/Card.astro';
 
 ### Les props d'enfants de CRA à Astro
 
-Convertit toutes les instances de `{children}` en un `<slot />` Astro. Ce dernier n'a pas besoin de recevoir `{children}` en tant que propriété de fonction et affichera automatiquement le contenu des enfants dans un `<slot />`.
+Convertissez toutes les instances de `{children}` en un `<slot />` Astro. Ce dernier n'a pas besoin de recevoir `{children}` en tant que propriété de fonction et affichera automatiquement le contenu des enfants dans un `<slot />`.
 
 ```astro title="src/components/MyComponent.astro" del={3-9} ins={11-13}
 ---
@@ -326,7 +326,7 @@ En savoir plus sur [l'utilisation spécifique de `<slot />` dans Astro](/fr/basi
 
 La récupération de données dans un composant Create React App est similaire à Astro, avec quelques légères différences.
 
-Vous devrez supprimer toutes les instances d'un crochet d'effet secondaire (`useEffect`) pour `import.meta.glob()` ou `getCollection()`/`getEntry()` pour accéder aux données depuis d'autres fichiers dans la source de votre projet.
+Vous devrez supprimer toutes les instances d'un hook d'effet secondaire (`useEffect`) pour `import.meta.glob()` ou `getCollection()`/`getEntry()` pour accéder aux données depuis d'autres fichiers dans la source de votre projet.
 
 Pour [récupérer des données distantes](/fr/guides/data-fetching/), utilisez `fetch()`.
 
@@ -342,7 +342,7 @@ const allBlogPosts = await getCollection('blog');
 // Obtention de toutes les entrées `src/pages/posts/`
 const allPosts = Object.values(import.meta.glob('../pages/post/*.md', { eager: true }));
 
-// Récupération des données à distance
+// Récupération de données distantes
 const response = await fetch('https://randomuser.me/api/');
 const data = await response.json();
 const randomUser = data.results[0];
@@ -351,33 +351,33 @@ const randomUser = data.results[0];
 
 En savoir plus sur l'importation de fichiers locaux avec [`import.meta.glob()`](/fr/guides/imports/#importmetaglob), [l'interrogation à l'aide de l'API Collections](/fr/guides/content-collections/#interroger-les-collections) ou [la récupération de données distantes](/fr/guides/data-fetching/).
 
-### Le style de CRA à Astro
+### La mise en forme de CRA à Astro
 
 Il se peut que vous deviez remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) par d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [Astro `<style>`](/fr/guides/styling/#styliser-avec-astro) pour les styles CSS étendus.
+Si nécessaire, convertissez les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [`<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>
 <div style="background-color: #f4f4f4; padding: 1em;">{message}</div>
 ```
 
-Tailwind est pris en charge après l'installation du [plugin Vite de Tailwind](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est nécessaire !
+Tailwind est pris en charge après l'installation du [module d'extension Tailwind pour Vite](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est nécessaire !
 
 En savoir plus sur [les styles dans Astro](/fr/guides/styling/).
 
 
 ## Dépannage
 
-Votre CRA pourrait « simplement fonctionner » dans Astro ! Mais il se peut que vous deviez procéder à des ajustements mineurs pour reproduire les fonctionnalités et/ou les styles de votre application existante.
+Votre application CRA pourrait « simplement fonctionner » dans Astro ! Mais il se peut que vous deviez procéder à des ajustements mineurs pour reproduire les fonctionnalités et/ou les styles de votre application existante.
 
-Si vous ne trouvez pas les réponses à vos questions dans ces documents, visitez le [serveur Discord d'Astro](https://astro.build/chat) et posez vos questions dans notre forum d'assistance !
+Si vous ne trouvez pas les réponses à vos questions dans cette documentation, visitez le [serveur Discord d'Astro](https://astro.build/chat) et posez vos questions dans notre forum d'assistance !
 
 ## Ressources communautaires
 
 <CardGrid>
 
-  <LinkCard title="Correction de code : le site web SIBA passe de Create-React-App à Astro (en)" href="https://brittanisavery.com/post/move-siba-to-astro"/>
+  <LinkCard title="Correction de code : le site web SIBA passe de Create-React-App à Astro (Anglais)" href="https://brittanisavery.com/post/move-siba-to-astro"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
@@ -12,37 +12,39 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-[Docusaurus](https://Docusaurus.io) est un constructeur de site web de documentation populaire construit sur React.
+[Docusaurus](https://Docusaurus.io) est un générateur de site web de documentation populaire construit sur React.
 
 ## Principales similitudes entre Docusaurus et Astro
 
 Docusaurus et Astro partagent certaines similitudes qui vous aideront à migrer votre projet :
 
-- Astro et Docusaurus sont tous deux des créateurs de sites modernes, basés sur JavaScript (Jamstack) et destinés aux [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu), comme les sites de documentation.
+- Astro et Docusaurus sont tous deux des générateurs de sites modernes, basés sur JavaScript (Jamstack) et destinés aux [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu), comme les sites de documentation.
 
-- Astro et Docusaurus supportent tous deux les [pages MDX](/fr/guides/markdown-content/). Vous devriez pouvoir utiliser vos fichiers `.mdx` existants pour Astro.
+- Astro et Docusaurus supportent tous deux les [pages MDX](/fr/guides/markdown-content/). Vous devriez pouvoir utiliser vos fichiers `.mdx` existants dans Astro.
 
 - Astro et Docusaurus utilisent [le routage basé sur les fichiers](/fr/guides/routing/) pour générer automatiquement des routes de pages pour tout fichier MDX situé dans `src/pages`. L'utilisation de la structure de fichiers d'Astro pour votre contenu existant et lors de l'ajout de nouvelles pages devrait vous sembler familière.
 
 - Astro dispose d'une [intégration officielle pour l'utilisation des composants React](/fr/guides/integrations-guide/react/). Notez que dans Astro, les fichiers React **doivent** avoir une extension `.jsx` ou `.tsx`.
 
-- Astro supporte [l'installation de paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour React. Vous pouvez conserver tout ou partie de vos composants et dépendances React existants.
+- Astro prend en charge [l'installation de paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour React. Vous pourrez peut-être conserver tout ou partie de vos composants et dépendances React existants.
 
-- La [syntaxe JSX d'Astro](/fr/basics/astro-components/#le-modèle-du-composant) devrait vous sembler familière si vous avez l'habitude d'écrire React.
+- La [syntaxe de type JSX d'Astro](/fr/basics/astro-components/#le-modèle-du-composant) devrait vous sembler familière si vous êtes habitués à écrire en React.
+
 
 ## Principales différences entre Docusaurus et Astro
 
-Lorsque vous reconstruisez votre site Docusaurus avec Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréer votre site Docusaurus avec Astro, vous remarquerez quelques différences importantes :
 
-- Docusaurus est une application monopage (SPA) basée sur React. Les sites Astro sont des applications multi-pages construites en utilisant des [composants `.astro`](/fr/basics/astro-components/), mais peuvent aussi supporter [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et le templating HTML brut.
+- Docusaurus est une application monopage (SPA) basée sur React. Les sites Astro sont des applications multi-pages construites en utilisant des [composants `.astro`](/fr/basics/astro-components/), mais peuvent également prendre en charge [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et les modèles HTML bruts.
 
-- Docusaurus a été conçu pour construire des sites web de documentation et possède des fonctionnalités intégrées spécifiques aux sites web de documentation que vous devriez construire vous-même dans Astro. Au lieu de cela, Astro propose certaines de ces fonctionnalités via [Starlight : un thème officiel pour la documentation](https://starlight.astro.build). Ce site web a inspiré Starlight et fonctionne désormais avec lui ! Vous pouvez également trouver d'autres [thèmes de documentation communautaires](https://astro.build/themes?search=&categories%5B%5D=docs) avec des fonctionnalités intégrées dans notre vitrine de thèmes.
+- Docusaurus a été conçu pour créer des sites web de documentation et dispose de certaines fonctionnalités intégrées spécifiques aux sites web de documentation que vous aurez à créer vous-même dans Astro. Au lieu de cela, Astro propose certaines de ces fonctionnalités via [Starlight : un thème officiel pour la documentation](https://starlight.astro.build). Ce site web a inspiré Starlight et fonctionne désormais avec lui ! Vous pouvez également trouver d'autres [thèmes de documentation communautaires](https://astro.build/themes?search=&categories%5B%5D=docs) avec des fonctionnalités intégrées dans notre vitrine de thèmes.
 
-- Les sites Docusaurus utilisent des pages MDX pour le contenu. Le thème docs d'Astro utilise par défaut des fichiers Markdown (`.md`) et ne nécessite pas l'utilisation de MDX. Vous pouvez optionnellement [installer l'intégration MDX d'Astro](/fr/guides/integrations-guide/mdx/) (inclus par défaut dans notre thème Starlight) et utiliser des fichiers `.mdx` en plus des fichiers Markdown standards.
+- Les sites Docusaurus utilisent des pages MDX pour le contenu. Le thème de documentation d'Astro utilise par défaut des fichiers Markdown (`.md`) et ne nécessite pas l'utilisation de MDX. Vous pouvez optionnellement [installer l'intégration MDX d'Astro](/fr/guides/integrations-guide/mdx/) (inclus par défaut dans notre thème Starlight) et utiliser des fichiers `.mdx` en plus des fichiers Markdown standards.
+
 
 ## Passer de Docusaurus à Astro
 
-Pour convertir un site de documentation Docusaurus en Astro, commencez par notre [modèle de démarrage officiel Starlight](https://starlight.astro.build), ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
+Pour convertir un site de documentation Docusaurus en Astro, commencez par notre [thème de documentation Starlight comme modèle de démarrage](https://starlight.astro.build) officiel, ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
 
 Vous pouvez passer un argument `--template` à la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles officiels. Vous pouvez aussi [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
@@ -66,13 +68,13 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
 
 L'intégration MDX d'Astro est incluse par défaut, ce qui vous permet de [transférer vos fichiers de contenu existants vers Starlight](https://starlight.astro.build/fr/getting-started/#ajouter-du-contenu) immédiatement.
 
-Vous pouvez trouver la documentation d'Astro, et d'autres modèles officiels, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
+Vous pouvez trouver le modèle de démarrage pour les sites de documentation d'Astro, et d'autres modèles officiels, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
 ## Ressources communautaires
 
 <CardGrid>
 
-  <LinkCard title="Accélération de la documentation par 10 (ru)" href="https://habr.com/ru/articles/880220/"/>
+  <LinkCard title="Accélération de la documentation par 10 (Russe)" href="https://habr.com/ru/articles/880220/"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-eleventy.mdx
@@ -12,27 +12,27 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-[Eleventy](https://11ty.dev) est un générateur de site statique open-source qui fonctionne avec plusieurs langages de template.
+[Eleventy](https://11ty.dev) est un générateur de sites statiques open source qui fonctionne avec plusieurs langages de modèles.
 
 ## Principales similitudes entre Eleventy (11ty) et Astro
 
 Eleventy (11ty) et Astro partagent certaines similitudes qui vous aideront à migrer votre projet :
 
-- Astro et Eleventy sont tous deux des constructeurs de sites modernes, basés sur JavaScript (Jamstack).
+- Astro et Eleventy sont tous deux des générateurs de sites modernes, basés sur JavaScript (Jamstack).
 
 - Astro et Eleventy vous permettent tous deux d'utiliser un [CMS headless, des APIs ou des fichiers Markdown pour les données](/fr/guides/data-fetching/). Vous pouvez continuer à utiliser votre système préféré de création de contenu et conserver votre contenu existant.
 
 ## Principales différences entre Eleventy (11ty) et Astro
 
-Lorsque vous reconstruisez votre site Eleventy (11ty) dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Eleventy (11ty) dans Astro, vous remarquerez quelques différences importantes :
 
-- Eleventy supporte une variété de langages de modélisation. Astro supporte [les composants de plusieurs frameworks JS populaires (par exemple React, Svelte, Vue, Solid)](/fr/guides/framework-components/), mais utilise des [mises en page Astro, des pages et des composants](/fr/basics/astro-components/) pour la plupart des templates de pages.
+- Eleventy prend en charge une variété de langages de création de modèles. Astro prend en charge l'[utilisation de composants de plusieurs frameworks JS populaires (par exemple React, Svelte, Vue, Solid)](/fr/guides/framework-components/), mais utilise des [mises en page, des pages et des composants](/fr/basics/astro-components/) Astro pour la plupart des modèles de pages.
 
-- Astro utilise un répertoire [`src/`](/fr/basics/project-structure/#src) pour tous les fichiers, y compris les métadonnées du site, qui sont disponibles pour être interrogés et traités pendant la construction du site. Dans ce dossier se trouve un [dossier spécial `src/pages/` pour le routage basé sur les fichiers](/fr/basics/astro-pages/).
+- Astro utilise un répertoire [`src/`](/fr/basics/project-structure/#src) pour tous les fichiers, y compris les métadonnées du site, qui sont disponibles pour être interrogés et traités pendant la création du site. Dans ce dossier se trouve un [dossier spécial `src/pages/` pour le routage basé sur les fichiers](/fr/basics/astro-pages/).
 
-- Astro utilise un dossier [`public/` pour les actifs statiques](/fr/basics/project-structure/#public) qui n'ont pas besoin d'être traités ou transformés pendant la construction.
+- Astro utilise un dossier [`public/` pour les ressources statiques](/fr/basics/project-structure/#public) qui n'ont pas besoin d'être traitées ou transformées pendant la compilation.
 
-- Dans Eleventy, le regroupement des fichiers CSS, JavaScript et autres actifs doit être configurés manuellement. [Astro s'en charge dès le départ](/fr/concepts/why-astro/#facile-à-utiliser).
+- Dans Eleventy, le regroupement du CSS, du JavaScript et des autres ressources doit être configuré manuellement. [Astro gère cela pour vous dès le départ](/fr/concepts/why-astro/#facile-à-utiliser).
 
 ## Passer d'Eleventy à Astro
 
@@ -60,7 +60,7 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
 
 Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration optionnelle) comme contenu pour [créer des pages Markdown ou MDX](/fr/guides/markdown-content/).
 
-Votre projet Eleventy vous a permis d'utiliser une variété de langages de templates pour construire votre site. Dans un projet Astro, la modélisation de vos pages sera principalement réalisée à l'aide de composants Astro, qui peuvent être utilisés comme éléments d'interface utilisateur, de mise en page et même de pages complètes. Vous pouvez explorer [la syntaxe des composants Astro](/fr/basics/astro-components/) pour voir comment créer des modèles dans Astro en utilisant des composants.
+Votre projet Eleventy vous a permis d'utiliser une variété de langages de création de modèles pour créer votre site. Dans un projet Astro, la création de modèles pour vos pages sera principalement réalisée à l'aide de composants Astro, qui peuvent être utilisés comme éléments d'interface utilisateur, de mises en page et même de pages complètes. Vous pouvez explorer [la syntaxe des composants Astro](/fr/basics/astro-components/) pour découvrir comment créer des modèles dans Astro en utilisant des composants.
 
 Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
@@ -68,9 +68,9 @@ Pour convertir d'autres types de sites, comme un portfolio ou un site de documen
 
 <CardGrid>
 
-  <LinkCard title="Ce site est désormais construit avec Astro (en)" href="https://aqandrew.com/blog/now-built-with-astro/" description="Pourquoi j'ai quitté Eleventy."/>
+  <LinkCard title="Ce site est désormais construit avec Astro (Anglais)" href="https://aqandrew.com/blog/now-built-with-astro/" description="Pourquoi j'ai quitté Eleventy."/>
 
-  <LinkCard title="Réécriture du site Web : 2025 (en)" href="https://www.welchcanavan.com/posts/site-rewrite-2025/" />
+  <LinkCard title="Réécriture du site Web : 2025 (Anglais)" href="https://www.welchcanavan.com/posts/site-rewrite-2025/" />
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
@@ -12,7 +12,7 @@ import { Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
 import AstroJSXTabs from '~/components/tabs/AstroJSXTabs.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de nos documents et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
+Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de notre documentation et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
 
 ## Principales similitudes entre Gatsby et Astro
 
@@ -20,7 +20,7 @@ Gatsby et Astro partagent certaines similitudes qui vous aideront à migrer votr
 
 - La [syntaxe des fichiers `.astro` est similaire à celle de JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx). Développer avec Astro devrait vous sembler familier.
 
-- Astro possède un support intégré pour [Markdown](/fr/guides/markdown-content/) et une intégration pour utiliser les fichiers MDX. En outre, vous pouvez configurer et continuer à utiliser plusieurs de vos plugins Markdown existants.
+- Astro possède une prise en charge intégrée pour [Markdown](/fr/guides/markdown-content/) et une intégration pour utiliser les fichiers MDX. En outre, vous pouvez configurer et continuer à utiliser plusieurs de vos modules d'extension Markdown existants.
 
 - Astro possède également une [intégration officielle pour utiliser des composants React](/fr/guides/integrations-guide/react/). Notez que dans Astro, les fichiers React **doivent** utiliser une extension `.jsx` ou `.tsx`.
 
@@ -30,11 +30,11 @@ Gatsby et Astro partagent certaines similitudes qui vous aideront à migrer votr
 
 ## Principales différences entre Gatsby et Astro
 
-Lorsque vous reconstruisez votre site Gatsby dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Gatsby dans Astro, vous remarquerez quelques différences importantes :
 
 - Les projets Gatsby sont des applications React d'une seule page et utilisent `index.js` comme racine de votre projet. Les projets Astro sont des sites de plusieurs pages et `index.astro` est votre page d'accueil.
 
-- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en une « barrière de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
+- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
 
 - [Données de fichiers locaux](/fr/guides/imports/): Gatsby utilise GraphQL pour récupérer des données à partir de vos fichiers de projet. Astro utilise les importations ESM et les fonctions d'attente de niveau supérieur (par exemple, [`import.meta.glob()`](/fr/guides/imports/#importmetaglob), [`getCollection()`](/fr/guides/content-collections/#interroger-les-collections)) pour importer des données à partir de vos fichiers de projet. Vous pouvez ajouter manuellement GraphQL à votre projet Astro mais il n'est pas inclus par défaut.
 
@@ -43,9 +43,9 @@ Lorsque vous reconstruisez votre site Gatsby dans Astro, vous remarquerez quelqu
 Chaque migration de projet sera différente, mais vous effectuerez certaines actions courantes lors de la conversion de Gatsby vers Astro.
 
 ### Créer un nouveau projet Astro
-Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes Astro](https://astro.build/themes).
+Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes d'Astro](https://astro.build/themes).
 
-Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos démarreurs officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
+Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles de démarrage officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
@@ -87,24 +87,24 @@ Consultez https://astro.new pour la liste complète des modèles de démarrage o
 
 Vous trouverez peut-être utile d'installer certaines des [intégrations facultatives d'Astro](/fr/guides/integrations-guide/) à utiliser lors de la conversion de votre projet Gatsby en Astro :
 
-- **@astrojs/react**: pour réutiliser certains de vos composants React orientés UI dans votre nouveau site Astro ou pour continuer à coder des composants React.
+- **@astrojs/react** : pour réutiliser certains de vos composants d'interface utilisateur React dans votre nouveau site Astro ou pour continuer à coder avec des composants React.
 
-- **@astrojs/mdx**: pour importer des fichiers MDX existants de votre projet Gatsby ou pour utiliser MDX dans votre nouveau site Astro.
+- **@astrojs/mdx** : pour importer des fichiers MDX existants de votre projet Gatsby ou pour utiliser MDX dans votre nouveau site Astro.
 
 ### Placer votre code dans `src`
 
-En suivant la [structure du projet d'Astro](/fr/basics/project-structure/):
+En suivant la [structure de projet d'Astro](/fr/basics/project-structure/):
 
 <Steps>
 1. **Supprimez** le dossier `public/` de Gatsby. 
     
-    Gatsby utilise le répertoire `public/` pour sa sortie de construction, vous pouvez donc supprimer ce dossier en toute sécurité. Vous n'aurez plus besoin d'une version construite de votre site Gatsby. (Astro utilise `dist/` par défaut pour la sortie de construction.)
+    Gatsby utilise le répertoire `public/` pour sa sortie de compilation, vous pouvez donc supprimer ce dossier en toute sécurité. Vous n'aurez plus besoin d'une version compilée de votre site Gatsby. (Astro utilise `dist/` par défaut pour la sortie de compilation.)
 
 2. **Renommez** le dossier `static/` de Gatsby en `public/`, et utilisez-le comme dossier `public/` d'Astro. 
 
     Astro utilise un dossier nommé `public/` pour les ressources statiques. Vous pouvez également copier le contenu de `static/` dans le dossier `public/` existant d'Astro.
 
-3. **Copiez ou déplacez** les autres fichiers et dossiers de Gatsby (par exemple, `components`, `pages`, etc.) selon vos besoins dans le dossier `src/` d'Astro pendant que vous reconstruisez votre site, en suivant la [structure de projet d'Astro](/fr/basics/project-structure/).
+3. **Copiez ou déplacez** les autres fichiers et dossiers de Gatsby (par exemple, `components`, `pages`, etc.) selon vos besoins dans le dossier `src/` d'Astro pendant que vous recréez votre site, en suivant la [structure de projet d'Astro](/fr/basics/project-structure/).
 
     Le dossier `src/pages/` d'Astro est un dossier spécial utilisé pour le routage basé sur des fichiers afin de créer les pages et les articles de votre site à partir de fichiers `.astro`, `.md` et `.mdx`. Vous n'aurez pas à configurer de comportement de routage pour vos fichiers Astro, Markdown et MDX.
 
@@ -119,7 +119,7 @@ Voici quelques conseils pour convertir un composant Gatsby `.js` en un composant
 
 2. Remplacez toute [syntaxe Gatsby ou JSX par une syntaxe Astro](#référence-conversion-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<Link to="">`, `{children}` et `className` par exemple.
 
-3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans une [« barrière de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
+3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires précédemment transmises à votre fonction Gatsby.
 
@@ -228,7 +228,7 @@ Alternativement, vous pouvez utiliser les [collections de contenu](/fr/guides/co
 
 ### Migration des tests
 
-Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de construction. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre ancien site Gatsby. Les bibliothèques de tests telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
+Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de compilation. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre ancien site Gatsby. Les bibliothèques de tests telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
 
 Voir le [guide de test](/fr/guides/testing/) d'Astro pour en savoir plus.
 
@@ -236,17 +236,17 @@ Voir le [guide de test](/fr/guides/testing/) d'Astro pour en savoir plus.
 
 Gatsby dispose de plusieurs fichiers de configuration de niveau supérieur qui incluent également des métadonnées de site et de page et qui sont utilisés pour le routage. Vous n'utiliserez aucun de ces fichiers `gatsby-*.js` dans votre projet Astro mais il se peut que vous puissiez réutiliser certains contenus au fur et à mesure que vous le construisez :
 
-- `gatsby-config.js`: Déplacez votre `siteMetadata: {}` dans `src/data/siteMetadata.js` (ou `siteMetadata.json`) pour importer des données à propos de votre site (titre, description, comptes sociaux, etc.) dans les mises en page.
+- `gatsby-config.js` : Déplacez votre `siteMetadata: {}` dans `src/data/siteMetadata.js` (ou `siteMetadata.json`) pour importer des données à propos de votre site (titre, description, comptes sociaux, etc.) dans les mises en page.
 
-- `gatsby-browser.js`: Pensez à ajouter tout ce qui est utilisé ici directement dans la balise `<head>` de votre [mise en page principale](#migration-des-fichiers-de-mise-en-page).
+- `gatsby-browser.js` : Pensez à ajouter tout ce qui est utilisé ici directement dans la balise `<head>` de votre [mise en page principale](#migration-des-fichiers-de-mise-en-page).
 
-- `gatsby-node.js`: Vous n'aurez pas besoin de créer vos propres nœuds dans Astro, mais la consultation du schéma présent dans ce fichier peut vous aider à définir les types dans votre projet Astro.
+- `gatsby-node.js` : Vous n'aurez pas besoin de créer vos propres nœuds dans Astro, mais la consultation du schéma présent dans ce fichier peut vous aider à définir les types dans votre projet Astro.
 
-- `gatsby-ssr.js`: Si vous choisissez d'utiliser SSR dans Astro, vous [ajouterez et configurerez l'adaptateur SSR](/fr/guides/on-demand-rendering/) de votre choix directement dans `astro.config.mjs`.
+- `gatsby-ssr.js` : Si vous choisissez d'utiliser SSR dans Astro, vous [ajouterez et configurerez l'adaptateur SSR](/fr/guides/on-demand-rendering/) de votre choix directement dans `astro.config.mjs`.
 
 ## Référence : Conversion en syntaxe Astro
 
-Voici quelques exemples de syntaxe spécifique à Gatsby que vous devrez convertir en syntaxe Astro. Voir davantage de [différences entre Astro et JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx) dans le guide pour écrire des composants Astro.
+Voici quelques exemples de syntaxe spécifique à Gatsby que vous devrez convertir en syntaxe Astro. Découvrez davantage de [différences entre Astro et JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx) dans le guide pour écrire des composants Astro.
 
 ### Les liens : de Gatsby à Astro
 
@@ -266,7 +266,7 @@ const { to } = Astro.props
 <a href={to}><slot /></a>
 ```
 
-### Les imports : de Gatsby à Astro
+### Les importations : de Gatsby à Astro
 
 Si nécessaire, mettez à jour toutes les [importations de fichiers](/fr/guides/imports/) pour référencer exactement les chemins de fichiers relatifs. Cela peut être fait en utilisant des [alias d'importation](/fr/guides/typescript/#alias-dimportation) ou en écrivant un chemin relatif dans son intégralité.
 
@@ -299,7 +299,7 @@ export default function MyComponent(props) {
 </div>
 ```
 
-Les composants React qui transmettent plusieurs ensembles d'enfants peuvent être migrés vers un composant Astro à l'aide des [emplacements nommés](/fr/basics/astro-components/#les-slots-nommés).
+Les composants React qui transmettent plusieurs ensembles d'enfants peuvent être migrés vers un composant Astro à l'aide des [slots nommés](/fr/basics/astro-components/#les-slots-nommés).
 
 En savoir plus sur [l'utilisation spécifique de `<slot />` dans Astro](/fr/basics/astro-components/#les-slots).
 
@@ -314,13 +314,13 @@ Si nécessaire, convertissez tous les objets de style en ligne (`style={{ fontWe
 <div style="background-color: #f4f4f4; padding: 1em;">{message}</div>
 ```
 
-Tailwind est pris en charge après l'installation du [plugin Tailwind pour Vite](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est requise !
+Tailwind est pris en charge après l'installation du [module d'extension Tailwind pour Vite](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est requise !
 
 L'ajout de styles globaux est obtenu dans Gatsby à l'aide des importations CSS dans `gatsby-browser.js`. Dans Astro, vous importerez des fichiers `.css` directement dans un composant de mise en page principal pour obtenir des styles globaux.
 
 En savoir plus sur les [styles dans Astro](/fr/guides/styling/).
 
-### Le plugin d'image Gatsby vers Astro
+### Les componsants d'image de Gatsby vers Astro
 
 Convertissez tous les composants `<StaticImage />` et `<GatsbyImage />` de Gatsby en [composant d'image propre à Astro](/fr/guides/images/) ou en code [HTML/JSX standard avec la balise `<img />`](/fr/guides/images/#images-dans-les-composants-framework-ui) selon les besoins dans vos composants React.
 
@@ -347,7 +347,7 @@ Pour continuer à utiliser des [images dans les fichiers Markdown (`.md`)](/fr/g
 
 ```
 
-Dans les composants React (`.jsx`), utilisez la syntaxe d'image JSX standard (`<img />`). Astro n'optimisera pas ces images, mais vous pouvez installer et utiliser des packages NPM pour plus de flexibilité.
+Dans les composants React (`.jsx`), utilisez la syntaxe d'image JSX standard (`<img />`). Astro n'optimisera pas ces images, mais vous pouvez installer et utiliser des paquets NPM pour plus de flexibilité.
 
 Vous pouvez en apprendre davantage sur [l'utilisation d'images dans Astro](/fr/guides/images/) dans le guide Images.
 
@@ -357,7 +357,7 @@ Supprimez toutes les références aux requêtes GraphQL et utilisez à la place 
 
 Ou, si vous utilisez des collections de contenu, interrogez vos fichiers Markdown et MDX dans `src/content/` en utilisant [`getEntry()` et `getCollection()`](/fr/guides/content-collections/#interroger-les-collections). 
 
-Ces demandes de données sont réalisées dans le frontmatter du composant Astro component utilisant ces données.
+Ces demandes de données sont réalisées dans le frontmatter du composant Astro utilisant ces données.
 
 ```astro title="src/pages/index.astro" del={2,12-28}
 ---
@@ -392,7 +392,7 @@ export const pageQuery = graphql`
 
 ## Exemple guidé : Mise en page, de Gatsby à Astro
 
-Cet exemple convertit la mise en page principale du projet (`layout.js`) du démarreur de blog de Gatsby à `src/layouts/Layout.astro`.
+Cet exemple convertit la mise en page principale du projet (`layout.js`) du modèle de démarrage de blog de Gatsby en `src/layouts/Layout.astro`.
 
 Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et un en-tête différent avec un lien vers l'accueil pour toutes les autres pages.
 
@@ -424,7 +424,7 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
           <header className="global-header">{header}</header>
           <main>{children}</main>
           <footer>
-            © {new Date().getFullYear()}, Construit avec
+            © {new Date().getFullYear()}, Créé avec
             {` `}
             <a href="https://www.gatsbyjs.com">Gatsby</a>
           </footer>
@@ -450,7 +450,7 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
       <header class="global-header">{header}</header>
       <main><slot /></main>
       <footer>
-        © {new Date().getFullYear()}, Construit avec
+        © {new Date().getFullYear()}, Créé avec
         {` `}
         <a href="https://www.astro.build">Astro</a>
       </footer>
@@ -476,7 +476,7 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
             <slot />
           </main>
           <footer>
-            &#169; {new Date().getFullYear()}, Construit avec
+            &#169; {new Date().getFullYear()}, Créé avec
             {` `}
             <a href="https://www.astro.build">Astro</a>
           </footer>
@@ -487,7 +487,7 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
 
 4. Ajoutez les importations, les props et le JavaScript nécessaires
   
-    Pour afficher de manière conditionnelle un en-tête basé sur l'itinéraire et le titre de la page dans Astro:
+    Pour afficher de manière conditionnelle un en-tête basé sur la route et le titre de la page dans Astro :
 
     - Fournissez les props via `Astro.props`. (Rappel : votre modèle Astro accède aux props à partir de son frontmatter, et non en les transmettant à une fonction.) 
     - Utilisez un opérateur ternaire pour afficher un en-tête s'il s'agit de la page d'accueil, et un en-tête différent dans le cas contraire. 
@@ -526,7 +526,7 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
             <slot />
           </main>
           <footer>
-            &#169; {new Date().getFullYear()}, Construit avec
+            &#169; {new Date().getFullYear()}, Créé avec
             {` `}
             <a href="https://www.astro.build">Astro</a>
           </footer>
@@ -568,37 +568,37 @@ Cette mise en page affiche un en-tête lors de la visite de la page d'accueil et
 ## Ressources communautaires
 
 <CardGrid>
-<LinkCard title="Migration de Gatsby à Astro (en)" href="https://loige.co/migrating-from-gatsby-to-astro/" 
+<LinkCard title="Migration de Gatsby à Astro (Anglais)" href="https://loige.co/migrating-from-gatsby-to-astro/" 
 description="Comment et pourquoi j'ai migré ce blog de Gatsby vers Astro et ce que j'ai appris au cours du processus." />
 
-<LinkCard title="La migration vers Astro était facile (en)" href="https://joelhooks.com/migrating-to-astro-was-ez" 
+<LinkCard title="La migration vers Astro était facile (Anglais)" href="https://joelhooks.com/migrating-to-astro-was-ez" 
 description="Il s’agit du processus de migration de Gatsby vers Astro et pourquoi j’ai choisi Astro." />
 
-<LinkCard title="Mon passage de Gatsby à Astro (en)" href="https://www.joshfinnie.com/blog/my-switch-from-gatsby-to-astro/" 
+<LinkCard title="Mon passage de Gatsby à Astro (Anglais)" href="https://www.joshfinnie.com/blog/my-switch-from-gatsby-to-astro/" 
 description="Le passage à Astro mérite vraiment un article de blog ! Il révolutionne le monde du développement web statique pour le meilleur."/>
 
-<LinkCard title="Pourquoi je suis passé de Gatsby à Astro (en)" href="https://dev.to/askrodney/why-i-moved-to-astro-from-gatsby-3fck" 
+<LinkCard title="Pourquoi je suis passé de Gatsby à Astro (Anglais)" href="https://dev.to/askrodney/why-i-moved-to-astro-from-gatsby-3fck" 
 description="Jetons un coup d’œil rapide sur ce qui m’a donné envie de changer et pourquoi Astro était un bon choix." />
 
-<LinkCard title="Une autre migration : de Gatsby à Astro (en)" href="https://logarithmicspirals.com/blog/migrating-from-gatsby-to-astro/" 
-description="Découvrez comment j'ai transféré mon site Web personnel de Gatsby vers Astro en partageant mes idées et mes expériences du processus de migration."/>
+<LinkCard title="Une autre migration : de Gatsby à Astro (Anglais)" href="https://logarithmicspirals.com/blog/migrating-from-gatsby-to-astro/" 
+description="Découvrez comment j'ai transféré mon site web personnel de Gatsby vers Astro en partageant mes idées et mes expériences du processus de migration."/>
 
-<LinkCard title="De l’impasse Gatsby au bonheur Astro : la refonte de mon site personnel (en)" href="https://jwn.gr/posts/migrating-from-gatsby-to-astro/" 
+<LinkCard title="De l’impasse Gatsby au bonheur Astro : la refonte de mon site personnel (Anglais)" href="https://jwn.gr/posts/migrating-from-gatsby-to-astro/" 
 description="Gatsby a montré son âge et je me suis retrouvé à chercher une alternative moderne. C'est là qu'est arrivé Astro, un framework qui a insufflé une nouvelle vie à ce site."/>
 
-<LinkCard title="Pourquoi et comment j'ai déplacé mon blog de Gatsby et React vers Astro et Preact (en)" href="https://www.helmerdavila.com/blog/en/why-and-how-i-moved-my-blog-away-from-gatsby-and-react-to-astro-js-and-preact" 
+<LinkCard title="Pourquoi et comment j'ai déplacé mon blog de Gatsby et React vers Astro et Preact (Anglais)" href="https://www.helmerdavila.com/blog/en/why-and-how-i-moved-my-blog-away-from-gatsby-and-react-to-astro-js-and-preact" 
 description="Tout est question de simplicité et de puissance à la fois." />
 
-<LinkCard title="Comment j'ai réécrit mon énorme site Gatsby de plus de 100 Go dans Astro et appris à l'aimer au passage (en)" href="https://dunedinsound.com/blog/how_i_rewrote_my_huge_gatsby_site_in_astro_and_learned_to_love_it_in_the_process/" 
+<LinkCard title="Comment j'ai réécrit mon énorme site Gatsby de plus de 100 Go dans Astro et appris à l'aimer au passage (Anglais)" href="https://dunedinsound.com/blog/how_i_rewrote_my_huge_gatsby_site_in_astro_and_learned_to_love_it_in_the_process/" 
 description="Tout est plus rapide. Plus heureux. Plus productif."/>
 
-<LinkCard title="Comment je suis passé de Gatsby à Astro (tout en gardant Drupal dans le mix) (en)" href="https://albert.skibinski.nl/en/blog/how-i-switched-gatsby-astro-while-keeping-drupal-mix/" 
+<LinkCard title="Comment je suis passé de Gatsby à Astro (tout en gardant Drupal dans le mix) (Anglais)" href="https://albert.skibinski.nl/en/blog/how-i-switched-gatsby-astro-while-keeping-drupal-mix/" 
 description="Je suis tombé sur l’Astro relativement nouveau, qui répondait à toutes les attentes."/>
 
-<LinkCard title="Migrer mon site web de Gatsby vers Astro (en)" href="https://dev.to/flashblaze/migrating-my-website-from-gatsby-to-astro-2ej5" 
+<LinkCard title="Migrer mon site web de Gatsby vers Astro (Anglais)" href="https://dev.to/flashblaze/migrating-my-website-from-gatsby-to-astro-2ej5" 
 description="Astro est soudainement apparu." />
 
-<LinkCard title="De Gatsby à Astro (en)" href="https://alvin.codes/writing/gatsby-to-astro" 
+<LinkCard title="De Gatsby à Astro (Anglais)" href="https://alvin.codes/writing/gatsby-to-astro" 
 description="Pourquoi et comment j'ai migré ce site web Gatsby vers Astro."/>
 
 </CardGrid>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gitbook.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gitbook.mdx
@@ -13,19 +13,20 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
 [GitBook](https://gitbook.com) est une plateforme web pour la création et la publication de documentation et de livres de manière collaborative, avec une intégration du contrôle de version et des fonctionnalités personnalisables.
 
+
 ## Principales similitudes entre GitBook et Astro
 
 GitBook et Astro partagent certaines similitudes qui vous aideront à migrer votre projet :
 
-- Astro et GitBook supportent tous deux [Markdown](/fr/guides/markdown-content/). Vous pouvez migrer toute votre documentation existante en utilisant la fonctionnalité Git Sync de GitBook.
+- Astro et GitBook prennent tous deux en charge [Markdown](/fr/guides/markdown-content/). Vous pouvez migrer toute votre documentation existante en utilisant la fonctionnalité Git Sync de GitBook.
 
 - Astro et GitBook utilisent tous deux une forme de [routage basé sur les fichiers](/fr/guides/routing/). L'utilisation de la structure de fichiers d'Astro pour votre contenu existant et lors de l'ajout de nouvelles pages devrait vous sembler familière.
 
 ## Principales différences entre GitBook et Astro
 
-Lorsque vous migrez vos documents GitBook vers Astro, vous remarquerez quelques différences importantes :
+Lorsque vous migrez votre documentation de GitBook vers Astro, vous remarquerez quelques différences importantes :
 
-- Un site GitBook est édité à l'aide d'un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine, ou choisir un éditeur/environnement de développement en nuage comme IDX, StackBlitz, CodeSandbox, ou Gitpod.
+- Un site GitBook est édité à l'aide d'un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine, ou choisir un éditeur/environnement de développement dans le cloud comme IDX, StackBlitz, CodeSandbox, ou Gitpod.
 
 - GitBook stocke votre contenu dans une base de données. Dans Astro, vous aurez des fichiers individuels (typiquement Markdown ou MDX) dans votre [répertoire de projet](/fr/basics/project-structure/) pour le contenu de chaque page. Vous pouvez également choisir d'utiliser un [CMS pour votre contenu](/fr/guides/cms/) et utiliser Astro pour récupérer et présenter les données.
 
@@ -34,7 +35,7 @@ Lorsque vous migrez vos documents GitBook vers Astro, vous remarquerez quelques 
 
 ## Passer de GitBook à Astro
 
-Pour convertir un site de documentation GitBook en Astro, commencez par notre modèle officiel [de départ pour de la documentation : Starlight](https://starlight.astro.build), ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
+Pour convertir un site de documentation GitBook en Astro, commencez par notre [thème de documentation Starlight comme modèle de démarrage](https://starlight.astro.build) officiel, ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
 
 Vous pouvez passer un argument `--template` à la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles officiels. Ou vous pouvez [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
@@ -18,7 +18,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 Gridsome et Astro partagent certaines similitudes qui vous aideront à migrer votre projet :
 
-- Gridsome et Astro sont tous deux des générateurs de sites statiques Javascript modernes avec des [structures de fichiers de projet similaire](/fr/basics/project-structure/#répertoires-et-fichiers).
+- Gridsome et Astro sont tous deux des générateurs de sites statiques Javascript modernes avec des [structures de fichiers de projet similaires](/fr/basics/project-structure/#répertoires-et-fichiers).
 
 - Gridsome et Astro utilisent tous deux un dossier `src/` pour les fichiers de votre projet et un [dossier spécial `src/pages/` pour le routage basé sur les fichiers](/fr/basics/astro-pages/). La création et la gestion des pages de votre site devraient vous sembler familières.
 
@@ -28,9 +28,9 @@ Gridsome et Astro partagent certaines similitudes qui vous aideront à migrer vo
 
 ## Principales différences entre Gridsome et Astro
 
-Lorsque vous reconstruisez votre site Gridsome dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Gridsome avec Astro, vous remarquerez quelques différences importantes :
 
-- Gridsome est une application monopage (SPA) basée sur Vue. Les sites Astro sont des applications multi-pages construites à l'aide de [composants `.astro`](/fr/basics/astro-components/), mais peuvent également supporter [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et le templating HTML brut.
+- Gridsome est une application monopage (SPA) basée sur Vue. Les sites Astro sont des applications multi-pages construites à l'aide de [composants `.astro`](/fr/basics/astro-components/), mais peuvent également prendre en charge [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et et des modèles HTML bruts.
 
 - En tant que SPA, Gridsome utilise `vue-router` pour le routage SPA, et `vue-meta` pour gérer `<head>`. Dans Astro, vous créerez des pages HTML séparées et contrôlerez le `<head>` de votre page directement, ou dans un [composant de mise en page](/fr/basics/layouts/).
 
@@ -60,11 +60,11 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
     </Fragment>
   </PackageManagerTabs>
 
-Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration optionnelle) comme contenu pour [créer des pages Markdown ou MDX] (/fr/guides/markdown-content/).
+Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration optionnelle) comme contenu pour [créer des pages Markdown ou MDX](/fr/guides/markdown-content/).
 
-La structure de projet de Gridsome étant similaire à celle d'Astro, vous pourrez peut-être copier plusieurs fichiers existants de votre projet au même endroit dans votre nouveau projet Astro. Cependant, les deux structures de projet ne sont pas identiques. Vous pouvez examiner [la structure de projet d'Astro](/fr/basics/project-structure/) pour voir quelles sont les différences.
+La structure de projet de Gridsome étant similaire à celle d'Astro, vous pourrez peut-être copier plusieurs fichiers existants de votre projet au même endroit dans votre nouveau projet Astro. Cependant, les structures des deux projet ne sont pas identiques. Vous souhaiterez peut-être examiner [la structure de projet d'Astro](/fr/basics/project-structure/) pour voir quelles sont les différences.
 
-Comme Astro interroge et importe vos fichiers locaux différemment de Gridsome, vous pouvez lire [comment charger des fichiers en utilisant `import.meta.glob()`](/fr/guides/imports/#importmetaglob) pour comprendre comment travailler avec vos fichiers locaux.
+Étant donné qu'Astro interroge et importe vos fichiers locaux différemment de Gridsome, vous souhaiterez peut-être lire comment charger des fichiers en utilisant [`import.meta.glob()`](/fr/guides/imports/#importmetaglob) pour comprendre comment travailler avec vos fichiers locaux.
 
 Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez d'autres modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
@@ -72,9 +72,9 @@ Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de docum
 
 <CardGrid>
 
-  <LinkCard title="Migration de Gridsome vers Astro (en)" href="https://fyodor.io/migration-from-gridsome-to-astro/"/>
+  <LinkCard title="Migration de Gridsome vers Astro (Anglais)" href="https://fyodor.io/migration-from-gridsome-to-astro/"/>
 
-  <LinkCard title="Bonjour Astro ! (en)" href="https://thamas.hu/astro-hello"/>
+  <LinkCard title="Bonjour Astro ! (Anglais)" href="https://thamas.hu/astro-hello"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-hugo.mdx
@@ -25,15 +25,16 @@ Hugo et Astro partagent certaines similitudes qui vous aideront à migrer votre 
 - Hugo et Astro vous permettent tous deux d'améliorer votre site avec une variété [d'intégrations et de paquets externes](https://astro.build/integrations/).
 
 
+
 ## Différences clés entre Hugo et Astro
 
-Lorsque vous reconstruisez votre site Hugo dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Hugo dans Astro, vous remarquerez quelques différences importantes :
 
 - Hugo utilise Go Templating pour la création de modèles de pages. La [syntaxe Astro](/fr/basics/astro-components/) est un surensemble de HTML similaire à JSX.
 
 - Astro n'utilise pas de shortcodes pour le contenu dynamique dans les fichiers Markdown standard, mais [l'intégration MDX d'Astro](/fr/guides/integrations-guide/mdx/) vous permet d'utiliser JSX et d'importer des composants dans les fichiers MDX.
 
-- Alors qu'Hugo peut utiliser des "partiels" pour des éléments de mise en page réutilisables, [Astro est entièrement basé sur des composants](/fr/basics/astro-components/). Tout fichier `.astro` peut être un composant, une mise en page ou une page entière, et peut importer et afficher n'importe quel autre composant Astro. Les composants Astro peuvent également inclure [d'autres composants d'interface utilisateur (par exemple React, Svelte, Vue, Solid)](/fr/guides/framework-components/) ainsi que du contenu ou des métadonnées provenant [d'autres fichiers de votre projet](/fr/guides/imports/), tels que Markdown ou MDX.
+- Alors qu'Hugo peut utiliser des « fichiers partiels » pour des éléments de mise en page réutilisables, [Astro est entièrement basé sur des composants](/fr/basics/astro-components/). Tout fichier `.astro` peut être un composant, une mise en page ou une page entière, et peut importer et afficher n'importe quel autre composant Astro. Les composants Astro peuvent également inclure [d'autres composants d'interface utilisateur (par exemple React, Svelte, Vue, Solid)](/fr/guides/framework-components/) ainsi que du contenu ou des métadonnées provenant [d'autres fichiers de votre projet](/fr/guides/imports/), tels que Markdown ou MDX.
 
 ## Passer de Hugo à Astro
 
@@ -69,11 +70,11 @@ Pour convertir d'autres types de sites, comme un portfolio ou un site de documen
 
 <CardGrid>
 
-  <LinkCard title="L'histoire de la migration d'Elio Struyf de Hugo vers Astro (en)" href="https://www.eliostruyf.com/migration-story-hugo-astro/"/>
+  <LinkCard title="L'histoire de la migration d'Elio Struyf de Hugo vers Astro (Anglais)" href="https://www.eliostruyf.com/migration-story-hugo-astro/"/>
 
-  <LinkCard title="Hugo Vs Astro - Quel générateur de site statique choisir en 2023 (en)" href="https://onebite.dev/hugo-vs-astro-which-static-site-generator-to-choose-in-2023/"/>
+  <LinkCard title="Hugo Vs Astro - Quel générateur de site statique choisir en 2023 (Anglais)" href="https://onebite.dev/hugo-vs-astro-which-static-site-generator-to-choose-in-2023/"/>
 
-  <LinkCard title="Leçons tirées d'une migration assistée par l'IA vers Astro (en)" href="https://bennet.org/blog/lessons-from-ai-assisted-migration-to-astro/" />
+  <LinkCard title="Leçons tirées d'une migration assistée par l'IA vers Astro (Anglais)" href="https://bennet.org/blog/lessons-from-ai-assisted-migration-to-astro/" />
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-jekyll.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-jekyll.mdx
@@ -27,9 +27,9 @@ Jekyll et Astro partagent certaines similitudes qui vous aideront à migrer votr
 
 ## Principales différences entre Jekyll et Astro
 
-Lorsque vous reconstruisez votre site Jekyll dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Jekyll avec Astro, vous remarquerez quelques différences importantes :
 
-- Jekyll étant avant tout une plate-forme de blogs, plusieurs fonctionnalités de blog sont intégrées, mais vous devrez peut-être les créer vous-même dans Astro. Vous pouvez également choisir un [thème de modèle de démarrage de blog](https://astro.build/themes?search=&categories%5B%5D=blog) qui inclut ces fonctionnalités. Par exemple, Jekyll dispose d'un support intégré pour les tags et les catégories que vous trouverez dans plusieurs thèmes de blog Astro, mais qui n'est pas inclus dans un projet Astro minimal.
+- Jekyll étant avant tout une plate-forme de blogs, plusieurs fonctionnalités de blog sont intégrées, mais vous devrez peut-être les créer vous-même dans Astro. Vous pouvez également choisir un [thème de modèle de démarrage de blog](https://astro.build/themes?search=&categories%5B%5D=blog) qui inclut ces fonctionnalités. Par exemple, Jekyll dispose d'une prise en charge intégrée pour les étiquettes et les catégories que vous trouverez dans plusieurs thèmes de blog pour Astro, mais qui n'est pas inclus dans un projet Astro minimal.
 
 - Jekyll utilise les modèles Liquid pour les éléments de mise en page réutilisables et la création de modèles. Astro utilise des fichiers JSX [`.astro` pour les modèles et les composants](/fr/basics/astro-components/). Tout fichier `.astro` peut être un composant, une mise en page ou une page entière, et peut importer et afficher n'importe quel autre composant Astro. Vous pouvez également construire en utilisant [d'autres composants de framework d'interface utilisateur (par exemple React, Svelte, Vue, Solid)](/fr/guides/framework-components/) ainsi que du contenu ou des métadonnées provenant [d'autres fichiers de votre projet](/fr/guides/imports/), comme Markdown ou MDX.
 
@@ -58,11 +58,11 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
     </Fragment>
   </PackageManagerTabs>
 
-Apportez vos fichiers Markdown existants comme contenu pour [créer des pages Markdown](/fr/guides/markdown-content/), en utilisant une [mise en page Astro Markdown](/fr/basics/layouts/#mises-en-page-markdown) au lieu d'un modèle Liquid.
+Apportez vos fichiers Markdown existants comme contenu pour [créer des pages Markdown](/fr/guides/markdown-content/), en utilisant une [mise en page Astro dans Markdown](/fr/basics/layouts/#mises-en-page-markdown) au lieu d'un modèle Liquid.
 
 Une grande partie du contenu de vos pages HTML existantes peut être convertie en [pages Astro](/fr/basics/astro-pages/), et vous pourrez également [utiliser des variables, des expressions de type JSX et des importations de composants directement dans vos modèles HTML](/fr/reference/astro-syntax/#expressions-type-jsx).
 
-Astro n'a pas de propriété `permalink` qui accepte les espaces réservés. Vous pouvez avoir besoin d'en savoir plus sur [le routage des pages d'Astro](/fr/guides/routing/) si vous voulez conserver votre structure d'URL existante. Vous pouvez également envisager de [définir des redirections chez un hébergeur comme Netlify](https://docs.netlify.com/routing/redirects/).
+Astro ne possède pas de propriété `permalink` acceptant des valeurs par défaut. Vous devrez peut-être vous renseigner sur [le routage des pages d'Astro](/fr/guides/routing/) si vous souhaitez conserver votre structure d'URL existante. Vous pouvez également envisager de [définir des redirections chez un hébergeur comme Netlify](https://docs.netlify.com/routing/redirects/).
 
 Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez les modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
@@ -70,9 +70,9 @@ Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de docum
 
 <CardGrid>
 
-  <LinkCard title="De Jekyll à Astro (en)" href="https://jackcarey.co.uk/posts/astro-rewrite/"/>
-  <LinkCard title="Au revoir Jekyll, bonjour Astro (en)" href="https://kiranrao.in/blog/bye-jekyll-hello-astro/" />
-  <LinkCard title="Retour vers le futur : la transition de notre blog technologique de Jekyll à Astro (en)" href="https://alasco.tech/2023/09/06/migrating-to-astro"/>
+  <LinkCard title="De Jekyll à Astro (Anglais)" href="https://jackcarey.co.uk/posts/astro-rewrite/"/>
+  <LinkCard title="Au revoir Jekyll, bonjour Astro (Anglais)" href="https://kiranrao.in/blog/bye-jekyll-hello-astro/" />
+  <LinkCard title="Retour vers le futur : la transition de notre blog technologique de Jekyll à Astro (Anglais)" href="https://alasco.tech/2023/09/06/migrating-to-astro"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
@@ -12,7 +12,7 @@ import { Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
 import AstroJSXTabs from '~/components/tabs/AstroJSXTabs.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de nos documents et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
+Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de notre documentation et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
 
 ## Principales similitudes entre Next.js et Astro
 
@@ -20,30 +20,30 @@ Next.js et Astro partagent certaines similitudes qui vous aideront à migrer vot
 
 - La [syntaxe des fichiers `.astro` est similaire à celle de JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx). Développer avec Astro devrait vous sembler familier.
 - Les projets Astro peuvent également être de type SSG ou [SSR avec prérendu au niveau de la page](/fr/guides/on-demand-rendering/).
-- Astro utilise le routage basé sur des fichiers et [permet à des pages spécialement nommées de créer des itinéraires dynamiques](/fr/guides/routing/#routes-dynamiques).
+- Astro utilise le routage basé sur des fichiers et [permet à des pages spécialement nommées de créer des routes dynamiques](/fr/guides/routing/#routes-dynamiques).
 - Astro est [basé sur les composants](/fr/basics/astro-components/), et votre structure de balisage sera similaire avant et après votre migration.
 - Astro possède des [intégrations officielles pour React, Preact et Solid](/fr/guides/integrations-guide/react/). Vous pouvez donc utiliser vos composants JSX existants. Notez que dans Astro, ces fichiers **doivent** avoir une extension `.jsx` ou `.tsx`.
 - Astro prend en charge [l'installation de paquets NPM](/fr/guides/imports/#paquets-npm), y compris les bibliothèques React. Beaucoup de vos dépendances existantes fonctionneront dans Astro.
 
 ## Principales différences entre Next.js et Astro
 
-Lorsque vous reconstruisez votre site Next.js dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Next.js avec Astro, vous remarquerez quelques différences importantes :
 
 - Next.js est une application React monopage et utilise `index.js` comme racine de votre projet. Astro est un site multipage et `index.astro` est votre page d'accueil.
 
-- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en une « barrière de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
+- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
 
 - [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour présenter votre contenu et pour vous permettre d'opter pour l'interactivité uniquement si nécessaire. Une application Next.js existante peut être conçue pour une interactivité élevée côté client et peut nécessiter des techniques Astro avancées pour inclure des éléments plus difficiles à répliquer à l'aide de composants `.astro`, tels que des tableaux de bord.
 
-## Convertissez votre projet Next.js
+## Convertir votre projet Next.js
 
 Chaque migration de projet sera différente, mais vous effectuerez certaines actions courantes lors de la conversion de Next.js vers Astro.
 
 ### Créer un nouveau projet Astro
 
-Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes Astro](https://astro.build/themes).
+Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes d'Astro](https://astro.build/themes).
 
-Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos démarreurs officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
+Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles de démarrage officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
@@ -85,27 +85,27 @@ Consultez https://astro.new pour la liste complète des modèles de démarrage o
 
 Vous trouverez peut-être utile d'installer certaines des [intégrations facultatives d'Astro](/fr/guides/integrations-guide/) à utiliser lors de la conversion de votre projet Next en Astro :
 
-- **@astrojs/react**: pour réutiliser certains de vos composants React orientés UI dans votre nouveau site Astro ou pour continuer à coder des composants React.
+- **@astrojs/react** : pour réutiliser certains de vos composants d'interface utilisateur React dans votre nouveau site Astro ou pour continuer à coder avec des composants React.
 
-- **@astrojs/mdx**: pour importer des fichiers MDX existants de votre projet Next ou pour utiliser MDX dans votre nouveau site Astro.
+- **@astrojs/mdx** : pour importer des fichiers MDX existants de votre projet Next ou pour utiliser MDX dans votre nouveau site Astro.
 
 ### Placer votre code source dans `src`
 
-En suivant la [structure du projet d'Astro](/fr/basics/project-structure/):
+En suivant la [structure de projet d'Astro](/fr/basics/project-structure/):
 
 <Steps>
 1. **Gardez** le dossier `public/` de Next intact. 
    
     Astro utilise le répertoire `public/` pour les ressources statiques, tout comme Next. Aucune modification n'est nécessaire pour ce dossier, ni pour son contenu.
 
-2. **Copiez ou déplacez** les autres fichiers et dossiers de Next (par exemple, `pages`, `styles`, etc.) dans le dossier `src/` d'Astro pendant que vous reconstruisez votre site en suivant [la structure du projet Astro](/fr/basics/project-structure/).
+2. **Copiez ou déplacez** les autres fichiers et dossiers de Next (par exemple, `pages`, `styles`, etc.) dans le dossier `src/` d'Astro pendant que vous recréez votre site en suivant [la structure de projet d'Astro](/fr/basics/project-structure/).
 
     Comme Next, le dossier `src/pages/` d'Astro est un dossier spécial utilisé pour le routage basé sur des fichiers. Tous les autres dossiers sont facultatifs et vous pouvez organiser le contenu de votre dossier `src/` comme vous le souhaitez. D'autres dossiers courants dans les projets Astro incluent `src/layouts/`, `src/components`, `src/styles`, `src/scripts`.
 </Steps>
 
 ### Le fichier de configuration d'Astro
 
-Astro possède un fichier de configuration à la racine de votre projet appelé  [`astro.config.mjs`](/fr/guides/configuring-astro/). Ceci est utilisé uniquement pour configurer votre projet Astro et toutes les intégrations installées, y compris les [adaptateurs SSR](/fr/guides/deploy/).
+Astro possède un fichier de configuration à la racine de votre projet appelé  [`astro.config.mjs`](/fr/guides/configuring-astro/). Il est utilisé uniquement pour configurer votre projet Astro et toutes les intégrations installées, y compris les [adaptateurs SSR](/fr/guides/deploy/).
 
 ### Astuces : Convertir les fichiers JSX en fichiers `.astro`
 
@@ -115,7 +115,7 @@ Voici quelques conseils pour convertir un composant Next `.js` en un composant `
 
 2. Remplacez [toute syntaxe Next ou JSX par une syntaxe Astro](#référence-convertir-la-syntaxe-nextjs-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<Link>`, `<Script>`, `{children}` et `className` par exemple.
 
-3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans une [« barrière de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
+3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires précédemment transmises à votre fonction Next.
 
@@ -154,7 +154,7 @@ Comparez le composant Next suivant et un composant Astro correspondant :
                     padding: `1em 1.5em`,
                     textAlign: `center`,
                     marginBottom: `1em`
-                }}>Astro has {stars} 🧑‍🚀</p>
+                }}>Astro possède {stars} 🧑‍🚀</p>
                 <Footer />
             </>
         )
@@ -176,7 +176,7 @@ Comparez le composant Next suivant et un composant Astro correspondant :
     const stars = json.stargazers_count || 0;
     ---
     <Header />
-    <p class="banner">Astro has {stars} 🧑‍🚀</p>
+    <p class="banner">Astro possède {stars} 🧑‍🚀</p>
     <Footer />
 
     <style>
@@ -206,7 +206,7 @@ Chaque page Astro nécessite explicitement la présence des balises `<html>`, `<
 ```astro title="src/layouts/Layout.astro"
 ---
 ---
-<html lang="en">
+<html lang="fr">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -231,7 +231,7 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 export default class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="fr">
         <Head>
           <link rel="icon" href="/favicon.ico" />
         </Head>
@@ -250,7 +250,7 @@ export default class MyDocument extends Document {
 2. Remplacez tous les composants React par `<html>`, `<head>`, `<slot>` et d'autres balises HTML standard.
 
     ```astro title="src/layouts/Document.astro"
-    <html lang="en">
+    <html lang="fr">
       <head>
           <link rel="icon" href="/favicon.ico" />
       </head>
@@ -268,7 +268,7 @@ Les fichiers de mise en page du répertoire `app/` de Next.js sont créés avec 
 ```jsx title="app/layout.jsx"
 export default function Layout({ children }) {
   return (
-    <html lang="en">
+    <html lang="fr">
       <body>{children}</body>
     </html>
   );
@@ -288,10 +288,10 @@ export default function Head() {
 <Steps>
 1. Créez un nouveau fichier de mise en page Astro en utilisant uniquement le JSX renvoyé.
 
-2. Remplacez ces deux fichiers par un seul fichier de mise en page Astro qui contient un shell de page (les balises `<html>`, `<head>` et `<body>`) et un `<slot/>` à la place de la propriété `{children}` de React :
+2. Remplacez ces deux fichiers par un seul fichier de mise en page Astro qui contient une enveloppe de page (les balises `<html>`, `<head>` et `<body>`) et un `<slot/>` à la place de la propriété `{children}` de React :
 
     ```astro title="src/layouts/Layout.astro"
-    <html lang="en">
+    <html lang="fr">
       <head>
           <title>Ma Page</title>
       </head>
@@ -316,13 +316,13 @@ Ces [pages `.astro`](/fr/basics/astro-pages/) doivent être situées dans `src/p
 
 #### Pages Markdown et MDX
 
-Astro dispose d'une prise en charge intégrée pour Markdown et d'une intégration facultative pour les fichiers MDX. Vous pouvez réutiliser tous les [fichiers Markdown et MDX existants](/fr/guides/markdown-content/), mais ils peuvent nécessiter quelques ajustements dans leur frontmatter, comme l'ajout de [la propriété spéciale `layout` d'Astro](/fr/basics/layouts/#mises-en-page-markdown). Vous n'aurez plus besoin de créer manuellement des pages pour chaque itinéraire généré par Markdown. Ces fichiers peuvent être placés dans `src/pages/` pour profiter du routage automatique basé sur les fichiers.
+Astro dispose d'une prise en charge intégrée pour Markdown et d'une intégration facultative pour les fichiers MDX. Vous pouvez réutiliser tous les [fichiers Markdown et MDX existants](/fr/guides/markdown-content/), mais ils peuvent nécessiter quelques ajustements dans leur frontmatter, comme l'ajout de [la propriété spéciale `layout` d'Astro](/fr/basics/layouts/#mises-en-page-markdown). Vous n'aurez plus besoin de créer manuellement des pages pour chaque route générée par Markdown. Ces fichiers peuvent être placés dans `src/pages/` pour profiter du routage automatique basé sur les fichiers.
 
 Alternativement, vous pouvez utiliser les [collections de contenu](/fr/guides/content-collections/) dans Astro pour stocker et gérer votre contenu. Vous récupérerez vous-même le contenu et [générerez ces pages de manière dynamique](/fr/guides/content-collections/#générer-des-routes-à-partir-du-contenu).
 
 ### Migration des tests
 
-Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de construction. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre site Next. Les bibliothèques de tests telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
+Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de compilation. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre site Next. Les bibliothèques de tests telles que Jest et React Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants React.
 
 Voir le [guide de test](/fr/guides/testing/) d'Astro pour en savoir plus.
 
@@ -346,7 +346,7 @@ const { to } = Astro.props;
 <a href={to}><slot /></a>
 ```
 
-### Les Imports : de Next vers Astro
+### Les importations : de Next vers Astro
 
 Mettez à jour toutes les [importations de fichiers](/fr/guides/imports/) pour référencer exactement les chemins de fichiers relatifs. Cela peut être fait en utilisant des [alias d'importation](/fr/guides/typescript/#alias-dimportation) ou en écrivant un chemin relatif dans son intégralité.
 
@@ -379,7 +379,7 @@ export default function MyComponent(props) {
 </div>
 ```
 
-Les composants React qui transmettent plusieurs ensembles d'enfants peuvent être migrés vers un composant Astro à l'aide des [emplacements nommés](/fr/basics/astro-components/#les-slots-nommés).
+Les composants React qui transmettent plusieurs ensembles d'enfants peuvent être migrés vers un composant Astro à l'aide des [slots nommés](/fr/basics/astro-components/#les-slots-nommés).
 
 En savoir plus sur [l'utilisation spécifique de `<slot />` dans Astro](/fr/basics/astro-components/#les-slots).
 
@@ -418,7 +418,7 @@ Si nécessaire, convertissez tous les objets de style en ligne (`style={{ fontWe
 <div style="background-color: #f4f4f4; padding: 1em;">{message}</div>
 ```
 
-Tailwind est pris en charge après l'installation du [plugin Vite de Tailwind](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est requise !
+Tailwind est pris en charge après l'installation du [module d'extension Tailwind pour Vite](/fr/guides/styling/#tailwind). Aucune modification de votre code Tailwind existant n'est requise !
 
 En savoir plus sur les [styles dans Astro](/fr/guides/styling/).
 
@@ -437,7 +437,7 @@ import rocket from '../assets/rocket.png';
 <img src={rocket.src} alt="Une fusée dans l'espace.">
 ```
 
-Dans les composants React (`.jsx`), utilisez la syntaxe d'image JSX standard (`<img />`). Astro n'optimisera pas ces images, mais vous pouvez installer et utiliser les packages NPM pour plus de flexibilité.
+Dans les composants React (`.jsx`), utilisez la syntaxe d'image JSX standard (`<img />`). Astro n'optimisera pas ces images, mais vous pouvez installer et utiliser les paquets NPM pour plus de flexibilité.
 
 Vous pouvez en apprendre davantage sur [l'utilisation d'images dans Astro](/fr/guides/images/) dans le guide Images.
 
@@ -532,7 +532,7 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `getSta
 
     Remarquez que :
 
-    - la fonction `getStaticProps` n'est plus nécessaire. Les données de l'API sont récupérées directement dans la barrière de code.
+    - la fonction `getStaticProps` n'est plus nécessaire. Les données de l'API sont récupérées directement dans le délimitateur de code.
     - Un composant `<Layout>` est importé et enveloppe le modèle de page.
 
     ```astro ins={2,4-16,19,31} title="src/pages/index.astro"
@@ -574,15 +574,15 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `getSta
 
 <CardGrid>
 
-  <LinkCard title="Pourquoi nous sommes passés à Astro (et pourquoi cela pourrait vous intéresser) (en)" href="https://www.datocms.com/blog/why-we-switched-to-astro" />
-  <LinkCard title="Migration de Next.js vers Astro (en)" href="https://johnzanussi.com/posts/nextjs-to-astro-migration" />
-  <LinkCard title="De NextJS à Astro (en)" href="https://vanntile.com/blog/next-to-astro" />
-  <LinkCard title="Conversion de Next.js en Astro (en)" href="https://ericclemmons.com/blog/converting-nextjs-to-astro" />
-  <LinkCard title="Migration vers Astro (depuis Next.js) (en)" href="https://www.raygesualdo.com/posts/migrating-to-astro-the-beginning/" />
-  <LinkCard title="Astro.js comme alternative à Next.js (en)" href="https://www.railyard.works/blog/astro-as-alternative-to-next" />
-  <LinkCard title="Pourquoi j'ai migré mon site web de Next.js vers Astro (en)" href="https://praveenjuge.com/blog/why-i-switched-my-website-from-nextjs-to-astro/" />
-  <LinkCard title="De NextJS à Astro : plus de contrôle = des sites plus rapides (en)" href="https://www.youtube.com/watch?v=PSzCtdM20Fc" />
-  <LinkCard title="Comment Astro a rendu mon site 100 fois plus rapide (en)" href="https://www.youtube.com/watch?v=cOxA3kMYtkM" />
+  <LinkCard title="Pourquoi nous sommes passés à Astro (et pourquoi cela pourrait vous intéresser) (Anglais)" href="https://www.datocms.com/blog/why-we-switched-to-astro" />
+  <LinkCard title="Migration de Next.js vers Astro (Anglais)" href="https://johnzanussi.com/posts/nextjs-to-astro-migration" />
+  <LinkCard title="De NextJS à Astro (Anglais)" href="https://vanntile.com/blog/next-to-astro" />
+  <LinkCard title="Conversion de Next.js en Astro (Anglais)" href="https://ericclemmons.com/blog/converting-nextjs-to-astro" />
+  <LinkCard title="Migration vers Astro (depuis Next.js) (Anglais)" href="https://www.raygesualdo.com/posts/migrating-to-astro-the-beginning/" />
+  <LinkCard title="Astro.js comme alternative à Next.js (Anglais)" href="https://www.railyard.works/blog/astro-as-alternative-to-next" />
+  <LinkCard title="Pourquoi j'ai migré mon site web de Next.js vers Astro (Anglais)" href="https://praveenjuge.com/blog/why-i-switched-my-website-from-nextjs-to-astro/" />
+  <LinkCard title="De NextJS à Astro : plus de contrôle = des sites plus rapides (Anglais)" href="https://www.youtube.com/watch?v=PSzCtdM20Fc" />
+  <LinkCard title="Comment Astro a rendu mon site 100 fois plus rapide (Anglais)" href="https://www.youtube.com/watch?v=cOxA3kMYtkM" />
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -13,7 +13,7 @@ import AstroVueTabs from '~/components/tabs/AstroVueTabs.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { FileTree } from '@astrojs/starlight/components';
 
-Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de nos documents et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
+Voici quelques concepts clés et stratégies de migration pour vous aider à démarrer. Utilisez le reste de notre documentation et notre [communauté sur Discord](https://astro.build/chat) pour continuer !
 
 > Ce guide fait référence à [Nuxt 2](https://v2.nuxt.com/fr/), et non au plus récent Nuxt 3. Bien que certains des concepts soient similaires, Nuxt 3 est une version plus récente du framework et peut nécessiter des stratégies différentes pour certaines parties de votre migration.
 
@@ -29,9 +29,9 @@ Nuxt et Astro partagent certaines similitudes qui vous aideront à migrer votre 
 
 ## Principales différences entre Nuxt et Astro
 
-Lorsque vous reconstruisez votre site Nuxt dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Nuxt dans Astro, vous remarquerez quelques différences importantes :
 
-- Nuxt est un SPA (application monopage) basé sur Vue. Les sites Astro sont des applications multipages créées à l'aide de composants `.astro`, mais ils peuvent également prendre en charge React, Preact, Vue.js, Svelte, SolidJS, AlpineJS et des modèles HTML brut.
+- Nuxt est une application monopage (SPA) basée sur Vue. Les sites Astro sont des applications multipages créées à l'aide de composants `.astro`, mais ils peuvent également prendre en charge React, Preact, Vue.js, Svelte, SolidJS, AlpineJS et des modèles HTML bruts.
 
 - [Routage des pages](/fr/basics/astro-pages/#routage-basé-sur-les-fichiers) : Nuxt utilise `vue-router` pour le routage SPA et `vue-meta` pour gérer `<head>`. Dans Astro, vous créerez des routes distinctes pour vos pages HTML et vous contrôlerez le contenu de la balise `<head>` directement dans votre page ou dans un composant de mise en page.
 
@@ -42,10 +42,9 @@ Lorsque vous reconstruisez votre site Nuxt dans Astro, vous remarquerez quelques
 Chaque migration de projet sera différente, mais vous effectuerez certaines actions courantes lors de la conversion de Nuxt vers Astro.
 
 ### Créer un nouveau projet Astro
+Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes d'Astro](https://astro.build/themes).
 
-Utilisez la commande `create astro` de votre gestionnaire de paquets pour lancer l'assistant CLI d'Astro ou choisissez un thème de communauté dans la [vitrine de thèmes Astro](https://astro.build/themes).
-
-Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos démarreurs officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
+Vous pouvez utiliser un argument `--template` avec la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles de démarrage officiels (par exemple `docs`, `blog`, `portfolio`). Vous pouvez également [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
   <PackageManagerTabs>
     <Fragment slot="npm">
@@ -87,7 +86,7 @@ Consultez https://astro.new pour la liste complète des modèles de démarrage o
 
 Vous trouverez peut-être cela utile d'installer certaines des [intégrations facultatives d'Astro](/fr/guides/integrations-guide/) lors de la conversion de votre projet Nuxt en Astro :
 
-- **@astrojs/vue** : pour réutiliser certains de vos composants Vue orientés UI dans votre nouveau site Astro ou pour continuer à coder des composants Vue.
+- **@astrojs/vue** : pour réutiliser certains de vos composants d'interface utilisateur Vue dans votre nouveau site Astro ou pour continuer à coder avec des composants Vue.
 
 - **@astrojs/mdx** : pour importer des fichiers MDX existants de votre projet Nuxt ou pour utiliser MDX dans votre nouveau site Astro.
 
@@ -111,7 +110,7 @@ Voici quelques conseils pour convertir un composant Nuxt `.vue` en un composant 
 
 2. Remplacez toute [syntaxe Nuxt ou Vue par une syntaxe Astro](#référence-convertir-la-syntaxe-nuxtjs-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<NuxtLink>`, `:class`, `{{variable}}` et `v-if`, par exemple.
 
-3. Déplacez le JavaScript présent dans `<script>` dans une « barrière de code » (`---`). Convertissez les propriétés de récupération de données de votre composant en JavaScript exécuté côté serveur - consultez [la récupération de données, de Nuxt vers Astro](#la-récupération-de-données-de-nuxt-à-astro). 
+3. Déplacez le JavaScript présent dans `<script>` dans un « délimitateur de code » (`---`). Convertissez les propriétés de récupération de données de votre composant en JavaScript exécuté côté serveur - consultez [la récupération de données, de Nuxt vers Astro](#la-récupération-de-données-de-nuxt-à-astro). 
 
 4. Utilisez `Astro.props` pour accéder à toutes les props supplémentaires précédemment transmises à votre composant Vue.
 
@@ -267,7 +266,7 @@ Lorsqu'elles font partie d'une [collection de contenu](/fr/guides/content-collec
 
 ### Migrer les tests
 
-Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de construction. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre site Nuxt. Les bibliothèques de tests telles que Jest et Vue Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants Vue.
+Comme Astro génère du HTML brut, il est possible d'écrire des tests de bout en bout en utilisant la sortie de l'étape de compilation. Tous les tests de bout en bout écrits précédemment peuvent fonctionner immédiatement si vous avez réussi à faire correspondre le balisage de votre site Nuxt. Les bibliothèques de tests telles que Jest et Vue Testing Library peuvent être importées et utilisées dans Astro pour tester vos composants Vue.
 
 Voir le [guide de test](/fr/guides/testing/) d'Astro pour en savoir plus.
 
@@ -324,6 +323,8 @@ const { to } = Astro.props
 ### Les importations, de Nuxt à Astro
 
 Si nécessaire, mettez à jour toutes les [importations de fichiers](/fr/guides/imports/) pour référencer exactement les chemins de fichiers relatifs. Cela peut être fait en utilisant des [alias d'importation](/fr/guides/typescript/#alias-dimportation) ou en écrivant un chemin relatif dans son intégralité.
+
+Notez que `.astro` et plusieurs autres types de fichiers doivent être importés avec leur extension de fichier complète.
 
 ```astro title="src/pages/authors/Fred.astro" ".astro"
 ---
@@ -385,7 +386,7 @@ Nuxt propose deux méthodes pour récupérer les données côté serveur :
 - [le hook `asyncData`](https://v2.nuxt.com/fr/docs/features/data-fetching/#async-data)
 - [le hook `fetch`](https://v2.nuxt.com/fr/docs/features/data-fetching/#le-hook-fetch)
 
-Dans Astro, récupérez les données à l’intérieur de la barrière de code de votre page.
+Dans Astro, récupérez les données à l’intérieur des délimitateurs de code de votre page.
 
 Migrez les éléments suivants :
 
@@ -403,7 +404,7 @@ Migrez les éléments suivants :
 }
 ```
 
-Vers une barrière de code sans fonction enveloppante :
+Dans les délimitateurs de code sans fonction enveloppante :
 
 ```astro title="src/pages/index.astro"
 ---
@@ -434,6 +435,7 @@ Nuxt utilise le style des composants de Vue pour générer le style d'une page.
     }
 </style>
 ```
+
  De même, dans Astro, vous pouvez insérer un élément `<style>` dans le modèle de votre page pour limiter la portée des styles au composant.
 
 ```astro title="src/pages/index.vue"
@@ -485,7 +487,7 @@ p {
 
 En savoir plus sur [les styles dans Astro](/fr/guides/styling/).
 
-### Les plugins d'image de Nuxt vers Astro
+### Les composants d'image de Nuxt vers Astro
 
 Convertissez tous les [composants `<nuxt-img/>` ou `<nuxt-picture/>` de Nuxt](https://image.nuxtjs.org/components/nuxt-img) en [composant d'image propre à Astro](/fr/guides/images/) dans les fichiers `.astro` ou `.mdx` ou en code [HTML standard avec la balise `<img>`](/fr/guides/images/#images-dans-les-composants-framework-ui) ou la balise `<picture>` selon le cas dans vos composants Vue.
 
@@ -621,7 +623,7 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `asyncD
 
     Remarquez que :
 
-    - La fonction `asyncData` n'est plus nécessaire. Les données de l'API sont récupérées directement dans la barrière de code.
+    - La fonction `asyncData` n'est plus nécessaire. Les données de l'API sont récupérées directement dans les délimitateurs de code.
     - Un composant `<Layout>` est importé et enveloppe le modèle de page.
       - Notre méthode `head()` de Nuxt est transmise au composant `<Layout>`, qui est transmis à l'élément `<title>` en tant que propriété.
 
@@ -674,9 +676,9 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `asyncD
 
 <CardGrid>
 
-  <LinkCard title="De Nuxt à Astro - reconstruire avec Astro (en)" href="https://dev.to/lindsaykwardell/from-nuxt-to-astro-rebuilding-with-astro-5ann"/>
+  <LinkCard title="De Nuxt à Astro - reconstruire avec Astro (Anglais)" href="https://dev.to/lindsaykwardell/from-nuxt-to-astro-rebuilding-with-astro-5ann"/>
 
-  <LinkCard title="Migration d'application de Nuxt 2 vers Astro 3 — de la configuration à la production (en)" href="https://stevenwoodson.com/blog/replatforming-from-nuxtjs-2-to-astro/"/>
+  <LinkCard title="Migration d'application de Nuxt 2 vers Astro 3 — de la configuration à la production (Anglais)" href="https://stevenwoodson.com/blog/replatforming-from-nuxtjs-2-to-astro/"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
@@ -19,21 +19,21 @@ Pelican et Astro partagent certaines similitudes qui vous aideront à migrer vot
 
 - Pelican et Astro sont tous deux des générateurs de sites statiques, idéalement adaptés aux [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) comme les blogs.
 
-- Pelican et Astro ont tous deux un support intégré pour [écrire en Markdown](/fr/guides/markdown-content/), y compris des propriétés YAML pour les métadonnées des pages. Cependant, Astro a très peu de propriétés frontmatter réservées par rapport à Pelican. Même si beaucoup de vos propriétés frontmatter Pelican existantes ne seront pas "spéciales" dans Astro, vous pouvez continuer à utiliser vos fichiers Markdown et valeurs frontmatter existants.
+- Pelican et Astro ont tous deux un support intégré pour [écrire en Markdown](/fr/guides/markdown-content/), y compris des propriétés YAML pour les métadonnées des pages. Cependant, Astro a très peu de propriétés frontmatter réservées par rapport à Pelican. Même si beaucoup de vos propriétés frontmatter Pelican existantes ne seront pas « spéciales » dans Astro, vous pouvez continuer à utiliser vos fichiers Markdown et valeurs frontmatter existants.
 
 ## Principales différences entre Pelican et Astro
 
-Lorsque vous reconstruisez votre site Pélican dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site Pélican avec Astro, vous remarquerez quelques différences importantes :
 
-- Pelican prend en charge l'écriture de contenu en Markdown et en texte reStructuré (`.rst`). Astro prend en charge les fichiers [créer des pages à partir de Markdown et MDX](/fr/guides/markdown-content/), mais ne prend pas en charge le texte reStructuré.
+- Pelican prend en charge l'écriture de contenu en Markdown et en reStructuredText (`.rst`). Astro prend en charge les fichiers [créer des pages à partir de Markdown et MDX](/fr/guides/markdown-content/), mais ne prend pas en charge reStructuredText.
 
 - Pelican utilise des fichiers HTML et la syntaxe Jinja pour la création de modèles. La [syntaxe Astro](/fr/basics/astro-components/) est un ensemble de HTML semblable à JSX. Tout HTML valide est une syntaxe `.astro` valide.
 
-- Pelican a été conçu pour construire des sites web riches en contenu, comme des blogs, et possède des fonctionnalités de blog intégrées que vous devriez construire vous-même dans Astro. Au lieu de cela, Astro offre certaines de ces fonctionnalités incluses dans un [thème de blog officiel](https://github.com/withastro/astro/tree/latest/examples/blog).
+- Pelican a été conçu pour créer des sites web riches en contenu, comme des blogs, et possède des fonctionnalités de blog intégrées que vous aurez à créer vous-même dans Astro. Au lieu de cela, Astro offre certaines de ces fonctionnalités incluses dans un [thème de blog officiel](https://github.com/withastro/astro/tree/latest/examples/blog).
 
 ## Passer de Pelican à Astro
 
-Pour convertir un site de documentation Pelican en Astro, commencez par notre [modèle de démarrage officiel Starlight](https://starlight.astro.build), ou explorez d'autres thèmes communautaires dans notre [vitrine](https://astro.build/themes/).
+Pour convertir un site de documentation Pelican en Astro, commencez par notre [thème de documentation Starlight comme modèle de démarrage](https://starlight.astro.build) officiel, ou explorez d'autres thèmes communautaires dans notre [vitrine](https://astro.build/themes/).
 
 Vous pouvez passer un argument `--template` à la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles officiels. Vous pouvez aussi [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
@@ -55,11 +55,11 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
     </Fragment>
   </PackageManagerTabs>
 
-Apportez vos fichiers de contenu Markdown existants en [créant des pages en Markdown](/fr/guides/markdown-content/). Vous pouvez toujours profiter de [l'acheminement par fichier](/fr/guides/routing/) en copiant ces documents du dossier `content/` de Pelican dans `src/pages/` dans Astro. Vous pouvez consulter [la structure du projet Astro](/fr/basics/project-structure/) pour savoir où les fichiers doivent être placés.
+Apportez vos fichiers de contenu Markdown existants en [créant des pages en Markdown](/fr/guides/markdown-content/). Vous pouvez toujours profiter du [routage par fichier](/fr/guides/routing/) en copiant ces documents du dossier `content/` de Pelican dans `src/pages/` dans Astro. Vous pouvez consulter [la structure de projet d'Astro](/fr/basics/project-structure/) pour savoir où les fichiers doivent être placés.
 
-Pelican a peut-être pris en charge une grande partie de la mise en page de votre site et des métadonnées pour vous. Vous pouvez lire [Construire des modèles Astro comme des enveloppes de page Markdown](/fr/basics/layouts/#mises-en-page-markdown) pour voir comment gérer vous-même les modèles dans Astro, y compris votre page `<head>`.
+Pelican a peut-être géré une grande partie de la mise en page et des métadonnées de votre site pour vous. Vous souhaiterez peut-être en savoir plus sur la [création de mises en page Astro en tant qu'enveloppes de page Markdown](/fr/basics/layouts/#mises-en-page-markdown) pour voir comment gérer vous-même la création de modèles dans Astro, y compris la balise `<head>` votre page.
 
-Comme Pelican, Astro dispose de nombreux plugins qui étendent ses fonctionnalités. Explorez la [liste officielle des intégrations](/fr/guides/integrations-guide/) pour ajouter des fonctionnalités telles que la prise en charge de MDX et trouvez des centaines d'autres intégrations gérées par la communauté dans le [Répertoire des intégrations Astro](https://astro.build/integrations/). Vous pouvez même utiliser l'[API Intégration d'Astro](/fr/reference/integrations-reference/) pour créer votre propre intégration personnalisée afin d'étendre les fonctionnalités de votre projet.
+Comme Pelican, Astro dispose de nombreux modules d'extension qui étendent ses fonctionnalités. Explorez la [liste officielle des intégrations](/fr/guides/integrations-guide/) pour ajouter des fonctionnalités telles que la prise en charge de MDX et trouvez des centaines d'autres intégrations gérées par la communauté dans le [répertoire des intégrations Astro](https://astro.build/integrations/). Vous pouvez même utiliser l'[API des intégrations d'Astro](/fr/reference/integrations-reference/) pour créer votre propre intégration personnalisée afin d'étendre les fonctionnalités de votre projet.
 
 Pour convertir d'autres types de sites, comme un portfolio ou un blog, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-sveltekit.mdx
@@ -12,31 +12,31 @@ i18nReady: true
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-[SvelteKit](https://kit.svelte.dev) est un cadre de travail pour la création d'applications web à partir de Svelte.
+[SvelteKit](https://kit.svelte.dev) est un framework pour la création d'applications web à partir de Svelte.
 
 ## Principales similitudes entre SvelteKit et Astro
 
 SvelteKit et Astro partagent certaines similitudes qui vous aideront à migrer votre projet :
 
-- SvelteKit et Astro sont tous deux des générateurs de sites statiques JavaScript modernes et des cadres de rendu côté serveur.
+- SvelteKit et Astro sont tous deux des générateurs de sites statiques JavaScript modernes et des frameworks de rendu côté serveur.
 
 - SvelteKit et Astro utilisent tous deux un dossier [`src/` pour les fichiers de votre projet](/fr/basics/project-structure/#src) et un [dossier spécial pour le routage basé sur les fichiers](/fr/basics/astro-pages/). La création et la gestion des pages de votre site devraient vous être familières.
 
-- Astro possède [une intégration officielle pour l'utilisation des composants Svelte](/fr/guides/integrations-guide/svelte/) et supporte [l'installation des paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour Svelte. Vous serez en mesure d'écrire des composants d'interface utilisateur Svelte, et pourrez peut-être conserver tout ou partie de vos composants et dépendances existants.
+- Astro possède [une intégration officielle pour l'utilisation des composants Svelte](/fr/guides/integrations-guide/svelte/) et prend en charge [l'installation des paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour Svelte. Vous serez en mesure d'écrire des composants d'interface utilisateur Svelte, et pourrez peut-être conserver tout ou partie de vos composants et dépendances existants.
 
 - Astro et SvelteKit vous permettent tous deux d'utiliser un [CMS headless, des APIs ou des fichiers Markdown pour les données](/fr/guides/data-fetching/). Vous pouvez continuer à utiliser votre système préféré de création de contenu et conserver votre contenu existant.
 
 ## Principales différences entre SvelteKit et Astro
 
-Lorsque vous reconstruisez votre site SvelteKit dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site SvelteKit avec Astro, vous remarquerez quelques différences importantes :
 
 - Les sites Astro sont des applications multi-pages, alors que SvelteKit utilise par défaut des SPA (applications mono-page) avec un rendu côté serveur, mais peut également créer des MPA, des SPA traditionnelles, ou vous pouvez mélanger ces techniques au sein d'une application.
 
-- [Composants](/fr/basics/astro-components/) : SvelteKit utilise [Svelte](https://svelte.dev). Les pages Astro sont construites en utilisant les [composants `.astro`](/fr/basics/astro-components/), mais peuvent aussi supporter [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et le templating HTML brut.
+- [Composants](/fr/basics/astro-components/) : SvelteKit utilise [Svelte](https://svelte.dev). Les pages Astro sont construites en utilisant les [composants `.astro`](/fr/basics/astro-components/), mais peuvent aussi prendre en charge [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et la création de modèles HTML bruts.
 
 - [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour mettre en valeur votre contenu et vous permettre d'opter pour l'interactivité uniquement en cas de besoin. Une application SvelteKit existante peut être conçue pour une forte interactivité côté client. Astro a des capacités intégrées pour travailler avec votre contenu, comme la génération de pages, mais peut nécessiter des techniques Astro avancées pour inclure des éléments qui sont plus difficiles à reproduire en utilisant les composants `.astro`, comme les tableaux de bord.
 
-- [Prêt pour du Markdown](/fr/guides/markdown-content/) : Astro intègre le support Markdown, et inclut une [propriété YAML `layout` spéciale frontmatter](/fr/basics/layouts/#mises-en-page-markdown) utilisée par fichier pour le templating des pages. Si vous convertissez un blog SvelteKit basé sur le Markdown, vous n'aurez pas à installer une intégration Markdown séparée et vous n'aurez pas à définir une mise en page via un fichier de configuration. Vous pouvez utiliser vos fichiers Markdown existants, mais vous devrez peut-être les réorganiser, car le routage basé sur les fichiers d'Astro ne nécessite pas de dossier pour chaque page.
+- [Prêt pour du Markdown](/fr/guides/markdown-content/) : Astro intègre la prise en charge de Markdown, et inclut une [propriété `layout` spéciale de frontmatter YAML](/fr/basics/layouts/#mises-en-page-markdown) utilisée par fichier pour la création de modèles de pages. Si vous convertissez un blog SvelteKit basé sur Markdown, vous n'aurez pas à installer une intégration Markdown séparée et vous n'aurez pas à définir une mise en page via un fichier de configuration. Vous pouvez utiliser vos fichiers Markdown existants, mais vous devrez peut-être les réorganiser, car le routage basé sur les fichiers d'Astro ne nécessite pas de dossier pour chaque page.
 
 
 ## Passer de SvelteKit à Astro
@@ -65,15 +65,15 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
 
 Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration optionnelle) comme contenu pour [créer des pages Markdown ou MDX](/fr/guides/markdown-content/).
 
-Bien que les composants de routage et de mise en page basés sur les fichiers soient similaires dans Astro, vous pouvez consulter [la structure de projet d'Astro](/fr/basics/project-structure/) pour savoir où les fichiers doivent être placés.
+Bien que les composants de routage et de mise en page basés sur les fichiers soient similaires dans Astro, vous souhaiterez peut-être en savoir plus sur [la structure de projet d'Astro](/fr/basics/project-structure/) pour savoir où les fichiers doivent être placés.
 
-Pour convertir d'autres types de sites, tels qu'un portfolio ou un site de documentation, consultez les modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
+Pour convertir d'autres types de sites, tels qu'un portfolio ou un site de documentation, consultez les modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
 ## Ressources communautaires
 
 <CardGrid>
 
-  <LinkCard title="Réécriture de mon blog de SvelteKit vers Astro (en)" href="https://kharann.com/blog/rewriting-my-blog/"/>
+  <LinkCard title="Réécriture de mon blog de SvelteKit vers Astro (Anglais)" href="https://kharann.com/blog/rewriting-my-blog/"/>
 
 </CardGrid>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-vuepress.mdx
@@ -18,24 +18,24 @@ VuePress et Astro partagent certaines similitudes qui vous aideront à migrer vo
 
 - VuePress et Astro sont tous deux des générateurs de sites statiques Javascript modernes avec des structures de fichiers de projet similaires. Tous deux utilisent un [dossier spécial `src/pages/` pour le routage basé sur les fichiers](/fr/basics/astro-pages/). La création et la gestion des pages de votre site devraient vous sembler familières.
 
-- Astro et VuePress sont tous deux conçus pour les [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu), avec un excellent support intégré pour les fichiers Markdown. L'écriture en Markdown vous sera familière et vous pourrez conserver votre contenu existant.
+- Astro et VuePress sont tous deux conçus pour les [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu), avec une excellente prise en charge intégrée des fichiers Markdown. L'écriture en Markdown vous sera familière et vous pourrez conserver votre contenu existant.
 
 - Astro possède [une intégration officielle pour l'utilisation des composants Vue](/fr/guides/integrations-guide/vue/) et prend en charge [l'installation des paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour Vue. Vous serez en mesure d'écrire des composants d'interface utilisateur Vue et pourrez conserver tout ou partie de vos composants et dépendances Vue existants.
 
 
 ## Principales différences entre VuePress et Astro
 
-Lorsque vous reconstruisez votre site VuePress dans Astro, vous remarquerez quelques différences importantes.
+Lorsque vous recréez votre site VuePress avec Astro, vous remarquerez quelques différences importantes.
 
-- VuePress est une application monopage (SPA) basée sur Vue. Les sites Astro sont des applications multi-pages construites à l'aide de [composants `.astro`](/fr/basics/astro-components/), mais peuvent également prendre en charge [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et le templating HTML brut.
+- VuePress est une application monopage (SPA) basée sur Vue. Les sites Astro sont des applications multi-pages construites à l'aide de [composants `.astro`](/fr/basics/astro-components/), mais peuvent également prendre en charge [React, Preact, Vue.js, Svelte, SolidJS, AlpineJS](/fr/guides/framework-components/) et la création de modèles HTML bruts.
 
 - [Modèles de mise en page](/fr/basics/layouts/) : Les sites VuePress sont créés à l'aide de fichiers Markdown (`.md`) pour le contenu des pages et de modèles HTML (`.html`) pour la mise en page. Astro est basé sur des composants et utilise des composants Astro, qui incluent des modèles HTML pour les pages, les mises en page et les éléments individuels de l'interface utilisateur. Astro peut également créer des [pages à partir de fichiers `.md` et `.mdx`](/fr/guides/markdown-content/), en utilisant un composant de mise en page Astro pour envelopper le contenu Markdown dans un modèle de page.
 
-- VuePress a été conçu pour construire des sites à fort contenu, centrés sur le Markdown, et possède des fonctionnalités intégrées spécifiques à la documentation que vous devriez construire vous-même dans Astro. Au lieu de cela, Astro offre des fonctionnalités spécifiques à la documentation par le biais d'un [modèle de démarrage officiel Starlight](https://starlight.astro.build). Ce site web a été la source d'inspiration de ce modèle ! Vous pouvez également trouver d'autres [thèmes de documentation communautaires](https://astro.build/themes?search=&categories%5B%5D=docs) avec des fonctionnalités intégrées dans notre vitrine de thèmes.
+- VuePress a été conçu pour construire des sites riches en contenu, centrés sur Markdown et possède des fonctionnalités intégrées spécifiques à la documentation que vous devriez créer vous-même dans Astro. Au lieu de cela, Astro offre des fonctionnalités spécifiques à la documentation par le biais d'un [thème de documentation officiel](https://starlight.astro.build). Ce site web a été la source d'inspiration de ce modèle ! Vous pouvez également trouver d'autres [thèmes de documentation communautaires](https://astro.build/themes?search=&categories%5B%5D=docs) avec des fonctionnalités intégrées dans notre vitrine de thèmes.
 
 ## Passer de VuePress à Astro
 
-Pour convertir un site de documentation VuePress en Astro, commencez par notre modèle officiel [de démarrage Starlight](https://starlight.astro.build), ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
+Pour convertir un site de documentation VuePress en Astro, commencez par notre [thème de documentation Starlight comme modèle de démarrage](https://starlight.astro.build) officiel, ou explorez d'autres thèmes de documentation communautaires dans notre [vitrine de thèmes](https://astro.build/themes?search=&categories%5B%5D=docs).
 
 Vous pouvez passer un argument `--template` à la commande `create astro` pour démarrer un nouveau projet Astro avec l'un de nos modèles officiels. Vous pouvez aussi [démarrer un nouveau projet à partir de n'importe quel dépôt Astro existant sur GitHub](/fr/install-and-setup/#utiliser-un-thème-ou-un-modèle-de-démarrage).
 
@@ -59,7 +59,7 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
 
 Apportez vos fichiers de contenu Markdown existants à [créer des pages Markdown](/fr/guides/markdown-content/). Vous pouvez toujours profiter du [routage basé sur les fichiers](/fr/guides/routing/) en déplaçant ces documents de `docs` dans VuePress vers `src/pages/` dans Astro. Créez des dossiers avec des noms qui correspondent à votre projet VuePress existant, et vous devriez être en mesure de conserver vos URLs existantes.
 
-VuePress, ou tout autre thème que vous avez installé, a probablement géré une grande partie de la mise en page et des métadonnées de votre site pour vous. Vous pouvez lire l'article sur [la construction de Layouts Astro en tant qu'enveloppes de page Markdown](/fr/basics/layouts/#mises-en-page-markdown) pour voir comment gérer vous-même le templating dans Astro, y compris votre page `<head>`.
+VuePress, ou tout autre thème que vous avez installé, a probablement géré une grande partie de la mise en page et des métadonnées de votre site pour vous. Vous souhaiterez peut-être en savoir plus sur [la création de mises en page Astro en tant qu'enveloppes de page Markdown](/fr/basics/layouts/#mises-en-page-markdown) pour découvrir comment gérer vous-même la création de modèles dans Astro, y compris la balise `<head>` de votre page.
 
 Vous pouvez trouver la documentation de démarrage d'Astro, ainsi que d'autres modèles, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-wordpress.mdx
@@ -15,7 +15,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 
 :::tip
-Vous pouvez [utiliser WordPress comme CMS headless (ou « sans-tête ») pour votre projet Astro](/fr/guides/cms/wordpress/). Suivez notre guide pour utiliser votre contenu WordPress existant dans un nouveau projet Astro.
+Vous pouvez [utiliser WordPress en tant que CMS headless pour votre projet Astro](/fr/guides/cms/wordpress/). Suivez notre guide pour utiliser votre contenu WordPress existant dans un nouveau projet Astro.
 :::
 
 ## Principales similitudes entre WordPress et Astro
@@ -28,11 +28,11 @@ WordPress et Astro partagent certaines similitudes qui vous aideront à migrer v
 
 ## Principales différences entre WordPress et Astro
 
-Lorsque vous reconstruisez votre site WordPress dans Astro, vous remarquerez quelques différences importantes :
+Lorsque vous recréez votre site WordPress avec Astro, vous remarquerez quelques différences importantes :
 
 - Un site WordPress est édité en utilisant un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine ou choisir un éditeur/environnement de développement en ligne comme IDX, StackBlitz, CodeSandbox ou Gitpod.
 
-- WordPress dispose d’un vaste marché de plugins et de thèmes. Dans Astro, vous trouverez quelques thèmes et [intégrations](https://astro.build/integrations/) disponibles, mais vous devrez peut-être désormais créer vous-même bon nombre de vos fonctionnalités existantes au lieu de rechercher des solutions tierces. Vous pouvez également choisir de commencer avec un [thème Astro](https://astro.build/themes) possédant des fonctionnalités intégrées !
+- WordPress dispose d’un vaste marché de modules d'extension et de thèmes. Dans Astro, vous trouverez quelques thèmes et [intégrations](https://astro.build/integrations/) disponibles, mais vous devrez peut-être désormais créer vous-même bon nombre de vos fonctionnalités existantes au lieu de rechercher des solutions tierces. Vous pouvez également choisir de commencer avec un [thème Astro](https://astro.build/themes) possédant des fonctionnalités intégrées !
 
 - WordPress enregistre votre contenu dans une base de données. Dans Astro, vous aurez des fichiers individuels (généralement Markdown ou MDX) résidant dans votre [dossier de projet](/fr/basics/project-structure/) pour le contenu de chaque page. Vous pouvez également choisir d'utiliser un [CMS pour votre contenu](/fr/guides/cms/), et même votre site WordPress existant, et d'utiliser Astro pour récupérer et présenter les données.
 
@@ -62,25 +62,25 @@ Vous pouvez utiliser l'argument `--template` avec la commande `create astro` pou
 
 Vous pouvez continuer à [utiliser votre blog WordPress existant comme CMS pour Astro](/fr/guides/cms/wordpress/), ce qui signifie que vous continuerez à utiliser votre tableau de bord WordPress pour rédiger vos articles. Vos contenus seront gérés par WordPress, mais tous les autres aspects de votre site Astro seront construits dans votre environnement d'édition de code, et vous [déployerez votre site Astro](/fr/guides/deploy/) séparément de votre site WordPress. (Assurez-vous de mettre à jour votre domaine chez votre hébergeur pour conserver la même URL de site web !)
 
-Vous souhaiterez peut-être suivre le [tutoriel Construire un blog](/fr/tutorial/0-introduction/) si vous débutez dans l'utilisation d'un éditeur de code et de GitHub pour stocker et déployer votre site. Il vous guidera à travers tous les comptes et configurations dont vous avez besoin ! Vous apprendrez également à [construire des composants Astro par vous-même](/fr/tutorial/3-components/), et il vous montrera comment [ajouter des articles de blog directement dans Astro](/fr/tutorial/2-pages/2/) si vous choisissez de ne pas utiliser WordPress pour rédiger vos contenus.
+Vous souhaiterez peut-être suivre le [tutoriel Construire un blog](/fr/tutorial/0-introduction/) si vous débutez dans l'utilisation d'un éditeur de code et de GitHub pour stocker et déployer votre site. Il vous guidera à travers tous les comptes et configurations dont vous avez besoin ! Vous apprendrez également à [créer des composants Astro par vous-même](/fr/tutorial/3-components/), et il vous montrera comment [ajouter des articles de blog directement dans Astro](/fr/tutorial/2-pages/2/) si vous choisissez de ne pas utiliser WordPress pour rédiger vos contenus.
 
-Si vous souhaitez déplacer tous vos articles existants vers Astro, vous pourriez trouver cet [outil pour exporter du contenu Markdown depuis WordPress utile](https://github.com/lonekorean/wordpress-export-to-markdown). Vous devrez peut-être apporter quelques ajustements au résultat si vous devez [convertir un site WordPress volumineux ou compliqué vers Markdown](https://swizec.com/blog/how-to-export-a-large-wordpress-site-to-markdown/).
+Si vous souhaitez déplacer tous vos articles existants vers Astro, vous pourriez trouver cet [outil utile pour exporter du contenu Markdown depuis WordPress](https://github.com/lonekorean/wordpress-export-to-markdown). Vous devrez peut-être apporter quelques ajustements au résultat si vous devez [convertir un site WordPress volumineux ou compliqué vers Markdown](https://swizec.com/blog/how-to-export-a-large-wordpress-site-to-markdown/).
 
 Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, découvrez plus de modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne IDX, StackBlitz, CodeSandbox et Gitpod.
 
 ## Ressources communautaires
 
 <CardGrid>
-  <LinkCard title="Au revoir Wordpress, bonjour Astro ! (en)" href="https://trib.tv/posts/2025/wordpress-to-astro/" />
-  <LinkCard title="Comment j'ai migré de Wordpress vers Astro (en)" href="https://itsthatlady.dev/blog/migrate-from-wordpress-to-astro/" />
-  <LinkCard title="Comment et pourquoi j'ai migré mon blog de WordPress vers Astro et Markdown (en)" href="https://levelup.gitconnected.com/how-and-why-i-moved-my-blog-from-wordpress-to-astro-and-markdown-3549672d5a86" />
-  <LinkCard title="Comment j'ai migré de WordPress vers Astro : j'ai augmenté mes scores Pagespeed à 100 % et réduit de 100 % les coûts d'hébergement (en)" href="https://devaradise.com/wordpress-to-static-website-astro/" />
-  <LinkCard title="Conversion d'un site, de WordPress à Astro (en)" href="https://share.transistor.fm/s/d86496cd" />
-  <LinkCard title="Comment convertir un blog WordPress en site statique Astro (en)" href="https://blog.okturtles.org/2024/10/convert-wordpress-to-static-site/" />
-  <LinkCard title="Pourquoi je suis passé de WordPress à Astro (en)" href="https://dev.to/fratzinger/why-i-switched-from-wordpress-to-astro-5ge" />
-  <LinkCard title="Pourquoi j'ai abandonné WordPress pour Astro (en)" href="https://vbartalis.xyz/en/blog/why-i-ditched-wordpress-for-astro-js/" />
-  <LinkCard title="DeWP : utilitaire pour utiliser vos données WordPress dans des projets Astro (en)" href="https://delucis.github.io/dewp/" />
-  <LinkCard title="Astro vs. WordPress : modèles de rendu du web moderne (en)" href="https://andrewkepson.com/blog/headless-wordpress/astro-vs-wordpress-rendering-patterns/" />
+  <LinkCard title="Au revoir Wordpress, bonjour Astro ! (Anglais)" href="https://trib.tv/posts/2025/wordpress-to-astro/" />
+  <LinkCard title="Comment j'ai migré de Wordpress vers Astro (Anglais)" href="https://itsthatlady.dev/blog/migrate-from-wordpress-to-astro/" />
+  <LinkCard title="Comment et pourquoi j'ai migré mon blog de WordPress vers Astro et Markdown (Anglais)" href="https://levelup.gitconnected.com/how-and-why-i-moved-my-blog-from-wordpress-to-astro-and-markdown-3549672d5a86" />
+  <LinkCard title="Comment j'ai migré de WordPress vers Astro : j'ai augmenté mes scores Pagespeed à 100 % et réduit de 100 % les coûts d'hébergement (Anglais)" href="https://devaradise.com/wordpress-to-static-website-astro/" />
+  <LinkCard title="Conversion d'un site, de WordPress à Astro (Anglais)" href="https://share.transistor.fm/s/d86496cd" />
+  <LinkCard title="Comment convertir un blog WordPress en site statique Astro (Anglais)" href="https://blog.okturtles.org/2024/10/convert-wordpress-to-static-site/" />
+  <LinkCard title="Pourquoi je suis passé de WordPress à Astro (Anglais)" href="https://dev.to/fratzinger/why-i-switched-from-wordpress-to-astro-5ge" />
+  <LinkCard title="Pourquoi j'ai abandonné WordPress pour Astro (Anglais)" href="https://vbartalis.xyz/en/blog/why-i-ditched-wordpress-for-astro-js/" />
+  <LinkCard title="DeWP : utilitaire pour utiliser vos données WordPress dans des projets Astro (Anglais)" href="https://delucis.github.io/dewp/" />
+  <LinkCard title="Astro vs. WordPress : modèles de rendu du web moderne (Anglais)" href="https://andrewkepson.com/blog/headless-wordpress/astro-vs-wordpress-rendering-patterns/" />
 </CardGrid>
 
 :::note[Vous avez une ressource à partager ?]

--- a/src/content/docs/fr/guides/migrate-to-astro/index.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/index.mdx
@@ -2,47 +2,48 @@
 title: Migrer un projet existant vers Astro
 description: Quelques trucs et astuces pour convertir votre site vers Astro.
 sidebar:
-  label: Aperçu des migrations de site
+  label: Vue d'ensemble de la migration de site
 i18nReady: true
 ---
 import MigrationGuidesNav from '~/components/MigrationGuidesNav.astro';
 
 **Prêt à convertir votre site vers Astro ?** Consultez l'un de nos guides afin d'obtenir des conseils sur la migration.
 
-## Guides de Migration
+## Guides de migration
 
 <MigrationGuidesNav />
 
 Notez que beaucoup de ces pages sont des **ébauches** : ce sont des collections de ressources qui attendent votre contribution !
 
-## Pourquoi migrer votre site vers Astro ?
+## Pourquoi migrer votre site vers Astro ?
 
-Astro offre de nombreux avantages : performance, simplicité et de nombreuses fonctionnalités que vous souhaitez, sont directement intégrées dans le framework. Lorsque vous avez besoin d'étendre votre site, Astro fournit plusieurs [intégrations officielles et communautaires tierces](https://astro.build/integrations).
+Astro offre de nombreux avantages : performance, simplicité et de nombreuses fonctionnalités que vous souhaitez sont directement intégrées dans le framework. Lorsque vous avez besoin d'étendre votre site, Astro fournit plusieurs [intégrations officielles et communautaires tierces](https://astro.build/integrations).
 
 La migration peut s'avérer moins compliquée que vous ne le pensez !
 
-Selon votre projet déjà existant, vous pourrez peut-être utiliser vos composants existants :
+En fonction de votre projet existant, vous pourrez peut-être réutiliser :
 
-- [Framework de composants UI](/fr/guides/framework-components/) directement dans Astro. 
+- vos [composants de framework UI](/fr/guides/framework-components/) directement dans Astro. 
 
-- [Feuilles de style ou bibliothèques CSS](/fr/guides/styling/) incluant Tailwind.
+- vos [feuilles de style ou bibliothèques CSS](/fr/guides/styling/), y compris Tailwind.
 
-- [Fichiers Markdown/MDX](/fr/guides/markdown-content/), configuré en utilisant votre [plugin remark et rehype](/fr/guides/markdown-content/#plugins-markdown).
+- vos [fichiers Markdown/MDX](/fr/guides/markdown-content/), configuré en utilisant vos [modules d'extension remark et rehype](/fr/guides/markdown-content/#plugins-markdown) existants.
 
-- [Contenu depuis un CMS](/fr/guides/cms/) à travers une intégration ou une API.
+- votre [contenu depuis un CMS](/fr/guides/cms/) à travers une intégration ou une API.
 
-## Quels projects puis-je convertir vers Astro ?
 
-[De nombreux sites existants peuvent être construits avec Astro](/fr/concepts/why-astro/). Astro est parfaitement adapté à vos sites existants basés sur le contenu, tels que les blogs, les landing pages, les sites marketing et les portfolios. Astro s'intègre à plusieurs Headless CMS populaires et vous permet de connecter des paniers de boutique eCommerce.
+## Quels projets puis-je convertir vers Astro ?
+
+[De nombreux sites existants peuvent être créés avec Astro](/fr/concepts/why-astro/). Astro est parfaitement adapté à vos sites existants basés sur le contenu tels que les blogs, les pages d'atterrissage, les sites marketing et les portfolios. Astro s'intègre à plusieurs CMS headless populaires et vous permet de connecter des paniers de boutique e-commerce.
 
 Astro vous permet d'avoir un site web entièrement généré de manière statique, une application dynamique avec des routes rendues à la demande ou une combinaison des deux avec [un contrôle complet sur le rendu de votre projet](/fr/guides/on-demand-rendering/), ce qui en fait un excellent remplacement pour les SSG ou pour les sites qui doivent récupérer certaines données de page à la volée.
 
-## Comment la conception de mon projet va-t-elle changer ?
+## Comment la conception de mon projet va-t-elle changer ?
 
 En fonction de votre projet existant, vous devrez peut-être penser différemment concernant :
 
-- Concevoir avec les [îles Astro](/fr/concepts/islands/#quest-ce-quun-îlot-) pour éviter d'envoyer du Javascript inutile au navigateur.
+- Concevoir avec les [îlots Astro](/fr/concepts/islands/#quest-ce-quun-îlot-) pour éviter d'envoyer du Javascript inutile au navigateur.
 
-- Fournir une interactivité côté client avec les [balises `<script>` côté client](/fr/guides/client-side-scripts/) ou les [composants de Framework UI](/fr/guides/framework-components/).
+- Fournir une interactivité côté client avec les [balises `<script>` côté client](/fr/guides/client-side-scripts/) ou les [composants de framework UI](/fr/guides/framework-components/).
 
-- Gérer [l'état partagé](/fr/recipes/sharing-state-islands/) avec les Nano Stores ou un Local Storage au lieu de Wrappers et Hooks à l'échelle de l'application.
+- Gérer [l'état partagé](/fr/recipes/sharing-state-islands/) avec Nano Stores ou le stockage local au lieu de hooks ou de wrappers à l'échelle de l'application.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations in `guides/migrate-to-astro` and `guides/media` (a single file) to improve the wording (see #11593):
* replace `sans tête` with `headless`
* replace `barrières de code` with `délimitateurs de code`
* replace `construit` with `créé`/`généré` in some places
* replace `construction` with `compilation`
* replace `template`  with `modèle`
* replace `île` with `îlot`
* replace `documents` with `documentation`
* replace `plugins` with `modules d'extension`
* replace `livraison` with `diffusion`
* replace `supporte` with `prend en charge`
* replace `actifs` with `ressources`
* replace `cadre` with `framework`
* replace `en` with `Anglais` in community links
* reword some sentences to make the reading easier
* add some changes to match the English version (missing words or sentences)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
