### PR TITLE
chore: update CSP docs for v5.9.2

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/csp.mdx
+++ b/src/content/docs/en/reference/experimental-flags/csp.mdx
@@ -21,7 +21,7 @@ Enables support for [Content Security Policy (CSP)](https://developer.mozilla.or
 
 Enabling this feature adds additional security to **Astro's handling of processed and bundled scripts and styles** by default, and allows you to further configure these, and additional, content types.
 
-This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` aren't supported.
+This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` are not supported, but you can [consider migrating to the browser native View Transition API](https://events-3bg.pages.dev/jotter/astro-view-transitions/) instead if you are not using Astro's enhancements to the native View Transitions and Navigation APIs.
 
 :::note
 Due to the nature of the Vite dev server, this feature isn't supported while working in `dev` mode. Instead, you can test this in your Astro project using `build` and `preview`.

--- a/src/content/docs/en/reference/experimental-flags/csp.mdx
+++ b/src/content/docs/en/reference/experimental-flags/csp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Experimental Content Security Policy
+title: Experimental Content Security Policy (CSP)
 sidebar:
   label: Content Security Policy
 i18nReady: true
@@ -21,7 +21,7 @@ Enables support for [Content Security Policy (CSP)](https://developer.mozilla.or
 
 Enabling this feature adds additional security to **Astro's handling of processed and bundled scripts and styles** by default, and allows you to further configure these, and additional, content types.
 
-This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. Additionally, [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` are not yet fully supported: when navigating from one page to another, some styles may not be applied and some scripts may not be executed.
+This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. Since v5.9.2, [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` are not supported anymore.
 
 :::note
 Due to the nature of the Vite dev server, this feature isn't supported while working in `dev` mode. Instead, you can test this in your Astro project using `build` and `preview`.

--- a/src/content/docs/en/reference/experimental-flags/csp.mdx
+++ b/src/content/docs/en/reference/experimental-flags/csp.mdx
@@ -21,7 +21,7 @@ Enables support for [Content Security Policy (CSP)](https://developer.mozilla.or
 
 Enabling this feature adds additional security to **Astro's handling of processed and bundled scripts and styles** by default, and allows you to further configure these, and additional, content types.
 
-This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. Since v5.9.2, [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` are not supported anymore.
+This experimental CSP feature has some limitations. Inline scripts are not supported out of the box, but you can [provide your own hashes](#hashes) for external and inline scripts. [Astro's view transitions](/en/guides/view-transitions/) using the `<ClientRouter />` aren't supported.
 
 :::note
 Due to the nature of the Vite dev server, this feature isn't supported while working in `dev` mode. Instead, you can test this in your Astro project using `build` and `preview`.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the CSP docs where view transitions via `ClientRouter` aren't supported anymore

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### For Astro version: `5.9.2`. See astro PR [#13914](https://github.com/withastro/astro/pull/13914).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
