### PR TITLE
i18n(fr): add `experimental-flags/raw-env-values.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/raw-env-values.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/raw-env-values.mdx
@@ -1,0 +1,50 @@
+---
+title: Valeurs brutes expérimentales des variables d'environnement
+sidebar:
+  label: Variables d'environnement brutes
+i18nReady: true
+---
+
+import Since from '~/components/Since.astro'
+
+<p>
+
+**Type :** `boolean`<br />
+**Par défaut :** `false`<br />
+<Since v="5.12.0" />
+</p>
+
+Astro vous permet de configurer un [schéma avec sûreté du typage pour vos variables d'environnement](/fr/guides/environment-variables/#variables-denvironnement-avec-sûreté-du-typage), et convertit les variables importées via `astro:env` dans le type attendu.
+
+Cependant, Astro convertit également vos variables d'environnement utilisées via `import.meta.env` dans certains cas, ce qui peut empêcher l'accès à certaines valeurs telles que les chaînes de caractères `"true"` (qui est convertie en valeur booléenne) et `"1"` (qui est convertie en nombre).
+
+L'option `experimental.rawEnvValues` désactive la coercition des valeurs d'`import.meta.env` qui sont renseignées à partir de `process.env`, vous permettant d'utiliser la valeur brute.
+
+Pour désactiver la coercition d'Astro sur les valeurs utilisées via `import.meta.env`, définissez l'option `experimental.rawEnvValues` sur `true` dans votre configuration Astro :
+
+```js title="astro.config.mjs" ins={4-6}
+import { defineConfig } from "astro/config"
+
+export default defineConfig({
+  experimental: {
+    rawEnvValues: true,
+  }
+})
+```
+
+## Utilisation
+
+L'activation de cette option expérimentale ne convertira plus les valeurs de chaîne de caractères en booléens ou en nombres. Cela aligne le comportement de `import.meta.env` dans Astro avec celui de [Vite](https://vite.dev/guide/env-and-mode.html#env-variables).
+
+Dans une future version majeure, Astro passera à la non-contrainte des valeurs d'`import.meta.env` par défaut, mais vous pouvez opter pour le comportement futur plus tôt en utilisant l'option `experimental.rawEnvValues` et si nécessaire, [mettre à jour votre projet](#mise-à-jour-de-votre-projet) en conséquence.
+
+### Mise à jour de votre projet
+
+Si vous vous appuyiez sur cette coercition, vous devrez peut-être mettre à jour le code de votre projet pour l'appliquer manuellement :
+
+```ts title="src/components/MyComponent.astro" del={1} ins={2}
+const enabled: boolean = import.meta.env.ENABLED
+const enabled: boolean = import.meta.env.ENABLED === "true"
+```
+
+Si vous avez besoin de coercition dans Astro, nous vous recommandons d'utiliser [`astro:env`](/fr/guides/environment-variables/).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translates in French the new `experimental-flags/raw-env-values.mdx` file added in #12033

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
