### PR TITLE
fix(content-loader-reference): update `store.set` usage in a snippet

### DIFF
--- a/src/content/docs/en/reference/content-loader-reference.mdx
+++ b/src/content/docs/en/reference/content-loader-reference.mdx
@@ -378,7 +378,7 @@ export function myLoader(settings): Loader {
       store.clear();
 
       for (const entry of entries) {
-        store.set(entry.id, {
+        store.set({
           id: entry.id,
           data: entry,
           // Assume each entry has a 'content' field with markdown content


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Someone has spotted in the core repo (https://github.com/withastro/astro/pull/14096) that the use of `store.set`  in the code snippet used for `renderMarkdown` was incorrect. They have corrected the changelog, but we should fix it here as well.
The [DataStore set function](http://localhost:4321/en/reference/content-loader-reference/#set) only takes one argument.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
