### PR TITLE
Remove references to "type: 'live'"

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
+++ b/src/content/docs/en/reference/experimental-flags/live-content-collections.mdx
@@ -38,7 +38,6 @@ import { defineLiveCollection } from 'astro:content';
 import { storeLoader } from '@mystore/astro-loader';
 
 const products = defineLiveCollection({
-  type: 'live',
   loader: storeLoader({
     apiKey: process.env.STORE_API_KEY,
     endpoint: 'https://api.mystore.com/v1',
@@ -107,7 +106,6 @@ import { cmsLoader } from '@example/cms-astro-loader';
 import { productLoader } from '@example/store-astro-loader';
 
 const articles = defineLiveCollection({
-  type: 'live',
   loader: cmsLoader({
     apiKey: process.env.CMS_API_KEY,
     contentType: 'article',
@@ -115,7 +113,6 @@ const articles = defineLiveCollection({
 });
 
 const products = defineLiveCollection({
-  type: 'live',
   loader: productLoader({
     apiKey: process.env.STORE_API_KEY,
   }),
@@ -494,7 +491,6 @@ import { z, defineLiveCollection } from 'astro:content';
 import { apiLoader } from './loaders/api-loader';
 
 const products = defineLiveCollection({
-  type: 'live',
   loader: apiLoader({ endpoint: process.env.API_URL }),
   schema: z
     .object({
@@ -633,7 +629,6 @@ Live collections use a different API than current preloaded content collections.
 1. **Execution time**: Run at request time instead of build time
 2. **Configuration file**: Use `src/live.config.ts` instead of `src/content.config.ts`
 3. **Collection definition**: Use `defineLiveCollection()` instead of `defineCollection()`
-4. **Collection type**: Set `type: "live"` in collection definition
 5. **Loader API**: Implement `loadCollection` and `loadEntry` methods instead of the `load` method
 6. **Data return**: Return data directly instead of storing in the data store
 7. **User-facing functions**: Use `getLiveCollection`/`getLiveEntry` instead of `getCollection`/`getEntry`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

We're removing the need to set the type when defining live collections.

#### Related issues & labels (optional)

https://github.com/withastro/astro/pull/14019

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
