### PR TITLE
i18n(fr): add `errors/live-content-config-error.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -126,6 +126,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**InvalidContentEntryDataError**](/fr/reference/errors/invalid-content-entry-data-error/)<br/>Les données d'entrée de contenu ne correspondent pas au schéma.
 - [**ContentLoaderReturnsInvalidId**](/fr/reference/errors/content-loader-returns-invalid-id/)<br/>Le chargeur de contenu a renvoyé une entrée avec un `id` non valide.
 - [**ContentEntryDataError**](/fr/reference/errors/content-entry-data-error/)<br/>Les données d'entrée de contenu ne correspondent pas au schéma.
+- [**LiveContentConfigError**](/fr/reference/errors/live-content-config-error/)<br/>Erreur dans la configuration du contenu en ligne.
 - [**ContentLoaderInvalidDataError**](/fr/reference/errors/content-loader-invalid-data-error/)<br/>L'entrée de contenu ne contient pas d'ID
 - [**InvalidContentEntrySlugError**](/fr/reference/errors/invalid-content-entry-slug-error/)<br/>Le Slug du contenu n'est pas valide.
 - [**ContentSchemaContainsSlugError**](/fr/reference/errors/content-schema-contains-slug-error/)<br/>Le schéma de contenu ne doit pas contenir `slug`.

--- a/src/content/docs/fr/reference/errors/live-content-config-error.mdx
+++ b/src/content/docs/fr/reference/errors/live-content-config-error.mdx
@@ -1,0 +1,14 @@
+---
+title: Erreur dans la configuration du contenu en ligne.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **Example error message:**<br/>
+The schema cannot be a function for live collections. Please use a schema object instead. Check your collection definitions in your live content config file.
+
+## Qu'est-ce qui a mal tourné ?
+Erreur dans la configuration du contenu en ligne.
+
+**Voir aussi :**
+-  [Contenu en ligne expérimental](/fr/reference/experimental-flags/live-content-collections/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds the French translation of `errors/live-content-config-error` added in #11901 and fixed in #11915.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
