### PR TITLE
Reference `<ClientRouter />` component rather than view transitions on Prefetch page

### DIFF
--- a/src/content/docs/en/guides/prefetch.mdx
+++ b/src/content/docs/en/guides/prefetch.mdx
@@ -170,7 +170,7 @@ Make sure to only import `prefetch()` in client-side scripts as it relies on bro
 
 ## Using with View Transitions
 
-When you use [View Transitions](/en/guides/view-transitions/) on a page, prefetching will also be enabled by default. It sets a default configuration of `{ prefetchAll: true }` which enables [prefetching for all links](#prefetch-all-links-by-default) on the page.
+When you use [Astro’s `<ClientRouter />`](/en/guides/view-transitions/#enabling-view-transitions-spa-mode)  on a page, prefetching will also be enabled by default. It sets a default configuration of `{ prefetchAll: true }` which enables [prefetching for all links](#prefetch-all-links-by-default) on the page.
 
 You can customize the prefetch configuration in `astro.config.mjs` to override the default. For example:
   


### PR DESCRIPTION
#### Description (required)

Astro´s `<ClientRouter />` component enables Astro´s prefetch feature by default.
Saying that _View Transitions_ set this default might be misleading.

#### Related issues & labels (optional)

- Closes #12021 

