### PR TITLE
i18n(fr): improve the wording in `guides/content-collections.mdx`

### DIFF
--- a/src/content/docs/fr/guides/content-collections.mdx
+++ b/src/content/docs/fr/guides/content-collections.mdx
@@ -13,7 +13,7 @@ import ReadMore from "~/components/ReadMore.astro"
 <p><Since v="2.0.0" /></p>
 
 **Les collections de contenu** sont le meilleur moyen de gérer des ensembles de contenu dans n'importe quel projet Astro. Les collections aident à organiser et à interroger vos documents, à activer Intellisense et la vérification de type dans votre éditeur et à fournir une sûreté du typage TypeScript automatique pour tout votre contenu.
-Astro v5.0 a introduit l'API Content Layer pour définir et interroger les collections de contenu. Cette API performante et évolutive fournit des chargeurs de contenu intégrés pour vos collections locales. Pour le contenu distant, vous pouvez utiliser des chargeurs tiers et créés par la communauté ou créer votre propre chargeur personnalisé et extraire vos données à partir de n'importe quelle source.
+Astro v5.0 a introduit l'API de couche de contenu pour définir et interroger les collections de contenu. Cette API performante et évolutive fournit des chargeurs de contenu intégrés pour vos collections locales. Pour le contenu distant, vous pouvez utiliser des chargeurs tiers et créés par la communauté ou créer votre propre chargeur personnalisé et extraire vos données à partir de n'importe quelle source.
 
 :::note
 Les projets peuvent continuer à utiliser l'API de collections de contenu héritée introduite dans Astro v2.0. Cependant, nous vous encourageons à [mettre à jour les collections existantes](/fr/guides/upgrade-to/v5/#héritage--api-des-collections-de-contenu-de-la-v20) lorsque vous le pouvez.
@@ -27,19 +27,19 @@ Les collections stockées localement dans votre projet ou sur votre système de 
 
 <FileTree>
 - src/
-- **newsletter/** la collection "newsletter"
+- **newsletter/** la collection « newsletter »
   - week-1.md une entrée de collection
   - week-2.md une entrée de collection
   - week-3.md une entrée de collection
-- **authors/** la collection "author"
+- **authors/** la collection « author »
   - authors.json un fichier unique contenant toutes les entrées de la collection
 </FileTree>
 
-Avec un chargeur de collection approprié, vous pouvez récupérer des données distantes à partir de n'importe quelle source externe, telle qu'un CMS, une base de données ou un système de paiement sans tête.
+Avec un chargeur de collection approprié, vous pouvez récupérer des données distantes à partir de n'importe quelle source externe, telle qu'un CMS, une base de données ou un système de paiement headless.
 
 ## Configuration TypeScript pour les collections
 
-Les collections de contenu s'appuient sur TypeScript pour fournir la validation Zod, Intellisense et la vérification de type dans votre éditeur. Si vous n'étendez pas l'un des paramètres TypeScript `strict` ou `strictest` d'Astro, vous devrez vous assurer que `compilerOptions` définisse les options suivantes dans votre fichier `tsconfig.json` :
+Les collections de contenu s'appuient sur TypeScript pour fournir la validation avec Zod, Intellisense et la vérification de type dans votre éditeur. Si vous n'étendez pas l'un des paramètres TypeScript `strict` ou `strictest` d'Astro, vous devrez vous assurer que `compilerOptions` définisse les options suivantes dans votre fichier `tsconfig.json` :
 
 ```json title="tsconfig.json" ins={5} {6}
 {
@@ -77,17 +77,17 @@ const dogs = defineCollection({ /* ... */ });
 export const collections = { blog, dogs };
 ```
 
-### Définir le `loader` de collection
+### Définir le chargeur de collection (`loader`)
 
-L'API Content Layer vous permet de récupérer votre contenu (qu'il soit stocké localement dans votre projet ou à distance) et utilise une propriété `loader` pour récupérer vos données.
+L'API de couche de contenu vous permet de récupérer votre contenu (qu'il soit stocké localement dans votre projet ou à distance) et utilise une propriété `loader` pour récupérer vos données.
 
 #### Chargeurs intégrés
 
-Astro fournit [deux fonctions de chargement intégrées](/fr/reference/content-loader-reference/#types-de-chargeurs) (`glob()` et `file()`) pour récupérer votre contenu local, ainsi qu'un accès à l'API pour construire votre propre chargeur et récupérer des données distantes.
+Astro fournit [deux fonctions de chargement intégrées](/fr/reference/content-loader-reference/#types-de-chargeurs) (`glob()` et `file()`) pour récupérer votre contenu local, ainsi qu'un accès à l'API pour créer votre propre chargeur et récupérer des données distantes.
 
-Le [chargeur `glob()`](/fr/reference/content-loader-reference/#le-chargeur-glob) crée des entrées à partir de répertoires de fichiers Markdown, MDX, Markdoc, JSON, ou YAML à partir de n'importe quel endroit du système de fichiers. Il accepte un `pattern` de fichiers d'entrée à faire correspondre à l'aide de modèles glob pris en charge par [micromatch](https://github.com/micromatch/micromatch#matching-features) et un chemin de fichier `base` indiquant où se trouvent vos fichiers. L'`id` de chaque entrée sera automatiquement généré à partir de son nom de fichier. Utilisez ce chargeur lorsque vous avez un fichier par entrée.
+Le [chargeur `glob()`](/fr/reference/content-loader-reference/#le-chargeur-glob) crée des entrées à partir de répertoires de fichiers Markdown, MDX, Markdoc, JSON, ou YAML à partir de n'importe quel endroit du système de fichiers. Il accepte un motif (`pattern`) de fichiers d'entrée à faire correspondre à l'aide de motifs glob pris en charge par [micromatch](https://github.com/micromatch/micromatch#matching-features) et un chemin de fichier `base` indiquant où se trouvent vos fichiers. L'`id` de chaque entrée sera automatiquement généré à partir de son nom de fichier. Utilisez ce chargeur lorsque vous avez un fichier par entrée.
 
-Le [chargeur `file()`](/fr/reference/content-loader-reference/#le-chargeur-file) crée plusieurs entrées à partir d'un seul fichier local. Chaque entrée du fichier doit avoir une propriété de clé `id` unique. Il accepte un chemin de fichier `base` vers votre fichier et éventuellement une [fonction `parser`](#fonction-parser) pour les fichiers de données qu'il ne peut pas analyser automatiquement. Utilisez ce chargeur lorsque votre fichier de données peut être analysé comme un tableau d'objets.
+Le [chargeur `file()`](/fr/reference/content-loader-reference/#le-chargeur-file) crée plusieurs entrées à partir d'un seul fichier local. Chaque entrée du fichier doit avoir un nom de propriété `id` unique. Il accepte un chemin de fichier `base` vers votre fichier et éventuellement une [fonction `parser`](#fonction-parser) pour les fichiers de données qu'il ne peut pas analyser automatiquement. Utilisez ce chargeur lorsque votre fichier de données peut être analysé comme un tableau d'objets.
 
 ```ts  title="src/content.config.ts" {5,9}
 import { defineCollection, z } from 'astro:content';
@@ -104,13 +104,13 @@ const dogs = defineCollection({
 
 const probes = defineCollection({
   // `loader` peut accepter un tableau de plusieurs modèles ainsi que des modèles de chaîne de caractères
-  // Chargez tous les fichiers Markdown dans le répertoire space-probes, à l'exception de ceux qui commencent par "voyager-"
+  // Chargez tous les fichiers Markdown dans le répertoire space-probes, à l'exception de ceux qui commencent par « voyager- »
   loader: glob({ pattern: ['*.md', '!voyager-*'], base: 'src/data/space-probes' }),
   schema: z.object({
     name: z.string(),
     type: z.enum(['Space Probe', 'Mars Rover', 'Comet Lander']),
     launch_date: z.date(),
-    status: z.enum(['Active', 'Inactive', 'Decommissioned']),
+    status: z.enum(['Actif', 'Inactif', 'Déclassé']),
     destination: z.string(),
     operator: z.string(),
     notable_discoveries: z.array(z.string()),
@@ -122,9 +122,9 @@ export const collections = { blog, dogs, probes };
 
 ##### Fonction `parser`
 
-Le chargeur `file()` accepte un second argument qui définit une fonction `parser`. Cela vous permet de spécifier un analyseur personnalisé (par exemple `toml.parse` ou `csv-parse`) pour créer une collection à partir du contenu d'un fichier.
+Le chargeur `file()` accepte un second argument qui définit une fonction d'analyse (`parser`). Cela vous permet de spécifier un analyseur personnalisé (par exemple `toml.parse` ou `csv-parse`) pour créer une collection à partir du contenu d'un fichier.
 
-Le chargeur `file()` détectera et analysera automatiquement un seul tableau d'objets à partir de fichiers JSON et YAML (en fonction de leur extension de fichier) sans avoir besoin d'un `parser` à moins que vous n'ayez un [document JSON imbriqué](#documents-json-imbriqués). Pour utiliser d'autres fichiers, tels que `.toml` et `.csv`, vous aurez besoin de créer une fonction d'analyse.
+Le chargeur `file()` détectera et analysera automatiquement un seul tableau d'objets à partir de fichiers JSON et YAML (en fonction de leur extension de fichier) sans avoir besoin d'un analyseur (`parser`) à moins que vous n'ayez un [document JSON imbriqué](#documents-json-imbriqués). Pour utiliser d'autres fichiers, tels que `.toml` et `.csv`, vous aurez besoin de créer une fonction d'analyse.
 
 L'exemple suivant définit une collection de contenu `dogs` à l'aide d'un fichier `.toml` :
 
@@ -138,7 +138,7 @@ id = "..."
 age = "..."
 ```
 
-Après avoir importé l'analyseur de TOML, vous pouvez charger la collection `dogs` dans votre projet en transmettant à la fois un chemin de fichier et la fonction `parser` au chargeur `file()`. Un processus similaire peut être utilisé pour définir une collection `cats` à partir d'un fichier `.csv` :
+Après avoir importé l'analyseur de TOML, vous pouvez charger la collection `dogs` dans votre projet en transmettant à la fois un chemin de fichier et la fonction d'analyse (`parser`) au chargeur `file()`. Un processus similaire peut être utilisé pour définir une collection `cats` à partir d'un fichier `.csv` :
 
 ```typescript title="src/content.config.ts"
 import { defineCollection } from "astro:content";
@@ -164,7 +164,7 @@ L'argument `parser` vous permet également de charger une seule collection à pa
 {"dogs": [{}], "cats": [{}]}
 ```
 
-Vous pouvez séparer ces collections en passant un `parser` personnalisé au chargeur `file()` pour chaque collection :
+Vous pouvez séparer ces collections en passant un analyseur personnalisé (`parser`) au chargeur `file()` pour chaque collection :
 
 ```typescript title="src/content.config.ts"
 const dogs = defineCollection({
@@ -175,7 +175,7 @@ const cats = defineCollection({
 });
 ```
 
-#### Construire un chargeur personnalisé
+#### Créer un chargeur personnalisé
 
 Vous pouvez créer un chargeur personnalisé pour récupérer du contenu distant à partir de n'importe quelle source de données, telle qu'un CMS, une base de données ou un point de terminaison d'API.
 
@@ -185,9 +185,9 @@ L'utilisation d'un chargeur pour récupérer vos données créera automatiquemen
 Recherchez des chargeurs créés par la communauté et des tiers dans le [répertoire des intégrations Astro](https://astro.build/integrations/?search=&categories%5B%5D=loaders).
 :::
 
-##### Chargeurs en ligne
+##### Chargeurs incorporés
 
-Vous pouvez définir un chargeur en ligne, à l'intérieur de votre collection, comme une fonction asynchrone qui renvoie un tableau d'entrées.
+Vous pouvez définir un chargeur incorporé, à l'intérieur de votre collection, comme une fonction asynchrone qui renvoie un tableau d'entrées.
 
 Ceci est utile pour les chargeurs qui n'ont pas besoin de contrôler manuellement la manière dont les données sont chargées et stockées. Chaque fois que le chargeur est appelé, il efface le magasin et recharge toutes les entrées.
 
@@ -196,7 +196,7 @@ const countries = defineCollection({
   loader: async () => {
     const response = await fetch("https://restcountries.com/v3.1/all");
     const data = await response.json();
-    // Doit renvoyer un tableau d'entrées avec une propriété id ou un objet avec des ID comme clés et des entrées comme valeurs
+    // Doit renvoyer un tableau d'entrées contenant une propriété id ou un objet avec des ID comme noms de propriété et des entrées comme valeurs
     return data.map((country) => ({
       id: country.cca3,
       ...country,
@@ -210,11 +210,11 @@ Les entrées renvoyées sont stockées dans la collection et peuvent être inter
 
 ##### Objets de chargement
 
-Pour un meilleur contrôle du processus de chargement, vous pouvez utiliser l'API Content Loader pour créer un objet de chargement. Par exemple, avec un accès direct à la méthode `load`, vous pouvez créer un chargeur qui permet de mettre à jour les entrées de manière incrémentielle ou d'effacer le magasin uniquement lorsque cela est nécessaire.
+Pour un meilleur contrôle du processus de chargement, vous pouvez utiliser l'API de chargement de contenu pour créer un objet de chargement. Par exemple, avec un accès direct à la méthode `load`, vous pouvez créer un chargeur qui permet de mettre à jour les entrées de manière incrémentielle ou d'effacer le magasin uniquement lorsque cela est nécessaire.
 
-Similairement à la création d'une intégration Astro ou d'un plugin Vite, vous pouvez [distribuer votre chargeur sous forme de paquet NPM](/fr/reference/publish-to-npm/) que d'autres peuvent utiliser dans leurs projets.
+Similairement à la création d'une intégration pour Astro ou d'un module d'extension pour Vite, vous pouvez [distribuer votre chargeur sous forme de paquet NPM](/fr/reference/publish-to-npm/) que d'autres peuvent utiliser dans leurs projets.
 
-<ReadMore>Consultez [l'API Content Layer complète](/fr/reference/content-loader-reference/) et des exemples de création de votre propre chargeur.</ReadMore>
+<ReadMore>Consultez [l'API de couche de contenu complète](/fr/reference/content-loader-reference/) et des exemples pour créer votre propre chargeur.</ReadMore>
 
 ### Définition d'un schéma de collection
 
@@ -289,13 +289,13 @@ defineCollection({
 
 ##### Méthodes de schéma Zod
 
-Toutes [les méthodes de schéma Zod](https://zod.dev/?id=schema-methods) (e.g. `.parse()`, `.transform()`) sont disponibles, avec certaines limitations. Notamment, l'exécution de contrôles de validation personnalisés sur les images à l'aide de `image().refine()` n'est pas prise en charge.
+Toutes [les méthodes de schéma Zod](https://zod.dev/?id=schema-methods) (p. ex. `.parse()`, `.transform()`) sont disponibles, avec certaines limitations. Notamment, l'exécution de contrôles de validation personnalisés sur les images à l'aide de `image().refine()` n'est pas prise en charge.
 
 #### Définition des références de collection
 
 Les entrées de collection peuvent également « faire référence » à d’autres entrées associées.
 
-Avec la [fonction `reference()`](/fr/reference/modules/astro-content/#reference) de l'API Collections, vous pouvez définir une propriété dans un schéma de collection en tant qu'entrée d'une autre collection. Par exemple, vous pouvez exiger que chaque entrée `space-shuttle` inclue une propriété `pilot` qui utilise le schéma propre à la collection `pilot` pour la vérification du type, la saisie semi-automatique et la validation.
+Avec la [fonction `reference()`](/fr/reference/modules/astro-content/#reference) de l'API des collections, vous pouvez définir une propriété dans un schéma de collection en tant qu'entrée d'une autre collection. Par exemple, vous pouvez exiger que chaque entrée `space-shuttle` inclue une propriété `pilot` qui utilise le schéma propre à la collection `pilot` pour la vérification du type, la saisie semi-automatique et la validation.
 
 Un exemple courant est un article de blog qui fait référence à des profils d'auteur réutilisables stockés au format JSON ou à des URL d'articles associés stockées dans la même collection :
 
@@ -337,18 +337,18 @@ relatedPosts:
 ---
 ```
 
-Ces références seront transformées en objets contenant une clé `collection` et une clé `id`, vous permettant de [les interroger facilement dans vos modèles](/fr/guides/content-collections/#accès-aux-données-référencées).
+Ces références seront transformées en objets contenant une propriété `collection` et une propriété `id`, vous permettant de [les interroger facilement dans vos modèles](/fr/guides/content-collections/#accès-aux-données-référencées).
 
 ### Définition d'identifiants personnalisés
 
 Lors de l'utilisation du chargeur `glob()` avec des fichiers Markdown, MDX, Markdoc ou JSON, chaque [`id`](/fr/reference/modules/astro-content/#id) d'entrée de contenu est automatiquement généré dans un format compatible URL basé sur le nom du fichier de contenu. L'`id` est utilisé pour interroger l'entrée directement à partir de votre collection. Il est également utile lors de la création de nouvelles pages et URL à partir de votre contenu.
 
-Vous pouvez remplacer l'`id` généré par une entrée en ajoutant votre propre propriété `slug` à la page de garde du fichier ou à l'objet de données pour les fichiers JSON. Ceci est similaire à la fonctionnalité « permalien » d'autres frameworks Web.
+Vous pouvez remplacer l'`id` généré par une entrée en ajoutant votre propre propriété `slug` au frontmatter du fichier ou à l'objet de données pour les fichiers JSON. Ceci est similaire à la fonctionnalité « permalien » d'autres frameworks Web.
 
 ```md title="src/blog/1.md" {3}
 ---
 title: Mon article de blog
-slug: mon-id-personnalise/supporte/les-barres-obliques
+slug: mon-id-personnalise/prend-en-charge/les-barres-obliques
 ---
 Le contenu de votre article de blog ici.
 ```
@@ -356,7 +356,7 @@ Le contenu de votre article de blog ici.
 ```json title="src/categories/1.json" {3}
 {
   "title": "Ma catégorie",
-  "slug": "mon-id-personnalise/supporte/les-barres-obliques",
+  "slug": "mon-id-personnalise/prend-en-charge/les-barres-obliques",
   "description": "Votre description de catégorie ici."
 }
 ```
@@ -400,7 +400,7 @@ const posts = (await getCollection('blog')).sort(
 
 ### Utilisation du contenu dans les modèles Astro
 
-Après avoir interrogé vos collections, vous pouvez accéder au contenu de chaque entrée directement dans votre modèle de composant Astro. Par exemple, vous pouvez créer une liste de liens vers vos articles de blog, en affichant les informations de la page de garde de votre entrée à l'aide de la propriété `data`.
+Après avoir interrogé vos collections, vous pouvez accéder au contenu de chaque entrée directement dans votre modèle de composant Astro. Par exemple, vous pouvez créer une liste de liens vers vos articles de blog, en affichant les informations du frontmatter de votre entrée à l'aide de la propriété `data`.
 
 
 ```astro title="src/pages/index.astro"
@@ -417,7 +417,7 @@ const posts = await getCollection('blog');
 ```
 #### Restitution du contenu
 
-Une fois la requête effectuée, vous pouvez restituer les entrées Markdown et MDX en HTML à l'aide de la propriété de fonction [`render()`](/fr/reference/modules/astro-content/#render). L'appel de cette fonction vous donne accès au contenu HTML restitué, y compris à la fois un composant `<Content />` et une liste de tous les titres restitués.
+Une fois la requête effectuée, vous pouvez restituer les entrées Markdown et MDX en HTML à l'aide de la propriété de fonction [`render()`](/fr/reference/modules/astro-content/#render). L'appel de cette fonction vous donne accès au contenu HTML restitué, y compris un composant `<Content />` et une liste de tous les titres restitués.
 
 ```astro title="src/pages/blog/post-1.astro" {5,8}
 ---
@@ -426,7 +426,7 @@ import { getEntry, render } from 'astro:content';
 const entry = await getEntry('blog', 'post-1');
 if (!entry) {
   // Traiter l'erreur, par exemple :
-  throw new Error('Could not find blog post 1');
+  throw new Error("Impossible de trouver l'article de blog 1");
 }
 const { Content, headings } = await render(entry);
 ---
@@ -438,7 +438,7 @@ const { Content, headings } = await render(entry);
 
 Un composant peut également transmettre une entrée de collection entière en tant que propriété.
 
-Vous pouvez utiliser l'utilitaire [`CollectionEntry`](/fr/reference/modules/astro-content/#collectionentry) pour saisir correctement les propriétés de votre composant à l'aide de TypeScript. Cet utilitaire prend un argument de chaîne qui correspond au nom de votre schéma de collection et héritera de toutes les propriétés du schéma de cette collection.
+Vous pouvez utiliser l'utilitaire [`CollectionEntry`](/fr/reference/modules/astro-content/#collectionentry) pour saisir correctement les propriétés de votre composant à l'aide de TypeScript. Cet utilitaire prend en tant qu'argument une chaîne de caractères qui correspond au nom de votre schéma de collection et héritera de toutes les propriétés du schéma de cette collection.
 
 ```astro title="src/components/BlogCard.astro" /CollectionEntry(?:<.+>)?/
 ---
@@ -466,17 +466,17 @@ const publishedBlogEntries = await getCollection('blog', ({ data }) => {
 });
 ```
 
-Vous pouvez également créer des pages provisoires qui sont disponibles lors de l'exécution du serveur de développement, mais qui ne sont pas construites dans la production :
+Vous pouvez également créer des pages provisoires qui sont disponibles lors de l'exécution du serveur de développement, mais qui ne sont pas générées en production :
 
 ```js
-// Exemple : Filtrer les entrées de contenu avec `draft: true` uniquement lors de la construction pour la production
+// Exemple : Filtrer les entrées de contenu avec `draft: true` uniquement lors de la compilation pour la production
 import { getCollection } from 'astro:content';
 const blogEntries = await getCollection('blog', ({ data }) => {
   return import.meta.env.PROD ? data.draft !== true : true;
 });
 ```
 
-L'argument filter permet également de filtrer les répertoires imbriqués dans une collection. Puisque `id` inclut le chemin imbriqué complet, vous pouvez filtrer par le début de chaque `id` pour ne renvoyer que les éléments d'un répertoire imbriqué spécifique :
+L'argument `filter` permet également de filtrer les répertoires imbriqués dans une collection. Puisque `id` inclut le chemin imbriqué complet, vous pouvez filtrer en utilisant le début de chaque `id` pour ne renvoyer que les éléments d'un répertoire imbriqué spécifique :
 
 ```js
 // Exemple : Filtrer les entrées par sous-répertoire dans la collection
@@ -488,7 +488,7 @@ const englishDocsEntries = await getCollection('docs', ({ id }) => {
 
 ### Accès aux données référencées
 
-Toutes [références définies dans votre schéma](/fr/guides/content-collections/#définition-des-références-de-collection) doivent être interrogées séparément après la première interrogation de votre entrée de collection. Puisque la [fonction `reference()`](/fr/reference/modules/astro-content/#reference) transforme une référence en un objet avec `collection` et `id` comme clés, vous pouvez utiliser la fonction `getEntry()` pour renvoyer un seul élément référencé ou `getEntries()` pour récupérer plusieurs entrées référencées à partir de l'objet `data` renvoyé.
+Toutes [références définies dans votre schéma](/fr/guides/content-collections/#définition-des-références-de-collection) doivent être interrogées séparément après la première interrogation de votre entrée de collection. Puisque la [fonction `reference()`](/fr/reference/modules/astro-content/#reference) transforme une référence en un objet avec `collection` et `id` comme propriétés, vous pouvez utiliser la fonction `getEntry()` pour renvoyer un seul élément référencé ou `getEntries()` pour récupérer plusieurs entrées référencées à partir de l'objet `data` renvoyé.
 
 ```astro title="src/pages/blog/welcome.astro"
 ---
@@ -496,7 +496,7 @@ import { getEntry, getEntries } from 'astro:content';
 
 const blogPost = await getEntry('blog', 'welcome');
 
-// Restituer une référence singulière (p. ex. `{collection: "authors", id: "ben-holmes"}`)
+// Restituer une seule référence (p. ex. `{collection: "authors", id: "ben-holmes"}`)
 const author = await getEntry(blogPost.data.author);
 // Restituer un tableau de références
 // (p. ex. `[{collection: "blog", id: "about-me"}, {collection: "blog", id: "my-year-in-review"}]`)
@@ -518,13 +518,13 @@ const relatedPosts = await getEntries(blogPost.data.relatedPosts);
 
 Les collections de contenu sont stockées en dehors du répertoire `src/pages/`. Cela signifie qu'aucune page ou route n'est générée par défaut pour vos éléments de collection.
 
-Vous devrez créer manuellement une nouvelle [route dynamique](/fr/guides/routing/#routes-dynamiques) si vous souhaitez générer des pages HTML pour chacune de vos entrées de collection, telles que des articles de blog individuels. Votre route dynamique va mettre en correspondance le paramètre de la requête entrante (ex : `Astro.params.slug` dans `src/pages/blog/[...slug].astro`) pour récupérer la bonne entrée à l'intérieur d'une collection.
+Vous devrez créer manuellement une nouvelle [route dynamique](/fr/guides/routing/#routes-dynamiques) si vous souhaitez générer des pages HTML pour chacune de vos entrées de collection, telles que des articles de blog individuels. Votre route dynamique va mettre en correspondance le paramètre de la requête entrante (p. ex. : `Astro.params.slug` dans `src/pages/blog/[...slug].astro`) pour récupérer la bonne entrée à l'intérieur d'une collection.
 
 La méthode exacte de génération des routes dépendra du fait que vos pages sont pré-rendues (par défaut) ou rendues à la demande par un serveur.
 
-### Construire pour une sortie statique (par défaut)
+### Créer pour une sortie statique (par défaut)
 
-Si vous créez un site Web statique (comportement par défaut d'Astro), utilisez la fonction [`getStaticPaths()`](/fr/reference/routing-reference/#getstaticpaths) pour créer plusieurs pages à partir d'un seul composant de page (par exemple `src/pages/[slug]`) pendant votre création.
+Si vous créez un site web statique (comportement par défaut d'Astro), utilisez la fonction [`getStaticPaths()`](/fr/reference/routing-reference/#getstaticpaths) pour créer plusieurs pages à partir d'un seul composant de page (par exemple `src/pages/[slug]`) au moment de la compilation.
 
 Appelez `getCollection()` à l'intérieur de `getStaticPaths()` pour que vos données de collection soient disponibles pour la création de routes statiques. Ensuite, créez les chemins d'URL individuels à l'aide de la propriété `id` de chaque entrée de contenu. Chaque page reçoit l'entrée de collection entière en tant que propriété à [utiliser dans votre modèle de page](#utilisation-du-contenu-dans-les-modèles-astro).
 
@@ -547,15 +547,15 @@ const { Content } = await render(post);
 <Content />
 ```
 
-Cela générera une route de page pour chaque entrée de la collection `blog`. Par exemple, une entrée dans `src/blog/hello-world.md` aura un `id` de `hello-world`, et donc son URL finale sera `/posts/hello-world/`.
+Cela générera une route de page pour chaque entrée de la collection `blog`. Par exemple, une entrée dans `src/blog/hello-world.md` possèdera un `id` avec la valeur `hello-world`, ainsi son URL finale sera `/posts/hello-world/`.
 
 :::note
 Si vos slugs personnalisés contiennent le caractère `/` pour produire des URLs avec plusieurs segments de chemin, vous devez utiliser un [paramètre du reste (par exemple `[...slug]`)](/fr/guides/routing/#paramètres-du-reste) dans le nom de fichier `.astro` pour cette page de routage dynamique.
 :::
 
-### Construction pour la sortie serveur (SSR)
+### Créer pour une sortie serveur (SSR)
 
-Si vous construisez un site web dynamique (en utilisant le support SSR d'Astro), vous n'êtes pas censé générer des chemins à l'avance pendant la construction. Au lieu de cela, votre page devrait examiner la requête (en utilisant `Astro.request` ou `Astro.params`) pour trouver le `slug` à la demande, et ensuite le récupérer en utilisant [`getEntry()`](/fr/reference/modules/astro-content/#getentry).
+Si vous créez un site web dynamique (en utilisant la prise en charge SSR d'Astro), vous n'êtes pas censé générer des chemins à l'avance pendant la compilation. Au lieu de cela, votre page devrait examiner la requête (en utilisant `Astro.request` ou `Astro.params`) pour obtenir le `slug` demandé, et ensuite récupérer l'entrée en utilisant [`getEntry()`](/fr/reference/modules/astro-content/#getentry).
 
 
 ```astro title="src/pages/posts/[id].astro"
@@ -572,7 +572,7 @@ const post = await getEntry("blog", id);
 if (post === undefined) {
 	return Astro.redirect("/404");
 }
-// 4. Rendre l'entrée en HTML dans le modèle
+// 4. Effecter le rendu de l'entrée en HTML dans le modèle
 const { Content } = await render(post);
 ---
 <h1>{post.data.title}</h1>
@@ -589,15 +589,15 @@ Vous pouvez [créer une collection](#définition-des-collections) à chaque fois
 
 Une grande partie des avantages liés à l’utilisation des collections provient de :
 
-- Définir une forme de données commune pour valider qu'une entrée individuelle est « correcte » ou « complète », évitant ainsi les erreurs de production.
+- La définition d'une structure de données commune pour valider qu'une entrée individuelle est « correcte » ou « complète », évitant ainsi les erreurs de production.
 - API axées sur le contenu conçues pour rendre les requêtes intuitives (par exemple, `getCollection()` au lieu de `import.meta.glob()`) lors de l'importation et du rendu du contenu sur vos pages.
 - Une [API de chargement de contenu](/fr/reference/content-loader-reference/) pour récupérer votre contenu qui fournit à la fois des chargeurs intégrés et un accès à l'API de bas niveau. Il existe plusieurs chargeurs tiers et communautaires disponibles, et vous pouvez créer votre propre chargeur personnalisé pour récupérer des données de n'importe où.
-- Performances et évolutivité. L'API Content Layer permet de mettre en cache les données entre les builds et convient à des dizaines de milliers d'entrées de contenu.
+- La performance et l'évolutivité. L'API de couche de contenu permet de mettre en cache les données entre les compilations et convient à des dizaines de milliers d'entrées de contenu.
 
 [Définissez vos données](#définition-des-collections) comme une collection lorsque :
 
 - Vous avez plusieurs fichiers ou données à organiser qui partagent la même structure globale (par exemple, des articles de blog écrits en Markdown qui ont tous les mêmes propriétés de frontmatter).
-- Vous disposez d'un contenu existant stocké à distance, par exemple dans un CMS, et vous souhaitez profiter des fonctions d'assistance des collections et de l'API Content Layer au lieu d'utiliser `fetch()` ou des SDK.
+- Vous disposez d'un contenu existant stocké à distance, par exemple dans un CMS, et vous souhaitez profiter des fonctions d'assistance des collections et de l'API de couche de contenu au lieu d'utiliser `fetch()` ou des SDK.
 - Vous devez récupérer (des dizaines de) milliers de données connexes et avez besoin d'une méthode d'interrogation et de mise en cache capable de gérer à grande échelle.
 
 ### Quand ne pas créer une collection

--- a/src/content/docs/fr/reference/content-loader-reference.mdx
+++ b/src/content/docs/fr/reference/content-loader-reference.mdx
@@ -224,7 +224,7 @@ const blog = defineCollection({
 
 ## API du chargeur d'objets
 
-L'API pour les [chargeurs en ligne](#chargeurs-en-ligne) est très simple et est présentée ci-dessus. Cette section présente l'API permettant de définir un chargeur sous forme d'objet.
+L'API pour les [chargeurs incorporés](#chargeurs-incorporés) est très simple et est présentée ci-dessus. Cette section présente l'API permettant de définir un chargeur sous forme d'objet.
 
 ### L'objet `Loader`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/content-collections.mdx` to improve the wording based on the French i18n guide update:
* translate the API names
* replace `supporte` with `prend en charge`
* replace `sans tête` with `headless`
* replace `page de garde` with `frontmatter`
* replace the translation of `object key` with `nom de propriété` (same as [MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/keys))
* use French quotes
* replace the translation of `build` with `compilation`/`créer`/`générer` where more appropriate than `construction`
* replace `modèle` with `motif` for glob patterns
* translate `parser`
* replace the translation for `inline`
* replace `plugin` with `module d'extension`
* replace `rendre` with `effectuer le rendu`
* tiny reword to make the reading smoother/match the English version meaning
* translate some examples

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
