### PR TITLE
i18n(fr): improve the wording in `upgrade-to/v3.mdx`

### DIFF
--- a/src/content/docs/fr/guides/upgrade-to/v3.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v3.mdx
@@ -1,6 +1,6 @@
 ---
-title: Mise à jour vers Astro v3
-description: Comment mettre à jour votre projet vers la dernière version d'Astro (v3.0).
+title: Mise à niveau vers Astro v3
+description: Comment mettre à niveau votre projet vers la dernière version d'Astro (v3.0).
 sidebar:
   label: v3.0
 i18nReady: true
@@ -52,9 +52,9 @@ Après avoir mis à niveau Astro vers la dernière version, vous n’aurez peut-
 Mais si vous remarquez des erreurs ou un comportement inattendu, veuillez vérifier ci-dessous ce qui a changé et qui pourrait nécessiter une mise à jour dans votre projet.
 :::
 
-## Indicateurs expérimentaux supprimés dans Astro v3.0
+## Options expérimentales supprimées dans Astro v3.0
 
-Supprimez les indicateurs expérimentaux suivants dans `astro.config.mjs` :
+Supprimez les options expérimentales suivantes dans `astro.config.mjs` :
 
 ```js del={5-8}
 // astro.config.mjs
@@ -70,14 +70,14 @@ export default defineConfig({
 
 Ces fonctionnalités sont désormais disponibles par défaut :
 
-- Les Transitions de Vue pour des transitions de page animées et des îles persistants. Consultez [les modifications cassantes liées à l'API des Transitions de Vue et les conseils de mise à niveau](#mettre-à-niveau-les-transitions-de-vue-vers-la-v3) si vous utilisiez cet indicateur expérimental.
-- Une nouvelle API de services d'images `astro:assets` pour utiliser des images dans Astro, comprenant un nouveau composant `<Image />` et une fonction `getImage()`. Veuillez lire les [conseils détaillés de mise à niveau pour vos images](#mettre-à-niveau-les-images-vers-la-v3) **que vous utilisiez ou non cet indicateur expérimental** pour voir comment cela pourrait affecter votre projet.
+- Les Transitions de Vue pour des transitions de page animées et des îlots persistants. Consultez [les changements non rétrocompatibles liés à l'API des Transitions de Vue et les conseils de mise à niveau](#mettre-à-niveau-les-transitions-de-vue-vers-la-v3) si vous utilisiez cette option expérimentale.
+- Une nouvelle API de services d'images `astro:assets` pour utiliser des images dans Astro, comprenant un nouveau composant `<Image />` et une fonction `getImage()`. Veuillez lire les [conseils détaillés de mise à niveau pour vos images](#mettre-à-niveau-les-images-vers-la-v3) **que vous utilisiez ou non cette option expérimentale** pour voir comment cela pourrait affecter votre projet.
 
-Apprenez-en davantage sur ces deux fonctionnalités intéressantes et bien plus encore dans [le billet de blog dédié à la v3.0](https://astro.build/blog/astro-3/)!
+Apprenez-en davantage sur ces deux fonctionnalités intéressantes et bien plus encore dans [le billet de blog dédié à la v3.0](https://astro.build/blog/astro-3/) !
 
-## Changements cassants dans Astro v3.0
+## Changements non rétrocompatibles dans Astro v3.0
 
-Astro v3.0 inclut quelques modifications majeures, ainsi que la suppression de certaines fonctionnalités précédemment obsolètes. Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 3.0, consultez ce guide pour un aperçu de toutes les modifications cassantes et des instructions sur la façon de mettre à jour votre base de code.
+Astro v3.0 inclut quelques quelques modifications majeures avec rupture de compatibilité, ainsi que la suppression de certaines fonctionnalités précédemment dépréciées. Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 3.0, consultez ce guide pour obtenir un aperçu de tous les changements non rétrocompatibles et des instructions sur la façon de mettre à jour votre base de code.
 
 Consultez [le journal des modifications](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md) pour les notes de version complètes.
 
@@ -133,7 +133,7 @@ Supprimez l'intégration `@astrojs/image` de votre projet. Vous devrez non seule
 
 Vous trouverez [des instructions complètes et étape par étape pour supprimer l'ancienne intégration d'image](#supprimé-astrojsimage) dans notre guide Images.
 
-La migration vers `astro:assets` apportera également de nouvelles options et fonctionnalités d'image que vous souhaiterez peut-être désormais utiliser. Veuillez consulter l'intégralité des [Conseils de mise à niveau d'image v3.0](#mettre-à-niveau-les-images-vers-la-v3) pour plus de détails !
+La migration vers `astro:assets` apportera également de nouvelles options et fonctionnalités d'image que vous souhaiterez peut-être désormais utiliser. Veuillez consulter l'intégralité des [conseils pour mettre à niveau les images vers la v3.0](#mettre-à-niveau-les-images-vers-la-v3) pour plus de détails !
 
 ```js del={3,7}
 // astro.config.mjs
@@ -149,7 +149,7 @@ export default defineConfig({
 
 ### Supprimé : composant `<Markdown />`
 
-Dans Astro v1.x, Astro a rendu obsolète le composant `<Markdown />` et l'a déplacé vers un paquet externe.
+Dans Astro v1.x, Astro a déprécié le composant `<Markdown />` et l'a déplacé vers un paquet externe.
 
 Astro v3.0 supprime complètement le paquet `@astrojs/markdown-component`. Le composant `<Markdown />` d'Astro ne fonctionnera plus dans votre projet.
 
@@ -167,18 +167,18 @@ Pour continuer à utiliser un composant `<Markdown />` similaire dans votre code
 
 Sinon, supprimez toutes les références d'importation du composant `<Markdown />` d'Astro et du composant lui-même dans vos fichiers `.astro`. Vous devrez réécrire votre contenu directement au format HTML ou [importer Markdown](/fr/guides/markdown-content/#importation-de-markdown) à partir d'un fichier `.md`.
 
-### Supprimé : API obsolètes de la v1.x
+### Supprimé : API dépréciées de la v1.x
 
-Dans Astro v1.x, Astro a rendu obsolète nos paramètres de configuration d'origine ainsi que la prise en charge de `<style global>` et `<script hoist>`. Cependant, ceux-ci étaient toujours pris en charge pour des raisons de rétrocompatibilité.
+Dans Astro v1.x, Astro a déprécié nos paramètres de configuration d'origine ainsi que la prise en charge de `<style global>` et `<script hoist>`. Cependant, ceux-ci étaient toujours pris en charge pour des raisons de rétrocompatibilité.
 
-Astro v3.0 supprime entièrement ces API obsolètes. Les [paramètres de configuration](/fr/reference/configuration-reference/) officiellement pris en charge et les syntaxes modernes `<style is:global>` et `<script>` doivent être utilisées à la place.
+Astro v3.0 supprime entièrement ces API dépréciées. Les [paramètres de configuration](/fr/reference/configuration-reference/) officiellement pris en charge et les syntaxes modernes `<style is:global>` et `<script>` doivent être utilisées à la place.
 
 #### Que devrais-je faire ?
 
 Si vous continuez à utiliser les API v1.x, utilisez plutôt les nouvelles API pour chaque fonctionnalité :
 
-- Options de configuration obsolètes : voir [le guide de migration 0.26](/fr/guides/upgrade-to/v1/#nouvelle-api-de-configuration)
-- Types d'attributs de script/style obsolètes : voir [le guide de migration 0.26](/fr/guides/upgrade-to/v1/#nouveau-comportement-de-script-par-défaut)
+- Options de configuration dépréciées : voir [le guide de migration 0.26](/fr/guides/upgrade-to/v1/#nouvelle-api-de-configuration)
+- Types d'attributs de script/style dépréciés : voir [le guide de migration 0.26](/fr/guides/upgrade-to/v1/#nouveau-comportement-de-script-par-défaut)
 
 ### Supprimé : Shims partiels pour les API Web dans le code serveur
 
@@ -198,7 +198,7 @@ Astro v3.0 supprime entièrement cette exportation.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez l'assistant obsolète `image()` de `astro:content`, supprimez-le car il n'existe plus. Validez les images via [l'assistant `image` de `schema`](#mettre-à-jour-les-schémas-des-collections-de-contenu) à la place :
+Si vous utilisez l'assistant déprécié `image()` du module `astro:content`, supprimez-le car il n'existe plus. Validez les images via [l'assistant `image` de `schema`](#mettre-à-jour-les-schémas-des-collections-de-contenu) à la place :
 
  ```ts title="src/content/config.ts" del={1} ins={2} "({ image })"
 import { defineCollection, z, image } from "astro:content";
@@ -280,12 +280,12 @@ Astro v3.0 supprime la transformation en kebab-case pour ces noms de variables C
 // src/components/MyAstroComponent.astro
 const myValue = "red"
 ---
-<!-- input -->
+<!-- entrée -->
 <div style={{ "--myValue": myValue }}></div>
 
-<!-- output (Astro 2.x) -->
+<!-- sortie (Astro 2.x) -->
 <div style="--my-value:var(--myValue);--myValue:red"></div>
-<!-- output (Astro 3.0) -->
+<!-- sortie (Astro 3.0) -->
 <div style="--myValue:red"></div>
 ```
 
@@ -316,7 +316,7 @@ Un [message d'erreur indiquant que la valeur de retour de `getStaticPath()` doit
 
 ### Déplacé : `astro check` nécessite désormais un paquet externe
 
-Dans Astro v2.x, [`astro check`](/fr/reference/cli-reference/#astro-check) était inclus dans Astro par défaut et ses dépendances étaient regroupées dans Astro. Cela signifiait un paquet plus volumineux, que vous ayez déjà utilisé ou non `astro check`. Cela vous empêchait également d'avoir le contrôle sur la version de TypeScript et d'Astro Language Server à utiliser.
+Dans Astro v2.x, [`astro check`](/fr/reference/cli-reference/#astro-check) était inclus dans Astro par défaut et ses dépendances étaient regroupées dans Astro. Cela signifiait un paquet plus volumineux, que vous ayez déjà utilisé ou non `astro check`. Cela vous empêchait également d'avoir le contrôle sur les versions de TypeScript et du serveur de langage d'Astro à utiliser.
 
 Astro v3.0 déplace la commande `astro check` du noyau Astro et nécessite désormais un paquet externe `@astrojs/check`. De plus, vous devez installer `typescript` dans votre projet pour utiliser la commande `astro check`.
 
@@ -324,11 +324,11 @@ Astro v3.0 déplace la commande `astro check` du noyau Astro et nécessite déso
 
 Exécutez la commande `astro check` après la mise à niveau vers Astro v3.0 et suivez les instructions pour installer les dépendances requises, ou installez manuellement `@astrojs/check` et `typescript` dans votre projet.
 
-### Obsolète : `build.excludeMiddleware` et `build.split`
+### Déprécié : `build.excludeMiddleware` et `build.split`
 
 Dans Astro v2.x, `build.excludeMiddleware` et `build.split` étaient utilisés pour modifier la façon dont certains fichiers spécifiques étaient émis lors de l'utilisation d'un adaptateur en mode SSR.
 
-Astro v3.0 remplace ces options de configuration de construction par de nouvelles [options de configuration de l'adaptateur SSR](/fr/guides/integrations-guide/#intégrations-officielles) pour effectuer les mêmes tâches : `edgeMiddleware` et `functionPerRoute`.
+Astro v3.0 remplace ces options de configuration de compilation par de nouvelles [options de configuration de l'adaptateur SSR](/fr/guides/integrations-guide/#intégrations-officielles) pour effectuer les mêmes tâches : `edgeMiddleware` et `functionPerRoute`.
 
 #### Que devrais-je faire ?
 
@@ -362,17 +362,17 @@ export default defineConfig({
 });
 ```
 
-### Obsolète : `markdown.drafts`
+### Déprécié : `markdown.drafts`
 
 Dans Astro v2.x, la configuration `markdown.drafts` vous permettait d'avoir des brouillons de pages disponibles lors de l'exécution du serveur de développement, mais non intégrées en production.
 
-Astro v3.0 abandonne cette fonctionnalité au profit de la méthode des collections de contenu permettant de gérer les brouillons de pages en filtrant manuellement, ce qui donne plus de contrôle sur la fonctionnalité.
+Astro v3.0 déprécie cette fonctionnalité au profit de la méthode des collections de contenu permettant de gérer les brouillons de pages en filtrant manuellement, ce qui donne plus de contrôle sur la fonctionnalité.
 
 #### Que devrais-je faire ?
 
-Pour continuer à marquer certaines pages de votre projet comme brouillons, [migrer vers les collections de contenu](/fr/guides/content-collections/) et filtrer manuellement les pages avec la propriété du frontmatter `draft: true` à la place.
+Pour continuer à marquer certaines pages de votre projet comme brouillons, [migrez vers les collections de contenu](/fr/guides/content-collections/) et filtrez manuellement les pages avec la propriété du frontmatter `draft: true` à la place.
 
-### Obsolète : renvoyer un objet simple dans les points de terminaison
+### Déprécié : renvoyer un objet simple dans les points de terminaison
 
 Dans Astro v2.x, les points de terminaison pouvaient renvoyer un objet simple, qui serait converti en réponse JSON.
 
@@ -389,7 +389,7 @@ export async function GET() {
 }
 ```
 
-Si vous avez vraiment besoin de conserver le format précédent, vous pouvez utiliser l'objet `ResponseWithEncoding` mais il sera obsolète à l'avenir.
+Si vous avez vraiment besoin de conserver le format précédent, vous pouvez utiliser l'objet `ResponseWithEncoding` mais il sera déprécié à l'avenir.
 
 ```ts title="endpoint.json.ts" del={2} ins={3}
 export async function GET() {
@@ -436,7 +436,7 @@ Mettez à jour toutes les références existantes à `localhost:3000`, par exemp
 
 ### Valeur par défaut modifiée : le `trailingSlash` d'import.meta.env.BASE_URL
 
-Dans Astro v2.x, `import.meta.env.BASE_URL` ajoutait à votre paramètre [`base`](/fr/reference/configuration-reference/#base) une [une barre oblique finale (`trailingSlash`)](/fr/reference/configuration-reference/#trailingslash) par défault. `trailingSlash: "ignore"` ajoutait également une barre oblique finale.
+Dans Astro v2.x, `import.meta.env.BASE_URL` ajoutait à votre paramètre [`base`](/fr/reference/configuration-reference/#base) [une barre oblique finale (`trailingSlash`)](/fr/reference/configuration-reference/#trailingslash) par défault. `trailingSlash: "ignore"` ajoutait également une barre oblique finale.
 
 Astro v3.0 n'ajoute plus `import.meta.env.BASE_URL` avec une barre oblique finale par défaut, ni lorsque `trailingSlash: "ignore"` est défini. (Le comportement existant de `base` en combinaison avec `trailingSlash: "always"` ou `trailingSlash: "never"` est inchangé.)
 
@@ -521,7 +521,7 @@ Astro v3.0 inclut désormais Sharp comme service de traitement d'image par défa
 #### Que devrais-je faire ?
 
 :::note
-Lors de l'utilisation d'un [gestionnaire de paquets strict](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) comme `pnpm`, vous devrez peut-être installer manuellement Sharp dans votre projet même s'il s'agit d'une dépendance Astro :
+Lors de l'utilisation d'un [gestionnaire de paquets strict](https://pnpm.io/pnpm-vs-npm#npms-flat-tree) comme `pnpm`, vous devrez peut-être installer manuellement Sharp dans votre projet même s'il s'agit d'une dépendance d'Astro :
 
 ```bash
 pnpm add sharp
@@ -540,7 +540,7 @@ export default defineConfig({
 })
 ```
 
-### Modifié : cas des méthodes de requête HTTP
+### Modifié : casse des méthodes de requête HTTP
 
 Dans Astro v2.x, les [méthodes de requête HTTP](/fr/guides/endpoints/#méthodes-http) étaient écrites en utilisant des noms de fonctions en minuscules : `get`, `post`, `put`, `all` et `del`.
 
@@ -584,7 +584,7 @@ import vue from '@astrojs/vue';
 import solid from '@astrojs/solid-js';
 
 export default defineConfig({
-  // Permettez à de nombreux frameworks de prendre en charge les différents types de composants.
+  // Activer plusieurs frameworks pour prendre en charge différents types de composants.
   // Aucun `include` n'est nécessaire si vous n'utilisez qu'un seul framework !
   integrations: [
     preact({
@@ -622,15 +622,15 @@ if (id) {
 }
 ```
 
-### Modifié : exécuter le CLI d'Astro par programmation
+### Modifié : exécuter la CLI d'Astro par programmation
 
-Dans Astro v2.x, le point d'entrée du paquet `"astro"` exportait et exécutait directement le CLI d'Astro. Il n'est pas recommandé d'exécuter Astro de cette façon dans la pratique.
+Dans Astro v2.x, le point d'entrée du paquet `"astro"` exportait et exécutait directement la CLI d'Astro. Il n'est pas recommandé d'exécuter Astro de cette façon dans la pratique.
 
-Astro v3.0 supprime le CLI du point d'entrée et exporte un nouvel ensemble d'API JavaScript expérimentales, notamment `dev()`, `build()`, `preview()` et `sync()`.
+Astro v3.0 supprime la CLI du point d'entrée et exporte un nouvel ensemble d'API JavaScript expérimentales, notamment `dev()`, `build()`, `preview()` et `sync()`.
 
 #### Que devrais-je faire ?
 
-Pour [exécuter l'Astro CLI par programmation](/fr/reference/programmatic-reference/), utilisez les nouvelles API JavaScript expérimentales :
+Pour [exécuter la CLI d'Astro par programmation](/fr/reference/programmatic-reference/), utilisez les nouvelles API JavaScript expérimentales :
 
 ```js
 import { dev, build } from "astro";
@@ -639,7 +639,7 @@ import { dev, build } from "astro";
 const devServer = await dev();
 await devServer.stop();
 
-// Construisez votre projet Astro
+// Compilez votre projet Astro
 await build();
 ```
 
@@ -675,7 +675,7 @@ const result = await transform(source, {
 
 ### Mettre à niveau les images vers la v3
 
-`astro:assets` n'est plus derrière un indicateur expérimental dans Astro v3.0.
+`astro:assets` n'est plus derrière une option expérimentale dans Astro v3.0.
 
 `<Image />` est désormais un composant intégré et l'intégration précédente `@astrojs/image` a été supprimée.
 
@@ -685,11 +685,11 @@ Veuillez suivre les instructions ci-dessous, le cas échéant, pour mettre à ni
 
 #### Mise à niveau depuis `experimental.assets`
 
-Si vous aviez précédemment activé l'indicateur expérimental pour `astro:assets`, vous devrez mettre à jour votre projet pour Astro v3.0 qui inclut désormais les fonctionnalités de ressources par défaut.
+Si vous aviez précédemment activé l'option expérimentale pour `astro:assets`, vous devrez mettre à jour votre projet pour Astro v3.0 qui inclut désormais les fonctionnalités de ressources par défaut.
 
-##### Supprimer l'indicateur `experimental.assets`
+##### Supprimer l'option `experimental.assets`
 
-Supprimez l'indicateur expérimental :
+Supprimez l'option expérimentale :
 
 ```js title="astro.config.mjs" del={4-6}
 import { defineConfig } from 'astro/config';
@@ -754,7 +754,7 @@ interface ImageMetadata {
 }
 ```
 
-Vous devez mettre à jour l'attribut `src` de toutes les balises `<img>` existantes (y compris les [images dans les composants du framework UI](/fr/guides/images/#images-dans-les-composants-framework-ui)) et vous pouvez également mettre à jour d'autres attributs qui sont désormais disponibles à partir de l'image importée.
+Vous devez mettre à jour l'attribut `src` de toutes les balises `<img>` existantes (y compris les [images dans les composants de framework UI](/fr/guides/images/#images-dans-les-composants-framework-ui)) et vous pouvez également mettre à jour d'autres attributs qui sont désormais disponibles à partir de l'image importée.
 
 ```astro title="src/components/MyComponent.astro" ".src" ".width" ".height" del={4} ins={6}
 ---
@@ -769,7 +769,7 @@ import rocket from '../images/rocket.svg';
 
 Les images relatives au dossier `src/` de votre projet peuvent désormais être référencées dans Markdown, MDX et Markdoc en utilisant la syntaxe Markdown standard `![alt](src)`.
 
-Cela vous permet de déplacer vos images du répertoire `public/` vers votre projet `src/` où elles seront désormais traitées et optimisées. Vos images existantes dans `public/` et les images distantes sont toujours valides mais ne sont pas optimisées par le processus de construction d'Astro.
+Cela vous permet de déplacer vos images du répertoire `public/` vers votre projet `src/` où elles seront désormais traitées et optimisées. Vos images existantes dans `public/` et les images distantes sont toujours valides mais ne sont pas optimisées par le processus de compilation d'Astro.
 
 ```md title="src/pages/posts/post-1.md" "/_astro" ".hash" "../../assets/"
 # Ma Page Markdown
@@ -781,9 +781,10 @@ Cela vous permet de déplacer vos images du répertoire `public/` vers votre pro
 ![Un ciel nocturne étoilé.](./stars.png)
 ```
 
-Si vous avez besoin de plus de contrôle sur les attributs de votre image, nous vous recommandons d'utiliser le format de fichier `.mdx`, qui vous permet d'inclure le composant `<Image />` d'Astro ou une balise JSX `<img />` en plus de la syntaxe Markdown. Utilisez l'[intégration MDX](/fr/guides/integrations-guide/mdx/) pour ajouter la prise en charge de MDX à Astro.
+Si vous avez besoin de plus de contrôle sur les attributs de votre image, nous vous recommandons d'utiliser le format de fichier `.mdx`, qui vous permet d'inclure le composant `<Image />` d'Astro ou une balise JSX `<img />` en plus de la syntaxe Markdown. Utilisez l'[intégration MDX](/fr/guides/integrations-guide/mdx/) pour ajouter la prise en charge de MDX dans Astro.
 
 #### Supprimer `@astrojs/image`
+
 
 Si vous utilisiez l'intégration d'images dans Astro v2.x, procédez comme suit :
 
@@ -804,9 +805,9 @@ Si vous utilisiez l'intégration d'images dans Astro v2.x, procédez comme suit�
     })
     ```
 
-2. Mettre à jour les types (si nécessaire).
+2. Mettez à jour les types (si nécessaire).
 
-		Si vous aviez des types spéciaux configurés pour `@astrojs/image` dans `src/env.d.ts`, vous devrez peut-être les ajouter à nouveau aux types Astro par défaut si votre mise à niveau vers la v3 n'a pas effectué cette étape pour vous.
+		Si vous aviez des types spéciaux configurés pour `@astrojs/image` dans `src/env.d.ts`, vous devrez peut-être les ajouter à nouveau aux types par défaut d'Astro si votre mise à niveau vers la v3 n'a pas effectué cette étape pour vous.
 
 		```ts title="src/env.d.ts" del={1} ins={2}
 		 /// <reference types="@astrojs/image/client" />
@@ -885,29 +886,30 @@ import Sprite from '../assets/logo.svg?url';
 </svg>
 ```
 
-Cette approche garantit que vous obtenez la chaîne de l'URL. Gardez à l'esprit que pendant le développement, Astro utilise un chemin `src/`, mais lors de la construction, il génère des chemins hachés comme `/_astro/cat.a6737dd3.png`.
+Cette approche garantit que vous obtenez la chaîne de l'URL. Gardez à l'esprit que pendant le développement, Astro utilise un chemin `src/`, mais lors de la compilation, il génère des chemins hachés comme `/_astro/cat.a6737dd3.png`.
 
 Si vous préférez travailler directement avec l'objet image lui-même, vous pouvez accéder à la propriété `.src`. Cette approche est la meilleure pour des tâches telles que la gestion des dimensions d’image pour les métriques Core Web Vitals et la prévention du CLS.
 
 Si vous passez au nouveau comportement d'importation, la combinaison des méthodes `?url` et `.src` pourrait être la bonne méthode pour une gestion transparente des images.
 
+
 ### Mettre à niveau les transitions de vue vers la v3
 
-Les transitions de vue ne sont plus derrière un indicateur expérimental dans Astro v3.0.
+Les transitions de vue ne sont plus derrière une option expérimentale dans Astro v3.0.
 
-Si vous n'aviez **pas** activé cet indicateur expérimental dans Astro 2.x, cela n'entraînera aucune modification radicale dans votre projet. La nouvelle API Transitions de Vue n'a aucun effet sur votre code existant.
+Si vous n'aviez **pas** activé cette option expérimentale dans Astro 2.x, cela n'entraînera aucune modification avec rupture de compatibilité dans votre projet. La nouvelle API Transitions de Vue n'a aucun effet sur votre code existant.
 
-Si vous utilisiez auparavant des transitions de vue expérimentales, des modifications importantes peuvent survenir lorsque vous mettez à niveau votre projet Astro à partir d'une version antérieure.
+Si vous utilisiez auparavant des transitions de vue expérimentales, vous pourriez rencontrer des changements non rétrocompatibles lorsque vous mettez à niveau votre projet Astro à partir d'une version antérieure.
 
 Veuillez suivre les instructions ci-dessous, le cas échéant, pour mettre à niveau **un projet Astro v2.x configuré avec `experimental.viewTransitions: true`** vers la v3.0.
 
 #### Mise à niveau depuis `experimental.viewTransitions`
 
-Si vous aviez précédemment activé l'indicateur expérimental pour les transitions de vue, vous devrez mettre à jour votre projet pour Astro v3.0 qui autorise désormais les transitions de vue par défaut.
+Si vous aviez précédemment activé l'option expérimentale pour les transitions de vue, vous devrez mettre à jour votre projet pour Astro v3.0 qui autorise désormais les transitions de vue par défaut.
 
-##### Supprimer l'indicateur `experimental.viewTransitions`
+##### Supprimer l'option `experimental.viewTransitions`
 
-Supprimez l'indicateur expérimental :
+Supprimez l'option expérimentale :
 
 ```js title="astro.config.mjs" del={4-6}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/fr/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v4.mdx
@@ -344,7 +344,7 @@ Astro v4.0 supprime entièrement la prise en charge des noms minuscules. Toutes 
 
 Si vous utilisez les noms minuscules obsolètes, vous devez maintenant les remplacer par leurs équivalents majuscules.
 
-Veuillez consulter le guide de migration v3 [pour obtenir des conseils sur l'utilisation des méthodes de requête HTTP en majuscules](/fr/guides/upgrade-to/v3/#modifié-cas-des-méthodes-de-requête-http).
+Veuillez consulter le guide de migration v3 [pour obtenir des conseils sur l'utilisation des méthodes de requête HTTP en majuscules](/fr/guides/upgrade-to/v3/#modifié-casse-des-méthodes-de-requête-http).
 
 ### Supprimé : Redirections 301 en cas d'absence d'un préfixe `base`
 

--- a/src/content/docs/fr/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v4.mdx
@@ -279,7 +279,7 @@ Astro v4.0 supprime entièrement ces propriétés.
 
 Si vous utilisez les options obsolètes `build.split` ou `build.excludeMiddleware`, vous devez maintenant les supprimer car elles n'existent plus.
 
-Veuillez consulter le guide de migration vers la v3 pour [mettre à jour ces propriétés de middleware obsolètes](/fr/guides/upgrade-to/v3/#obsolète-buildexcludemiddleware-et-buildsplit) avec les configurations d'adaptateur.
+Veuillez consulter le guide de migration vers la v3 pour [mettre à jour ces propriétés de middleware obsolètes](/fr/guides/upgrade-to/v3/#déprécié-buildexcludemiddleware-et-buildsplit) avec les configurations d'adaptateur.
 
 ### Supprimé : `Astro.request.params`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of `upgrade-to/v3.mdx` based on #11593 and #11795
* update the translation of `breaking changes`, `upgrade`, `deprecated`, `flag`
* replace `le CLI` with `la CLI`
* replace the translation of `build` where more appropriate
* small fixes and rewording to make the reading easier

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
