### PR TITLE
fix(guides/authentication): update the highlighted lines in a code snippet

### DIFF
--- a/src/content/docs/en/guides/authentication.mdx
+++ b/src/content/docs/en/guides/authentication.mdx
@@ -126,7 +126,7 @@ import Layout from 'src/layouts/Base.astro';
 
 You can fetch the user's session using the `getSession` method.
 
-```astro title="src/pages/index.astro" {3,5}
+```astro title="src/pages/index.astro" {3,7}
 ---
 import Layout from 'src/layouts/Base.astro';
 import { getSession } from 'auth-astro/server';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since  #11899, one code snippet in `guides/authentication` was no longer highlighting the right line. See the second code snippet in [Usage](https://docs.astro.build/en/guides/authentication/#usage): it should be the `getSession` usage instead of `prerender`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
