### PR TITLE
i18n(fr): improve the wording in `guides/routing.mdx`

### DIFF
--- a/src/content/docs/fr/guides/routing.mdx
+++ b/src/content/docs/fr/guides/routing.mdx
@@ -8,45 +8,45 @@ import RecipeLinks from "~/components/RecipeLinks.astro"
 import Since from '~/components/Since.astro'
 import ReadMore from '~/components/ReadMore.astro'
 
-Astro utilise **le routage basé sur les fichiers** pour générer vos URLs de construction en fonction de la disposition des fichiers dans le répertoire `src/pages/` de votre projet.
+Astro utilise **le routage basé sur les fichiers** pour générer vos URLs au moment de la compilation en fonction de la structure des fichiers dans le répertoire `src/pages/` de votre projet.
 
 ## Naviguer entre les pages
 
 Astro utilise des éléments HTML standard [`<a>`](https://developer.mozilla.org/fr-FR/docs/Web/HTML/Element/a) pour naviguer entre les routes. Il n'y a pas de composant `<Link>` spécifique au framework.
 
 ```astro title="src/pages/index.astro"
-<p>En savoir plus <a href="/about/">about</a> Astro !</p>
+<p>En savoir plus <a href="/about/">à propos</a> d'Astro !</p>
 
-<!-- Avec `base: "/docs"` de configuré  -->
+<!-- Avec `base: "/docs"` configuré  -->
 <p>Apprenez-en plus dans notre section <a href="/docs/reference/">référence</a> !</p> 
 ```
 
-## Routes Statiques
+## Routes statiques
 
-Les composants de page `.astro` ainsi que les fichiers Markdown et MDX (`.md`, `.mdx`) dans le répertoire `src/pages` **deviennent automatiquement des pages de votre site web**. La route de chaque page correspond à son chemin et à son nom de fichier dans le répertoire `src/pages`.
+Les [composants de page](/fr/basics/astro-pages/) `.astro` ainsi que les fichiers Markdown et MDX (`.md`, `.mdx`) dans le répertoire `src/pages/` **deviennent automatiquement des pages de votre site web**. La route de chaque page correspond à son chemin et à son nom de fichier dans le répertoire `src/pages/`.
 
 ```diff
-# Exemple : Routes Statiques
-src/pages/index.astro        -> mysite.com/
-src/pages/about.astro        -> mysite.com/about
-src/pages/about/index.astro  -> mysite.com/about
-src/pages/about/me.astro     -> mysite.com/about/me
-src/pages/posts/1.md         -> mysite.com/posts/1
+# Exemple : Routes statiques
+src/pages/index.astro           -> monsite.com/
+src/pages/a-propos.astro        -> monsite.com/a-propos
+src/pages/a-propos/index.astro  -> monsite.com/a-propos
+src/pages/a-propos/moi.astro    -> monsite.com/a-propos/moi
+src/pages/articles/1.md         -> monsite.com/articles/1
 ```
 
 :::tip
-Il n'y a pas de « configuration de routage » séparée à maintenir dans un projet Astro ! Lorsque vous ajoutez un fichier au répertoire `/src/pages`, une nouvelle route est automatiquement créée pour vous. Dans les constructions statiques, vous pouvez personnaliser le format de sortie du fichier en utilisant l'option de configuration [`build.format`](/fr/reference/configuration-reference/#buildformat).
+Il n'y a pas de « configuration de routage » séparée à maintenir dans un projet Astro ! Lorsque vous ajoutez un fichier au répertoire `/src/pages`, une nouvelle route est automatiquement créée pour vous. Dans les compilations statiques, vous pouvez personnaliser le format de sortie du fichier en utilisant l'option de configuration [`build.format`](/fr/reference/configuration-reference/#buildformat).
 :::
 
-## Routes Dynamiques
+## Routes dynamiques
 
 Un fichier de page Astro peut spécifier des paramètres de route dynamiques dans son nom de fichier pour générer des pages correspondantes. Par exemple, vous pouvez créer un fichier `authors/[author].astro` qui génère une page de biographie pour chaque auteur de votre blog. `author` devient un _paramètre_ accessible depuis l'intérieur de la page.
 
-Dans le mode statique par défaut d'Astro, ces pages sont générées au moment de la construction, et vous devez donc prédéterminer la liste des `author` qui obtiendront un fichier correspondant. En mode SSR, une page sera générée sur demande pour toute route correspondante.
+Dans le mode statique par défaut d'Astro, ces pages sont générées au moment de la compilation, et vous devez donc prédéterminer la liste des auteurs (`author`) qui obtiendront un fichier correspondant. En mode SSR, une page sera générée sur demande pour toute route correspondante.
 
-### Mode Statique (SSG)
+### Mode statique (SSG)
 
-Parce que toutes les routes doivent être déterminées au moment de la construction, une route dynamique doit exporter une fonction `getStaticPaths()` qui renvoie un tableau d'objets avec une propriété `params`. Chacun de ces objets générera une route correspondante.
+Parce que toutes les routes doivent être déterminées au moment de la compilation, une route dynamique doit exporter une fonction `getStaticPaths()` qui renvoie un tableau d'objets avec une propriété `params`. Chacun de ces objets générera une route correspondante.
 
 `[dog].astro` définit le paramètre dynamique `dog` dans son nom de fichier, donc les objets retournés par `getStaticPaths()` doivent inclure `dog` dans leurs `params`. La page peut alors accéder à ce paramètre en utilisant `Astro.params`.
 
@@ -84,11 +84,11 @@ const { lang, version } = Astro.params;
 
 Cela va générer `/en-v1/info` et `/fr-v2/info`.
 
-Les paramètres peuvent être inclus dans des parties séparées du chemin, ainsi nous pourrions utiliser `src/pages/[lang]/[version]/info.astro` avec le même `getStaticPaths` pour générer `/en/v1/info` et `/fr/v2/info`.
+Les paramètres peuvent être inclus dans des parties séparées du chemin, ainsi nous pourrions utiliser `src/pages/[lang]/[version]/info.astro` avec la même fonction `getStaticPaths()` pour générer `/en/v1/info` et `/fr/v2/info`.
 
-#### Décodage de `params`
+#### Décodage des paramètres (`params`)
 
-Les `params` fournis à la fonction `getStaticPaths()` ne sont pas décodés. Utilisez la fonction [`decodeURI`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) lorsque vous avez besoin de décoder les valeurs des paramètres.
+Les paramètres (`params`) fournis à la fonction `getStaticPaths()` ne sont pas décodés. Utilisez la fonction [`decodeURI`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/decodeURI) lorsque vous avez besoin de décoder les valeurs des paramètres.
 
 ```astro title="src/pages/[slug].astro"
 --- 
@@ -104,9 +104,9 @@ export function getStaticPaths() {
 
 <RecipeLinks slugs={["fr/recipes/i18n"]} />
 
-### Paramètres REST
+### Paramètres du reste
 
-Si vous avez besoin de plus de flexibilité dans le routage de vos URL, vous pouvez utiliser un [paramètre REST](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Functions/rest_parameters) (`[...path]`) dans votre nom de fichier `.astro` pour correspondre à des chemins de fichiers de n'importe quelle profondeur :
+Si vous avez besoin de plus de flexibilité dans le routage de vos URL, vous pouvez utiliser un [paramètre du reste](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Functions/rest_parameters) (`[...path]`) dans votre nom de fichier `.astro` pour faire correspondre les chemins de fichiers de n'importe quelle profondeur :
 
 ```astro title="src/pages/sequences/[...path].astro"
 ---
@@ -122,9 +122,9 @@ const { path } = Astro.params;
 ---
 ```
 
-Cela générera `/sequences/un/deux/trois`, `/sequences/quatre`, et `/sequences`. (Définir le paramètre REST à `undefined` lui permet de correspondre à la page de premier niveau).
+Cela générera `/sequences/un/deux/trois`, `/sequences/quatre`, et `/sequences`. (Définir le paramètre du reste sur `undefined` lui permet de correspondre à la page de premier niveau).
 
-Les paramètres REST peuvent être utilisés avec **d'autres paramètres nommés**. Par exemple, nous pourrions représenter la visionneuse de fichiers de GitHub avec une route dynamique comme celle-ci :
+Les paramètres du reste peuvent être utilisés avec **d'autres paramètres nommés**. Par exemple, nous pourrions représenter la visionneuse de fichiers de GitHub avec une route dynamique comme celle-ci :
 
 ```
 /[org]/[repo]/tree/[branch]/[...file]
@@ -143,7 +143,7 @@ Dans cet exemple, une requête pour `/withastro/astro/tree/main/docs/public/favi
 
 #### Exemple : Pages dynamiques à plusieurs niveaux
 
-Ici, nous utilisons un paramètre REST (`[...slug]`) et la fonctionnalité [`props`](/fr/reference/routing-reference/#transmission-de-données-avec-props) de `getStaticPaths()` pour générer des pages pour des slugs de différentes profondeurs.
+Ici, nous utilisons un paramètre du reste (`[...slug]`) et la fonctionnalité [`props`](/fr/reference/routing-reference/#transmission-de-données-avec-props) de `getStaticPaths()` pour générer des pages pour des slugs de différentes profondeurs.
 
 ```astro title="src/pages/[...slug].astro"
 ---
@@ -189,9 +189,9 @@ const { title, text } = Astro.props;
 
 ### Routes dynamiques à la demande
 
-Pour [le rendu à la demande](/fr/guides/on-demand-rendering/) avec un adaptateur, les routes dynamiques sont définies de la même manière : incluez des crochets `[param]` ou `[...path]` dans vos noms de fichiers pour faire correspondre des chaînes de caractères ou des chemins arbitraires. Cependant, comme les routes ne sont plus construites à l'avance, la page sera servie à n'importe quelle route correspondante. Comme il ne s'agit pas de routes « statiques », `getStaticPaths` ne doit pas être utilisé.
+Pour [le rendu à la demande](/fr/guides/on-demand-rendering/) avec un adaptateur, les routes dynamiques sont définies de la même manière : incluez des crochets `[param]` ou `[...path]` dans vos noms de fichiers pour faire correspondre des chaînes de caractères ou des chemins arbitraires. Cependant, comme les routes ne sont plus générées à l'avance, la page sera servie à n'importe quelle route correspondante. Comme il ne s'agit pas de routes « statiques », `getStaticPaths` ne doit pas être utilisé.
 
-Pour les routes rendues à la demande, un seul paramètre reste utilisant la syntaxe de décomposition peut être utilisé dans le nom de fichier (par exemple `src/pages/[locale]/[...slug].astro` ou `src/pages/[...locale]/[slug].astro`, mais pas `src/pages/[...locale]/[...slug].astro`).
+Pour les routes rendues à la demande, un seul paramètre du reste utilisant la syntaxe de décomposition peut être utilisé dans le nom de fichier (par exemple `src/pages/[locale]/[...slug].astro` ou `src/pages/[...locale]/[slug].astro`, mais pas `src/pages/[...locale]/[...slug].astro`).
 
 ```astro title="src/pages/resources/[resource]/[id].astro"
 ---
@@ -205,7 +205,7 @@ Cette page sera servie pour toute valeur de `resource` et `id` : `resources/user
 
 #### Modification de l'exemple `[...slug]` pour le mode SSR
 
-Comme les pages SSR ne peuvent pas utiliser `getStaticPaths`, elles ne peuvent pas recevoir de props. Ici, nous modifions notre [exemple précédent](#exemple--pages-dynamiques-à-plusieurs-niveaux) pour qu'il fonctionne en SSR en cherchant la valeur du paramètre `slug` dans un objet. Si la route est à la racine (« / »), le paramètre `slug` sera `undefined`. Si la valeur n'existe pas dans l'objet, nous redirigeons vers une page 404.
+Comme les pages SSR ne peuvent pas utiliser `getStaticPaths()`, elles ne peuvent pas recevoir de props. L'[exemple précédent](#exemple--pages-dynamiques-à-plusieurs-niveaux) peut être adapté au mode SSR en recherchant la valeur du paramètre `slug` dans un objet. Si la route est à la racine (« / »), le paramètre `slug` sera `undefined`. Si la valeur n'existe pas dans l'objet, nous redirigeons vers une page 404.
 
 ```astro title="src/pages/[...slug].astro"
 ---
@@ -297,13 +297,13 @@ export default defineConfig({
 });
 ```
 
-Lors de l'exécution de `astro build`, Astro produira des fichiers HTML avec la balise [meta refresh](https://developer.mozilla.org/fr-FR/docs/Web/HTML/Element/meta#examples) par défaut. Les adaptateurs supportés écriront à la place le fichier de configuration de l'hôte avec les redirections.
+Lors de l'exécution de `astro build`, Astro produira des fichiers HTML avec la balise [meta refresh](https://developer.mozilla.org/fr-FR/docs/Web/HTML/Element/meta#examples) par défaut. Les adaptateurs pris en charge écriront plutôt le fichier de configuration de l'hôte avec les redirections.
 
-Le code de statut est `301` par défaut. Si l'on construit des fichiers HTML, le code de statut n'est pas utilisé par le serveur.
+Le code de statut est `301` par défaut. Lors de la création de fichiers HTML, ce code n'est pas utilisé par le serveur.
 
-### Redirections Dynamiques
+### Redirections dynamiques
 
-Globalement sur `Astro`, la méthode `Astro.redirect` vous permet de rediriger vers une autre page dynamiquement. Vous pouvez le faire après avoir vérifié que l'utilisateur est connecté en récupérant sa session à partir d'un cookie.
+Dans la variable globale `Astro`, la méthode `Astro.redirect` vous permet de rediriger vers une autre page dynamiquement. Vous pouvez le faire après avoir vérifié si l'utilisateur est connecté en récupérant sa session à partir d'un cookie.
 
 ```astro title="src/pages/account.astro" {8}
 ---
@@ -328,7 +328,7 @@ Une réécriture vous permet de servir une route différente sans rediriger le n
 Pour un contenu qui a été déplacé de façon permanente, ou pour diriger l'utilisateur vers une page différente avec une nouvelle URL (par exemple, le tableau de bord d'un utilisateur après sa connexion), utilisez plutôt une [redirection](#redirections).
 :::
 
-Les réécritures peuvent être utiles pour afficher le même contenu sur plusieurs chemins (par exemple, `/products/shoes/men/` et `/products/men/shoes/`) sans avoir à maintenir deux fichiers sources différents.
+Les réécritures peuvent être utiles pour afficher le même contenu sur plusieurs chemins (par exemple, `/produits/chaussures/homme/` et `/produits/homme/chaussures/`) sans avoir à maintenir deux fichiers sources différents.
 
 Les réécritures sont également utiles à des fins de référencement et d'expérience utilisateur. Elles vous permettent d'afficher un contenu qui, autrement, nécessiterait de rediriger votre visiteur vers une autre page ou renverrait un statut 404. Une utilisation courante des réécritures consiste à afficher le même contenu localisé pour différentes variantes d'une langue.
 
@@ -350,7 +350,7 @@ export function GET(context) {
 }
 ```
 
-Si l'URL passée à `Astro.rewrite()` émet une erreur d'exécution, Astro affichera l'erreur en superposition dans le cadre du développement et renverra un code d'état 500 dans le cadre de la production. Si l'URL n'existe pas dans votre projet, un code d'état 404 sera retourné.
+Si l'URL transmise à `Astro.rewrite()` génère une erreur au moment de l'exécution, Astro affichera l'erreur en superposition en mode développement et renverra un code d'état 500 en production. Si l'URL n'existe pas dans votre projet, un code d'état 404 sera renvoyé.
 
 Vous pouvez intentionnellement créer une réécriture pour afficher votre page `/404`, par exemple pour indiquer qu'un produit de votre boutique e-commerce n'est plus disponible :
 
@@ -376,13 +376,13 @@ export const onRequest = async (context, next) => {
 }
 ``` 
 
-Avant d'afficher le contenu du chemin de réécriture spécifié, la fonction `Astro.rewrite()` déclenche une nouvelle phase complète d'affichage. Celle-ci ré-exécute tout middleware pour la nouvelle route/demande.
+Avant d'afficher le contenu du chemin de réécriture spécifié, la fonction `Astro.rewrite()` déclenche une nouvelle phase complète de rendu. Celle-ci ré-exécute tout middleware pour la nouvelle route/requête.
 
 <ReadMore>Voir la référence de l'API [`Astro.rewrite()`](/fr/reference/api-reference/#rewrite) pour plus d'informations.</ReadMore>
 
-## Ordre de Priorité des Routes
+## Ordre de priorité des routes
 
-Il est possible que plusieurs routes définies tentent de construire le même chemin d'URL. Par exemple, toutes ces routes pourraient construire `/posts/create` :
+Il est possible que plusieurs routes définies tentent de générer le même chemin d'URL. Par exemple, toutes ces routes pourraient générer `/posts/create` :
 
 <FileTree>
 - src/pages/
@@ -394,10 +394,10 @@ Il est possible que plusieurs routes définies tentent de construire le même ch
     - [...slug].astro
 </FileTree>
 
-Astro a besoin de savoir quelle route doit être utilisée pour construire la page. Pour ce faire, il les trie dans l'ordre selon les règles suivantes :
+Astro a besoin de savoir quelle route doit être utilisée pour générer la page. Pour ce faire, il les trie dans l'ordre selon les règles suivantes :
 
-- Les [routes réservées](#routes-réservées) dans Astro
-- Les routes avec plus de segments de chemin seront prioritaires sur les itinéraires moins spécifiques. Dans l'exemple ci-dessus, toutes les routes sous `/posts/` sont prioritaires sur `/[...slug].astro` à la racine.
+- Les [routes réservées](#routes-réservées) d'Astro
+- Les routes avec plus de segments de chemin seront prioritaires sur les routes moins spécifiques. Dans l'exemple ci-dessus, toutes les routes sous `/posts/` sont prioritaires sur `/[...slug].astro` à la racine.
 - Les routes statiques sans paramètres de chemin sont prioritaires sur les routes dynamiques. Par exemple, `/posts/create.astro` est prioritaire sur toutes les autres routes de l'exemple.
 - Les routes dynamiques utilisant des paramètres nommés sont prioritaires sur les paramètres restants. Par exemple, `/posts/[page].astro` est prioritaire sur `/posts/[...slug].astro`.
 - Les routes dynamiques pré-rendues ont la priorité sur les routes dynamiques du serveur.
@@ -405,20 +405,20 @@ Astro a besoin de savoir quelle route doit être utilisée pour construire la pa
 - Les routes basées sur des fichiers ont priorité sur les redirections.
 - Si aucune des règles ci-dessus ne décide de l'ordre, les routes sont triées par ordre alphabétique en fonction des paramètres régionaux par défaut de votre installation Node.
 
-Dans l'exemple ci-dessus, voici quelques exemples de la manière dont les règles feront correspondre une URL demandée à la route utilisée pour construire le code HTML :
+Dans l'exemple ci-dessus, voici quelques exemples de la manière dont les règles feront correspondre une URL demandée à la route utilisée pour générer le code HTML :
 
-- `pages/post/create.astro` - Ne construira que des `/post/create`.
-- `pages/post/[pid].ts` - Construira `/post/abc`, `/post/xyz`, etc. Mais pas `/post/create`.
-- `pages/posts/[page].astro` - Construira `/posts/1`, `/posts/2`, etc. Mais pas `/posts/create`, `/posts/abc` ni `/posts/xyz`.
-- `pages/post/[...slug].astro` - Construira `/post/1/2`, `/post/a/b/c`, etc. Mais pas `/post/create`, `/post/1`, `/post/abc` etc.
-- `pages/[...slug].astro` - Construira `/abc`, `/xyz`, `/abc/xyz`, etc. Mais pas `/posts/create`, `/posts/1`, `/posts/abc`, etc.
+- `pages/post/create.astro` - Ne générera que `/post/create`.
+- `pages/post/[pid].ts` - Générera `/post/abc`, `/post/xyz`, etc. Mais pas `/post/create`.
+- `pages/posts/[page].astro` - Générera `/posts/1`, `/posts/2`, etc. Mais pas `/posts/create`, `/posts/abc` ni `/posts/xyz`.
+- `pages/post/[...slug].astro` - Générera `/post/1/2`, `/post/a/b/c`, etc. Mais pas `/post/create`, `/post/1`, `/post/abc` etc.
+- `pages/[...slug].astro` - Générera `/abc`, `/xyz`, `/abc/xyz`, etc. Mais pas `/posts/create`, `/posts/1`, `/posts/abc`, etc.
 
 ### Routes réservées
 
 Les routes internes ont la priorité sur les routes définies par l'utilisateur ou par l'intégration, car elles sont nécessaires au déroulement des fonctionnalités d'Astro. Les routes réservées d'Astro sont les suivantes :
 
 - `_astro/` : Fournit toutes les ressources statiques au client, y compris les documents CSS, les scripts client intégrés, les images optimisées et toutes les ressources Vite.
-- `_server_islands/` : Sert les composants dynamiques différés dans une [Île de serveur](/fr/guides/server-islands/).
+- `_server_islands/` : Sert les composants dynamiques différés dans un [îlot de serveur](/fr/guides/server-islands/).
 - `_actions/` : Sert toutes les [actions](/fr/guides/actions/) définies.
 
 ## Pagination
@@ -443,7 +443,7 @@ export function getStaticPaths({ paginate }) {
   // Génère des pages à partir de notre tableau d'astronautes, avec 2 par page
   return paginate(astronautPages, { pageSize: 2 });
 }
-// Toutes les données paginées sont passées dans la propriété "page"
+// Toutes les données paginées sont passées dans la propriété « page »
 const { page } = Astro.props;
 ---
 <!-- Affiche le numéro de la page actuelle. `Astro.params.page` peut aussi être utilisé ! -->
@@ -487,9 +487,9 @@ interface Page<T = any> {
 		prev: string | undefined;
 		/** URL de la page suivante (s'il y en a une) */
 		next: string | undefined;
-		/** url de la première page (si la page actuelle n'est pas la première page) */
+		/** URL de la première page (si la page actuelle n'est pas la première page) */
 		first: string | undefined;
-		/** url de la dernière page (si la page actuelle n'est pas la dernière) */
+		/** URL de la dernière page (si la page actuelle n'est pas la dernière) */
 		last: string | undefined;
 	};
 }
@@ -500,7 +500,7 @@ L'exemple suivant affiche les informations actuelles de la page ainsi que des li
 ```astro /(?<=const.*)(page)/ /page\\.[a-zA-Z]+(?:\\.(?:prev|next|first|last))?/
 ---
 // src/pages/astronauts/[page].astro
-// Paginons la même liste d'objets `{ astronaut }` que l'exemple précédent
+// Paginer la même liste d'objets `{ astronaut }` que dans l'exemple précédent
 export function getStaticPaths({ paginate }) { /* ... */ }
 const { page } = Astro.props;
 ---
@@ -514,22 +514,22 @@ const { page } = Astro.props;
 {page.url.last ? <a href={page.url.last}>Fin</a> : null}
 ```
 
-<ReadMore>En savoir plus sur [la propriété `page` de pagination](/fr/reference/routing-reference/#la-propriété-de-pagination-page).</ReadMore>
+<ReadMore>En savoir plus sur [la propriété `page` de la pagination](/fr/reference/routing-reference/#la-propriété-de-pagination-page).</ReadMore>
 
-### Pagination Imbriquée
+### Pagination imbriquée
 
-Un cas d'utilisation plus avancé de la pagination est la **pagination imbriquée**, c'est-à-dire lorsque la pagination est combinée avec d'autres paramètres d'itinéraires dynamiques. Vous pouvez utiliser la pagination imbriquée pour regrouper votre collection paginée en fonction d'une propriété ou d'une balise.
+Un cas d'utilisation plus avancé de la pagination est la **pagination imbriquée**. Elle se produit lorsque la pagination est combinée à d'autres paramètres de route dynamiques. Vous pouvez utiliser la pagination imbriquée pour regrouper votre collection paginée par propriété ou étiquette.
 
-Par exemple, si vous voulez grouper vos posts Markdown paginés par une balise, vous utiliserez la pagination imbriquée en créant une page `/src/pages/[tag]/[page].astro` qui correspondra aux URLS suivantes :
+Par exemple, si vous souhaitez regrouper vos articles Markdown paginés par une étiquette, vous utiliserez la pagination imbriquée en créant une page `/src/pages/[tag]/[page].astro` qui correspondra aux URL suivantes :
 
 - `/red/1` (tag=red)
 - `/red/2` (tag=red)
 - `/blue/1` (tag=blue)
 - `/green/1` (tag=green)
 
-La pagination imbriquée fonctionne en renvoyant un tableau de résultats `paginate()` de `getStaticPaths()`, un pour chaque groupe.
+La pagination imbriquée fonctionne en renvoyant un tableau de résultats paginés (`paginate()`) à partir de `getStaticPaths()`, un pour chaque groupe.
 
-Dans l'exemple suivant, nous allons implémenter la pagination imbriquée pour construire les URLs listées ci-dessus :
+Dans l'exemple suivant, nous allons implémenter la pagination imbriquée pour générer les URLs listées ci-dessus :
 
 ```astro /(?:[(]|=== )(tag)/ "params: { tag }," /const [{ ]*(page|params)/
 ---
@@ -537,9 +537,9 @@ Dans l'exemple suivant, nous allons implémenter la pagination imbriquée pour c
 export function getStaticPaths({ paginate }) {
   const allTags = ["red", "blue", "green"];
   const allPosts = Object.values(import.meta.glob("../pages/post/*.md", { eager: true }));
-  // Pour chaque tag, retourne un résultat `paginate()`.
+  // Pour chaque étiquette, renvoyer un résultat paginé (`paginate()`).
   // Assurez-vous de passer `{ params: { tag } }` à la fonction `paginate()`
-  // afin qu'Astro sache à quel groupe de tags le résultat est destiné.
+  // afin qu'Astro sache à quel groupe d'étiquettes le résultat est destiné.
   return allTags.map((tag) => {
     const filteredPosts = allPosts.filter((post) => post.frontmatter.tag === tag);
     return paginate(filteredPosts, {
@@ -555,11 +555,11 @@ const params = Astro.params;
 
 ## Exclure des pages
 
-Vous pouvez exclure des pages ou des répertoires dans `src/pages` de la construction en préfixant leurs noms par un trait de soulignement (`_`). Les fichiers avec le préfixe `_` ne seront pas reconnus par le routeur et ne seront pas placés dans le répertoire `dist/`.
+Vous pouvez exclure des pages ou des répertoires dans `src/pages` de la compilation en préfixant leurs noms par un trait de soulignement (`_`). Les fichiers avec le préfixe `_` ne seront pas reconnus par le routeur et ne seront pas placés dans le répertoire `dist/`.
 
-Cela vous permet de créer des pages privées, et aussi de placer les tests, les utilitaires et les composants dans les pages correspondantes, en les empêchant d'être construits dans des fichiers `.html` et placés dans le répertoire `dist/`.
+Cela vous permet de créer des pages privées, et aussi de placer les tests, les utilitaires et les composants dans les pages correspondantes, en les empêchant d'être compilés dans des fichiers `.html` et placés dans le répertoire `dist/`.
 
-Dans cet exemple, seuls `src/pages/index.astro` et `src/pages/projects/project1.md` seront construits comme routes de pages et fichiers HTML.
+Dans cet exemple, seuls `src/pages/index.astro` et `src/pages/projets/projet1.md` seront compilées comme routes de pages et fichiers HTML.
 
 <FileTree>
 - src/pages/
@@ -568,8 +568,8 @@ Dans cet exemple, seuls `src/pages/index.astro` et `src/pages/projects/project1.
     - page2.md
   - _page-cachée.astro
   - **index.astro**
-  - projects/
-    - _SomeComponent.astro
-    - _utils.js
-    - **project1.md**
+  - projets/
+    - _UnComposant.astro
+    - _utilitaires.js
+    - **projet1.md**
 </FileTree>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/routing`:
* to apply changes based on the French i18n update
  * replace `île` with `îlot`
  * replace `construction` with `génération`/`compilation`
  * remove capital letters when not needed in French
  * replace `support` with `prise en charge`
  * use a consistent translation of `tag` (ie. `étiquette` in this context)
  * use French quotes
  * translate some more examples/avoid partially translated examples
* to fix some mismatches with the English version
* to make the reading smoother by rewording some parts
* replace the translation for `rest parameters`: using `REST` (uppercase) can be confusing because of REST API... [MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Functions/rest_parameters) and other sources use `paramètre du reste`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
