### PR TITLE
Document `suppress` in `supportedAstroFeatures`

### DIFF
--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -71,6 +71,7 @@ export type AdapterSupportsKind = 'unsupported' | 'stable' | 'experimental' | 'd
 export type AdapterSupportWithMessage = {
 	support: Exclude<AdapterSupportsKind, 'stable'>;
 	message: string;
+  suppress?: 'default' | 'all';
 };
 
 export type AdapterSupport = AdapterSupportsKind | AdapterSupportWithMessage;
@@ -419,6 +420,56 @@ export default function createIntegration() {
             sharpImageService: {
               support: 'limited',
               message: 'This adapter has limited support for Sharp, certain features may not work as expected.'
+            }
+          } 
+        });
+      },
+    },
+  };
+}
+```
+
+If the default log message sent along with your custom message can cause confusion, you can use `suppress: "default"` to suppress the default message:
+
+```js title="my-adapter.mjs" ins={13}
+export default function createIntegration() {
+  return {
+    name: '@matthewp/my-adapter',
+    hooks: {
+      'astro:config:done': ({ setAdapter }) => {
+        setAdapter({
+          name: '@matthewp/my-adapter',
+          serverEntrypoint: '@matthewp/my-adapter/server.js',
+          supportedAstroFeatures: {
+            sharpImageService: {
+              support: 'limited',
+              message: 'This adapter has limited support for Sharp, certain features may not work as expected.',
+              suppress: 'default'
+            }
+          } 
+        });
+      },
+    },
+  };
+}
+```
+
+You can also use `suppress: "all"` to suppress all messages for a specific feature, useful if it doesn't impact users in a specific context:
+
+```js title="my-adapter.mjs" ins={13}
+export default function createIntegration() {
+  return {
+    name: '@matthewp/my-adapter',
+    hooks: {
+      'astro:config:done': ({ setAdapter }) => {
+        setAdapter({
+          name: '@matthewp/my-adapter',
+          serverEntrypoint: '@matthewp/my-adapter/server.js',
+          supportedAstroFeatures: {
+            sharpImageService: {
+              support: 'limited',
+              message: 'This adapter has limited support for Sharp, certain features may not work as expected.',
+              suppress: 'all'
             }
           } 
         });


### PR DESCRIPTION
#### Description (required)

This adds documentation for `suppress: "all"` and `suppress: "default"` in the `supportedAstroFeatures` property of `setAdapter()`.

#### Related issues & labels (optional)

- Core PR: https://github.com/withastro/astro/pull/13842/