### PR TITLE
i18n(fr): update `guides/content-collections`

### DIFF
--- a/src/content/docs/fr/guides/content-collections.mdx
+++ b/src/content/docs/fr/guides/content-collections.mdx
@@ -387,11 +387,13 @@ const poodleData = await getEntry('dogs', 'poodle');
 L'ordre de tri des collections générées est non déterministe et dépend de la plateforme. Cela signifie que si vous appelez `getCollection()` et que vous avez besoin que vos entrées soient renvoyées dans un ordre spécifique (par exemple, des articles de blog triés par date), vous devez trier vous-même les entrées de la collection :
 
 ```astro title="src/pages/blog.astro"
+---
 import { getCollection } from 'astro:content';
 
 const posts = (await getCollection('blog')).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+---
 ```
 
 <ReadMore>Voir la liste complète des propriétés renvoyées par le [type `CollectionEntry`](/fr/reference/modules/astro-content/#collectionentry).</ReadMore>

--- a/src/content/docs/fr/guides/content-collections.mdx
+++ b/src/content/docs/fr/guides/content-collections.mdx
@@ -383,6 +383,17 @@ const poodleData = await getEntry('dogs', 'poodle');
 
 
 ```
+
+L'ordre de tri des collections générées est non déterministe et dépend de la plateforme. Cela signifie que si vous appelez `getCollection()` et que vous avez besoin que vos entrées soient renvoyées dans un ordre spécifique (par exemple, des articles de blog triés par date), vous devez trier vous-même les entrées de la collection :
+
+```astro title="src/pages/blog.astro"
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort(
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+```
+
 <ReadMore>Voir la liste complète des propriétés renvoyées par le [type `CollectionEntry`](/fr/reference/modules/astro-content/#collectionentry).</ReadMore>
 
 ### Utilisation du contenu dans les modèles Astro


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11908 and #11944 to the French translation of `guides/content-collections`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
