### PR TITLE
fix(basics/ps): add an exception to 'src/pages' requirment

### DIFF
--- a/src/content/docs/en/basics/project-structure.mdx
+++ b/src/content/docs/en/basics/project-structure.mdx
@@ -81,7 +81,7 @@ While this guide describes some popular conventions used in the Astro community,
 Pages routes are created for your site by adding [supported file types](/en/basics/astro-pages/#supported-page-files) to this directory.
 
 :::caution
-`src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!
+`src/pages` is a **required** sub-directory in your Astro project. Without it, your site will have no pages or routes!, unless you use `injectRoiute()` [an optional callback of the setup hook of the integration API](/en/reference/integrations-reference/#injectroute-option)
 :::
 
 ### `src/components`


### PR DESCRIPTION


#### Description (required)

This doc regatrding that the project has to have `src/page` directory, is not accurate, this change adds an exception. 

 It's possible for the project to not have 'src/pages', if 'injectRoiute' is used, simliar to Starlight theme[^1].

  https://github.com/withastro/docs/blob/734084c6bc05be64a43c77f582540394f5ab8206/src/content/docs/en/reference/integrations-reference.mdx?plain=1#L415-L428

