### PR TITLE
fix(live-content-collections): increment `ol` + consistent verb tense

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
@@ -616,12 +616,12 @@ Live content collections have some limitations compared to build-time collection
 
 Live collections use a different API than current preloaded content collections. Key differences include:
 
-1. **Execution time**: Runs at request time instead of build time
-1. **Configuration file**: Use `src/live.config.ts` instead of `src/content.config.ts`
-1. **Collection definition**: Use `defineLiveCollection()` instead of `defineCollection()`
-1. **Collection type**: Set `type: "live"` in collection definition
-1. **Loader API**: Implement `loadCollection` and `loadEntry` methods instead of the `load` method
-1. **Data return**: Return data directly instead of storing in the data store
-1. **User-facing functions**: Use `getLiveCollection`/`getLiveEntry` instead of `getCollection`/`getEntry`
+1. **Execution time**: Run at request time instead of build time
+2. **Configuration file**: Use `src/live.config.ts` instead of `src/content.config.ts`
+3. **Collection definition**: Use `defineLiveCollection()` instead of `defineCollection()`
+4. **Collection type**: Set `type: "live"` in collection definition
+5. **Loader API**: Implement `loadCollection` and `loadEntry` methods instead of the `load` method
+6. **Data return**: Return data directly instead of storing in the data store
+7. **User-facing functions**: Use `getLiveCollection`/`getLiveEntry` instead of `getCollection`/`getEntry`
 
 For a complete overview and to give feedback on this experimental API, see the [Live Content collections RFC](https://github.com/withastro/roadmap/blob/feat/live-loaders/proposals/0055-live-content-loaders.md).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In `experimental-flags/live-content-collections`:
* Fixes an ordered list: The rendered list is incremented but the MDX file numbers all elements with 1.
* Uses a consistent verb tense in the same list:  Not sure if we should use `[They] run` or `[it] runs` for the verb tense but currently we have a mix between the two. I guess the plural form makes more sense since we don't use the singular in the opening sentence.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: `consistency/formatting`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
