### PR TITLE
Add `cacheHint.lastModified` to live collections

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
@@ -552,12 +552,16 @@ export function myLoader(config): LiveLoader<MyData> {
           id: item.id,
           data: item,
           // You can optionally provide cache hints for each entry
-          // These are merged with the collection's cache hint
           cacheHint: {
             tags: [`product-${item.id}`, `category-${item.category}`],
           },
         })),
         cacheHint: {
+          // All fields are optional, and are combined with each entry's cache hints
+          // tags are merged from all entries
+          // maxAge is the shortest maxAge of all entries and the collection
+          // lastModified is the most recent lastModified of all entries and the collection
+          lastModified: new Date(item.lastModified),
           tags: ['products'],
           maxAge: 300, // 5 minutes
         },
@@ -569,6 +573,7 @@ export function myLoader(config): LiveLoader<MyData> {
         id: item.id,
         data: item,
         cacheHint: {
+          lastModified: new Date(item.lastModified),
           tags: [`product-${item.id}`, `category-${item.category}`],
           maxAge: 3600, // 1 hour
         },
@@ -593,9 +598,14 @@ if (error) {
 }
 
 // Apply cache hints to response headers
-if (cacheHint) {
+if (cacheHint?.tags) {
   Astro.response.headers.set('Cache-Tag', cacheHint.tags.join(','));
+}
+if (cacheHint?.maxAge) {
   Astro.response.headers.set('Cache-Control', `s-maxage=${cacheHint.maxAge}`);
+}
+if (cacheHint?.lastModified) {
+  Astro.response.headers.set('Last-Modified', cacheHint.lastModified.toUTCString());
 }
 ---
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a new field to experimental live collections. This is released in 5.10.1

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
