### PR TITLE
i18n(fr): improve the wording in `guides/styling.mdx`

### DIFF
--- a/src/content/docs/fr/basics/astro-components.mdx
+++ b/src/content/docs/fr/basics/astro-components.mdx
@@ -73,7 +73,7 @@ Le modèle de composant se trouve sous le délimiteur de code et détermine la s
 
 Si vous écrivez du HTML brut ici, votre composant affichera ce HTML dans n'importe quelle page Astro où il est importé et utilisé.
 
-Cependant, la [syntaxe du modèle de composant d'Astro](/fr/reference/astro-syntax/) prend également en charge les **expressions JavaScript**, les balises [`<style>`](/fr/guides/styling/#styliser-avec-astro) et [`<script>`](/fr/guides/client-side-scripts/#utilisation-du-script-dans-astro) d'Astro, les **composants importés** et les [**directives spéciales d'Astro**](/fr/reference/directives-reference/). Les données et valeurs définies dans le script du composant peuvent être utilisées dans le modèle de composant pour produire du HTML créé dynamiquement.
+Cependant, la [syntaxe du modèle de composant d'Astro](/fr/reference/astro-syntax/) prend également en charge les **expressions JavaScript**, les balises [`<style>`](/fr/guides/styling/#mettre-en-forme-avec-astro) et [`<script>`](/fr/guides/client-side-scripts/#utilisation-du-script-dans-astro) d'Astro, les **composants importés** et les [**directives spéciales d'Astro**](/fr/reference/directives-reference/). Les données et valeurs définies dans le script du composant peuvent être utilisées dans le modèle de composant pour produire du HTML créé dynamiquement.
 
 ```astro title="src/components/MyFavoritePokemon.astro"
 ---

--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -185,7 +185,7 @@ Vous pouvez personnaliser la façon dont remark analyse votre Markdown dans `ast
 
 ### Ajouter des plugins remark et rehype
 
-Astro prend en charge l'ajout de plugins tiers [remark](https://github.com/remarkjs/remark) et [rehype](https://github.com/rehypejs/rehype) pour Markdown. Ces plugins vous permettent d'étendre votre Markdown avec de nouvelles fonctionnalités, comme [générer automatiquement une table des matières](https://github.com/remarkjs/remark-toc), [appliquer des étiquettes accessibles aux émojis](https://github.com/florianeckerstorfer/remark-a11y-emoji) et [styliser votre Markdown](/fr/guides/styling/#style-markdown).
+Astro prend en charge l'ajout de plugins tiers [remark](https://github.com/remarkjs/remark) et [rehype](https://github.com/rehypejs/rehype) pour Markdown. Ces plugins vous permettent d'étendre votre Markdown avec de nouvelles fonctionnalités, comme [générer automatiquement une table des matières](https://github.com/remarkjs/remark-toc), [appliquer des étiquettes accessibles aux émojis](https://github.com/florianeckerstorfer/remark-a11y-emoji) et [styliser votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown).
 
 Nous vous encourageons à consulter [awesome-remark](https://github.com/remarkjs/awesome-remark) et [awesome-rehype](https://github.com/rehypejs/awesome-rehype) parmi les plugins populaires ! Consultez le fichier README de chaque plugin pour obtenir des instructions d'installation spécifiques.
 
@@ -391,7 +391,7 @@ const {frontmatter} = Astro.props;
 </html>
 ```
 
-Lorsque vous utilisez la propriété frontmatter `layout`, vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement. Vous pouvez désormais également [styliser votre Markdown](/fr/guides/styling/#style-markdown) dans votre composant de mise en page.
+Lorsque vous utilisez la propriété frontmatter `layout`, vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement. Vous pouvez désormais également [styliser votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown) dans votre composant de mise en page.
 
 <ReadMore>En savoir plus sur les [Mises en page Markdown](/fr/basics/layouts/#mises-en-page-markdown).</ReadMore>
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-create-react-app.mdx
@@ -355,7 +355,7 @@ En savoir plus sur l'importation de fichiers locaux avec [`import.meta.glob()`](
 
 Il se peut que vous deviez remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) par d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [`<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold ;"`). Vous pouvez également utiliser une balise [`<style>` d'Astro](/fr/guides/styling/#mettre-en-forme-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
@@ -307,7 +307,7 @@ En savoir plus sur [l'utilisation spécifique de `<slot />` dans Astro](/fr/basi
 
 Vous devrez peut-être remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) avec d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#mettre-en-forme-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
@@ -411,7 +411,7 @@ En savoir plus sur les [importations de fichiers locaux avec `import.meta.glob()
 
 Vous devrez peut-être remplacer les [bibliothèques CSS-in-JS](https://github.com/withastro/astro/issues/4432) (par exemple, `styled-components`) avec d'autres options CSS disponibles dans Astro.
 
-Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro) pour limiter la portée des styles CSS.
+Si nécessaire, convertissez tous les objets de style (`style={{ fontWeight: "bold" }}`) en attributs de style HTML (`style="font-weight:bold;"`). Ou utilisez la [balise `<style>` d'Astro](/fr/guides/styling/#mettre-en-forme-avec-astro) pour limiter la portée des styles CSS.
 
 ```astro title="src/components/Card.astro" del={1} ins={2}
 <div style={{backgroundColor: `#f4f4f4`, padding: `1em`}}>{message}</div>

--- a/src/content/docs/fr/guides/styling.mdx
+++ b/src/content/docs/fr/guides/styling.mdx
@@ -1,8 +1,9 @@
 ---
 title: Styles et CSS
-description: Apprenez à mettre en forme des composants dans Astro avec des styles à portée limitée, des CSS externes et des outils tels que Sass et PostCSS.
+description: >-
+  Apprenez à mettre en forme des composants dans Astro avec des styles à portée
+  limitée, du CSS externe et des outils tels que Sass et PostCSS.
 i18nReady: true
-
 ---
 import Since from '~/components/Since.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
@@ -13,7 +14,7 @@ import RecipeLinks from "~/components/RecipeLinks.astro";
 
 Astro a été conçu pour rendre la mise en forme et l'écriture CSS un jeu d'enfant. Écrivez votre propre CSS directement dans un composant Astro ou importez votre bibliothèque CSS préférée comme [Tailwind][tailwind]. Les langages avancés de mise en forme comme [Sass][sass] et [Less][less] sont également pris en charge.
 
-##  Styliser avec Astro
+## Mettre en forme avec Astro
 
 La mise en forme d'un composant Astro est aussi simple que l'ajout d'une balise `<style>` à votre composant ou à votre modèle de page. Lorsque vous placez une balise `<style>` à l'intérieur d'un composant Astro, Astro détecte le CSS et gère vos styles pour vous, automatiquement.
 
@@ -167,12 +168,12 @@ import MyComponent from "../components/MyComponent.astro"
 Parce que l'attribut `data-astro-cid-*` inclut l'enfant dans la portée de son parent, il est possible que les styles passent en cascade du parent à l'enfant. Pour éviter que cela n'ait des effets secondaires inattendus, assurez-vous d'utiliser des noms de classe uniques dans le composant enfant.
 :::
 
-### Styles en ligne
+### Styles incorporés dans un élément
 
-Vous pouvez mettre en forme les éléments HTML en ligne en utilisant l'attribut `style`. Il peut s'agir d'une chaîne CSS ou d'un objet de propriétés CSS :
+Vous pouvez mettre en forme les éléments HTML directement à l'aide de l'attribut `style`. Il peut s'agir d'une chaîne CSS ou d'un objet de propriétés CSS :
 
 ```astro title="src/pages/index.astro"
-// Ils sont équivalents:
+// Ils sont équivalents :
 <p style={{ color: "brown", textDecoration: "underline" }}>Mon texte</p>
 <p style="color: brown; text-decoration: underline;">Mon texte</p>
 ```
@@ -200,11 +201,11 @@ import '../styles/utils.css';
 <html><!-- Votre page ici --></html>
 ```
 
-L'importation de CSS via ESM est supportée à l'intérieur de n'importe quel fichier JavaScript, y compris les composants JSX comme React et Preact.  Cela peut être utile pour écrire des styles granulaires par composant pour vos composants React. 
+L'importation de CSS via ESM est prise en charge à l'intérieur de n'importe quel fichier JavaScript, y compris les composants JSX comme React et Preact.  Cela peut être utile pour écrire des styles granulaires par composant pour vos composants React. 
 
 ### Importer une feuille de style à partir d'un paquet npm
 
-Vous pouvez également avoir besoin de charger des feuilles de style à partir d'un paquet npm externe. Ceci est particulièrement courant pour les utilitaires comme [Open Props](https://open-props.style/). Si votre paquet **recommande l'utilisation d'une extension de fichier** (ex. `nom-du-paquet/styles.css` au lieu de `nom-du-paquet/styles`), cela devrait fonctionner comme n'importe quelle feuille de style locale :
+Vous pouvez également avoir besoin de charger des feuilles de style à partir d'un paquet npm externe. Ceci est particulièrement courant pour les utilitaires comme [Open Props](https://open-props.style/). Si votre paquet **recommande l'utilisation d'une extension de fichier** (p. ex. `nom-du-paquet/styles.css` au lieu de `nom-du-paquet/styles`), cela devrait fonctionner comme n'importe quelle feuille de style locale :
 
 ```astro {3}
 ---
@@ -216,7 +217,7 @@ import 'package-name/styles.css';
 
 Si votre paquet **ne suggère pas l'utilisation d'une extension de fichier** (c'est-à-dire `nom-du-paquet/styles`), vous devrez d'abord mettre à jour votre configuration Astro !
 
-Disons que vous importez un fichier CSS depuis `nom-du-paquet` appelé `normalize` (avec l'extension de fichier omise). Pour s'assurer que nous pouvons rendre votre page correctement, ajoutez `nom-du-paquet` au [tableau `vite.ssr.noExternal`](https://vite.dev/config/ssr-options.html#ssr-noexternal) :
+Disons que vous importez un fichier CSS depuis `nom-du-paquet` appelé `normalize` (avec l'extension de fichier omise). Pour s'assurer que nous pouvons correctement effectuer le pré-rendu de votre page, ajoutez `nom-du-paquet` au [tableau `vite.ssr.noExternal`](https://vite.dev/config/ssr-options.html#ssr-noexternal) :
 
 ```js ins={7}
 // astro.config.mjs
@@ -246,9 +247,9 @@ import 'package-name/normalize';
 <html><!-- Votre page ici --></html>
 ```
 
-### Charger une feuille de style statique via les balises "link"
+### Charger une feuille de style statique via les balises « link »
 
-Vous pouvez également utiliser l'élément `<link>` pour charger une feuille de style sur la page. Il doit s'agir d'un chemin d'URL absolu vers un fichier CSS situé dans votre répertoire `/public`, ou d'une URL vers un site web externe. Les valeurs href `<link>` relatives ne sont pas supportées.
+Vous pouvez également utiliser l'élément `<link>` pour charger une feuille de style sur la page. Il doit s'agir d'un chemin d'URL absolu vers un fichier CSS situé dans votre répertoire `/public`, ou d'une URL vers un site web externe. Les valeurs href des liens (`<link>`) relatifs ne sont pas prises en charge.
 
 ```astro title="src/pages/index.astro" {3,5}
 <head>
@@ -278,7 +279,7 @@ Si une règle est plus _spécifique_ qu'une autre, sa valeur sera prioritaire, q
 </style>
 <div>
   <h1>
-    Cette en-tête sera mauve !
+    Cet en-tête sera mauve !
   </h1>
 </div>
 ```
@@ -291,7 +292,7 @@ Si deux règles ont la même spécificité, l'_ordre d'apparition_ est évalué 
 </style>
 <div>
   <h1>
-    Cette en-tête sera rouge !
+    Cet en-tête sera rouge !
   </h1>
 </div>
 ```
@@ -322,7 +323,7 @@ import "./make-it-purple.css"
 </style>
 <div>
   <h1>
-    Cette en-tête sera rouge !
+    Cet en-tête sera rouge !
   </h1>
 </div>
 ```
@@ -343,7 +344,7 @@ import "./make-it-purple.css"
 </style>
 <div>
   <h1 id="intro">
-    Cette en-tête sera mauve !
+    Cet en-tête sera mauve !
   </h1>
 </div>
 ```
@@ -372,7 +373,7 @@ import "./make-it-purple.css"
 </style>
 <div>
   <h1>
-    Cette en-tête sera mauve !
+    Cet en-tête sera mauve !
   </h1>
 </div>
 ```
@@ -397,13 +398,13 @@ import PurpleComponent from "./PurpleComponent.astro";
 </style>
 <div>
   <h1>
-    Cette en-tête sera mauve !
+    Cet en-tête sera mauve !
   </h1>
 </div>
 ```
 
 :::tip
-Un modèle courant dans Astro consiste à importer des feuilles de style CSS globales à l'intérieur d'un [Layout](/fr/basics/layouts/). Veillez à importer le composant Layout avant les autres importations afin qu'il ait la priorité la plus faible.
+Un modèle courant dans Astro consiste à importer des feuilles de style CSS globales à l'intérieur d'un [composant Layout](/fr/basics/layouts/). Veillez à importer le composant Layout avant les autres importations afin qu'il ait la priorité la plus faible.
 :::
 
 ### Balises de lien
@@ -425,7 +426,7 @@ import "../components/make-it-purple.css"
 	</head>
 	<body>
 		<div>
-			<h1>Cette en-tête sera mauve</h1>
+			<h1>Cet en-tête sera mauve</h1>
 		</div>
 	</body>
 </html>
@@ -435,13 +436,13 @@ import "../components/make-it-purple.css"
 
 Astro prend en charge l'ajout de bibliothèques, d'outils et de frameworks CSS populaires à votre projet, comme [Tailwind](https://tailwindcss.com) et bien d'autres encore !
 
-Astro prend en charge Tailwind 3 et 4. Vous pouvez [ajouter la prise en charge de Tailwind 4 via un plugin Vite](#ajouter-tailwind-4) à votre projet avec une commande CLI, ou installer manuellement les dépendances héritées pour ajouter la [prise en charge de Tailwind 3 via une intégration Astro](#prise-en-charge-héritée-de-tailwind-3).
+Astro prend en charge Tailwind 3 et 4. Vous pouvez [ajouter la prise en charge de Tailwind 4 via un module d'extension pour Vite](#ajouter-tailwind-4) à votre projet avec une commande CLI, ou installer manuellement les dépendances héritées pour ajouter la [prise en charge de Tailwind 3 via une intégration Astro](#prise-en-charge-héritée-de-tailwind-3).
 
 Pour [mettre à niveau votre projet Astro de Tailwind 3 à 4](#mettre-à-niveau-depuis-tailwind-3), vous devrez à la fois ajouter la prise en charge de Tailwind 4 et supprimer la prise en charge héritée de Tailwind 3.
 
 ### Ajouter Tailwind 4
 
-Dans Astro `>=5.2.0`, utilisez la commande `astro add tailwind` de votre gestionnaire de paquets pour installer le plugin Vite officiel pour Tailwind. Pour ajouter la prise en charge de Tailwind 4 aux versions antérieures d'Astro, suivez les [instructions dans la documentation de Tailwind][tailwind] pour ajouter manuellement le plugin Vite `@tailwindcss/vite`.
+Dans Astro `>=5.2.0`, utilisez la commande `astro add tailwind` de votre gestionnaire de paquets pour installer le module d'extension officiel de Tailwind pour Vite. Pour ajouter la prise en charge de Tailwind 4 aux versions antérieures d'Astro, suivez les [instructions dans la documentation de Tailwind][tailwind] pour ajouter manuellement le module d'extension `@tailwindcss/vite` pour Vite.
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -461,7 +462,7 @@ Dans Astro `>=5.2.0`, utilisez la commande `astro add tailwind` de votre gestion
   </Fragment>
 </PackageManagerTabs>
 
-Ensuite, importez `tailwindcss` dans `src/styles/global.css` (ou un autre fichier CSS de votre choix) pour rendre les classes Tailwind disponibles pour votre projet Astro. Ce fichier incluant l'importation sera créé par défaut si vous avez utilisé la commande `astro add tailwind` pour installer le plugin Vite.
+Ensuite, importez `tailwindcss` dans `src/styles/global.css` (ou un autre fichier CSS de votre choix) pour rendre les classes Tailwind disponibles pour votre projet Astro. Ce fichier incluant l'importation sera créé par défaut si vous avez utilisé la commande `astro add tailwind` pour installer le module d'extension pour Vite.
 
 ```css title="src/styles/global.css"
 @import "tailwindcss";
@@ -477,10 +478,10 @@ import "../styles/global.css";
 
 ### Mettre à niveau depuis Tailwind 3
 
-Suivez les étapes pour mettre à jour un projet Astro existant qui utilise Tailwind v3 (en utilisant l'intégration `@astrojs/tailwind`) vers Tailwind 4 (en utilisant [le plugin `@tailwindcss/vite`](https://tailwindcss.com/docs/installation/framework-guides/astro)).
+Suivez les étapes pour mettre à jour un projet Astro existant qui utilise Tailwind v3 (en utilisant l'intégration `@astrojs/tailwind`) vers Tailwind 4 (en utilisant [le module d'extension `@tailwindcss/vite`](https://tailwindcss.com/docs/installation/framework-guides/astro)).
 
 <Steps>
-1. [Ajoutez la prise en charge de Tailwind 4 à votre projet](#ajouter-tailwind-4) via la CLI pour la dernière version d'Astro, ou en ajoutant le plugin Vite manuellement.
+1. [Ajoutez la prise en charge de Tailwind 4 à votre projet](#ajouter-tailwind-4) via la CLI pour la dernière version d'Astro, ou en ajoutant le module d'extension pour Vite manuellement.
 
 2. Désinstallez l'intégration `@astrojs/tailwind` de votre projet :
 
@@ -640,17 +641,17 @@ export default defineConfig({
 
 ```
 
-### Dans les composants du framework
+### Dans les composants de framework
 
 Vous pouvez également utiliser tous les préprocesseurs CSS ci-dessus dans les frameworks JS ! Veillez à suivre les modèles recommandés par chaque framework :
 
-- **React** / **Preact** : `importer les styles depuis './styles.module.scss';`
+- **React** / **Preact** : `import Styles from './styles.module.scss';`
 - **Vue** : `<style lang="scss">`
 - **Svelte** : `<style lang="scss">`
 
 ## PostCSS
 
-Astro est livré avec PostCSS inclus dans [Vite](https://vite.dev/guide/features.html#postcss). Pour configurer PostCSS pour votre projet, créez un fichier `postcss.config.cjs` à la racine du projet. Vous pouvez importer des plugins en utilisant `require()` après les avoir installés (par exemple `npm install autoprefixer`).
+Astro est livré avec PostCSS inclus dans [Vite](https://vite.dev/guide/features.html#postcss). Pour configurer PostCSS pour votre projet, créez un fichier `postcss.config.cjs` à la racine du projet. Vous pouvez importer des modules d'extension en utilisant `require()` après les avoir installés (par exemple `npm install autoprefixer`).
 
 ```js title="postcss.config.cjs" ins={3-4}
 module.exports = {
@@ -666,41 +667,41 @@ module.exports = {
 
 ### 📘 React / Preact
 
-`.jsx` supportent à la fois les CSS globales et les modules CSS. Pour activer ces derniers, utilisez l'extension `.module.css` (ou `.module.scss`/`.module.sass` si vous utilisez Sass).
+Les fichiers `.jsx` prennent en charge à la fois les CSS globales et les modules CSS. Pour activer ces derniers, utilisez l'extension `.module.css` (ou `.module.scss`/`.module.sass` si vous utilisez Sass).
 
 ```jsx title="src/components/MyReactComponent.jsx" /[a-z]+(\\.module\\.css)/
 import './global.css'; // inclure le CSS global
-import Styles from './styles.module.css'; // Utiliser des modules CSS (qui doivent se terminer par `.module.css`, `.module.scss`, ou `.module.sass`!)
+import Styles from './styles.module.css'; // Utiliser des modules CSS (qui doivent se terminer par `.module.css`, `.module.scss`, ou `.module.sass` !)
 ```
 
 ### 📗 Vue
 
-Vue dans Astro supporte les mêmes méthodes que `vue-loader` :
+Vue dans Astro prend en charge les mêmes méthodes que `vue-loader` :
 
-- [vue-loader - Scoped CSS][vue-scoped]
-- [vue-loader - CSS Modules][vue-css-modules]
+- [vue-loader - CSS à portée limitée][vue-scoped]
+- [vue-loader - modules CSS][vue-css-modules]
 
 ### 📕 Svelte
 
 Svelte dans Astro fonctionne aussi exactement comme prévu : [Documentation sur la mise en forme avec Svelte][svelte-style].
 
-## Style Markdown
+## Mettre en forme Markdown
 
-Toutes les méthodes de style Astro sont disponibles pour un [composant de mise en page Markdown](/fr/basics/layouts/#mises-en-page-markdown), mais des méthodes différentes auront des effets de style différents sur votre page.
+Toutes les méthodes de mise en forme d'Astro sont disponibles dans un [composant de mise en page Markdown](/fr/basics/layouts/#mises-en-page-markdown), mais des méthodes différentes auront des effets de style différents sur votre page.
 
 Vous pouvez appliquer des styles globaux à votre contenu Markdown en ajoutant des [feuilles de style importées](#styles-externes) à la mise en page qui englobe le contenu de votre page. Il est également possible d'appliquer un style à votre document Markdown avec des balises [`<style is:global>`](#styles-globaux) dans le composant de mise en page.  Notez que tous les styles ajoutés sont soumis à [l'ordre de cascade d'Astro](#ordre-de-cascade), et vous devriez vérifier votre page rendue avec soin pour vous assurer que vos styles sont appliqués comme prévu.
 
-Vous pouvez également ajouter des intégrations CSS, notamment [Tailwind](/fr/recipes/tailwind-rendered-markdown/). Si vous utilisez Tailwind, le [plugin de typographie](https://tailwindcss.com/docs/typography-plugin) peut être utile pour styliser Markdown.
+Vous pouvez également ajouter des intégrations CSS, notamment [Tailwind](/fr/recipes/tailwind-rendered-markdown/). Si vous utilisez Tailwind, le [module d'extension de typographie](https://tailwindcss.com/docs/typography-plugin) peut être utile pour mettre en forme Markdown.
 
 ## Production
 
-### Contrôle des paquets
+### Contrôle des regroupements
 
-Lorsque Astro construit votre site pour un déploiement en production, il minifie et combine votre CSS en morceaux. Chaque page de votre site reçoit son propre bloc et, en outre, les feuilles de style CSS partagées entre plusieurs pages sont divisées en blocs distincts afin d'être réutilisées.
+Lorsque Astro compile votre site pour un déploiement en production, il minifie et combine votre CSS en **blocs**. Chaque page de votre site reçoit son propre bloc et, en outre, le CSS partagé entre plusieurs pages est ensuite divisé en blocs distincts afin d'être réutilisé.
 
-Cependant, lorsque plusieurs pages partagent des styles, certains morceaux partagés peuvent devenir très petits. S'ils étaient tous envoyés séparément, cela entraînerait de nombreuses requêtes de feuilles de style et affecterait les performances du site. C'est pourquoi, par défaut, Astro ne liera que les éléments de votre HTML dont la taille est supérieure à 4kB en tant que balises `<link rel="stylesheet">`, tout en intégrant les éléments plus petits dans `<style type="text/css">`. Cette approche permet de trouver un équilibre entre le nombre de requêtes supplémentaires et le volume de CSS qui peut être mis en cache entre les pages.
+Cependant, lorsque plusieurs pages partagent des styles, certains blocs partagés peuvent devenir très petits. S'ils étaient tous envoyés séparément, cela entraînerait de nombreuses requêtes de feuilles de style et affecterait les performances du site. C'est pourquoi, par défaut, Astro liera dans votre HTML uniquement ceux dont la taille est supérieure à 4kB en tant que balises `<link rel="stylesheet">`, tout en incorporant dans la page les plus petits avec `<style type="text/css">`. Cette approche permet de trouver un équilibre entre le nombre de requêtes supplémentaires et le volume de CSS qui peut être mis en cache entre les pages.
 
-Vous pouvez configurer la taille à partir de laquelle les feuilles de style seront liées en externe (en octets) en utilisant l'option `assetsInlineLimit` de construction vite. Notez que cette option affecte également l'intégration en ligne des scripts et des images.
+Vous pouvez configurer la taille à partir de laquelle les feuilles de style seront liées en externe (en octets) grâce à l'option de compilation `assetsInlineLimit` de Vite. Notez que cette option affecte également l'incorporation des scripts et des images.
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -714,7 +715,7 @@ export default defineConfig({
 });
 ```
 
-Si vous préférez que tous les styles de projet restent externes, vous pouvez configurer l'option de construction `inlineStylesheets`.
+Si vous préférez que tous les styles de projet restent externes, vous pouvez configurer l'option de compilation `inlineStylesheets`.
 
 ```js
 import { defineConfig } from 'astro/config';
@@ -726,12 +727,12 @@ export default defineConfig({
 });
 ```
 
-Vous pouvez également définir cette option sur `'always'`, ce qui intégrera en ligne toutes les feuilles de style.
+Vous pouvez également définir cette option sur `'always'`, ce qui incorporera dans la page toutes les feuilles de style.
 
 ## Avancé
 
 :::caution
-Soyez prudent lorsque vous contournez le regroupement CSS intégré d'Astro ! Les styles ne seront pas automatiquement inclus dans la sortie construite, et il est de votre responsabilité de vous assurer que le fichier référencé est correctement inclus dans la sortie finale de la page.
+Soyez prudent lorsque vous contournez le regroupement CSS intégré d'Astro ! Les styles ne seront pas automatiquement inclus dans la sortie compilée, et il est de votre responsabilité de vous assurer que le fichier référencé est correctement inclus dans la sortie finale de la page.
 :::
 
 ### Importations CSS avec `?raw`
@@ -756,7 +757,7 @@ Pour les cas d'utilisation avancés, vous pouvez importer une référence URL di
 Cela n'est pas recommandé pour la plupart des utilisateurs. Placez plutôt vos fichiers CSS à l'intérieur de `public/` pour obtenir une référence URL cohérente.
 
 :::caution
-Importer un fichier CSS plus petit avec `?url` peut retourner le contenu encodé en base64 du fichier CSS en tant qu'URL de données dans votre compilation finale. Soit vous écrivez votre code pour supporter les URLs de données encodées (`data:text/css;base64,...`), soit vous mettez l'option de configuration [`vite.build.assetsInlineLimit`](https://vite.dev/config/#build-assetsinlinelimit) à `0` pour désactiver cette fonctionnalité.
+Importer un fichier CSS plus petit avec `?url` peut retourner le contenu encodé en base64 du fichier CSS en tant qu'URL de données dans votre compilation finale. Soit vous écrivez votre code pour prendre en charge les URLs de données encodées (`data:text/css;base64,...`), soit vous définissez l'option de configuration [`vite.build.assetsInlineLimit`](https://vite.dev/config/#build-assetsinlinelimit) sur `0` pour désactiver cette fonctionnalité.
 :::
 
 ```astro title="src/components/RawStylesUrl.astro" "?url"

--- a/src/content/docs/fr/tutorial/2-pages/4.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/4.mdx
@@ -201,6 +201,6 @@ const textCase = "uppercase";
 ### Ressources
 - [Comparaison entre la syntaxe d'Astro et JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx)
 
-- [La balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro)
+- [La balise `<style>` d'Astro](/fr/guides/styling/#mettre-en-forme-avec-astro)
 
 - [Les variables CSS dans Astro](/fr/guides/styling/#variables-css)

--- a/src/content/docs/fr/tutorial/2-pages/5.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/5.mdx
@@ -148,6 +148,6 @@ Votre page À propos est désormais mise en forme en utilisant *à la fois* le f
 ### Ressources
 - [Comparaison entre la syntaxe d'Astro et JSX](/fr/reference/astro-syntax/#différences-entre-astro-et-jsx)
 
-- [La balise `<style>` d'Astro](/fr/guides/styling/#styliser-avec-astro)
+- [La balise `<style>` d'Astro](/fr/guides/styling/#mettre-en-forme-avec-astro)
 
 - [Les variables CSS dans Astro](/fr/guides/styling/#variables-css)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Following #11593 and #11795, updates the wording used in `guides/styling.mdx`:
* replace `styliser` with `mettre en forme` (+ fix links in other pages)
* replace `plugin` with `module d'extension`
* replace `supporter` with `prise en charge`
* replace `construire` with `compiler` where more appropriate
* replace `paquet` with `regroupement` for `bundle`
* replace `cette en-tête` with `cet en-tête` (it's [a masculine noun](https://www.larousse.fr/dictionnaires/francais/en-t%C3%AAte/29917))
* replace the translation of `inline` with something more meaningful than `en ligne` 
* fix some tiny mismatches with the English version

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
