### PR TITLE
i18n(fr): update `experimental-flags/live-content-collections.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/live-content-collections.mdx
@@ -162,7 +162,9 @@ Ces erreurs ont une méthode statique `is()` que vous pouvez utiliser pour véri
 export const prerender = false; // Pas nécessaire en mode `server`
 
 import { getLiveEntry, LiveEntryNotFoundError } from 'astro:content';
+
 const { entry, error } = await getLiveEntry('products', Astro.params.id);
+
 if (error) {
   if (LiveEntryNotFoundError.is(error)) {
     console.error(`Produit non trouvé : ${error.message}`);
@@ -312,7 +314,7 @@ Astro générera lui-même certaines erreurs, en fonction de la réponse du char
 - Si un schéma est défini pour la collection et que les données ne correspondent pas au schéma, Astro renverra une erreur `LiveCollectionValidationError`.
 - Si le chargeur renvoie une indication de cache non valide, Astro renverra une erreur `LiveCollectionCacheHintError`. Le champ `cacheHint` est facultatif ; si vous n'avez pas de données valides à renvoyer, vous pouvez simplement l'omettre.
 
-```ts title="mon-chargeur.ts" {6-8}
+```ts title="mon-chargeur.ts" {9-11}
 import type { LiveLoader } from 'astro/loaders';
 import { MyLoaderError } from './errors.js';
 
@@ -338,7 +340,8 @@ Le chargeur doit exporter une fonction qui renvoie l'objet `LiveLoader`, permett
 
 ## Sûreté du typage
 
-Comme les collections de contenu classiques, les collections en ligne peuvent être typées pour garantir la sécurité des types dans vos données. [L'utilisation des schémas Zod](#utilisation-des-schémas-zod) est prise en charge, mais n'est pas requise pour définir les types de collections en ligne. Contrairement aux collections préchargées définies au moment de la compilation, les chargeurs en ligne peuvent plutôt choisir de transmettre des types génériques à l'interface `LiveLoader`. Vous pouvez définir les types de vos collections et données d'entrée, ainsi que des types de filtres personnalisés pour les requêtes et des types d'erreur personnalisés pour la gestion des erreurs.
+Comme les collections de contenu classiques, les collections en ligne peuvent être typées pour garantir la sécurité des types dans vos données. [L'utilisation des schémas Zod](#utilisation-des-schémas-zod) est prise en charge, mais n'est pas requise pour définir les types de collections en ligne. Contrairement aux collections préchargées définies au moment de la compilation, les chargeurs en ligne peuvent plutôt choisir de transmettre des types génériques à l'interface `LiveLoader`.
+Vous pouvez définir les types de vos collections et données d'entrée, ainsi que des types de filtres personnalisés pour les requêtes et des types d'erreur personnalisés pour la gestion des erreurs.
 
 ### Données avec sûreté du typage
 
@@ -468,7 +471,9 @@ Lorsque vous utilisez `getLiveCollection()` ou `getLiveEntry()`, TypeScript déd
 export const prerender = false; // Pas nécessaire en mode `server`
 
 import { getLiveEntry } from 'astro:content';
+
 const { entry, error } = await getLiveEntry('produits', '123');
+
 if (error) {
   if (error.name === 'MyLoaderError') {
     console.error(`Erreur du chargeur : ${error.message} (code : ${error.code})`);
@@ -616,11 +621,11 @@ Les collections de contenu en ligne présentent certaines limitations par rappor
 Les collections en ligne utilisent une API différente de celle des collections de contenu préchargées actuelles. Les principales différences sont les suivantes :
 
 1. **Moment de l'exécution** : elles s'exécutent au moment de la demande plutôt qu'au moment de la compilation
-1. **Fichier de configuration** : elles utilisent `src/live.config.ts` au lieu de `src/content.config.ts`
-1. **Définition de collection** : elles utilisent `defineLiveCollection()` au lieu de `defineCollection()`
-1. **Type de collection** : elles définissent `type: "live"` dans la définition de la collection
-1. **API du chargeur** : elles implémentent les méthodes `loadCollection` et `loadEntry` au lieu de la méthode `load`
-1. **Retour de données** : elles renvoient les données directement au lieu de les enregistrer dans le magasin de données
-1. **Fonctions exposées à l'utilisateur** : elles utilisent `getLiveCollection`/`getLiveEntry` au lieu de `getCollection`/`getEntry`
+2. **Fichier de configuration** : elles utilisent `src/live.config.ts` au lieu de `src/content.config.ts`
+3. **Définition de collection** : elles utilisent `defineLiveCollection()` au lieu de `defineCollection()`
+4. **Type de collection** : elles définissent `type: "live"` dans la définition de la collection
+5. **API du chargeur** : elles implémentent les méthodes `loadCollection` et `loadEntry` au lieu de la méthode `load`
+6. **Retour de données** : elles renvoient les données directement au lieu de les enregistrer dans le magasin de données
+7. **Fonctions exposées à l'utilisateur** : elles utilisent `getLiveCollection`/`getLiveEntry` au lieu de `getCollection`/`getEntry`
 
 Pour un aperçu complet et pour donner votre avis sur cette API expérimentale, consultez le [RFC des collections de contenu en ligne](https://github.com/withastro/roadmap/blob/feat/live-loaders/proposals/0055-live-content-loaders.md).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11920 and #11923 to the French translation of `experimental-flags/live-content-collections` (note: verb tense was already fixed in the translation).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
