### PR TITLE
Update `priority` prop reference

### DIFF
--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -142,7 +142,7 @@ However, both of these properties are required for images stored in your `public
 
 A list of pixel densities to generate for the image.
 
-The `densities` attribute is not compatible with responsive images using a `layout` property and will be ignored if set.
+The `densities` attribute is not compatible with [responsive images](#responsive-image-properties) with a `layout` prop or `image.layout` config set, and will be ignored if set.
 
 If provided, this value will be used to generate a `srcset` attribute on the `<img>` tag. Do not provide a value for `widths` when using this value.
 
@@ -293,7 +293,7 @@ import { Image } from 'astro:assets';
 
 `inferSize` can fetch the dimensions of a [remote image from a domain that has not been authorized](/en/guides/images/#authorizing-remote-images), however the image itself will remain unprocessed.
 
-#### priority
+##### priority
 
 <p>
 
@@ -312,9 +312,9 @@ import myImage from '../assets/my_image.png';
 <Image src={myImage} priority alt="A description of my image" />
 ```
 
-When `priority: true` (or the shorthand syntax `priority`) is added to the `<Image />` or `<Picture />` component, it will add the following attributes to instruct the browser to load the image immediately:
+When `priority="true"` (or the shorthand syntax `priority`) is added to the `<Image />` or `<Picture />` component, it will add the following attributes to instruct the browser to load the image immediately:
 
-```
+```html
 loading="eager"
 decoding="sync"
 fetchpriority="high"
@@ -534,19 +534,6 @@ Values match those of CSS `object-fit`. Defaults to `cover`, or the value of [`i
 Enabled when the [`layout`](#layout) property is set or configured. Defines the position of the image crop for a responsive image if the aspect ratio is changed. 
 
 Values match those of CSS `object-position`. Defaults to `center`, or the value of [`image.objectPosition`](/en/reference/configuration-reference/#imageobjectposition) if set. Can be used to override the default `object-position` styles. 
-
-##### priority
-
-<p>
-
-**Type:** `boolean` <br />
-**Default:** `false` <br />
-<Since v="5.10.0" />
-</p>
-
-Enabled when the [`layout`](#layout) property is set or configured. If set, eagerly loads a responsive image. Otherwise, images will be lazy-loaded. Use this for your largest above-the-fold image. Defaults to `false`.
-
-
 
 ### `getImage()`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since 5.10, `priority` has been allowed on all images, not just responsive ones. This PR removes the duplicated prop from the responsive section, fixes the heading level, and clarifies some of the wording

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.12.1`. See astro PR [#14094](https://github.com/withastro/astro/pull/14094).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
