### PR TITLE
i18n(fr): improve the wording in `upgrade-to/v1.mdx`

### DIFF
--- a/src/content/docs/fr/guides/upgrade-to/v1.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v1.mdx
@@ -8,31 +8,31 @@ i18nReady: false
 import { Steps } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Ce guide vous aidera à effectuer la mise à niveau grâce aux modifications majeures apportées aux versions antérieures à la v1 d'Astro.
+Ce guide vous aidera à effectuer la mise à niveau à travers les changements non rétrocompatibles apportés aux versions antérieures à la v1 d'Astro.
 
 Vous pouvez mettre à jour la version d'Astro de votre projet vers la dernière version à l'aide de votre gestionnaire de paquets. Si vous utilisez les intégrations Astro, vous souhaiterez également les mettre à jour vers la dernière version.
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  # mettre à jour la dépendance astro :
+  # mettre à niveau la dépendance astro :
   npm upgrade astro
-  # ou, pour mettre à jour toutes les dépendances :
+  # ou, pour mettre à niveau toutes les dépendances :
   npm upgrade
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  # mettre à jour la dépendance astro :
+  # mettre à niveau la dépendance astro :
   pnpm upgrade astro
-  # ou, pour mettre à jour toutes les dépendances :
+  # ou, pour mettre à niveau toutes les dépendances :
   pnpm upgrade
   ```
   </Fragment>
   <Fragment slot="yarn">
   ```shell
-  # mettre à jour la dépendance astro :
+  # mettre à niveau la dépendance astro :
   yarn upgrade astro
-  # ou, pour mettre à jour toutes les dépendances :
+  # ou, pour mettre à niveau toutes les dépendances :
   yarn upgrade
   ```
   </Fragment>
@@ -46,9 +46,9 @@ Astro v1.0 introduit certains changements dont vous devez être conscient lors d
 
 ### Mis à jour : Vite 3
 
-Astro v1.0 est passé de Vite 2 à [Vite 3](https://vite.dev/). Nous avons géré la majeure partie de la mise à niveau pour vous dans Astro ; cependant, certains comportements subtils de Vite peuvent encore changer entre les versions. Reportez-vous au [Guide de migration Vite](https://vite.dev/guide/migration.html#general-changes) officiel si vous rencontrez des problèmes.
+Astro v1.0 est passé de Vite 2 à [Vite 3](https://vite.dev/). Nous avons géré la majeure partie de la mise à niveau pour vous dans Astro ; cependant, certains comportements subtils de Vite peuvent encore changer entre les versions. Reportez-vous au [guide de migration officiel de Vite](https://vite.dev/guide/migration.html#general-changes) si vous rencontrez des problèmes.
 
-### Obsolète : `Astro.canonicalURL`
+### Déprécié : `Astro.canonicalURL`
 
 Vous pouvez maintenant utiliser le nouvel assistant [`Astro.url`](/fr/reference/api-reference/#url) pour construire votre propre URL canonique à partir de l'URL de la page/de la demande actuelle. 
 
@@ -73,7 +73,7 @@ Utilisons le bloc de style suivant dans un composant Astro à titre d'exemple :
 </style>
 ```
 
-Auparavant, Astro transformerait cela en CSS suivant, qui a une spécificité de `0-1-1` — une spécificité plus élevée que le CSS source :
+Auparavant, Astro aurait transformé cela en CSS suivant, qui a une spécificité de `0-1-1` — une spécificité plus élevée que le CSS source :
 
 ```css del=".astro-XXXXXX"
 div.astro-XXXXXX { color: red; } /* spécificité 0-1-1 */
@@ -87,14 +87,14 @@ div:where(.astro-XXXXXX) { color: red; } /* spécificité 0-0-1 */
 L'augmentation de spécificité précédente rendait difficile la combinaison de styles à portée limitée dans Astro avec d'autres fichiers CSS ou bibliothèques de styles (par exemple Tailwind, les modules CSS, Styled Components, Stitches). Ce changement permettra aux styles à portée limitée d'Astro de fonctionner de manière cohérente avec ces derniers tout en préservant les limites exclusives qui empêchent les styles de s'appliquer en dehors du composant.
 
 :::caution
-Lors de la mise à niveau, veuillez inspecter visuellement la sortie de votre site pour vous assurer que tout est stylisé comme prévu. Sinon, recherchez votre style à portée limitée et augmentez manuellement la spécificité du sélecteur pour qu'elle corresponde à l'ancien comportement.
+Lors de la mise à niveau, veuillez inspecter visuellement la sortie de votre site pour vous assurer que tout est mise en forme comme prévu. Sinon, recherchez votre style à portée limitée et augmentez manuellement la spécificité du sélecteur pour qu'elle corresponde à l'ancien comportement.
 :::
 
-### Obsolète : Composants et JSX dans Markdown
+### Déprécié : Composants et JSX dans Markdown
 
-Astro ne prend plus en charge par défaut les composants ou les expressions JSX dans les pages Markdown. Pour un support à long terme, vous devez migrer vers l'intégration [`@astrojs/mdx`](/fr/guides/integrations-guide/mdx/).
+Astro ne prend plus en charge par défaut les composants ou les expressions JSX dans les pages Markdown. Pour une prise en charge à long terme, vous devez migrer vers l'intégration [`@astrojs/mdx`](/fr/guides/integrations-guide/mdx/).
 
-Pour faciliter la migration, un nouvel indicateur `legacy.astroFlavoredMarkdown` (supprimé dans la version 2.0) peut être utilisé pour réactiver les fonctionnalités Markdown précédentes.
+Pour faciliter la migration, une nouvelle option `legacy.astroFlavoredMarkdown` (supprimée dans la version 2.0) peut être utilisé pour réactiver les fonctionnalités Markdown précédentes.
 
 ### Conversion des fichiers `.md` existants en `.mdx`
 
@@ -154,7 +154,7 @@ Si vous n'êtes pas familier avec MDX, voici quelques étapes que vous pouvez su
 </Steps>
 
 :::tip
-Pendant votre transition vers MDX, vous souhaiterez peut-être activer l'indicateur `legacy.astroFlavoredMarkdown` (supprimé dans la version 2.0) et inclure les fichiers **`.md` et `.mdx`**, afin que votre site continue de fonctionner normalement avant même que tous vos fichiers n’aient été convertis. Voici une façon de procéder :
+Pendant votre transition vers MDX, vous souhaiterez peut-être activer l'option `legacy.astroFlavoredMarkdown` (supprimée dans la version 2.0) et inclure les fichiers **`.md` et `.mdx`**, afin que votre site continue de fonctionner normalement avant même que tous vos fichiers n’aient été convertis. Voici une façon de procéder :
 
 ```astro
 ---
@@ -177,9 +177,9 @@ Astro prend désormais en charge [MDX](https://mdxjs.com/) via notre [intégrati
 
 Le 4 avril 2022, nous avons publié la version bêta d'Astro 1.0 ! 🎉
 
-Si vous venez de la v0.25 ou d'une version antérieure, assurez-vous d'avoir lu et suivi le [Guide de migration v0.26](#migration-vers-la-v026) ci-dessous qui contenait plusieurs changements majeurs.
+Si vous venez de la v0.25 ou d'une version antérieure, assurez-vous d'avoir lu et suivi le [guide de migration vers la v0.26](#migration-vers-la-v026) ci-dessous qui contenait plusieurs changements majeurs avec rupture de compatibilité.
 
-La version `v1.0.0-beta.0` d'Astro ne contenait aucune modification majeure. Vous trouverez ci-dessous de petits changements introduits pendant la période bêta.
+La version `v1.0.0-beta.0` d'Astro ne contenait aucune modification non rétrocompatible. Vous trouverez ci-dessous de petits changements introduits pendant la période bêta.
 
 ### Modifié : Flux RSS
 
@@ -190,7 +190,7 @@ Les flux RSS doivent maintenant être générés à l'aide du paquet `@astrojs/r
 
 Notre API de configuration a été repensée pour résoudre quelques points de confusion flagrants qui s'étaient accumulés au cours de l'année dernière. La plupart des options de configuration viennent d'être déplacées ou renommées, ce qui, espérons-le, constituera une mise à jour rapide pour la plupart des utilisateurs. Quelques options ont été remaniées plus en profondeur et peuvent nécessiter quelques modifications supplémentaires :
 
-- `.buildOptions.site` a été remplacé par `.site` (votre domaine déployé) et un nouvelle option `.base` (votre sous-chemin déployé).
+- `.buildOptions.site` a été remplacé par `.site` (votre domaine déployé) et une nouvelle option `.base` (votre sous-chemin déployé).
 - `.markdownOptions` a été remplacé par `.markdown`, un objet de configuration essentiellement similaire avec quelques petites modifications pour simplifier la configuration de Markdown.
 - `.sitemap` a été déplacé dans l'intégration [@astrojs/sitemap](https://www.npmjs.com/package/@astrojs/sitemap).
 
@@ -200,11 +200,11 @@ Consultez notre [RFC0019](https://github.com/withastro/rfcs/blob/main/proposals/
 
 ### Nouvelle API Markdown
 
-Astro v0.26 publie une toute nouvelle API Markdown pour votre contenu. Cela comprenait trois changements majeurs destinés aux utilisateurs :
+Astro v0.26 publie une toute nouvelle API Markdown pour votre contenu. Cela comprenait trois changements majeurs pour les utilisateurs :
 - Vous pouvez désormais importer du contenu Markdown directement à l'aide d'une importation ESM (`import`/`import()`).
-- Une nouvelle API `Astro.glob()`, pour des importations globales plus faciles (notamment pour Markdown).
-- **CHANGEMENT DE RUPTURE :** `Astro.fetchContent()` a été supprimé et remplacé par `Astro.glob()`
-- **CHANGEMENT DE RUPTURE :** Les objets Markdown ont une interface mise à jour.
+- Une nouvelle API `Astro.glob()`, pour des importations glob plus faciles (notamment pour Markdown).
+- **CHANGEMENT NON RÉTROCOMPATIBLE :** `Astro.fetchContent()` a été supprimé et remplacé par `Astro.glob()`
+- **CHANGEMENT NON RÉTROCOMPATIBLE :** Les objets Markdown ont une interface mise à jour.
 
 ```js del={2} ins={4}
 // v0.25
@@ -225,8 +225,8 @@ Les balises `<script>` dans les composants Astro sont désormais créées, regro
 
 Cela inclut quelques changements à prendre en compte :
 
-- **RUPTURE :** `<script hoist>` est le nouveau comportement par défaut de `<script>`. L'attribut `hoist` a été supprimé. Pour utiliser le nouveau comportement par défaut, assurez-vous qu'il n'y a pas d'autres attributs sur la balise `<script>`. Par exemple, supprimez `type="module"` si vous l'utilisiez auparavant.
-- Nouvelle directive `<script is:inline>`, pour rétablir le comportement par défaut d'une balise `<script>` (non construit, dégroupé, non modifié par Astro).
+- **NON RÉTROCOMPATIBLE :** `<script hoist>` est le nouveau comportement par défaut de `<script>`. L'attribut `hoist` a été supprimé. Pour utiliser le nouveau comportement par défaut, assurez-vous qu'il n'y a pas d'autres attributs sur la balise `<script>`. Par exemple, supprimez `type="module"` si vous l'utilisiez auparavant.
+- Nouvelle directive `<script is:inline>`, pour rétablir le comportement par défaut d'une balise `<script>` (non compilé, dégroupé, non modifié par Astro).
 - Nouvelle directive `<style is:inline>`, pour laisser une balise de style en ligne dans le modèle de page (similaire au comportement `<script>` précédent).
 - Nouvelle directive `<style is:global>` pour remplacer `<style global>` dans une prochaine version.
 
@@ -255,7 +255,7 @@ Consultez notre [RFC0018](https://github.com/withastro/rfcs/blob/main/proposals/
 
 ### Autres changements
 
-- Amélioration de l'API `Astro.slots` pour prendre en charge la transmission d'arguments aux emplacements basés sur des fonctions. Cela permet la création de composants utilitaires plus ergonomiques qui acceptent une fonction de rappel en tant qu'enfant.
+- Amélioration de l'API `Astro.slots` pour prendre en charge la transmission d'arguments aux slots basés sur des fonctions. Cela permet la création de composants utilitaires plus ergonomiques qui acceptent une fonction de rappel en tant qu'enfant.
 - Mise à jour du formatage de la sortie CLI, en particulier en ce qui concerne le rapport d'erreurs.
 - Mise à jour de `@astrojs/compiler`, corrigeant quelques bugs liés à l'utilisation de RegExp dans frontmatter
 
@@ -263,17 +263,16 @@ Consultez notre [RFC0018](https://github.com/withastro/rfcs/blob/main/proposals/
 
 ### Les intégrations Astro
 
-La configuration des « moteurs de rendu » a été remplacée par un nouveau système d'intégration officiel ! Cela débloque de nouvelles fonctionnalités vraiment intéressantes pour Astro. Vous pouvez lire notre guide [Utilisation des intégrations](/fr/guides/integrations-guide/) pour obtenir plus de détails sur l'utilisation de ce nouveau système.
+La configuration des moteurs de rendu (`renderers`) a été remplacée par un nouveau système d'intégration officiel ! Cela débloque de nouvelles fonctionnalités vraiment intéressantes pour Astro. Vous pouvez lire notre guide sur l'[utilisation des intégrations](/fr/guides/integrations-guide/) pour obtenir plus de détails sur l'utilisation de ce nouveau système.
 
-Les intégrations remplacent notre concept original de « moteurs de rendu » et s'accompagnent de quelques modifications importantes et de nouveaux paramètres par défaut pour les utilisateurs existants. Ces changements sont traités ci-dessous.
+Les intégrations remplacent notre concept original de moteurs de rendu (`renderers`) et s'accompagnent de quelques changements non rétrocompatibles et de nouveaux paramètres par défaut pour les utilisateurs existants. Ces changements sont traités ci-dessous.
 
-#### Supprimé : Support intégré de frameworks
+#### Supprimé : Prise en charge intégrée de frameworks
 
 Auparavant, React, Preact, Svelte et Vue étaient tous inclus par défaut avec Astro. À partir de la version 0.25.0, Astro ne propose plus de moteur de rendu intégré. Si vous n'aviez pas d'entrée de configuration `renderers` déjà définie pour votre projet, vous devrez maintenant installer ces frameworks vous-même.
 
 Lisez notre [procédure étape par étape](/fr/guides/integrations-guide/) pour savoir comment ajouter une nouvelle intégration Astro pour le(s) framework(s) que vous utilisez actuellement.
-
-#### Obsolète : Moteurs de rendu
+#### Déprécié : Moteurs de rendu
 
 :::note
 Lisez cette section si vous avez des « moteurs de rendu » personnalisés déjà définis dans votre fichier de configuration.
@@ -287,14 +286,14 @@ Pour une procédure pas à pas plus approfondie, lisez notre [guide étape par �
 
 ```shell add={3-4}
 # Installez vos nouvelles intégrations et frameworks :
-# (Lisez la procédure complète : https://docs.astro.build/fr/guides/integrations-guide)
+# (Consultez la procédure complète : https://docs.astro.build/fr/guides/integrations-guide)
 npm install @astrojs/lit lit
 npm install @astrojs/react react react-dom
 ```
 
 ```js ins={3-4,8} del={7}
 // Ensuite, mettez à jour votre fichier `astro.config.mjs` :
-// (Lisez la procédure complète : https://docs.astro.build/fr/guides/integrations-guide)
+// (Consultez la procédure complète : https://docs.astro.build/fr/guides/integrations-guide)
 import lit from '@astrojs/lit';
 import react from '@astrojs/react';
 
@@ -304,7 +303,7 @@ export default {
 }
 ```
 
-| Moteurs de rendu obsolètes sur npm | Intégrations v0.25+ sur npm |
+| Moteurs de rendu dépréciés sur npm | Intégrations v0.25+ sur npm |
 | ---------------------------------- | --------------------------- |
 | @astrojs/renderer-react            | @astrojs/react              |
 | @astrojs/renderer-preact           | @astrojs/preact             |
@@ -329,7 +328,7 @@ Si vous voyez un avertissement `"Cannot find package 'react'"` (ou similaire) lo
 
 Si vous utilisez `npm` et Node v16+, cela peut être automatiquement géré pour vous par `npm`, puisque la dernière version de `npm` (v7+) installe automatiquement des dépendances homologues comme celle-ci. Dans ce cas, l'installation d'un framework tel que « React » dans votre projet est une étape facultative mais néanmoins recommandée.
 
-### Mis à jour : Coloration syntaxique
+### Mise à jour : Coloration syntaxique
 
 Nous aimons trouver des valeurs par défaut sensées qui « fonctionnent » dès le départ. Dans ce cadre, nous avons décidé de faire de [Shiki](https://github.com/shikijs/shiki) notre nouveau colorateur de syntaxe par défaut. Celui-ci est préconfiguré avec le thème `github-dark`, fournissant une coloration sans configuration de vos blocs de code, et cela sans ajouter de classes CSS, feuilles de style ou JS côté client superflus.
 
@@ -350,20 +349,19 @@ import { Prism } from '@astrojs/prism';
 ### Mise à niveau de l'analyseur CSS
 
 Notre analyseur CSS interne a été mis à jour et offre une meilleure prise en charge de la syntaxe CSS avancée, comme les requêtes de conteneur. Cela devrait être un changement pratiquement invisible pour la plupart des utilisateurs, mais nous espérons que les utilisateurs avancés apprécieront la prise en charge des nouvelles fonctionnalités CSS.
-
 ## Migration vers la v0.24
 
 :::note
-La nouvelle stratégie de construction est activée par défaut sur 0.24. Si vous rencontrez un problème, vous pouvez continuer à utiliser l'ancienne stratégie de construction en passant l'indicateur `--legacy-build`. Veuillez [ouvrir un ticket](https://github.com/withastro/astro/issues/new/choose) afin que nous puissions résoudre les problèmes liés à la nouvelle stratégie de construction.
+La nouvelle stratégie de compilation est activée par défaut sur 0.24. Si vous rencontrez un problème, vous pouvez continuer à utiliser l'ancienne stratégie de compilation en transmettant l'option `--legacy-build`. Veuillez [ouvrir un ticket](https://github.com/withastro/astro/issues/new/choose) afin que nous puissions résoudre les problèmes liés à la nouvelle stratégie de compilation.
 :::
 
-La version 0.24 a introduit une nouvelle stratégie de *construction statique* qui modifie le comportement de quelques fonctionnalités. Dans les versions précédentes d'Astro, ce comportement était disponible avec un indicateur d'adhésion : `--experimental-static-build`.
+La version 0.24 a introduit une nouvelle stratégie de *compilation statique* qui modifie le comportement de quelques fonctionnalités. Dans les versions précédentes d'Astro, ce comportement était disponible avec une option d'adhésion : `--experimental-static-build`.
 
-Pour être prêt pour la transition, soyez conscient des modifications suivantes qui seront nécessaires pour passer à ce nouveau moteur de construction. Vous pouvez apporter ces modifications à votre base de code à tout moment afin d'être prêt plus tôt que prévu.
+Pour être prêt pour la transition, soyez conscient des modifications suivantes qui seront nécessaires pour passer à ce nouveau moteur de compilation. Vous pouvez apporter ces modifications à votre base de code à tout moment afin d'être prêt plus tôt que prévu.
 
-### Obsolète : `Astro.resolve()`
+### Déprécié : `Astro.resolve()`
 
-`Astro.resolve()` vous permet d'obtenir des URL résolues vers des ressources que vous pourriez vouloir référencer dans le navigateur. Ceci était le plus couramment utilisé à l'intérieur des balises `<link>` et `<img>` pour charger des fichiers CSS et des images selon les besoins. Malheureusement, cela ne fonctionnera plus car Astro construit désormais les ressources au *moment de la construction* plutôt qu'au *moment du rendu*. Vous souhaiterez mettre à niveau les références de vos ressources vers l’une des options évolutives suivantes disponibles à l’avenir :
+`Astro.resolve()` vous permet d'obtenir des URL résolues vers des ressources que vous pourriez vouloir référencer dans le navigateur. Ceci était le plus couramment utilisé à l'intérieur des balises `<link>` et `<img>` pour charger des fichiers CSS et des images selon les besoins. Malheureusement, cela ne fonctionnera plus car Astro génère désormais les ressources au *moment de la compilation* plutôt qu'au *moment du rendu*. Vous souhaiterez mettre à niveau les références de vos ressources vers l’une des options évolutives suivantes disponibles à l’avenir :
 
 #### Comment résoudre les fichiers CSS
 
@@ -372,7 +370,7 @@ Pour être prêt pour la transition, soyez conscient des modifications suivantes
 **Exemple :** `import './style.css';`  
 **Quand l'utiliser :** Si votre fichier CSS réside dans le répertoire `src/` et que vous souhaitez des fonctionnalités automatiques de création et d'optimisation CSS.
 
-Utilisez une importation ESM pour ajouter du CSS à la page. Astro détecte ces importations CSS, puis construit, optimise et ajoute automatiquement le CSS à la page. C'est le moyen le plus simple de migrer depuis `Astro.resolve()` tout en conservant la création/regroupement automatique fourni par Astro.
+Utilisez une importation ESM pour ajouter du CSS à la page. Astro détecte ces importations CSS, puis compile, optimise et ajoute automatiquement le CSS à la page. C'est le moyen le plus simple de migrer depuis `Astro.resolve()` tout en conservant la création/regroupement automatique fourni par Astro.
 
 ```astro
 ---
@@ -415,7 +413,7 @@ Notez que cette approche ignore le traitement, le regroupement et les optimisati
 **Exemple :** `<script hoist>import './some-external-script.js';</script>`  
 **Quand l'utiliser :** Si votre script externe réside à l'intérieur de `src/` _et_ s'il prend en charge le type de module ESM.
 
-Utilisez une importation ESM à l'intérieur d'un élément `<script hoist>` dans votre modèle Astro, et Astro inclura le fichier JavaScript dans votre version finale. Astro détecte ces importations JavaScript côté client, puis crée, optimise et ajoute automatiquement le JavaScript à la page. C'est le moyen le plus simple de migrer depuis `Astro.resolve()` tout en conservant la création/le regroupement automatique fourni par Astro.
+Utilisez une importation ESM à l'intérieur d'un élément `<script hoist>` dans votre modèle Astro, et Astro inclura le fichier JavaScript dans votre version finale. Astro détecte ces importations JavaScript côté client, puis compile, optimise et ajoute automatiquement le JavaScript à la page. C'est le moyen le plus simple de migrer depuis `Astro.resolve()` tout en conservant la création/le regroupement automatique fourni par Astro.
 
 ```astro
 <script hoist>
@@ -427,7 +425,7 @@ Notez qu'Astro regroupera ce script externe avec le reste de votre JavaScript c�
 
 #### Comment résoudre les images et autres ressources
 
-**1. Chemin d'URL absolu (Recommended)**
+**1. Chemin d'URL absolu (Recommandé)**
 
 **Exemple :** `<img src="/penguin.png">`  
 **Quand l'utiliser :** Si votre ressource réside à l'intérieur de `public/`.
@@ -449,11 +447,11 @@ import imgUrl from './penguin.png';
 <img src={imgUrl} />
 ```
 
-De la même manière qu'Astro gère CSS, l'importation ESM permet à Astro d'effectuer automatiquement quelques optimisations de construction simples. Par exemple, toute ressource à l'intérieur de `src/` qui est importée à l'aide d'une importation ESM (ex : `import imgUrl from './penguin.png'`) verra son nom de fichier haché automatiquement. Cela peut vous permettre de mettre en cache le fichier de manière plus agressive sur le serveur, améliorant ainsi les performances de l'utilisateur. À l’avenir, Astro pourrait ajouter d’autres optimisations comme celle-ci.
+De la même manière qu'Astro gère CSS, l'importation ESM permet à Astro d'effectuer automatiquement quelques optimisations de compilation simples. Par exemple, toute ressource à l'intérieur de `src/` qui est importée à l'aide d'une importation ESM (ex : `import imgUrl from './penguin.png'`) verra son nom de fichier haché automatiquement. Cela peut vous permettre de mettre en cache le fichier de manière plus agressive sur le serveur, améliorant ainsi les performances de l'utilisateur. À l’avenir, Astro pourrait ajouter d’autres optimisations comme celle-ci.
 
 **Astuce :** Si vous n'aimez pas les importations ESM statiques, Astro prend également en charge les importations ESM dynamiques. Nous ne recommandons cette option que si vous préférez cette syntaxe : `<img src={(await import('./penguin.png')).default} />`.
 
-### Obsolète : Traitement par défaut de `<script>`
+### Déprécié : Traitement par défaut de `<script>`
 
 Auparavant, tous les éléments `<script>` étaient lus à partir de la sortie HTML finale et traités + regroupés automatiquement. Ce comportement n'est plus le comportement par défaut. À partir de la version 0.24, vous devez accepter le traitement des éléments `<script>` via l'attribut `hoist`. Le `type="module"` est également requis pour les modules remontés.
 
@@ -477,10 +475,10 @@ Preprocessor dependency "sass" not found. Did you install it?
 
 Dans notre quête visant à réduire la taille de l'installation via NPM, nous avons déplacé [Sass](https://sass-lang.com/) vers une dépendance facultative. Si vous utilisez Sass dans votre projet, vous devez vous assurer d'exécuter `npm install sass --save-dev` pour l'enregistrer en tant que dépendance.
 
-### Obsolète : HTML sans échappement
+### Déprécié : HTML sans échappement
 
-Dans Astro v0.23+, le contenu HTML non échappé dans les expressions est désormais obsolète.
-Dans les versions futures, le contenu des expressions aura des chaînes échappées pour se protéger contre toute injection HTML involontaire.
+Dans Astro v0.23+, le contenu HTML non échappé dans les expressions est désormais déprécié.
+Dans les versions futures, le contenu des expressions aura des chaînes de caractères échappées pour se protéger contre toute injection HTML involontaire.
 
 ```astro del={1} ins={2}
 <h1>{title}</h1> <!-- <h1>Hello <strong>World</strong></h1> -->
@@ -528,9 +526,9 @@ export default {
 
 Pour en savoir plus sur la configuration de Vite, veuillez visiter leur [guide de configuration](https://vite.dev/config/).
 
-#### Les extensions de Vite
+#### Les modules d'extension de Vite
 
-Dans Astro v0.21+, les plugins Vite peuvent être configurés dans `astro.config.mjs`.
+Dans Astro v0.21+, les modules d'extension de Vite peuvent être configurés dans `astro.config.mjs`.
 
 ```js ins={4-6}
 import { imagetools } from 'vite-imagetools';
@@ -542,11 +540,11 @@ export default {
 };
 ```
 
-Pour en savoir plus sur les plugins Vite, veuillez consulter leur [guide des plugins](https://vite.dev/guide/using-plugins.html).
+Pour en savoir plus sur les modules d'extension de Vite, veuillez consulter leur [guide des modules d'extension](https://vite.dev/guide/using-plugins.html).
 
 #### Modifications apportées par Vite aux moteurs de rendu
 
-Dans Astro v0.21+, les plugins doivent désormais utiliser `viteConfig()`.
+Dans Astro v0.21+, les modules d'extension doivent désormais utiliser `viteConfig()`.
 
 ```js del={8-9} ins={2,10-23}
 // renderer-svelte/index.js
@@ -575,7 +573,7 @@ export default {
 }
 ```
 
-Pour en savoir plus sur les plugins Vite, veuillez consulter leur [guide des plugins](https://vite.dev/guide/using-plugins.html).
+Pour en savoir plus sur les modules d'extension de Vite, veuillez consulter leur [guide des modules d'extension](https://vite.dev/guide/using-plugins.html).
 
 :::note
 Dans les versions précédentes, ceux-ci étaient configurés avec `snowpackPlugin` ou `snowpackPluginOptions`.
@@ -595,8 +593,6 @@ Dans Astro v0.21+, des alias d'importation peuvent être ajoutés dans `tsconfig
   }
 }
 ```
-
-_Ces alias sont intégrés automatiquement dans [VSCode](https://code.visualstudio.com/docs/languages/jsconfig) et d'autres éditeurs._
 
 ### Extensions de fichiers dans les importations
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of `upgrade-to/v1.mdx` based on #11593 and #11795
* update the translation of `breaking changes`, `upgrade`, `deprecated`, `flag`
* replace `stylisé` with `mise en forme`
* replace `construction` with `compilation where more appropriate`
* remove `glob` translation
* translate `plugin`
* tiny fixes and rewording to make the reading easier

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
