### PR TITLE
Fix Firefox sidebar content flash

### DIFF
--- a/src/components/tabs/TabPanel.astro
+++ b/src/components/tabs/TabPanel.astro
@@ -36,6 +36,7 @@ const attributes: HTMLAttributes<'div'> = initial ? { 'data-initial': 'true' } :
 	@keyframes tab-panel-appear {
 		from {
 			display: none;
+			content-visibility: hidden;
 		}
 	}
 </style>

--- a/src/components/tabs/TabPanel.astro
+++ b/src/components/tabs/TabPanel.astro
@@ -35,6 +35,8 @@ const attributes: HTMLAttributes<'div'> = initial ? { 'data-initial': 'true' } :
 
 	@keyframes tab-panel-appear {
 		from {
+			/* `content-visibility` is set as well as `display` to work around a Firefox
+			   bug where animations containing only `display: none` don’t play. */
 			display: none;
 			content-visibility: hidden;
 		}


### PR DESCRIPTION
As this was brought up in today's T&D, this PR fixes a flash of invalid active tab in both the sidebar and the tutorial tracker (they both use the same component).

After investigating, it looks like Firefox refuses to animate when the `from` keyframe [only contains the `display: none;` property](https://github.com/withastro/docs/blob/2bf83d22e659c3acec7d46393c63a19c8ec7d8e1/src/components/tabs/TabPanel.astro#L37-L39) (even tho it should use a discrete animation type).

This PR adds `content-visibility: hidden;` to the `from` keyframe, which seems to trigger the animation correctly in Firefox and does not seem to change any other behavior.

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #11611
- Suggested label: site improvement

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->