### PR TITLE
i18n(ja): correct Japanese typo in guides/integrations-guide/react.mdx

### DIFF
--- a/src/content/docs/ja/guides/integrations-guide/react.mdx
+++ b/src/content/docs/ja/guides/integrations-guide/react.mdx
@@ -136,7 +136,7 @@ export default defineConfig({
 ### 子要素のパース
 AstroコンポーネントからReactコンポーネントへ渡される子要素は、Reactノードではなくプレーンな文字列としてパースされます。
 
-例えば、下の`<ReactComponent />`には子要素が一つしか渡されませません。
+例えば、下の`<ReactComponent />`には子要素が一つしか渡されません。
 
 ```astro
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR fixes a small Japanese typo in the React integration documentation.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- No specific issue for this typo fix -->
- Suggested label: `documentation`, `typo`, `i18n`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
