### PR TITLE
fix(guides/actions): update code snippets markers [i18nIgnore]

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -348,7 +348,7 @@ The following example shows a validated newsletter registration form that accept
 
 3. Add a `<script>` to the HTML form to submit the user input. This example overrides the form's default submit behavior to call `actions.newsletter()`, and redirects to `/confirmation` using the `navigate()` function:
 
-    ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+    ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
     <form>
       <label for="email">E-mail</label>
       <input id="email" required type="email" name="email" />

--- a/src/content/docs/fr/guides/actions.mdx
+++ b/src/content/docs/fr/guides/actions.mdx
@@ -348,7 +348,7 @@ L'exemple suivant montre un formulaire d'inscription à une newsletter validé q
 
 3. Ajoutez un `<script>` au formulaire HTML pour soumettre la saisie de l'utilisateur. Cet exemple remplace le comportement de soumission par défaut du formulaire pour appeler `actions.newsletter()` et redirige vers `/confirmation` à l'aide de la fonction `navigate()` :
 
-    ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+    ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
     <form>
       <label for="email">E-mail</label>
       <input id="email" required type="email" name="email" />

--- a/src/content/docs/ja/guides/actions.mdx
+++ b/src/content/docs/ja/guides/actions.mdx
@@ -345,7 +345,7 @@ export const server = {
 
 3. フォームに`<script>`を追加し、ユーザー入力を送信します。この例ではフォームの既定の送信動作を上書きして`actions.newsletter()`を呼び出し、成功時に`/confirmation`へリダイレクトします。
 
-   ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+   ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
    <form>
      <label for="email">E-mail</label>
      <input id="email" required type="email" name="email" />

--- a/src/content/docs/ko/guides/actions.mdx
+++ b/src/content/docs/ko/guides/actions.mdx
@@ -348,7 +348,7 @@ export const server = {
     
 3. HTML 양식에 `<script>`를 추가하여 사용자 입력을 제출합니다. 이 예시에서는 양식의 기본 제출 동작을 재정의하여 `actions.newsletter()`를 호출하고 `navigate()` 함수를 사용하여 `/confirmation`으로 리디렉션합니다:
 
-    ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+    ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
     <form>
       <label for="email">E-mail</label>
       <input id="email" required type="email" name="email" />

--- a/src/content/docs/pl/guides/actions.mdx
+++ b/src/content/docs/pl/guides/actions.mdx
@@ -351,7 +351,7 @@ Poniższy przykład pokazuje zwalidowany formularz rejestracji newslettera, któ
 
 3. Dodaj `<script>` do formularza HTML, aby przesłać dane użytkownika. Ten przykład nadpisuje domyślne zachowanie przycisku `submit` formularza, aby wywołać `actions.newsletter()`, a następnie przekierowuje na `/confirmation` za pomocą funkcji `navigate()`:
 
-    ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+    ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
     <form>
       <label for="email">E-mail</label>
       <input id="email" required type="email" name="email" />

--- a/src/content/docs/zh-cn/guides/actions.mdx
+++ b/src/content/docs/zh-cn/guides/actions.mdx
@@ -347,7 +347,7 @@ Actions 将解析提交的表单数据为一个对象，使用每个输入的 `n
 
 3. 添加一个 `<script>` 到 HTML 表单中以提交用户输入。这个例子覆盖了表单的默认提交行为，调用 `actions.newsletter()`，并使用 `navigate()` 函数重定向到 `/confirmation`：
 
-    ```astro title=src/components/Newsletter.astro ins={11-23} collapse={2-8}
+    ```astro title=src/components/Newsletter.astro ins={11-22} collapse={2-8}
     <form>
       <label for="email">E-mail</label>
       <input id="email" required type="email" name="email" />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes highlighting of two code snippets in `guides/actions`:
* The [first one](https://docs.astro.build/en/guides/actions/#handling-an-actionerror) was missing a `?` present in the code, so the highlighting wasn't working
* The [second one](https://docs.astro.build/en/guides/actions/#validating-form-data) included the closing `<script>` tag but not the opening tag.

I also updated the translations as I didn't want to bother the translators for such small changes. 😅 

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `code snippet update`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
