### PR TITLE
fix: build forms recipe

### DIFF
--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -147,7 +147,7 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 
     Error messages can be sent back to the client by storing them in an `errors` object and accessing it in the template. 
 
-    ```astro title="src/pages/register.astro" ins={2, 7, 14-24, 43, 48, 53}
+    ```astro title="src/pages/register.astro" ins={7, 14-24, 43, 48, 53}
     ---
     export const prerender = false; // Not needed in 'server' mode
     

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -25,7 +25,6 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 2. Add a `<form>` tag with some inputs to the page. Each input should have a `name` attribute that describes the value of that input. 
 
     Be sure to include a `<button>` or `<input type="submit">` element to submit the form.
-Co
     ```astro title="src/pages/register.astro"
     ---
     ---

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -105,7 +105,7 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 
 5.  Check for the `POST` method in the frontmatter and access the form data using `Astro.request.formData()`. Wrap this in a `try ... catch` block to handle cases when the `POST` request wasn't sent by a form and the `formData` is invalid.
 
-    ```astro title="src/pages/register.astro" ins={2-15} "Astro.request.formData()"
+    ```astro title="src/pages/register.astro" ins={2-16} "Astro.request.formData()"
     ---
     export const prerender = false; // Not needed in 'server' mode
     

--- a/src/content/docs/en/recipes/build-forms.mdx
+++ b/src/content/docs/en/recipes/build-forms.mdx
@@ -25,7 +25,7 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 2. Add a `<form>` tag with some inputs to the page. Each input should have a `name` attribute that describes the value of that input. 
 
     Be sure to include a `<button>` or `<input type="submit">` element to submit the form.
-
+Co
     ```astro title="src/pages/register.astro"
     ---
     ---
@@ -106,8 +106,10 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 
 5.  Check for the `POST` method in the frontmatter and access the form data using `Astro.request.formData()`. Wrap this in a `try ... catch` block to handle cases when the `POST` request wasn't sent by a form and the `formData` is invalid.
 
-    ```astro title="src/pages/register.astro" ins={2-14} "Astro.request.formData()"
+    ```astro title="src/pages/register.astro" ins={2-15} "Astro.request.formData()"
     ---
+    export const prerender = false; // Not needed in 'server' mode
+    
     if (Astro.request.method === "POST") {
       try {
         const data = await Astro.request.formData();
@@ -146,8 +148,10 @@ Astro pages that are rendered on demand can both display and handle forms. In th
 
     Error messages can be sent back to the client by storing them in an `errors` object and accessing it in the template. 
 
-    ```astro title="src/pages/register.astro" ins={5, 12-22, 41, 46, 51}
+    ```astro title="src/pages/register.astro" ins={2, 7, 14-24, 43, 48, 53}
     ---
+    export const prerender = false; // Not needed in 'server' mode
+    
     import { isRegistered, registerUser } from "../../data/users"
     import { isValidEmail } from "../../utils/isValidEmail";
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

  #### Description (required)

  <!-- Please describe the change you are proposing, and why -->

  Adds a helpful comment `export const prerender = false; // Not needed in 'server' mode` to the form handling code examples in the build-forms recipe documentation.

  This clarifies that pages handling forms need to be server-rendered (not pre-rendered at build time) to avoid the "Content-Type was not one of 'multipart/form-data' or
  'application/x-www-form-urlencoded'" error that users have been encountering.

  The comment follows the same pattern used in Astro's on-demand rendering documentation for consistency.

  <!-- Please make changes in **one language** only -->

  #### Related issues & labels (optional)

  - Closes #11575
  - Suggested label: `improve existing docs`

  <!-- For a new/changed feature in an upcoming Astro release? -->
  <!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
  <!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

  <!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

  <!-- #### First-time contributor to Astro Docs? -->

  <!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
  <!-- https://astro.build/chat -->
