### PR TITLE
i18n(fr): improve the wording in already updated files (second pass)

### DIFF
--- a/src/content/docs/fr/basics/astro-components.mdx
+++ b/src/content/docs/fr/basics/astro-components.mdx
@@ -34,7 +34,7 @@ Un composant Astro est composé de deux parties principales : le **script du com
 
 ### Le script du composant
 
-Astro utilise des délimitateurs de code (`---`) pour identifier le script du composant dans votre composant Astro. Si vous avez déjà écrit du Markdown avant, vous pourriez être déjà familier avec un concept similaire appelé *frontmatter.* Astro est directement inspiré de cela.
+Astro utilise des délimiteurs de code (`---`) pour identifier le script du composant dans votre composant Astro. Si vous avez déjà écrit du Markdown avant, vous pourriez être déjà familier avec un concept similaire appelé *frontmatter.* Astro est directement inspiré de cela.
 
 Vous pouvez utiliser le script du composant pour écrire le code JavaScript nécessaire au rendu de votre modèle. Cela peut inclure :
 
@@ -59,17 +59,17 @@ const data = await fetch('UNE_URL_SECRETE_API/utilisateurs').then(r => r.json())
 <!-- Votre modèle ici ! -->
 ```
 
-Le délimitateur de code est conçu pour garantir que le code JavaScript que vous écrivez à l'intérieur « ne puisse pas s'échapper ». Il ne sera pas visible dans le frontend de votre application et ne tombera pas entre les mains de votre utilisateur. Vous pouvez écrire du code JavaScript coûteux (en terme de performance) ou sensible (comme un appel à votre base de données privée) sans vous soucier qu'il se retrouve dans le navigateur l'utilisateur.
+Le délimiteur de code est conçu pour garantir que le code JavaScript que vous écrivez à l'intérieur « ne puisse pas s'échapper ». Il ne sera pas visible dans le frontend de votre application et ne tombera pas entre les mains de votre utilisateur. Vous pouvez écrire du code JavaScript coûteux (en terme de performance) ou sensible (comme un appel à votre base de données privée) sans vous soucier qu'il se retrouve dans le navigateur l'utilisateur.
 
 :::note
 Le script du composant Astro utilise TypeScript, ce qui vous permet d'ajouter une syntaxe supplémentaire à JavaScript pour les outils d'édition et la vérification des erreurs.
 
-<ReadMore>En savoir plus sur le [support TypeScript intégré](/fr/guides/typescript/) d'Astro.</ReadMore>
+<ReadMore>En savoir plus sur la [prise en charge intégrée de TypeScript](/fr/guides/typescript/) dans Astro.</ReadMore>
 :::
 
 ### Le modèle du composant
 
-Le modèle de composant se trouve sous le délimitateur de code et détermine la sortie HTML de votre composant.
+Le modèle de composant se trouve sous le délimiteur de code et détermine la sortie HTML de votre composant.
 
 Si vous écrivez du HTML brut ici, votre composant affichera ce HTML dans n'importe quelle page Astro où il est importé et utilisé.
 
@@ -84,7 +84,7 @@ import ReactPokemonComponent from '../components/ReactPokemonComponent.jsx';
 const myFavoritePokemon = [/* ... */];
 const { title } = Astro.props;
 ---
-<!-- Les commentaires HTML sont supportés ! -->
+<!-- Les commentaires HTML sont pris en charge ! -->
 {/* La syntaxe des commentaires JavaScript est aussi valide ! */}
 
 <Banner />

--- a/src/content/docs/fr/editor-setup.mdx
+++ b/src/content/docs/fr/editor-setup.mdx
@@ -98,7 +98,7 @@ Pour ajouter la prise en charge du formatage des fichiers `.astro` en dehors de 
       </Fragment>
     </PackageManagerTabs>
 
-2. Créez un fichier de configuration `.prettierrc.mjs` (ou `.prettierrc.json`, `.prettierrc.mjs`, ou [dans d'autres formats supportés](https://prettier.io/docs/configuration)) à la racine de votre projet et ajoutez-y `prettier-plugin-astro`.
+2. Créez un fichier de configuration `.prettierrc.mjs` (ou `.prettierrc.json`, `.prettierrc.mjs`, ou [dans d'autres formats pris en charge](https://prettier.io/docs/configuration)) à la racine de votre projet et ajoutez-y `prettier-plugin-astro`.
 
     Dans ce fichier, vous pouvez également spécifier manuellement l'analyseur pour les fichiers Astro.
 

--- a/src/content/docs/fr/guides/backend/supabase.mdx
+++ b/src/content/docs/fr/guides/backend/supabase.mdx
@@ -109,7 +109,7 @@ Votre projet doit maintenant inclure ces fichiers :
 
 ## Ajout de l'authentification avec Supabase
 
-Supabase fournit l'authentification dès le départ. Elle supporte l'authentification par email/mot de passe et l'authentification OAuth avec de nombreux fournisseurs dont GitHub, Google, et plusieurs autres.
+Supabase fournit l'authentification dès le départ. Elle prend en charge l'authentification par email/mot de passe et l'authentification OAuth avec de nombreux fournisseurs dont GitHub, Google, et plusieurs autres.
 
 ### Prérequis
 
@@ -369,7 +369,7 @@ export const supabase = createClient(
 );
 ```
 
-Ensuite, dans le tableau de bord de Supabase, activez le fournisseur OAuth que vous souhaitez utiliser. Vous pouvez trouver la liste des fournisseurs supportés dans l'onglet **Authentication > Providers** de votre projet Supabase.
+Ensuite, dans le tableau de bord de Supabase, activez le fournisseur OAuth que vous souhaitez utiliser. Vous pouvez trouver la liste des fournisseurs pris en charge dans l'onglet **Authentication > Providers** de votre projet Supabase.
 
 L'exemple suivant utilise GitHub comme fournisseur OAuth. Pour connecter votre projet à GitHub, suivez les étapes de la [documentation de Supabase](https://supabase.com/docs/guides/auth/social-login/auth-github).
 

--- a/src/content/docs/fr/guides/cms/frontmatter-cms.mdx
+++ b/src/content/docs/fr/guides/cms/frontmatter-cms.mdx
@@ -31,7 +31,7 @@ Une fois que Front Matter CMS est installé, vous obtiendrez une nouvelle icône
 - Cliquez sur le bouton **Initialiser le projet** (__Initialize project__) dans le panneau Front Matter
 - L'écran de bienvenue s'ouvre et vous pouvez commencer à initialiser le projet.
 - Cliquez sur la première étape pour **Initialiser le projet**.
-- Comme Astro est l'un des frameworks supportés, vous pouvez le sélectionner dans la liste.
+- Comme Astro est l'un des frameworks pris en charge, vous pouvez le sélectionner dans la liste.
 - Enregistrez vos dossiers de contenu, dans ce cas, le dossier `src/content/blog`.
 
   :::note

--- a/src/content/docs/fr/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/fr/guides/deploy/cloudflare.mdx
@@ -199,4 +199,4 @@ Si vous créez un projet qui utilise le rendu à la demande avec [l'adaptateur C
 
 - Si vous importez directement une API de l'environnement d'exécution Node.js, veuillez consulter la documentation Astro sur la [compatibilité Node.js](/fr/guides/integrations-guide/cloudflare/#compatibilité-nodejs) de Cloudflare pour savoir comment résoudre ce problème.
 
-- Si vous importez un paquet qui importe une API de l'environnement d'exécution Node.js, vérifiez avec l'auteur du paquet s'il supporte la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un autre paquet.
+- Si vous importez un paquet qui importe une API de l'environnement d'exécution Node.js, vérifiez avec l'auteur du paquet s'il prend en charge la syntaxe d'importation `node:*`. Si ce n'est pas le cas, vous devrez peut-être trouver un autre paquet.

--- a/src/content/docs/fr/guides/deploy/index.mdx
+++ b/src/content/docs/fr/guides/deploy/index.mdx
@@ -27,9 +27,9 @@ Une façon rapide de déployer votre site web est de connecter le dépôt Git (p
 Ces hébergeurs détectent automatiquement les push sur le dépôt de votre projet Astro, compilent votre site et le déploient sur le web sur une URL personnalisée ou sur votre nom de domaine personnel. Souvent, la configuration d’un déploiement sur ces plateformes suivra des étapes similaires à celles-ci :
 
 <Steps>
-1. Ajoutez votre dépôt à un provider Git (p. ex. sur GitHub, GitLab, Bitbucket)
+1. Ajoutez votre dépôt à un fournisseur Git (p. ex. sur GitHub, GitLab, Bitbucket)
 
-2. Choisissez un hébergeur qui supporte le *déploiement continu* (p. ex. [Netlify](/fr/guides/deploy/netlify/) ou [Vercel](/fr/guides/deploy/vercel/)) et importez votre dépôt Git en tant que nouveau projet / site.
+2. Choisissez un hébergeur qui prend en charge le *déploiement continu* (p. ex. [Netlify](/fr/guides/deploy/netlify/) ou [Vercel](/fr/guides/deploy/vercel/)) et importez votre dépôt Git en tant que nouveau projet / site.
 
     De nombreux hébergeurs vont reconnaître votre projet en tant que site Astro, et devraient automatiquement appliquer la configuration appropriée pour compiler et déployer votre site comme montré ci-dessous. (Dans le cas contraire, ces paramètres peuvent être modifiés.)
 

--- a/src/content/docs/fr/guides/integrations-guide/db.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/db.mdx
@@ -111,7 +111,7 @@ const Comment = defineTable({
 });
 ```
 
-Les colonnes sont configurées en utilisant l'utilitaire `column`. `column` supporte les types suivants :
+Les colonnes sont configurées en utilisant l'utilitaire `column`. `column` prend en charge les types suivants :
 
 - **`column.text(...)`** - Stocke du contenu textuel simple ou enrichi
 - **`column.number(...)`** - Stocke des valeurs entières et des valeurs à virgule flottante
@@ -218,7 +218,7 @@ Vérifier s'il y a des différences entre la configuration de la base de donnée
 
 - `--remote` Exécuter sur votre base de données compatible libSQL. L'omettre pour exécuter sur votre serveur de développement.
 
-Exécute un fichier `.ts` ou `.js` pour lire ou écrire dans votre base de données. Cette commande accepte un chemin de fichier comme argument, et supporte l'utilisation du module `astro:db` pour écrire des requêtes sûres. Utilisez l'option `--remote` pour exécuter sur votre base de données compatible libSQL, ou ignorez l'option pour lancer l'exécution sur votre serveur de développement. Découvrez comment [amorcer les données de développement](/fr/guides/astro-db/#alimentez-votre-base-de-données-pour-le-développement) pour un exemple de fichier.
+Exécute un fichier `.ts` ou `.js` pour lire ou écrire dans votre base de données. Cette commande accepte un chemin de fichier comme argument, et prend en charge l'utilisation du module `astro:db` pour écrire des requêtes sûres. Utilisez l'option `--remote` pour exécuter sur votre base de données compatible libSQL, ou ignorez l'option pour lancer l'exécution sur votre serveur de développement. Découvrez comment [amorcer les données de développement](/fr/guides/astro-db/#alimentez-votre-base-de-données-pour-le-développement) pour un exemple de fichier.
 
 ### `astro db shell --query <sql-string>`
 

--- a/src/content/docs/fr/guides/integrations-guide/index.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/index.mdx
@@ -105,7 +105,7 @@ Il y a trois façons d'importer une intégration dans votre projet Astro :
 
 1. [En installant un paquet d'intégration npm](#installation-dun-paquet-npm).
 2. En important votre propre intégration depuis un fichier local dans votre projet.
-3. En écrivant votre intégration en ligne, directement dans votre fichier de configuration.
+3. En écrivant votre intégration directement dans votre fichier de configuration.
 
 ```js
 // astro.config.mjs
@@ -119,7 +119,7 @@ export default defineConfig({
     installedIntegration(),
     // 2. Importer depuis un fichier JS local
     localIntegration(),
-    // 3. Depuis un objet en ligne
+    // 3. Un objet défini directement dans le fichier
     {name: 'namespace:id', hooks: { /* ... */ }},
   ]
 })

--- a/src/content/docs/fr/guides/integrations-guide/node.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/node.mdx
@@ -112,7 +112,7 @@ Tout d'abord, [effectuer une compilation](/fr/guides/deploy/#compiler-votre-site
 
 ### Middleware
 
-Le point d'entrée du serveur est compilé dans `./dist/server/entry.mjs` par défaut. Ce module exporte une fonction `handler` qui peut être utilisée avec n'importe quel framework qui supporte les objets Node `request` et `response`.
+Le point d'entrée du serveur est compilé dans `./dist/server/entry.mjs` par défaut. Ce module exporte une fonction `handler` qui peut être utilisée avec n'importe quel framework qui prend en charge les objets Node `request` et `response`.
 
 Par exemple, avec Express :
 

--- a/src/content/docs/fr/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/preact.mdx
@@ -18,7 +18,7 @@ Cette **[intégration Astro][astro-integration]** permet le rendu et l'hydratati
 
 Preact est une bibliothèque qui vous permet de créer des composants d'interface utilisateur interactifs pour le web. Si vous souhaitez créer des fonctionnalités interactives sur votre site à l'aide de JavaScript, vous préférerez peut-être utiliser son format de composant plutôt que d'utiliser directement les API du navigateur.
 
-Preact est également un excellent choix si vous avez déjà utilisé React. Preact fournit la même API que React, mais dans un format beaucoup plus petit de 3 Ko. Il supporte même le rendu de nombreux composants React en utilisant l'option de configuration `compat` (voir ci-dessous).
+Preact est également un excellent choix si vous avez déjà utilisé React. Preact fournit la même API que React, mais dans un format beaucoup plus petit de 3 Ko. Il prend même en charge le rendu de nombreux composants React en utilisant l'option de configuration `compat` (voir ci-dessous).
 
 **Vous souhaitez en savoir plus sur Preact avant d'utiliser cette intégration ?**
 Consultez ["Learn Preact" (Anglais)](https://preactjs.com/tutorial), un tutoriel interactif sur leur site web.

--- a/src/content/docs/fr/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/sitemap.mdx
@@ -308,7 +308,7 @@ Elle reçoit en paramètre un objet `SitemapItem` qui peut avoir ces propriété
 
 Cette propriété `links` contient une liste `LinkItem` de pages alternatives, y compris une page parent.
 
-Le type `LinkItem` a deux champs : `url` (l'URL pleinement qualifiée de la version de cette page pour la langue spécifiée) et `lang` (un code de langue supporté et ciblé par cette version de la page).
+Le type `LinkItem` a deux champs : `url` (l'URL pleinement qualifiée de la version de cette page pour la langue spécifiée) et `lang` (un code de langue pris en charge et ciblé par cette version de la page).
 
 La fonction `serialize` doit retourner `SitemapItem`, touché ou non.
 

--- a/src/content/docs/fr/guides/media/cloudinary.mdx
+++ b/src/content/docs/fr/guides/media/cloudinary.mdx
@@ -197,7 +197,7 @@ PUBLIC_CLOUDINARY_API_KEY="<Votre clé API>"
 CLOUDINARY_API_SECRET="<Votre secret API>"
 ```
 
-Configurez votre compte avec une nouvelle instance Cloudinary en ajoutant le code suivant entre les délimitateurs de code de votre composant Astro :
+Configurez votre compte avec une nouvelle instance Cloudinary en ajoutant le code suivant entre les délimiteurs de code de votre composant Astro :
 
 ```js title="Component.astro"
 ---

--- a/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
@@ -52,7 +52,7 @@ Lorsque vous recréez votre site CRA avec Astro, vous remarquerez quelques diff�
 
 - CRA est une application à page unique qui utilise `index.js` comme racine de votre projet. Astro est un site multi-pages, et `index.astro` est votre page d'accueil.
 
-- Les composants [`.astro`](/fr/basics/astro-components/) ne sont pas écrits en tant que fonctions exportées qui renvoient un modèle de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et un corps exclusivement pour le HTML que vous générez.
+- Les composants [`.astro`](/fr/basics/astro-components/) ne sont pas écrits en tant que fonctions exportées qui renvoient un modèle de page. Au lieu de cela, vous diviserez votre code en un « délimiteur de code » pour votre JavaScript et un corps exclusivement pour le HTML que vous générez.
 
 - [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour mettre en valeur votre contenu et vous permettre d'opter pour l'interactivité uniquement en cas de besoin. Une application CRA existante peut être conçue pour une interactivité élevée côté client et peut nécessiter des techniques Astro avancées pour inclure des éléments plus difficiles à reproduire en utilisant des composants `.astro`, tels que des tableaux de bord.
 
@@ -269,7 +269,7 @@ Voici quelques conseils pour convertir un composant CRA `.js` en un composant `.
 
 2. Modifiez toute [syntaxe CRA ou JSX en Astro](#référence--convertir-la-syntaxe-cra-en-astro) ou selon les normes web HTML. Cela inclut `{children}` et `className`, par exemple.
 
-3. Déplacez tout JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement à l'intérieur du modèle HTML avec Astro.
+3. Déplacez tout JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimiteur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement à l'intérieur du modèle HTML avec Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires qui ont été précédemment transmises à votre fonction CRA.
 
@@ -355,7 +355,7 @@ En savoir plus sur l'importation de fichiers locaux avec [`import.meta.glob()`](
 
 Il se peut que vous deviez remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) par d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [`<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [`<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
@@ -20,7 +20,7 @@ Docusaurus et Astro partagent certaines similitudes qui vous aideront à migrer 
 
 - Astro et Docusaurus sont tous deux des générateurs de sites modernes, basés sur JavaScript (Jamstack) et destinés aux [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu), comme les sites de documentation.
 
-- Astro et Docusaurus supportent tous deux les [pages MDX](/fr/guides/markdown-content/). Vous devriez pouvoir utiliser vos fichiers `.mdx` existants dans Astro.
+- Astro et Docusaurus prennent tous deux en charge les [pages MDX](/fr/guides/markdown-content/). Vous devriez pouvoir utiliser vos fichiers `.mdx` existants dans Astro.
 
 - Astro et Docusaurus utilisent [le routage basé sur les fichiers](/fr/guides/routing/) pour générer automatiquement des routes de pages pour tout fichier MDX situé dans `src/pages`. L'utilisation de la structure de fichiers d'Astro pour votre contenu existant et lors de l'ajout de nouvelles pages devrait vous sembler familière.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
@@ -34,7 +34,7 @@ Lorsque vous recréez votre site Gatsby dans Astro, vous remarquerez quelques di
 
 - Les projets Gatsby sont des applications React d'une seule page et utilisent `index.js` comme racine de votre projet. Les projets Astro sont des sites de plusieurs pages et `index.astro` est votre page d'accueil.
 
-- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
+- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimiteur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
 
 - [Données de fichiers locaux](/fr/guides/imports/): Gatsby utilise GraphQL pour récupérer des données à partir de vos fichiers de projet. Astro utilise les importations ESM et les fonctions d'attente de niveau supérieur (par exemple, [`import.meta.glob()`](/fr/guides/imports/#importmetaglob), [`getCollection()`](/fr/guides/content-collections/#interroger-les-collections)) pour importer des données à partir de vos fichiers de projet. Vous pouvez ajouter manuellement GraphQL à votre projet Astro mais il n'est pas inclus par défaut.
 
@@ -119,7 +119,7 @@ Voici quelques conseils pour convertir un composant Gatsby `.js` en un composant
 
 2. Remplacez toute [syntaxe Gatsby ou JSX par une syntaxe Astro](#référence-conversion-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<Link to="">`, `{children}` et `className` par exemple.
 
-3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
+3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimiteur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires précédemment transmises à votre fonction Gatsby.
 
@@ -307,7 +307,7 @@ En savoir plus sur [l'utilisation spécifique de `<slot />` dans Astro](/fr/basi
 
 Vous devrez peut-être remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) avec d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez tous les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
@@ -22,7 +22,7 @@ Gridsome et Astro partagent certaines similitudes qui vous aideront à migrer vo
 
 - Gridsome et Astro utilisent tous deux un dossier `src/` pour les fichiers de votre projet et un [dossier spécial `src/pages/` pour le routage basé sur les fichiers](/fr/basics/astro-pages/). La création et la gestion des pages de votre site devraient vous sembler familières.
 
-- Astro possède [une intégration officielle pour l'utilisation des composants Vue](/fr/guides/integrations-guide/vue/) et supporte [l'installation des paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour Vue. Vous serez en mesure d'écrire des composants d'interface utilisateur Vue et de conserver tout ou partie de vos composants Vue et dépendances Gridsome existants.
+- Astro possède [une intégration officielle pour l'utilisation des composants Vue](/fr/guides/integrations-guide/vue/) et prend en charge [l'installation des paquets NPM](/fr/guides/imports/#paquets-npm), dont plusieurs pour Vue. Vous serez en mesure d'écrire des composants d'interface utilisateur Vue et de conserver tout ou partie de vos composants Vue et dépendances Gridsome existants.
 
 - Astro et Gridsome vous permettent tous deux d'utiliser un [CMS headless, des APIs ou des fichiers Markdown pour les données](/fr/guides/data-fetching/). Vous pouvez continuer à utiliser votre système préféré de création de contenu et conserver votre contenu existant.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
@@ -31,7 +31,7 @@ Lorsque vous recréez votre site Next.js avec Astro, vous remarquerez quelques d
 
 - Next.js est une application React monopage et utilise `index.js` comme racine de votre projet. Astro est un site multipage et `index.astro` est votre page d'accueil.
 
-- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimitateur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
+- [Les composants `.astro`](/fr/basics/astro-components/) ne sont pas écrits sous forme de fonctions exportées renvoyant des modèles de page. Au lieu de cela, vous diviserez votre code en un « délimiteur de code » pour votre JavaScript et en un corps dédié au HTML que vous générez.
 
 - [Axé sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) : Astro a été conçu pour présenter votre contenu et pour vous permettre d'opter pour l'interactivité uniquement si nécessaire. Une application Next.js existante peut être conçue pour une interactivité élevée côté client et peut nécessiter des techniques Astro avancées pour inclure des éléments plus difficiles à répliquer à l'aide de composants `.astro`, tels que des tableaux de bord.
 
@@ -115,7 +115,7 @@ Voici quelques conseils pour convertir un composant Next `.js` en un composant `
 
 2. Remplacez [toute syntaxe Next ou JSX par une syntaxe Astro](#référence-convertir-la-syntaxe-nextjs-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<Link>`, `<Script>`, `{children}` et `className` par exemple.
 
-3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimitateur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
+3. Déplacez tout le JavaScript nécessaire, y compris les instructions d'importation, dans un [« délimiteur de code » (`---`)](/fr/basics/astro-components/#le-script-du-composant). Remarque : le JavaScript utilisé pour [afficher le contenu de manière conditionnelle](/fr/reference/astro-syntax/#html-dynamique) est souvent écrit directement dans le modèle HTML dans Astro.
 
 4. Utilisez [`Astro.props`](/fr/reference/api-reference/#props) pour accéder à toutes les props supplémentaires précédemment transmises à votre fonction Next.
 
@@ -411,7 +411,7 @@ En savoir plus sur les [importations de fichiers locaux avec `import.meta.glob()
 
 Vous devrez peut-être remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) avec d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez tous les objets de style en ligne (`style={{ fontWeight: "bold" }}`) en attributs de style HTML en ligne (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>
@@ -532,7 +532,7 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `getSta
 
     Remarquez que :
 
-    - la fonction `getStaticProps` n'est plus nécessaire. Les données de l'API sont récupérées directement dans le délimitateur de code.
+    - la fonction `getStaticProps` n'est plus nécessaire. Les données de l'API sont récupérées directement dans le délimiteur de code.
     - Un composant `<Layout>` est importé et enveloppe le modèle de page.
 
     ```astro ins={2,4-16,19,31} title="src/pages/index.astro"

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -110,7 +110,7 @@ Voici quelques conseils pour convertir un composant Nuxt `.vue` en un composant 
 
 2. Remplacez toute [syntaxe Nuxt ou Vue par une syntaxe Astro](#référence-convertir-la-syntaxe-nuxtjs-en-syntaxe-astro) ou par des normes web HTML. Ceci comprend `<NuxtLink>`, `:class`, `{{variable}}` et `v-if`, par exemple.
 
-3. Déplacez le JavaScript présent dans `<script>` dans un « délimitateur de code » (`---`). Convertissez les propriétés de récupération de données de votre composant en JavaScript exécuté côté serveur - consultez [la récupération de données, de Nuxt vers Astro](#la-récupération-de-données-de-nuxt-à-astro). 
+3. Déplacez le JavaScript présent dans `<script>` dans un « délimiteur de code » (`---`). Convertissez les propriétés de récupération de données de votre composant en JavaScript exécuté côté serveur - consultez [la récupération de données, de Nuxt vers Astro](#la-récupération-de-données-de-nuxt-à-astro). 
 
 4. Utilisez `Astro.props` pour accéder à toutes les props supplémentaires précédemment transmises à votre composant Vue.
 
@@ -386,7 +386,7 @@ Nuxt propose deux méthodes pour récupérer les données côté serveur :
 - [le hook `asyncData`](https://v2.nuxt.com/fr/docs/features/data-fetching/#async-data)
 - [le hook `fetch`](https://v2.nuxt.com/fr/docs/features/data-fetching/#le-hook-fetch)
 
-Dans Astro, récupérez les données à l’intérieur des délimitateurs de code de votre page.
+Dans Astro, récupérez les données à l’intérieur des délimiteurs de code de votre page.
 
 Migrez les éléments suivants :
 
@@ -404,7 +404,7 @@ Migrez les éléments suivants :
 }
 ```
 
-Dans les délimitateurs de code sans fonction enveloppante :
+Dans les délimiteurs de code sans fonction enveloppante :
 
 ```astro title="src/pages/index.astro"
 ---
@@ -623,7 +623,7 @@ Voici comment recréer cela dans `src/pages/index.astro`, en remplaçant `asyncD
 
     Remarquez que :
 
-    - La fonction `asyncData` n'est plus nécessaire. Les données de l'API sont récupérées directement dans les délimitateurs de code.
+    - La fonction `asyncData` n'est plus nécessaire. Les données de l'API sont récupérées directement dans les délimiteurs de code.
     - Un composant `<Layout>` est importé et enveloppe le modèle de page.
       - Notre méthode `head()` de Nuxt est transmise au composant `<Layout>`, qui est transmis à l'élément `<title>` en tant que propriété.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
@@ -19,7 +19,7 @@ Pelican et Astro partagent certaines similitudes qui vous aideront à migrer vot
 
 - Pelican et Astro sont tous deux des générateurs de sites statiques, idéalement adaptés aux [sites web axés sur le contenu](/fr/concepts/why-astro/#axé-sur-le-contenu) comme les blogs.
 
-- Pelican et Astro ont tous deux un support intégré pour [écrire en Markdown](/fr/guides/markdown-content/), y compris des propriétés YAML pour les métadonnées des pages. Cependant, Astro a très peu de propriétés frontmatter réservées par rapport à Pelican. Même si beaucoup de vos propriétés frontmatter Pelican existantes ne seront pas « spéciales » dans Astro, vous pouvez continuer à utiliser vos fichiers Markdown et valeurs frontmatter existants.
+- Pelican et Astro possèdent tous deux une prise en charge intégrée pour [écrire en Markdown](/fr/guides/markdown-content/), y compris les propriétés YAML du frontmatter pour les métadonnées des pages. Cependant, Astro a très peu de propriétés de frontmatter réservées par rapport à Pelican. Même si beaucoup de propriétés existantes dans votre frontmatter Pelican ne seront pas « spéciales » dans Astro, vous pouvez continuer à utiliser vos fichiers Markdown et les valeurs du frontmatter existants.
 
 ## Principales différences entre Pelican et Astro
 

--- a/src/content/docs/fr/install-and-setup.mdx
+++ b/src/content/docs/fr/install-and-setup.mdx
@@ -30,7 +30,7 @@ Vous préférez essayer Astro dans votre navigateur ? Consultez [astro.new](ht
 
 ## Compatibilité avec les navigateurs
 
-Astro est construit avec Vite, qui cible par défaut les navigateurs supportant le JavaScript moderne. Pour une référence complète, vous pouvez consulter la [liste des versions de navigateurs actuellement prises en charge par Vite](https://vite.dev/guide/build.html#browser-compatibility).
+Astro est construit avec Vite, qui cible par défaut les navigateurs prenant en charge le JavaScript moderne. Pour une référence complète, vous pouvez consulter la [liste des versions de navigateurs actuellement prises en charge par Vite](https://vite.dev/guide/build.html#browser-compatibility).
 
 ## Installer à partir de l'assistant CLI
 
@@ -243,7 +243,7 @@ Si vous préférez ne pas utiliser notre outil CLI automatique `create astro`, v
 
     ```astro title="src/pages/index.astro"
     ---
-    // Bienvenue dans Astro ! Tout ce qui se trouve entre ces délimitateur de
+    // Bienvenue dans Astro ! Tout ce qui se trouve entre ces délimiteurs de
     // code à trois tirets est le « frontmatter de votre composant ». Il ne
     // s'exécute jamais dans le navigateur.
     console.log("Ceci s'exécute dans votre terminal, et non dans le navigateur !");

--- a/src/content/docs/fr/tutorial/2-pages/1.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/1.mdx
@@ -152,7 +152,7 @@ Suivez ces étapes à chaque fois que vous faites une pause dans votre travail !
 
 <Checklist>
 - [ ] Je peux créer une nouvelle page pour mon site web et y ajouter un lien depuis une page existante.
-- [ ] Je peux valider mes modifications sur GitHub et mettre à jour mon site en direct sur Netlify.
+- [ ] Je peux valider mes modifications sur GitHub et mettre à jour mon site sur Netlify.
 </Checklist>
 </Box>
 

--- a/src/content/docs/fr/tutorial/2-pages/2.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/2.mdx
@@ -78,7 +78,7 @@ Maintenant que vous avez créé des pages à l'aide de fichiers `.astro`, il est
 </Steps>
 
 :::note
-Les informations en haut du fichier, à l'intérieur des délimitateurs de code, sont appelées « frontmatter ». Ces données, y compris les étiquettes (« tags ») et l'image de l'article, sont des informations *à propos de* votre article qu'Astro peut utiliser. Elles n'apparaissent pas automatiquement sur la page, mais nous y accéderons plus tard dans le tutoriel pour améliorer votre site. 
+Les informations en haut du fichier, à l'intérieur des délimiteurs de code, sont appelées « frontmatter ». Ces données, y compris les étiquettes (« tags ») et l'image de l'article, sont des informations *à propos de* votre article qu'Astro peut utiliser. Elles n'apparaissent pas automatiquement sur la page, mais nous y accéderons plus tard dans le tutoriel pour améliorer votre site. 
 :::
 
 ## Ajouter des liens vers vos articles

--- a/src/content/docs/fr/tutorial/2-pages/3.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/3.mdx
@@ -53,7 +53,7 @@ Ouvrez `about.astro`, qui devrait ressembler à ceci :
 ```
 
 <Steps>
-1. Ajoutez la ligne de code JavaScript suivante dans le script du frontmatter, entre les **délimitateurs de code**:
+1. Ajoutez la ligne de code JavaScript suivante dans le script du frontmatter, entre les **délimiteurs de code**:
 
     ```astro title="src/pages/about.astro" ins={2}
     ---
@@ -103,7 +103,7 @@ Ouvrez `about.astro`, qui devrait ressembler à ceci :
 ## Écrire des expressions JavaScript dans Astro
 
 <Steps>
-1. Ajoutez le code JavaScript suivant dans votre frontmatter, entre les **délimitateurs de code** :
+1. Ajoutez le code JavaScript suivant dans votre frontmatter, entre les **délimiteurs de code** :
 
       (Vous pouvez personnaliser le code à votre convenance, mais ce tutoriel utilisera l'exemple suivant.)
 
@@ -175,7 +175,7 @@ Ouvrez `about.astro`, qui devrait ressembler à ceci :
           Lorsque vous êtes à l'intérieur de la section du modèle HTML d'un composant Astro.
           </Option>
         <Option>
-          Entre les délimitateurs de code dans un composant Astro.
+          Entre les délimiteurs de code dans un composant Astro.
         </Option>
     </MultipleChoice>
 </Box>

--- a/src/content/docs/fr/tutorial/2-pages/4.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/4.mdx
@@ -87,7 +87,7 @@ En utilisant les balises `<style></style>` d'Astro, vous pouvez mettre en forme 
 </Steps>
 
 ## Utiliser votre première variable CSS
-La balise `<style>` d'Astro peut également référencer toutes les variables de votre script du frontmatter en utilisant la directive `define:vars={ {...} }`. Vous pouvez **définir des variables dans vos délimitateurs de code**, puis les **utiliser comme variables CSS dans votre balise de style**.
+La balise `<style>` d'Astro peut également référencer toutes les variables de votre script du frontmatter en utilisant la directive `define:vars={ {...} }`. Vous pouvez **définir des variables dans vos délimiteurs de code**, puis les **utiliser comme variables CSS dans votre balise de style**.
 
 <Steps>
 1. Définissez une variable `skillColor` en l'ajoutant au script du frontmatter de `src/pages/about.astro` comme ceci :

--- a/src/content/docs/fr/tutorial/3-components/1.mdx
+++ b/src/content/docs/fr/tutorial/3-components/1.mdx
@@ -42,14 +42,14 @@ Pour rassembler les fichiers `.astro` qui généreront du HTML, mais qui ne devi
     <a href="/blog/">Blog</a>
     ```
     :::tip
-    S'il n'y a rien dans le frontmatter de votre fichier `.astro`, vous n'avez pas à écrire les délimitateurs de code. Vous pouvez toujours les ajouter quand vous en aurez besoin.
+    S'il n'y a rien dans le frontmatter de votre fichier `.astro`, vous n'avez pas à écrire les délimiteurs de code. Vous pouvez toujours les ajouter quand vous en aurez besoin.
     :::
 </Steps>
 
 ### Importer et utiliser Navigation.astro
 
 <Steps>
-1. Retournez dans le fichier `index.astro` et importez votre nouveau composant à l'intérieur des délimitateurs de code :
+1. Retournez dans le fichier `index.astro` et importez votre nouveau composant à l'intérieur des délimiteurs de code :
 
     ```astro title="src/pages/index.astro" ins={2}
     ---
@@ -81,7 +81,7 @@ Votre site contient le même HTML qu'auparavant. Mais maintenant, ces trois lign
 Importez et utilisez le composant `<Navigation />` dans les deux autres pages de votre site (`about.astro` et `blog.astro`) en utilisant la même méthode.
 
 N'oubliez pas
-- d'ajouter une instruction d'importation en haut du script du composant, à l'intérieur des délimitateurs de code.
+- d'ajouter une instruction d'importation en haut du script du composant, à l'intérieur des délimiteurs de code.
 - de remplacer le code existant par le composant de navigation.
 
 </Box>

--- a/src/content/docs/fr/tutorial/3-components/4.mdx
+++ b/src/content/docs/fr/tutorial/3-components/4.mdx
@@ -242,7 +242,7 @@ Ces commandes sont toutes exécutées au moment de la compilation pour créer du
         dans des balises `<script>`
       </Option>
       <Option>
-        entre les délimitateurs de code d'un fichier `.astro`
+        entre les délimiteurs de code d'un fichier `.astro`
       </Option>
       <Option>
         dans un fichier `global.css`

--- a/src/content/docs/fr/tutorial/6-islands/1.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/1.mdx
@@ -170,7 +170,7 @@ import SvelteCounter from '../components/SvelteCounter.svelte';
       <Spoiler>**Similaires** : Ils affichent tous deux les mêmes éléments HTML et ont initialement le même aspect. **Différents** : Le composant avec la directive `client:load` se réexécutera après le chargement de la page, et tous les éléments interactifs qu'il contient fonctionneront.</Spoiler>
     </p>
 
-3. Supposez que le composant `SvelteCounter` affiche un nombre et comporte un bouton pour l'augmenter. Si vous ne pouviez pas voir le code de votre site web, seulement la page publiée en direct, comment sauriez-vous lequel des deux composants `<SvelteCounter />` a utilisé `client:visible` ?
+3. Supposez que le composant `SvelteCounter` affiche un nombre et comporte un bouton pour l'augmenter. Si vous ne pouviez pas voir le code de votre site web, seulement la page publiée, comment sauriez-vous lequel des deux composants `<SvelteCounter />` a utilisé `client:visible` ?
 
     <p>
       <Spoiler>Essayez de cliquer sur le bouton et voyez lequel est interactif. S'il répond à votre entrée, il a dû avoir une directive `client:`.</Spoiler>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
Sorry for the title not really explicit 😅 

#### Description (required)

This PR updates all the files already reviewed since #11593 to apply changes from the new i18n-guide update, see #11795
* replace `délimitateur` with `délimiteur`
* replace `support` with `prise en charge`
* remove `en direct` where it doesn't make sense
* update the use of `en ligne` for `inline` by either rewording the sentence or removing `en ligne` because I think the context is already clear no need to make the sentence cumbersome by repeating `dans le fichier`.
* reword a sentence in the Pelican guide to make reading smoother.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
