### PR TITLE
feat: document experimental static headers

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -327,7 +327,11 @@ export default defineConfig({
 });
 ```
 
-#### `experimentalStaticHeaders`
+## Experimental features
+
+The following features are also available for use, but may be subject to breaking changes in future updates. Please follow the [`@astrojs/netlify` CHANGELOG](https://github.com/withastro/astro/tree/main/packages/integrations/netlify/CHANGELOG.md) carefully for updates if you are using these features in your project.
+
+### `experimentalStaticHeaders`
 
 <p>
   **Type:** `boolean` <br />

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -327,6 +327,32 @@ export default defineConfig({
 });
 ```
 
+#### `experimentalStaticHeaders`
+
+<p>
+  **Type:** `boolean` <br />
+</p>
+
+If enabled, the adapter will save [static headers in the framework API file](https://docs.netlify.com/frameworks-api/#headers).
+
+Here is the list of the headers that are added:
+- The CSP header of the static pages is added when CSP support is enabled.
+
+```js title="astro.config.mjs" {6}
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify';
+
+export default defineConfig({
+  experimental: {
+    cps: true
+  },
+  adapter: netlify({
+    experimentalStaticHeaders: true 
+  })
+});
+```
+
+
 ## Examples
 
 * The [Astro Netlify Edge Starter](https://github.com/sarahetter/astro-netlify-edge-starter) provides an example and a guide in the README.

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -336,14 +336,14 @@ The following features are also available for use, but may be subject to breakin
 <p>
   **Type:** `boolean` <br />
   **Default:** `false`<br />
-  <Since v="6.5.0"  pkg="@astrojs/netlify"/>
+  <Since v="6.4.0"  pkg="@astrojs/netlify"/>
 </p>
 
 Enables specifying custom headers for prerendered pages in Netlify's configuration.
 
 If enabled, the adapter will save [static headers in the Framework API config file](https://docs.netlify.com/frameworks-api/#headers) when provided by Astro features, such as Content Security Policy.
 
-For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify's configuration, instead of creating a `<meta>` element:
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify configuration, instead of creating a `<meta>` element:
 
 ```js title="astro.config.mjs" {9}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -344,7 +344,7 @@ import netlify from '@astrojs/netlify';
 
 export default defineConfig({
   experimental: {
-    cps: true
+    csp: true
   },
   adapter: netlify({
     experimentalStaticHeaders: true 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -345,7 +345,7 @@ If enabled, the adapter will save [static headers in the Framework API config fi
 
 For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify's configuration, instead of creating a `<meta>` element:
 
-```js title="astro.config.mjs" {6}
+```js title="astro.config.mjs" {9}
 import { defineConfig } from 'astro/config';
 import netlify from '@astrojs/netlify';
 

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -331,12 +331,15 @@ export default defineConfig({
 
 <p>
   **Type:** `boolean` <br />
+  **Default:** `false`<br />
+  <Since v="6.5.0"  pkg="@astrojs/netlify"/>
 </p>
 
-If enabled, the adapter will save [static headers in the framework API file](https://docs.netlify.com/frameworks-api/#headers).
+Enables specifying custom headers for prerendered pages in Netlify's configuration.
 
-Here is the list of the headers that are added:
-- The CSP header of the static pages is added when CSP support is enabled.
+If enabled, the adapter will save [static headers in the Framework API config file](https://docs.netlify.com/frameworks-api/#headers) when provided by Astro features, such as Content Security Policy.
+
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify's configuration, instead of creating a `<meta>` element:
 
 ```js title="astro.config.mjs" {6}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -10,6 +10,7 @@ i18nReady: true
 ---
 
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import Since from '~/components/Since.astro';
 
 This adapter allows Astro to deploy your [on-demand rendered routes and features](/en/guides/on-demand-rendering/) to Node targets, including [server islands](/en/guides/server-islands/), [actions](/en/guides/actions/), and [sessions](/en/guides/sessions/).
 

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -111,12 +111,13 @@ export default defineConfig({
 
 <p>
   **Type:** `boolean` <br />
+  **Default:** `false`<br />
+  <Since v="9.3.0"  pkg="@astrojs/node"/>
 </p>
 
-If enabled, the adapter will serve the headers of the static pages using the `Response` object. 
+If enabled, the adapter will serve the headers of prerendered pages using the `Response` object when provided by Astro features, such as Content Security Policy.
 
-Here is the list of the headers that are added:
-- The CSP header of the static pages is added when CSP support is enabled.
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP headers to the `Response` object instead of creating a `<meta>` element:
 
 ```js title="astro.config.mjs" {6}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -106,6 +106,32 @@ export default defineConfig({
 });
 ```
 
+
+### `experimentalStaticHeaders`
+
+<p>
+  **Type:** `boolean` <br />
+</p>
+
+If enabled, the adapter will serve the headers of the static pages using the `Response` object. 
+
+Here is the list of the headers that are added:
+- The CSP header of the static pages is added when CSP support is enabled.
+
+```js title="astro.config.mjs" {6}
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+
+export default defineConfig({
+  experimental: {
+    cps: true
+  },
+  adapter: node({
+    experimentalStaticHeaders: true 
+  })
+});
+```
+
 ## Usage
 
 First, [performing a build](/en/guides/deploy/#building-your-site-locally). Depending on which `mode` selected (see above) follow the appropriate steps below:

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -124,7 +124,7 @@ import node from '@astrojs/node';
 
 export default defineConfig({
   experimental: {
-    cps: true
+    csp: true
   },
   adapter: node({
     experimentalStaticHeaders: true 

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -120,7 +120,7 @@ If enabled, the adapter will serve the headers of prerendered pages using the `R
 
 For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP headers to the `Response` object instead of creating a `<meta>` element:
 
-```js title="astro.config.mjs" {6}
+```js title="astro.config.mjs" {9}
 import { defineConfig } from 'astro/config';
 import node from '@astrojs/node';
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -362,6 +362,36 @@ export default defineConfig({
 });
 ```
 
+## Experimental features
+
+The following features are also available for use, but may be subject to breaking changes in future updates. Please follow the [`@astrojs/vercel` CHANGELOG](https://github.com/withastro/astro/tree/main/packages/integrations/vercel/CHANGELOG.md) carefully for updates if you are using these features in your project.
+
+### `experimentalStaticHeaders`
+
+**Type:** `boolean`<br/>
+**Available for:** Serverless
+<Since pkg="@astrojs/vercel" v="8.2.0" />
+
+Enables specifying custom headers for prerendered pages in Vercel's configuration.
+
+If enabled, the adapter will save [static headers in the Vercel `config.json` file](https://vercel.com/docs/project-configuration#headers) when provided by Astro features, such as Content Security Policy.
+
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify's configuration, instead of creating a `<meta>` element:
+
+```js title="astro.config.mjs" {9}
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel';
+
+export default defineConfig({
+  experimental: {
+    csp: true
+  },
+  adapter: vercel({
+    experimentalStaticHeaders: true 
+  })
+});
+```
+
 ### Running Astro middleware on Vercel Edge Functions
 
 The `@astrojs/vercel` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -362,37 +362,6 @@ export default defineConfig({
 });
 ```
 
-## Experimental features
-
-The following features are also available for use, but may be subject to breaking changes in future updates. Please follow the [`@astrojs/vercel` CHANGELOG](https://github.com/withastro/astro/tree/main/packages/integrations/vercel/CHANGELOG.md) carefully for updates if you are using these features in your project.
-
-### `experimentalStaticHeaders`
-
-**Type:** `boolean`<br/>
-  **Default:** `false`<br />
-**Available for:** Serverless <br/>
-<Since pkg="@astrojs/vercel" v="8.2.0" />
-
-Enables specifying custom headers for prerendered pages in Vercel's configuration.
-
-If enabled, the adapter will save [static headers in the Vercel `vercel.json` file](https://vercel.com/docs/project-configuration#headers) when provided by Astro features, such as Content Security Policy.
-
-For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Vercel configuration, instead of creating a `<meta>` element:
-
-```js title="astro.config.mjs" {9}
-import { defineConfig } from 'astro/config';
-import vercel from '@astrojs/vercel';
-
-export default defineConfig({
-  experimental: {
-    csp: true
-  },
-  adapter: vercel({
-    experimentalStaticHeaders: true 
-  })
-});
-```
-
 ### Running Astro middleware on Vercel Edge Functions
 
 The `@astrojs/vercel` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When `edgeMiddleware` is enabled, an edge function will execute your middleware code for all requests including static assets, prerendered pages, and on-demand rendered pages.
@@ -424,12 +393,6 @@ declare namespace App {
   }
 }
 ```
-
-### Node.js Version Support
-
-The `@astrojs/vercel` adapter supports specific Node.js versions for deploying your Astro project on Vercel. To view the supported Node.js versions on Vercel, click on the settings tab for a project and scroll down to "Node.js Version" section.
-
-Check out the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#default-and-available-versions) to learn more.
 
 ### Sessions
 
@@ -482,6 +445,43 @@ For example, if you have installed [a Redis integration](https://vercel.com/mark
       },
     });
     ```
+
+## Node.js Version Support
+
+The `@astrojs/vercel` adapter supports specific Node.js versions for deploying your Astro project on Vercel. To view the supported Node.js versions on Vercel, click on the settings tab for a project and scroll down to "Node.js Version" section.
+
+Check out the [Vercel documentation](https://vercel.com/docs/functions/serverless-functions/runtimes/node-js#default-and-available-versions) to learn more.
+
+## Experimental features
+
+The following features are also available for use, but may be subject to breaking changes in future updates. Please follow the [`@astrojs/vercel` CHANGELOG](https://github.com/withastro/astro/tree/main/packages/integrations/vercel/CHANGELOG.md) carefully for updates if you are using these features in your project.
+
+### `experimentalStaticHeaders`
+
+**Type:** `boolean`<br/>
+  **Default:** `false`<br />
+**Available for:** Serverless <br/>
+<Since pkg="@astrojs/vercel" v="8.2.0" />
+
+Enables specifying custom headers for prerendered pages in Vercel's configuration.
+
+If enabled, the adapter will save [static headers in the Vercel `vercel.json` file](https://vercel.com/docs/project-configuration#headers) when provided by Astro features, such as Content Security Policy.
+
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Vercel configuration, instead of creating a `<meta>` element:
+
+```js title="astro.config.mjs" {9}
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel';
+
+export default defineConfig({
+  experimental: {
+    csp: true
+  },
+  adapter: vercel({
+    experimentalStaticHeaders: true 
+  })
+});
+```
 
 </Steps>
 

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -369,14 +369,15 @@ The following features are also available for use, but may be subject to breakin
 ### `experimentalStaticHeaders`
 
 **Type:** `boolean`<br/>
-**Available for:** Serverless
+  **Default:** `false`<br />
+**Available for:** Serverless <br/>
 <Since pkg="@astrojs/vercel" v="8.2.0" />
 
 Enables specifying custom headers for prerendered pages in Vercel's configuration.
 
-If enabled, the adapter will save [static headers in the Vercel `config.json` file](https://vercel.com/docs/project-configuration#headers) when provided by Astro features, such as Content Security Policy.
+If enabled, the adapter will save [static headers in the Vercel `vercel.json` file](https://vercel.com/docs/project-configuration#headers) when provided by Astro features, such as Content Security Policy.
 
-For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Netlify's configuration, instead of creating a `<meta>` element:
+For example, when [experimental Content Security Policy](/en/reference/experimental-flags/csp/) is enabled, `experimentalStaticHeaders` can be used to add the CSP `headers` to your Vercel configuration, instead of creating a `<meta>` element:
 
 ```js title="astro.config.mjs" {9}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -446,6 +446,8 @@ For example, if you have installed [a Redis integration](https://vercel.com/mark
     });
     ```
 
+</Steps>
+
 ## Node.js Version Support
 
 The `@astrojs/vercel` adapter supports specific Node.js versions for deploying your Astro project on Vercel. To view the supported Node.js versions on Vercel, click on the settings tab for a project and scroll down to "Node.js Version" section.
@@ -482,7 +484,5 @@ export default defineConfig({
   })
 });
 ```
-
-</Steps>
 
 [astro-integration]: /en/guides/integrations-guide/

--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -460,10 +460,12 @@ The following features are also available for use, but may be subject to breakin
 
 ### `experimentalStaticHeaders`
 
+<p>
 **Type:** `boolean`<br/>
-  **Default:** `false`<br />
+**Default:** `false`<br />
 **Available for:** Serverless <br/>
 <Since pkg="@astrojs/vercel" v="8.2.0" />
+</p>
 
 Enables specifying custom headers for prerendered pages in Vercel's configuration.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR adds documentation of `experimentalStaticHeaders` for the Node.js adapter and Netlify adpater.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->
 #### For Astro version: `5.11`. See astro PR [#13972](https://github.com/withastro/astro/pull/13972).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
