### PR TITLE
i18n(fr): improve the wording in `upgrade-to/v2.mdx`

### DIFF
--- a/src/content/docs/fr/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v2.mdx
@@ -1,6 +1,6 @@
 ---
-title: Mise à jour vers Astro v2
-description: Comment mettre à jour votre projet vers la dernière version d'Astro.
+title: Mise à niveau vers Astro v2
+description: Comment mettre à niveau votre projet vers la dernière version d'Astro.
 sidebar:
   label: v2.0
 i18nReady: true
@@ -11,11 +11,11 @@ import { Steps } from '@astrojs/starlight/components';
 
 Ce guide vous aidera à effectuer la migration à partir d'Astro v1 vers Astro v2.
 
-Vous avez besoin de mettre à jour un projet plus vieux vers la v1 ? Consultez notre [ancien guide de migration](/fr/guides/upgrade-to/v1/).
+Vous avez besoin de mettre à niveau un projet plus vieux vers la v1 ? Consultez notre [ancien guide de migration](/fr/guides/upgrade-to/v1/).
 
-## Mettre à jour Astro
+## Mettre à niveau Astro
 
-Mettez à jour la version d'Astro de votre projet vers la dernière version à l'aide de votre gestionnaire de packages. Si vous utilisez les intégrations Astro, veuillez également les mettre à jour vers la dernière version.
+Mettez à jour la version d'Astro de votre projet vers la dernière version à l'aide de votre gestionnaire de paquets. Si vous utilisez les intégrations Astro, veuillez également les mettre à jour vers la dernière version.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -23,7 +23,7 @@ Mettez à jour la version d'Astro de votre projet vers la dernière version à l
   # Mise à niveau vers Astro v2.x
   npm install astro@latest
   
-  # Exemple : mettre à jour les intégrations React et Tailwind
+  # Exemple : mettre à niveau les intégrations React et Tailwind
   npm install @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
@@ -32,7 +32,7 @@ Mettez à jour la version d'Astro de votre projet vers la dernière version à l
   # Mise à niveau vers Astro v2.x
   pnpm add astro@latest
 
-  # Exemple : mettre à jour les intégrations React et Tailwind
+  # Exemple : mettre à niveau les intégrations React et Tailwind
   pnpm add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
@@ -41,15 +41,15 @@ Mettez à jour la version d'Astro de votre projet vers la dernière version à l
   # Mise à niveau vers Astro v2.x
   yarn add astro@latest
   
-  # Exemple : mettre à jour les intégrations React et Tailwind
+  # Exemple : mettre à niveau les intégrations React et Tailwind
   yarn add @astrojs/react@latest @astrojs/tailwind@latest
   ```
   </Fragment>
 </PackageManagerTabs>
 
-## Changements majeurs d'Astro v2.0
+## Changements non rétrocompatibles dans Astro v2.0
 
-Astro v2.0 inclut quelques modifications majeures, ainsi que la suppression de certaines fonctionnalités précédemment obsolètes. Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 2.0, consultez ce guide pour avoir un aperçu de toutes les modifications majeures et pour obtenir des instructions sur la façon de mettre à jour votre base de code.
+Astro v2.0 inclut quelques modifications majeures avec rupture de compatibilité, ainsi que la suppression de certaines fonctionnalités précédemment dépréciées. Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 2.0, consultez ce guide pour obtenir un aperçu de tous les changements non rétrocompatibles et des instructions sur la façon de mettre à jour votre base de code.
 
 Consultez [le journal des modifications](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md) pour accéder aux notes de version complètes.
 
@@ -105,11 +105,11 @@ export default defineConfig({
 });
 ```
 
-### Modifié : un dossier `_astro/` dédié aux ressources de construction
+### Modifié : un dossier `_astro/` dédié aux ressources générées
 
-Dans la version 1.x, les ressources étaient construites à divers emplacements, notamment `assets/`, `chunks/` et la racine de la sortie de construction.
+Dans la version 1.x, les ressources étaient générées à divers emplacements, notamment dans `assets/`, dans `chunks/` et à la racine de la sortie de compilation.
 
-Astro v2.0 déplace et unifie l'emplacement de toutes les ressources générées lors de la construction vers un nouveau dossier `_astro/`.
+Astro v2.0 déplace et unifie l'emplacement de toutes les ressources générées lors de la compilation vers un nouveau dossier `_astro/`.
 
 <FileTree>
 - dist/
@@ -124,15 +124,15 @@ Vous pouvez contrôler cet emplacement avec la [nouvelle option de configuration
 
 Mettez à jour la configuration de votre plateforme de déploiement si elle dépend de l'emplacement de ces ressources.
 
-### Modifié : configuration de l'extension Markdown
+### Modifié : configuration des modules d'extension Markdown
 
 #### Supprimé : `extendDefaultPlugins`
 
-Dans la v1.x, Astro utilisait `markdown.extendDefaultPlugins` pour réactiver les plugins par défaut d'Astro lors de l'ajout de vos propres plugins Markdown.
+Dans la v1.x, Astro utilisait `markdown.extendDefaultPlugins` pour réactiver les modules d'extension par défaut d'Astro lors de l'ajout de vos propres modules d'extension Markdown.
 
 Astro v2.0 supprime entièrement cette option de configuration puisqu'il s'agit désormais du comportement par défaut.
 
-L'application d'extensions Remark et Rehype dans votre configuration Markdown **ne désactive plus les extensions par défaut d'Astro**. GitHub-Flavored Markdown et Smartypants sont désormais appliqués, que vous personnalisiez ou non `remarkPlugins` et `rehypePlugins`.
+L'application de modules d'extension Remark et Rehype dans votre configuration Markdown **ne désactive plus les modules d'extension par défaut d'Astro**. GitHub-Flavored Markdown et Smartypants sont désormais appliqués, que vous personnalisiez ou non `remarkPlugins` et `rehypePlugins`.
 
 ##### Que devrais-je faire ?
 
@@ -151,13 +151,13 @@ export default defineConfig({
 
 #### Ajouté : `gfm` et `smartypants`
 
-Dans la v1.x, vous pouviez choisir de désactiver les deux extensions Markdown (GitHub-Flavored Markdown et SmartyPants) intégrées par défaut dans Astro en définissant `markdown.extendDefaultPlugins: false`.
+Dans la v1.x, vous pouviez choisir de désactiver les deux modules d'extensions Markdown (GitHub-Flavored Markdown et SmartyPants) intégrées par défaut dans Astro en définissant `markdown.extendDefaultPlugins: false`.
 
-Astro v2.0 remplace `markdown.extendDefaultPlugins: false` par des options booléennes distinctes pour contrôler individuellement chacune des extensions Markdown intégrées par défaut dans Astro. Ces options sont activées par défaut et peuvent être définies sur `false` indépendamment.
+Astro v2.0 remplace `markdown.extendDefaultPlugins: false` par des options booléennes distinctes pour contrôler individuellement chacun des modules d'extension Markdown intégrées par défaut dans Astro. Ces options sont activées par défaut et peuvent être définies sur `false` indépendamment.
 
 ##### Que devrais-je faire ?
 
-Supprimez `extendDefaultPlugins: false` et ajoutez les indicateurs pour désactiver chaque plugin individuellement.
+Supprimez `extendDefaultPlugins: false` et ajoutez les options pour désactiver chaque module d'extension individuellement.
 
 - `markdown.gfm: false` désactive GitHub-Flavored Markdown
 - `markdown.smartypants: false` désactive SmartyPants
@@ -175,11 +175,11 @@ export default defineConfig({
 });
 ```
 
-### Modifié : configuration du plugin MDX
+### Modifié : configuration des modules d'extension MDX
 
 #### Remplacé : `extendPlugins` a été remplacé par `extendMarkdownConfig`
 
-Dans la v1.x, l'option `extendPlugins` de l'intégration MDX gérait la façon dont vos fichiers MDX devaient hériter de votre configuration Markdown : toute votre configuration Markdown (`markdown`), ou les plugins par défaut d'Astro uniquement (`default`).
+Dans la v1.x, l'option `extendPlugins` de l'intégration MDX gérait la façon dont vos fichiers MDX devaient hériter de votre configuration Markdown : toute votre configuration Markdown (`markdown`), ou les modules d'extension par défaut d'Astro uniquement (`default`).
 
 Astro v2.0 remplace le comportement contrôlé par `mdx.extendPlugins` par trois nouvelles options configurables indépendamment qui sont définies sur `true` par défaut :
 
@@ -205,7 +205,7 @@ export default defineConfig({
 });
 ```
 
-Remplacez `extendPlugins : 'defaults'` par `extendMarkdownConfig: false` et ajoutez les options distinctes pour GitHub-Flavored Markdown et SmartyPants pour activer ces plugins par défaut individuellement dans MDX.
+Remplacez `extendPlugins: 'defaults'` par `extendMarkdownConfig: false` et ajoutez les options distinctes pour GitHub-Flavored Markdown et SmartyPants pour activer ces modules d'extension par défaut individuellement dans MDX.
 
 ```js del={8} ins={9-11}
 // astro.config.mjs
@@ -251,19 +251,19 @@ export default defineConfig({
 
 Revisitez votre configuration Markdown et MDX et comparez votre configuration existante avec les nouvelles options disponibles.
 
-### Modifié : accès du plugin au frontmatter
+### Modifié : accès des modules d'extension au frontmatter
 
-Dans la version 1.x, les extensions Remark et Rehype n'avaient pas accès au frontmatter de l'utilisateur. Astro a fusionné le frontmatter de des extensions avec le frontmatter de votre fichier, sans transmettre ce dernier à vos extensions.
+Dans la version 1.x, les modules d'extension Remark et Rehype n'avaient pas accès au frontmatter de l'utilisateur. Astro fusionnait le frontmatter des modules d'extension avec le frontmatter de votre fichier, sans transmettre ce dernier à vos modules d'extension.
 
-Astro v2.0 donne aux extensions Remark et Rehype l'accès au frontmatter de l'utilisateur via l'injection de frontmatter. Cela permet aux auteurs d' extensions de modifier le frontmatter existant d'un utilisateur ou de calculer de nouvelles propriétés basées sur d'autres propriétés.
+Astro v2.0 donne aux modules d'extension Remark et Rehype l'accès au frontmatter de l'utilisateur via l'injection de frontmatter. Cela permet aux auteurs de modules d'extension de modifier le frontmatter existant d'un utilisateur ou de calculer de nouvelles propriétés basées sur d'autres propriétés.
 
 #### Que devrais-je faire ?
 
-Vérifiez toutes les extensions Remark et Rehype que vous avez écrites pour voir si leur comportement a changé. Notez que `data.astro.frontmatter` est désormais le frontmatter _complet_ du document Markdown ou MDX, plutôt qu'un objet vide.
+Vérifiez tous les modules d'extension Remark et Rehype que vous avez écrites pour voir si leur comportement a changé. Notez que `data.astro.frontmatter` est désormais le frontmatter _complet_ du document Markdown ou MDX, plutôt qu'un objet vide.
 
 ### Modifié : Configuration RSS
 
-Dans la v1.x, le paquet RSS d'Astro vous permettait d'utiliser `items: import.meta.glob(...)` pour générer une liste d'éléments de flux RSS. Cette utilisation est désormais obsolète et sera éventuellement supprimée.
+Dans la v1.x, le paquet RSS d'Astro vous permettait d'utiliser `items: import.meta.glob(...)` pour générer une liste d'éléments de flux RSS. Cette utilisation est désormais dépréciée et sera éventuellement supprimée.
 
 Astro v2.0 introduit une enveloppe `pagesGlobToRssItems()` à la propriété `items`.
 
@@ -286,9 +286,9 @@ export async function get(context) {
 }
 ```
 
-### Modifié : prise en charge de Svelte IDE
+### Modifié : prise en charge de Svelte dans les IDE
 
-Astro v2.0 nécessite un fichier `svelte.config.js` dans votre projet si vous utilisez [l'intégration `@astrojs/svelte`](/fr/guides/integrations-guide/svelte/). Ceci est nécessaire pour fournir l’auto-complétion de l’IDE.
+Astro v2.0 nécessite un fichier `svelte.config.js` dans votre projet si vous utilisez [l'intégration `@astrojs/svelte`](/fr/guides/integrations-guide/svelte/). Ceci est nécessaire pour fournir l’auto-complétion dans l’IDE.
 
 #### Que devrais-je faire ?
 
@@ -313,7 +313,7 @@ Astro v2.0 supprime complètement l'option `legacy.astroFlavoredMarkdown`. L'imp
 
 #### Que devrais-je faire ?
 
-Supprimez cet indicateur hérité. Il n'est plus disponible dans Astro.
+Supprimez cette option héritée. Elle n'est plus disponible dans Astro.
 
 ```js del={3-5}
 // astro.config.mjs
@@ -329,7 +329,7 @@ Si vous utilisiez cette fonctionnalité dans la v1.x, nous vous recommandons [d'
 
 ### Supprimé : `Astro.resolve()`
 
-Dans la version 0.24, Astro a rendu obsolète `Astro.resolve()` pour obtenir des URL résolues vers des ressources que vous pourriez vouloir référencer dans le navigateur.
+Dans la version 0.24, Astro a déprécié `Astro.resolve()` pour obtenir des URL résolues vers des ressources que vous pourriez vouloir référencer dans le navigateur.
 
 Astro v2.0 supprime complètement cette option. La présence d'`Astro.resolve()` dans votre code provoquera une erreur.
 
@@ -349,7 +349,7 @@ import imageUrl from './image.png';
 
 ### Supprimé : `Astro.fetchContent()`
 
-Dans la version 0.26, Astro a rendu obsolète `Astro.fetchContent()` pour récupérer les données de vos fichiers Markdown locaux.
+Dans la version 0.26, Astro a déprécié `Astro.fetchContent()` pour récupérer les données de vos fichiers Markdown locaux.
 
 Astro v2.0 supprime complètement cette option. La présence d'`Astro.fetchContent()` dans votre code provoquera une erreur.
 
@@ -366,7 +366,7 @@ const allPosts = await Astro.glob('./posts/*.md');
 
 ### Supprimé : `Astro.canonicalURL`
 
-Dans la version 1.0, Astro a rendu obsolète `Astro.canonicalURL` pour construire une URL canonique.
+Dans la version 1.0, Astro a déprécié `Astro.canonicalURL` pour construire une URL canonique.
 
 Astro v2.0 supprime complètement cette option. La présence d'`Astro.canonicalURL` dans votre code provoquera une erreur.
 
@@ -382,7 +382,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 ```
 
-### Mise à jour : Vite 4
+### Mis à jour : Vite 4
 
 Astro v2.0 passe de Vite 3 à [Vite 4](https://vite.dev/), sorti en Décembre 2022.
 
@@ -392,9 +392,9 @@ Aucune modification de votre code ne devrait être nécessaire ! Nous avons gé
 
 Reportez-vous au [Guide de migration Vite](https://vite.dev/guide/migration.html) officiel si vous rencontrez des problèmes.
 
-## Indicateurs expérimentaux supprimés dans Astro v2.0
+## Options expérimentales supprimées dans Astro v2.0
 
-Supprimez les indicateurs expérimentaux suivants de `astro.config.mjs` :
+Supprimez les options expérimentales suivantes de `astro.config.mjs` :
 
 ```js del={5-9}
 // astro.config.mjs


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of `upgrade-to/v2.mdx` based on #11593 and #11795
* update the translation of `breaking changes`, `upgrade`, `deprecated`, `flag`
* replace the translation of `build` where more appropriate
* translate `plugins`
* tiny fixes and rewording to make the reading easier

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
