### PR TITLE
i18n(fr): update two `errors` reference

### DIFF
--- a/src/content/docs/fr/reference/errors/data-collection-entry-parse-error.mdx
+++ b/src/content/docs/fr/reference/errors/data-collection-entry-parse-error.mdx
@@ -7,4 +7,4 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 > Impossible d'analyser `COLLECTION_ENTRY_NAME`.
 
 ## Qu'est-ce qui a mal tourné ?
-Les entrées de collection avec `type: 'data'` doivent renvoyer un objet au format JSON valide (pour les entrées `.json`) ou YAML (pour les entrées `.yaml`).
+Les entrées de collection utilisant `type: 'data'` doivent renvoyer un objet avec du JSON (pour les entrées `.json`), du YAML (pour les entrées `.yaml`) ou du TOML (pour les entrées `.toml`) valide.

--- a/src/content/docs/fr/reference/errors/file-parser-not-found.mdx
+++ b/src/content/docs/fr/reference/errors/file-parser-not-found.mdx
@@ -7,7 +7,7 @@ githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/
 > **FileParserNotFound**: No parser was found for 'FILE_NAME'. Pass a parser function (e.g. `parser: csv`) to the `file` loader.
 
 ## Qu'est-ce qui a mal tourné ?
-Le chargeur `file` ne peut pas déterminer quel analyseur utiliser. Veuillez fournir un analyseur personnalisé (par exemple `toml.parse` ou `csv-parse`) pour créer une collection à partir de votre type de fichier.
+Le chargeur `file` ne peut pas déterminer quel analyseur utiliser. Veuillez fournir un analyseur personnalisé (par exemple `csv-parse`) pour créer une collection à partir de votre type de fichier.
 
 **Voir aussi :**
 -  [Transmettre un analyseur (`parser`) au chargeur `file`](/fr/guides/content-collections/#fonction-parser)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #12033 to the French translations of `errors/file-parser-not-found` and `errors/data-collection-entry-parse-error`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
