### PR TITLE
i18n(fr): update `experimental-flags/live-content-collections.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/live-content-collections.mdx
@@ -552,12 +552,16 @@ export function myLoader(config): LiveLoader<MyData> {
           id: item.id,
           data: item,
           // Vous pouvez éventuellement fournir des indications de cache pour chaque entrée
-          // Celles-ci sont fusionnées avec l'indication de cache de la collection
           cacheHint: {
             tags: [`produit-${item.id}`, `categorie-${item.category}`],
           },
         })),
         cacheHint: {
+          // Tous les champs sont facultatifs et sont combinés avec les indications de cache de chaque entrée
+          // les étiquettes sont fusionnées à partir de toutes les entrées
+          // maxAge est l'âge maximal le plus court de toutes les entrées et de la collection
+          // lastModified est la dernière modification la plus récente de toutes les entrées et de la collection
+          lastModified: new Date(item.lastModified),
           tags: ['produits'],
           maxAge: 300, // 5 minutes
         },
@@ -569,6 +573,7 @@ export function myLoader(config): LiveLoader<MyData> {
         id: item.id,
         data: item,
         cacheHint: {
+          lastModified: new Date(item.lastModified),
           tags: [`produit-${item.id}`, `categorie-${item.category}`],
           maxAge: 3600, // 1 heure
         },
@@ -593,9 +598,14 @@ if (error) {
 }
 
 // Appliquer des indications de cache aux en-têtes de réponse
-if (cacheHint) {
+if (cacheHint?.tags) {
   Astro.response.headers.set('Cache-Tag', cacheHint.tags.join(','));
+}
+if (cacheHint?.maxAge) {
   Astro.response.headers.set('Cache-Control', `s-maxage=${cacheHint.maxAge}`);
+}
+if (cacheHint?.lastModified) {
+  Astro.response.headers.set('Last-Modified', cacheHint.lastModified.toUTCString());
 }
 ---
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #11929 to the French translation of `experimental-flags/live-content-collections`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
