### PR TITLE
Feat: Filter current page from BackendGuidesNav

### DIFF
--- a/src/components/BackendGuidesNav.astro
+++ b/src/components/BackendGuidesNav.astro
@@ -8,6 +8,9 @@ import CardsNav from './NavGrid/CardsNav.astro';
 const lang = getLanguageFromURL(Astro.url.pathname);
 const enPages = englishPages.filter(isBackendEntry);
 
+const currentPath = Astro.url.pathname;
+const currentPageId = currentPath.split('/').filter(Boolean).pop();
+
 const links = enPages
 	.sort((a, b) => {
 		// Sort alphabetically.
@@ -17,8 +20,17 @@ const links = enPages
 		const { service } = page.data;
 		const pageUrl = '/' + page.id.replace('en/', `${lang}/`) + '/';
 		const logo = isLogoKey(page.id.split('/').pop());
-		return { title: service, href: pageUrl, logo };
-	});
+		const pageId = page.id.split('/').pop();
+
+		return {
+			title: service,
+			href: pageUrl,
+			logo,
+			pageId,
+			isActive: pageId === currentPageId,
+		};
+	})
+	.filter((link) => !link.isActive);
 ---
 
 <section>


### PR DESCRIPTION
#### Description (required)

What: Remove the current page from the backend services navigation component to prevent showing the page the user is already on.

Why: When viewing a specific backend service page (e.g., /guides/backend/turso/), it's illogical to show that same service in the navigation list. This improves UX by filtering out the current page and only showing other available backend services for navigation.

How: Added logic to extract the current page ID from the URL path and filter it out from the links array before passing to the CardsNav component.

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
Discord: 2u841r 
