### PR TITLE
i18n(fr): improve the wording in `upgrade-to/v4.mdx`

### DIFF
--- a/src/content/docs/fr/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v4.mdx
@@ -1,6 +1,6 @@
 ---
-title: Mise à jour vers Astro v4
-description: Comment mettre à jour votre projet vers la dernière version d'Astro (v4.0).
+title: Mise à niveau vers Astro v4
+description: Comment mettre à niveau votre projet vers la dernière version d'Astro (v4.0).
 sidebar:
   label: v4.0
 i18nReady: true
@@ -11,7 +11,7 @@ Ce guide vous aidera à migrer d'Astro v3 vers Astro v4.
 
 Besoin de mettre à niveau un ancien projet vers la v3 ? Consultez notre [ancien guide de migration](/fr/guides/upgrade-to/v3/).
 
-Besoin de voir la documentation v3 ? Visitez cette [ancienne version du site de documentation (instantané de la v3.6 non maintenu)](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/).
+Besoin de voir la documentation de la v3 ? Visitez cette [ancienne version du site de documentation (instantané de la v3.6 non maintenu)](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/).
 
 ## Mettre à niveau Astro
 
@@ -46,15 +46,15 @@ Après avoir mis à niveau Astro vers la dernière version, vous n’aurez peut-
 Mais si vous remarquez des erreurs ou un comportement inattendu, veuillez vérifier ci-dessous ce qui a changé et qui pourrait nécessiter une mise à jour dans votre projet.
 :::
 
-Astro v4.0 inclut [des modifications potentiellement cassantes](#changements-cassants), ainsi que la [suppression de certaines fonctionnalités précédemment obsolètes](#fonctionnalités-précédemment-obsolètes-désormais-supprimées).
+Astro v4.0 inclut [des modifications potentiellement non rétrocompatibles](#changements-non-rétrocompatibles), ainsi que la [suppression de certaines fonctionnalités précédemment dépréciées](#fonctionnalités-précédemment-dépréciées-désormais-supprimées).
 
-Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 4.0, consultez ce guide pour un aperçu de toutes les modifications importantes et des instructions sur la façon de mettre à jour votre base de code.
+Si votre projet ne fonctionne pas comme prévu après la mise à niveau vers la version 4.0, consultez ce guide pour obtenir un aperçu de tous les changements non rétrocompatibles et des instructions sur la façon de mettre à jour votre base de code.
 
 Consultez [le journal des modifications](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md) pour les notes de version complètes.
 
-## Indicateurs expérimentaux supprimés dans Astro v4.0
+## Options expérimentales supprimées dans Astro v4.0
 
-Supprimez l'indicateur expérimental `devOverlay` et déplacez toute configuration `i18n` au niveau supérieur dans `astro.config.mjs` :
+Supprimez l'option expérimentale `devOverlay` et déplacez toute configuration `i18n` au niveau supérieur dans `astro.config.mjs` :
 
 ```js del={5-9} ins={11-14} title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -80,7 +80,7 @@ Apprenez-en davantage sur ces deux fonctionnalités intéressantes et bien plus 
 
 ## Mises à niveau
 
-Toute mise à niveau majeure des dépendances d'Astro peut introduire dans votre projet des changements cassants.
+Toute mise à niveau majeure des dépendances d'Astro peut introduire dans votre projet des changements avec rupture de compatibilité.
 
 ### Mise à niveau : Vite 5.0
 
@@ -90,32 +90,32 @@ Astro v4.0 passe de Vite 4 à Vite 5.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez des plugins, une configuration ou des API spécifiques à Vite, consultez le [Guide de migration de Vite](https://vite.dev/guide/migration) pour connaître leurs modifications majeures et mettez à niveau votre projet si nécessaire. Il n’y a aucun changement majeur dans Astro lui-même.
+Si vous utilisez des modules d'extension, une configuration ou des API spécifiques à Vite, consultez le [guide de migration de Vite](https://vite.dev/guide/migration) pour connaître leurs changements non rétrocompatibles et mettez à niveau votre projet si nécessaire. Il n’y a aucun changement avec rupture de compatibilité dans Astro lui-même.
 
 ### Mise à niveau : dépendances unified, remark et rehype
 
 Dans Astro v3.x, unified v10 et ses paquets associés compatibles avec Remark/Rehype étaient utilisés pour traiter Markdown et MDX.
 
-Astro v4.0 mets à jour [unified vers la v11](https://github.com/unifiedjs/unified/releases/tag/11.0.0) et les autres paquets Remark/Rehype vers leur dernière version.
+Astro v4.0 mets à niveau [unified vers la v11](https://github.com/unifiedjs/unified/releases/tag/11.0.0) et les autres paquets Remark/Rehype vers leur dernière version.
 
 #### Que devrais-je faire ?
 
 Si vous avez utilisé des paquets Remark/Rehype personnalisés, mettez-les tous à jour vers la dernière version à l'aide de votre gestionnaire de paquets pour vous assurer qu'ils prennent en charge la version 11 d'unified. Les paquets que vous utilisez se trouvent dans `astro.config.mjs`.
 
-Il ne devrait pas y avoir de changements importants si vous utilisez des paquets activement mis à jour, mais certains paquets peuvent ne pas encore être compatibles avec la v11 d'unified.
+Il ne devrait pas y avoir de changements avec rupture de compatibilité si vous utilisez des paquets activement mis à jour, mais certains paquets peuvent ne pas encore être compatibles avec la v11 d'unified.
 Inspectez visuellement vos pages Markdown/MDX avant le déploiement pour vous assurer que votre site fonctionne comme prévu.
 
-## Changements cassants
+## Changements non rétrocompatibles
 
-Les modifications suivantes sont considérées comme des modifications majeures dans Astro. Les modifications majeures peuvent ou non fournir une rétrocompatibilité temporaire, et toute la documentation est mise à jour pour faire référence uniquement au code actuellement pris en charge.
+Les modifications suivantes sont considérées comme des modifications avec rupture de compatibilité dans Astro. Ces changements peuvent ou non fournir une rétrocompatibilité temporaire, et toute la documentation est mise à jour pour faire référence uniquement au code actuellement pris en charge.
 
 Si vous avez besoin de vous référer à la documentation d'un projet v3.x, vous pouvez parcourir cet [instantané (non maintenu) de la documentation datant d'avant la sortie de la v4.0](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/).
 
-### Renommé : `entrypoint` (API d'intégrations)
+### Renommé : `entrypoint` (API des intégrations)
 
-Dans Astro v3.x, la propriété de l'API d'intégration `injectRoute` qui spécifiait le point d'entrée de la route était nommée `entryPoint`.
+Dans Astro v3.x, la propriété `injectRoute` de l'API des intégrations qui spécifiait le point d'entrée de la route était nommée `entryPoint`.
 
-Astro v4.0 renomme cette propriété en `entrypoint` pour être cohérente avec les autres API Astro. La propriété `entryPoint` est obsolète mais continuera à fonctionner et enregistrera un avertissement vous invitant à mettre à jour votre code.
+Astro v4.0 renomme cette propriété en `entrypoint` pour être cohérente avec les autres API d'Astro. La propriété `entryPoint` est dépréciée mais continuera à fonctionner et enregistrera un avertissement vous invitant à mettre à jour votre code.
 
 #### Que devrais-je faire ?
 
@@ -129,7 +129,7 @@ injectRoute({
 });
 ```
 
-### Modifié : signature d'`app.render` dans l'API d'intégration
+### Modifié : signature d'`app.render` dans l'API des intégrations
 
 Dans Astro v3.0, la méthode `app.render()` acceptait `routeData` et `locals` comme arguments distincts et facultatifs.
 
@@ -172,7 +172,7 @@ export default function createIntegration() {
 }
 ```
 
-### Supprimé : Propriété `path` du langage Shiki
+### Supprimé : Propriété du chemin de langage (`path`) de Shiki
 
 Dans Astro v3.x, un langage Shiki transmis à `markdown.shikiConfig.langs` était automatiquement converti en un langage compatible Shikiji. Shikiji est l'outil interne utilisé par Astro pour la coloration syntaxique.
 
@@ -198,17 +198,17 @@ export default defineConfig({
 })
 ```
 
-## Obsolètes
+## Dépréciées
 
-Les fonctionnalités obsolètes suivantes ne sont plus prises en charge et ne sont plus documentées. Veuillez mettre à jour votre projet en conséquence.
+Les fonctionnalités dépréciées suivantes ne sont plus prises en charge et ne sont plus documentées. Veuillez mettre à jour votre projet en conséquence.
 
-Certaines fonctionnalités obsolètes peuvent temporairement continuer à fonctionner jusqu'à ce qu'elles soient complètement supprimées. D'autres peuvent n'avoir aucun effet en silence ou générer une erreur vous invitant à mettre à jour votre code.
+Certaines fonctionnalités dépréciées peuvent temporairement continuer à fonctionner jusqu'à ce qu'elles soient complètement supprimées. D'autres peuvent n'avoir aucun effet en silence ou générer une erreur vous invitant à mettre à jour votre code.
 
-### Obsolète : `handleForms` pour les événements `submit` de Transitions de Vue
+### Déprécié : `handleForms` pour les événements `submit` de Transitions de Vue
 
 Dans Astro v3.x, les projets utilisant le composant `<ViewTransitions />` devaient accepter de gérer les événements `submit` pour les éléments `form`. Cela était fait en transmettant une propriété `handleForms`.
 
-Astro v4.0 gère par défaut les événements `submit` pour les éléments `form` lorsque `<ViewTransitions />` est utilisé. La propriété `handleForms` est obsolète et n'a plus aucun effet.
+Astro v4.0 gère par défaut les événements `submit` pour les éléments `form` lorsque `<ViewTransitions />` est utilisé. La propriété `handleForms` est dépréciée et n'a plus aucun effet.
 
 #### Que devrais-je faire ?
 
@@ -236,15 +236,15 @@ Pour désactiver la gestion des événements `submit`, ajoutez l'attribut `data-
 </form>
 ```
 
-## Fonctionnalités précédemment obsolètes désormais supprimées
+## Fonctionnalités précédemment dépréciées désormais supprimées
 
-Les fonctionnalités obsolètes suivantes ont désormais été entièrement supprimées de la base de code et ne peuvent plus être utilisées. Certaines de ces fonctionnalités peuvent avoir continué à fonctionner dans votre projet même après la dépréciation. D’autres n’ont peut-être eu aucun effet en silence.
+Les fonctionnalités dépréciées suivantes ont désormais été entièrement supprimées de la base de code et ne peuvent plus être utilisées. Certaines de ces fonctionnalités peuvent avoir continué à fonctionner dans votre projet même après la dépréciation. D’autres n’ont peut-être eu aucun effet en silence.
 
-Désormais, les projets contenant ces fonctionnalités supprimées ne pourront pas être construits et il n'y aura plus de documentation à l'appui vous invitant à supprimer ces fonctionnalités.
+Désormais, les projets contenant ces fonctionnalités supprimées ne pourront pas être compilés et il n'y aura plus de documentation à l'appui vous invitant à supprimer ces fonctionnalités.
 
 ### Supprimé : renvoyer des objets simples à partir des points de terminaison
 
-Dans Astro v3.x, le renvoi d'objets simples à partir des points de terminaison était obsolète, mais était toujours pris en charge pour maintenir la compatibilité avec Astro v2. Un utilitaire `ResponseWithEncoding` a également été fourni pour faciliter la migration.
+Dans Astro v3.x, le renvoi d'objets simples à partir des points de terminaison était déprécié, mais était toujours pris en charge pour maintenir la compatibilité avec Astro v2. Un utilitaire `ResponseWithEncoding` a également été fourni pour faciliter la migration.
 
 Astro v4.0 supprime la prise en charge des objets simples et exige que les points de terminaison renvoient toujours une réponse (`Response`). L'utilitaire `ResponseWithEncoding` est également supprimé au profit d'un type `Response` approprié.
 
@@ -271,19 +271,19 @@ Pour supprimer l'utilisation de `ResponseWithEncoding`, refactorisez votre code 
 
 ### Supprimé : `build.split` et `build.excludeMiddleware`
 
-Dans Astro v3.0, les options de configuration de build `build.split` et `build.excludeMiddleware` ont été définies comme obsolètes et remplacées par des [options de configuration de l'adaptateur](/fr/reference/adapter-reference/#fonctionnalités-de-ladaptateur) pour effectuer les mêmes tâches.
+Dans Astro v3.0, les options de configuration de compilation `build.split` et `build.excludeMiddleware` ont été dépréciées et remplacées par des [options de configuration de l'adaptateur](/fr/reference/adapter-reference/#fonctionnalités-de-ladaptateur) pour effectuer les mêmes tâches.
 
 Astro v4.0 supprime entièrement ces propriétés.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez les options obsolètes `build.split` ou `build.excludeMiddleware`, vous devez maintenant les supprimer car elles n'existent plus.
+Si vous utilisez les options dépréciées `build.split` ou `build.excludeMiddleware`, vous devez maintenant les supprimer car elles n'existent plus.
 
-Veuillez consulter le guide de migration vers la v3 pour [mettre à jour ces propriétés de middleware obsolètes](/fr/guides/upgrade-to/v3/#obsolète-buildexcludemiddleware-et-buildsplit) avec les configurations d'adaptateur.
+Veuillez consulter le guide de migration vers la v3 pour [mettre à jour ces propriétés de middleware dépréciées](/fr/guides/upgrade-to/v3/#déprécié-buildexcludemiddleware-et-buildsplit) avec les configurations d'adaptateur.
 
 ### Supprimé : `Astro.request.params`
 
-Dans Astro v3.0, l'API `Astro.request.params` était obsolète, mais préservée pour des raisons de rétrocompatibilité.
+Dans Astro v3.0, l'API `Astro.request.params` était dépréciée, mais préservée pour des raisons de rétrocompatibilité.
 
 Astro v4.0 supprime complètement cette option.
 
@@ -298,25 +298,25 @@ const { id } = Astro.params;
 
 ### Supprimé : `markdown.drafts`
 
-Dans Astro v3.0, l'utilisation de `markdown.drafts` pour contrôler la création de brouillons était obsolète.
+Dans Astro v3.0, l'utilisation de `markdown.drafts` pour contrôler la création de brouillons était dépréciée.
 
 Astro v4.0 supprime complètement cette option.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez la configuration obsolète `markdown.drafts`, vous devez maintenant la supprimer car elle n'existe plus.
+Si vous utilisez l'option de configuration dépréciée `markdown.drafts`, vous devez maintenant la supprimer car elle n'existe plus.
 
 Pour continuer à marquer certaines pages de votre projet comme brouillons, [migrer vers les collections de contenu](/fr/guides/content-collections/) et filtrer manuellement les pages contenant la propriété `draft: true` dans le frontmatter.
 
 ### Supprimé : `getHeaders()`
 
-Dans Astro v3.0, l'exportation Markdown `getHeaders()` a été définie comme obsolète et remplacée par `getHeadings()`.
+Dans Astro v3.0, l'exportation Markdown `getHeaders()` a été dépréciée et remplacée par `getHeadings()`.
 
 Astro v4.0 supprime complètement cette option.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez la méthode obsolète `getHeaders()`, vous devez maintenant le supprimer car elle n'existe plus. Remplacez toutes les instances par `getHeadings()`, qui est le remplacement pris en charge.
+Si vous utilisez la méthode dépréciée `getHeaders()`, vous devez maintenant le supprimer car elle n'existe plus. Remplacez toutes les instances par `getHeadings()`, qui est le remplacement pris en charge.
 
 ```js del={2} ins={3}
 const posts = await Astro.glob('../content/blog/*.mdx');
@@ -326,9 +326,9 @@ const firstPostHeadings = posts.at(0).getHeadings();
 
 ### Supprimé : utilisation de `rss` dans `getStaticPaths()`
 
-Dans Astro v3.0, l'utilisation de l'assistant `rss` obsolète dans `getStaticPaths()` générerait une erreur.
+Dans Astro v3.0, l'utilisation de l'assistant déprécié `rss` dans `getStaticPaths()` générerait une erreur.
 
-Astro v4.0 supprime entièrement cette aide.
+Astro v4.0 supprime entièrement cet assistant.
 
 #### Que devrais-je faire ?
 
@@ -336,15 +336,15 @@ Si vous utilisez la méthode non prise en charge pour générer des flux RSS, vo
 
 ### Supprimé : noms de méthodes HTTP en minuscules
 
-Dans Astro v3.0, l'utilisation de noms de méthodes de requête HTTP en minuscules (`get`, `post`, `put`, `all`, `del`) était obsolète.
+Dans Astro v3.0, l'utilisation de noms de méthodes de requête HTTP en minuscules (`get`, `post`, `put`, `all`, `del`) était dépréciées.
 
 Astro v4.0 supprime entièrement la prise en charge des noms minuscules. Toutes les méthodes de requête HTTP doivent désormais être écrites en majuscules.
 
 #### Que devrais-je faire ?
 
-Si vous utilisez les noms minuscules obsolètes, vous devez maintenant les remplacer par leurs équivalents majuscules.
+Si vous utilisez les noms en minuscules dépréciés, vous devez maintenant les remplacer par leurs équivalents en majuscules.
 
-Veuillez consulter le guide de migration v3 [pour obtenir des conseils sur l'utilisation des méthodes de requête HTTP en majuscules](/fr/guides/upgrade-to/v3/#modifié-cas-des-méthodes-de-requête-http).
+Veuillez consulter le guide de migration de la v3 [pour obtenir des conseils sur l'utilisation des méthodes de requête HTTP en majuscules](/fr/guides/upgrade-to/v3/#modifié-casse-des-méthodes-de-requête-http).
 
 ### Supprimé : Redirections 301 en cas d'absence d'un préfixe `base`
 
@@ -366,7 +366,7 @@ L'exemple suivant montre l'attribut `src` requis pour afficher une image du doss
 
 ### Supprimé : Conversion automatique d'`astro/client-image`
 
-Dans Astro v3.x, le type `astro/client-image` (utilisé pour l'intégration d'image obsolète) a été supprimé mais a été automatiquement converti en `astro/client` — le type par défaut d'Astro — s'il est trouvé dans votre fichier `env.d.ts `.
+Dans Astro v3.x, le type `astro/client-image` (utilisé pour l'intégration d'image dépréciée) a été supprimé mais a été automatiquement converti en `astro/client` — le type par défaut d'Astro — s'il est trouvé dans votre fichier `env.d.ts `.
 
 Astro v4.0 ignore `astro/client-image` et ne mettra plus à jour automatiquement `env.d.ts` pour vous.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the wording in the French translation of `upgrade-to/v4.mdx` based on #11593 and #11795
* update the translation of `breaking changes`, `upgrade`, `deprecated`, `flag`
* translate `plugins`
* replace the translation of `build` where more appropriate
* small rewording to make the reading easier

> [!NOTE]
> The broken links should be fixed once #11835 is merged: I applied the links updates on this PR to avoid a potential Git conflict while updating the branch since I also updated the paragraphs here.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
