### PR TITLE
on-demand rendering for experimental Live Content collections

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
@@ -21,7 +21,7 @@ Live content collections are a new type of [content collection](/en/guides/conte
 
 ## Basic usage
 
-To enable the feature, add the `experimental.liveContentCollections` flag to your `astro.config.mjs` file:
+To enable the feature, make sure you have an adapter configured for [on-demand rendering](/en/guides/on-demand-rendering/) and add the `experimental.liveContentCollections` flag to your `astro.config.mjs` file:
 
 ```js title="astro.config.mjs"
 {
@@ -52,6 +52,8 @@ You can then use the dedicated `getLiveCollection()` and `getLiveEntry()` functi
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveCollection, getLiveEntry } from 'astro:content';
 
 // Get all products
@@ -126,6 +128,8 @@ You can then get content from both loaders with a unified API:
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveCollection, getLiveEntry } from 'astro:content';
 
 // Use loader-specific filters
@@ -155,6 +159,8 @@ These errors have a static `is()` method that you can use to check the type of e
 
 ```astro "LiveEntryNotFoundError.is(error)"
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry, LiveEntryNotFoundError } from 'astro:content';
 const { entry, error } = await getLiveEntry('products', Astro.params.id);
 if (error) {
@@ -281,6 +287,8 @@ You can then render both content and metadata from live collection entries in pa
 
 ```astro "render(entry)" "<Content />"
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry, render } from 'astro:content';
 const { entry, error } = await getLiveEntry('articles', Astro.params.id);
 if (error) {
@@ -350,6 +358,8 @@ When you use `getLiveCollection()` or `getLiveEntry()`, TypeScript will infer th
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry } from 'astro:content';
 const { entry: product } = await getLiveEntry('products', '123');
 // TypeScript knows product.data is of type Product
@@ -456,6 +466,8 @@ When you use `getLiveCollection()` or `getLiveEntry()`, TypeScript will infer th
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry } from 'astro:content';
 const { entry, error } = await getLiveEntry('products', '123');
 if (error) {
@@ -504,6 +516,8 @@ When using Zod schemas, validation errors are automatically caught and returned 
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry, LiveCollectionValidationError } from 'astro:content';
 
 const { entry, error } = await getLiveEntry('products', '123');
@@ -564,6 +578,8 @@ You can then use these hints in your pages:
 
 ```astro
 ---
+export const prerender = false; // Not needed in 'server' mode
+
 import { getLiveEntry } from 'astro:content';
 
 const { entry, error, cacheHint } = await getLiveEntry('products', Astro.params.id);


### PR DESCRIPTION
This PR adds more explicit guidance re: on-demand rendering required to use live content collections. Includes:

- a prompt to make sure you have an adapter configured before adding the experimental feature

- the following standard line for opting out of prerendering on an individual page for any `.astro` code snippet:

```
export const prerender = false; // Not needed in 'server' mode
```
