### PR TITLE
Update Lunaria (Fixes Netlify deploy issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@astrojs/sitemap": "^3.3.0",
     "@astrojs/starlight": "^0.34.4",
     "@expressive-code/plugin-collapsible-sections": "^0.41.2",
-    "@lunariajs/core": "https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0",
+    "@lunariajs/core": "https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3",
     "canvas-confetti": "^1.6.0",
     "jsdoc-api": "^9.3.4",
     "rehype-slug": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.41.2
         version: 0.41.2
       '@lunariajs/core':
-        specifier: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0
-        version: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0
+        specifier: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3
+        version: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3
       canvas-confetti:
         specifier: ^1.6.0
         version: 1.6.0
@@ -743,8 +743,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0':
-    resolution: {tarball: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0}
+  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3':
+    resolution: {tarball: https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3}
     version: 0.1.1
     engines: {node: '>=18.17.0'}
 
@@ -1367,8 +1367,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   cookie-es@1.2.2:
@@ -2384,6 +2384,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-all@5.0.0:
+    resolution: {integrity: sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==}
+    engines: {node: '>=16'}
+
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
@@ -2399,6 +2403,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@6.0.0:
+    resolution: {integrity: sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==}
+    engines: {node: '>=16'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -4008,12 +4016,13 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@4c8b9b0':
+  '@lunariajs/core@https://pkg.pr.new/lunariajs/lunaria/@lunariajs/core@f07e1a3':
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.2
       jiti: 2.3.3
       js-yaml: 4.1.0
       neotraverse: 0.6.18
+      p-all: 5.0.0
       path-to-regexp: 6.3.0
       picomatch: 4.0.2
       simple-git: 3.27.0
@@ -4808,7 +4817,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  consola@3.2.3: {}
+  consola@3.4.2: {}
 
   cookie-es@1.2.2: {}
 
@@ -6221,6 +6230,10 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-all@5.0.0:
+    dependencies:
+      p-map: 6.0.0
+
   p-finally@1.0.0: {}
 
   p-limit@3.1.0:
@@ -6234,6 +6247,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@6.0.0: {}
 
   p-queue@6.6.2:
     dependencies:

--- a/scripts/lunaria/components.ts
+++ b/scripts/lunaria/components.ts
@@ -283,7 +283,7 @@ export const ContentDetailsLinks = (
 			links.history(
 				fileStatus.source.path,
 				'git' in localization
-					? new Date(localization.git.latestTrackedChange.date).toISOString()
+					? new Date(localization.git.latestTrackedCommit.date).toISOString()
 					: undefined
 			),
 			'source change history'

--- a/scripts/tuesday-bot.ts
+++ b/scripts/tuesday-bot.ts
@@ -13,7 +13,7 @@ async function setDiscordMessage() {
 
 	const toTranslate = status.filter(
 		(s) =>
-			new Date(s.source.git.latestTrackedChange.date) >
+			new Date(s.source.git.latestTrackedCommit.date) >
 			new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
 	);
 


### PR DESCRIPTION

#### Description (required)

This updates the Lunaria prerelease to the latest version (we were a few versions behind). This means there are a few refactors, new small features, and fixes (including one for the Netlify deploy)

Here's a dashboard upload you can test with these changes:
https://test-lunaria-fix.netlify.app/

Note: there are quite a few status changes between this and our current dashboard, from my investigation these all seem to be correct and related to fixes in how Lunaria directives are detected/applied.

For example, `ko` and `fr` both get a new outdated page from the 5.0 release PR, the `@lunaria-track:` directive didn't include localizations at *all*, so these files that had only link changes were marked as outdated in that PR and for some reason they weren't properly shown in the dashboard before.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
