### PR TITLE
docs: fix example domain and improve clarity in config guide

### DIFF
--- a/src/content/docs/en/guides/configuring-astro.mdx
+++ b/src/content/docs/en/guides/configuring-astro.mdx
@@ -52,7 +52,7 @@ Here are some first steps you might choose to take with a new Astro project.
 
 ### Add your deployment domain
 
-For generating your sitemap and creating canonical URLs, configure your deployment URL in the [`site`](/en/reference/configuration-reference/#site) option. If you are deploying to a path (e.g. `www.example/docs`), you can also configure a [`base`](/en/reference/configuration-reference/#base) for the root of your project.
+For generating your sitemap and creating canonical URLs, configure your deployment URL in the [`site`](/en/reference/configuration-reference/#site) option. If you are deploying to a path (e.g. `www.example.com/docs`), you can also configure a [`base`](/en/reference/configuration-reference/#base) for the root of your project.
 
 Additionally, different deployment hosts may have different behavior regarding trailing slashes at the end of your URLs. (e.g. `example.com/about` vs `example.com/about/`). Once your site is deployed, you may need to configure your [`trailingSlash`](/en/reference/configuration-reference/#trailingslash) preference.
 
@@ -70,7 +70,7 @@ export default defineConfig({
 
 Astro does not use its configuration file for common SEO or meta data, only for information required to build your project code and render it to HTML.
 
-Instead, this information is added to your page `<head>` in HTML `<link>` and `<meta>` tags, just as if you were writing plain HTML pages.
+Instead, this information is added to your page `<head>` using standard HTML `<link>` and `<meta>` tags, just as if you were writing plain HTML pages.
 
 One common pattern for Astro sites is to create a `<Head />` [`.astro` component](/en/basics/astro-components/) that can be added to a common [layout component](/en/basics/layouts/) so it can apply to all your pages.
 


### PR DESCRIPTION
- Corrected the example deployment domain from www.example/docs to www.example.com/docs
- Reworded the explanation about adding metadata to clarify the use of standard HTML <link> and <meta> tags

Suggested label: fix