### PR TITLE
Randomize ads at build time

### DIFF
--- a/src/components/RightSidebar/RandomizedAd.astro
+++ b/src/components/RightSidebar/RandomizedAd.astro
@@ -1,0 +1,9 @@
+---
+import ScrimbaAd from './ScrimbaAd.astro';
+import LearnAstroAd from './LearnAstroAd.astro';
+
+const ads = [ScrimbaAd, LearnAstroAd];
+const Ad = ads[Math.floor(Math.random() * ads.length)];
+---
+
+<Ad />

--- a/src/components/RightSidebar/ad.ts
+++ b/src/components/RightSidebar/ad.ts
@@ -1,2 +1,2 @@
 // The currently running sidebar ad
-export { default as Ad } from './ScrimbaAd.astro';
+export { default as Ad } from './RandomizedAd.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates how we display our ads. Currently, we have a single ad rendered on all pages. This PR randomly picks one of the available ads at build time for each page. Over time that means people should see a roughly balanced mix of the different ads we have on rotation. For now this 
