### PR TITLE
Update MCP server Raycast install link

### DIFF
--- a/src/content/docs/en/guides/build-with-ai.mdx
+++ b/src/content/docs/en/guides/build-with-ai.mdx
@@ -133,7 +133,7 @@ Refer to the [OpenAI MCP documentation](https://platform.openai.com/docs/mcp#tes
 
 Install by clicking the button below:
 
-<LinkButton href="raycast://mcp/install?%7B%22name%22%3A%22Astro%20docs%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.docs.astro.build%2Fmcp%22%7D">Add to Raycast</LinkButton>
+<LinkButton href="raycast://mcp/install?%7B%22name%22%3A%22Astro%20docs%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%20%22mcp-remote%22%2C%20%22https%3A%2F%2Fmcp.docs.astro.build%2Fmcp%22%5D%7D">Add to Raycast</LinkButton>
 
 [More info on using MCP servers with Raycast](https://manual.raycast.com/model-context-protocol)
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As [reported on Mastodon](https://indieweb.social/@zero_gravitas/114864839962052827), even tho the MCP server Raycast install link used to work for me [earlier this afternoon](https://github.com/withastro/docs/pull/12019#issuecomment-3078754800) on `v1.100.0`, it looks like it's no longer working on [`v1.101.0`](https://www.raycast.com/changelog/1-101-0) ([released 10 hours ago](https://x.com/raycast/status/1945456589756043466) and which includes changes to both MCP server and Streamable HTTP support).

To temporarily address this, this PR updates the Raycast install link to use a proxy like the [Windsurf instructions do](https://docs.astro.build/en/guides/build-with-ai/#windsurf).

For reference, here is the new decoded URL:

```
{"name":"Astro docs","type":"stdio","command":"npx","args":["-y", "mcp-remote", "https://mcp.docs.astro.build/mcp"]}
```

Also adding a video of the entire workflow working for me locally:

https://github.com/user-attachments/assets/5ba3bd4f-0af6-4431-b39f-926504c0e84b


#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->