### PR TITLE
i18n(fr): update `errors/live-content-config-error.mdx`

### DIFF
--- a/src/content/docs/fr/reference/errors/live-content-config-error.mdx
+++ b/src/content/docs/fr/reference/errors/live-content-config-error.mdx
@@ -12,3 +12,4 @@ Erreur dans la configuration du contenu en ligne.
 
 **Voir aussi :**
 -  [Contenu en ligne expérimental](/fr/reference/experimental-flags/live-content-collections/)
+


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a blank line at the end of the French translation of `errors/live-content-config-error` to set it as up to date. The English version was updated in #11926 ... but this only adds empty lines at the end of the file.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
