### PR TITLE
i18n(fr): improve the wording in `server-islands` & `syntax-highlighting`

### DIFF
--- a/src/content/docs/fr/guides/server-islands.mdx
+++ b/src/content/docs/fr/guides/server-islands.mdx
@@ -12,9 +12,9 @@ Cela signifie que votre visiteur verra les parties les plus importantes de votre
 
 Un îlot de serveur est un [composant Astro](/fr/basics/astro-components/) normal rendu par le serveur, qui est chargé de différer le rendu jusqu'à ce que son contenu soit disponible.
 
-Votre page sera rendue immédiatement avec tout [contenu de repli](#contenu-de-repli-de-l%C3%AElot-de-serveur). Ensuite, le contenu du composant est récupéré sur le client et affiché lorsqu'il est disponible.
+Votre page sera immédiatement affichée avec le [contenu de repli](#contenu-de-repli-de-l%C3%AElot-de-serveur) spécifié en tant que contenu substituable. Ensuite, le contenu du composant est récupéré sur le client et affiché lorsqu'il est disponible.
 
-Avec [un adaptateur installé](/fr/guides/on-demand-rendering/#adaptateurs-de-serveur) pour effectuer le rendu différé, ajoutez la directive [`server:defer`](/fr/reference/directives-reference/#directives-serveur) à n'importe quel composant de votre page pour le transformer en sa propre îlot :
+Avec [un adaptateur installé](/fr/guides/on-demand-rendering/#adaptateurs-de-serveur) pour effectuer le rendu différé, ajoutez la directive [`server:defer`](/fr/reference/directives-reference/#directives-serveur) à n'importe quel composant de votre page pour le transformer en son propre îlot :
 
 ```astro title="src/pages/index.astro" "server:defer"
 ---
@@ -52,7 +52,7 @@ import GenericAvatar from '../components/GenericAvatar.astro';
 </Avatar>
 ```
 
-Ce contenu de secours peut-être, par exemple, un avatar générique au lieu de celui de l'utilisateur :
+Par exemple, ce contenu de repli peut être :
 
 - Un avatar générique au lieu de celui de l'utilisateur.
 - Une interface utilisateur remplaçable, telle que des messages personnalisés.

--- a/src/content/docs/fr/guides/syntax-highlighting.mdx
+++ b/src/content/docs/fr/guides/syntax-highlighting.mdx
@@ -8,9 +8,9 @@ import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-Astro est doté d'un support intégré pour [Shiki](https://shiki.style/) et [Prism](https://prismjs.com/). Il fournit une coloration syntaxique pour :
+Astro est doté d'une prise en charge intégrée pour [Shiki](https://shiki.style/) et [Prism](https://prismjs.com/). Il fournit une coloration syntaxique pour :
 
-- toutes les [barrières de code (\`\`\`)](#blocs-de-code-markdown) utilisées dans un fichier Markdown ou MDX.
+- tous les [délimiteurs de code (\`\`\`)](#blocs-de-code-markdown) utilisés dans un fichier Markdown ou MDX.
 - les contenus dans le [composant intégré `<Code />`](#code-) (alimenté par Shiki) dans les fichiers `.astro`.
 - les contenus dans le [composant `<Prism />`](#prism-) (alimenté par Prism) dans les fichiers `.astro`.
 
@@ -18,7 +18,7 @@ Ajoutez [des intégrations communautaires telles que Expressive Code](https://as
 
 ## Blocs de code Markdown
 
-Un bloc de code Markdown est indiqué par un bloc avec trois accents graves \`\`\` au début et à la fin. Vous pouvez indiquer le langage de programmation utilisé après les guillemets d'ouverture pour indiquer comment colorer et styliser votre code pour le rendre plus facile à lire.
+Un bloc de code Markdown est indiqué par un bloc avec trois accents graves \`\`\` au début et à la fin. Vous pouvez indiquer le langage de programmation utilisé après les accents graves d'ouverture pour indiquer comment colorer et mettre en forme votre code pour le rendre plus facile à lire.
 
 ``````markdown
 ```js
@@ -30,11 +30,11 @@ var fun = function lang(l) {
 ```
 ``````
 
-Les blocs de code Markdown d'Astro sont stylisés par Shiki par défaut, préconfigurés avec le thème `github-dark`. La sortie compilée sera limitée aux styles en ligne sans classes CSS, feuilles de style ou JS côté client superflus.
+Les blocs de code Markdown d'Astro sont mis en forme par Shiki par défaut, préconfigurés avec le thème `github-dark`. La sortie compilée sera limitée aux `style`s incorporés sans classes CSS, feuilles de style ou JS côté client superflus.
 
 Vous pouvez [ajouter une feuille de style Prism et passer à la mise en évidence de Prism](#ajouter-une-feuille-de-style-prism), ou désactivez complètement la coloration syntaxique d'Astro, avec l'option de configuration [`markdown.syntaxHighlight`](/fr/reference/configuration-reference/#markdownsyntaxhighlight).
 
-<ReadMore>Consultez la [référence `markdown.shikiConfig` complète](/fr/reference/configuration-reference/#markdownshikiconfig) pour avoir un aperçu complet des options de coloration syntaxique Markdown disponibles lors de l'utilisation de Shiki.</ReadMore>
+<ReadMore>Consultez la [référence `markdown.shikiConfig`](/fr/reference/configuration-reference/#markdownshikiconfig) complète pour avoir un aperçu complet des options de coloration syntaxique Markdown disponibles lors de l'utilisation de Shiki.</ReadMore>
 
 ### Définir un thème Shiki par défaut
 
@@ -140,10 +140,10 @@ import { Code } from 'astro:components';
 <Code code={`const foo = 'bar';`} lang="js" theme="dark-plus" />
 <!-- Facultatif : Activer le retour à la ligne. -->
 <Code code={`const foo = 'bar';`} lang="js" wrap />
-<!-- Facultatif : Générer du code en ligne. -->
+<!-- Facultatif : Générer du code au sein du texte. -->
 <p>
   <Code code={`const foo = 'bar';`} lang="js" inline />
-  sera rendu en ligne.
+  sera rendu au sein du texte.
 </p>
 <!-- Facultatif : defaultColor -->
 <Code code={`const foo = 'bar';`} lang="js" defaultColor={false} />
@@ -153,7 +153,7 @@ import { Code } from 'astro:components';
 
 <p><Since v="4.11.0" /></p>
 
-[Les Transformateurs de Shiki](https://shiki.style/packages/transformers#shikijs-transformers) peuvent éventuellement être appliqués au code en les transmettant via la propriété `transformers` sous forme de tableau. Depuis Astro v4.14.0, vous pouvez également fournir une chaîne de caractères à [l'attribut `meta` de Shiki](https://shiki.style/guide/transformers#meta) pour transmettre des options aux transformateurs.
+[Les transformateurs de Shiki](https://shiki.style/packages/transformers#shikijs-transformers) peuvent éventuellement être appliqués au code en les transmettant via la propriété `transformers` sous forme de tableau. Depuis Astro v4.14.0, vous pouvez également fournir une chaîne de caractères à [l'attribut `meta` de Shiki](https://shiki.style/guide/transformers#meta) pour transmettre des options aux transformateurs.
 
 Notez que `transformers` n'applique que les classes et vous devez fournir vos propres règles CSS pour cibler les éléments de votre bloc de code.
 
@@ -182,9 +182,9 @@ console.log(foo + bar) // [!code focus]
 
 ### `<Prism />`
 
-Ce composant fournit une coloration syntaxique spécifique au langage pour les blocs de code en appliquant les classes CSS de Prism. Notez que vous devez [fournir une feuille de style CSS de Prism](#ajouter-une-feuille-de-style-prism) (ou apporter la vôtre) pour styliser les classes.
+Ce composant fournit une coloration syntaxique spécifique au langage pour les blocs de code en appliquant les classes CSS de Prism. Notez que vous devez [fournir une feuille de style CSS de Prism](#ajouter-une-feuille-de-style-prism) (ou apporter la vôtre) pour ajouter des styles aux classes.
 
-Pour utiliser le composant de coloration syntaxique `Prism`, vous devez installer le package `@astrojs/prism` :
+Pour utiliser le composant de coloration syntaxique `Prism`, vous devez installer le paquet `@astrojs/prism` :
 
 <PackageManagerTabs>
   <Fragment slot="npm">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations of `guides/server-islands` and `guides/syntax-highlighting` based on the [French i18n guide update](https://github.com/withastro/docs/blob/main/i18n-guides/fran%C3%A7ais.md):
* reword some parts to match the English version
* fix typo
* replace `support` with `pris en charge`
* replace `barrières` with `délimiteurs`
* replace `styliser` with `mettre en forme`
* replace the translation for `inline styles`/`inline code`
* replace `package` with `paquet`

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
