### PR TITLE
i18n(fr): update `tutorial/*`

### DIFF
--- a/src/content/docs/fr/tutorial/0-introduction/index.mdx
+++ b/src/content/docs/fr/tutorial/0-introduction/index.mdx
@@ -7,6 +7,9 @@ sidebar:
 description: >-
   Apprenez les bases d'Astro grâce à un tutoriel basé sur un projet. Toutes les connaissances préalables dont vous avez besoin pour commencer !
 i18nReady: true
+head:
+  - tag: title
+    content: Tutoriel de création d'un blog | Docs
 ---
 import Checklist from '~/components/Checklist.astro';
 import Box from '~/components/tutorial/Box.astro';

--- a/src/content/docs/fr/tutorial/1-setup/index.mdx
+++ b/src/content/docs/fr/tutorial/1-setup/index.mdx
@@ -8,6 +8,9 @@ description: >-
   Préparez votre environnement de développement, créez et déployez votre
   premier site Astro
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 1 - Configuration | Docs"
 ---
 import Checklist from '~/components/Checklist.astro';
 import Box from '~/components/tutorial/Box.astro';

--- a/src/content/docs/fr/tutorial/2-pages/index.mdx
+++ b/src/content/docs/fr/tutorial/2-pages/index.mdx
@@ -6,6 +6,9 @@ description: |-
   Tutoriel : Créer votre premier blog avec Astro —
   Créez, mettez en forme et liez les pages d'articles sur votre site
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 2 - Pages | Docs"
 ---
 import Checklist from '~/components/Checklist.astro';
 import Box from '~/components/tutorial/Box.astro';

--- a/src/content/docs/fr/tutorial/3-components/index.mdx
+++ b/src/content/docs/fr/tutorial/3-components/index.mdx
@@ -6,6 +6,9 @@ description: |-
   Tutoriel : Créer votre premier blog avec Astro —
   Créez des composants Astro pour réutiliser le code des éléments communs sur votre site web
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 3 - Composants | Docs"
 ---
 import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';

--- a/src/content/docs/fr/tutorial/4-layouts/index.mdx
+++ b/src/content/docs/fr/tutorial/4-layouts/index.mdx
@@ -8,6 +8,9 @@ description: >-
   Utilisez les mises en page Astro pour partager des éléments et des styles
   communs entre vos pages et vos articles.
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 4 - Mises en page | Docs"
 ---
 import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';

--- a/src/content/docs/fr/tutorial/5-astro-api/index.mdx
+++ b/src/content/docs/fr/tutorial/5-astro-api/index.mdx
@@ -8,6 +8,9 @@ description: >-
   Récupérer et utiliser des données à partir des fichiers du projet pour
   générer dynamiquement le contenu des pages et les routes
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 5 - API d'Astro | Docs"
 ---
 import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';

--- a/src/content/docs/fr/tutorial/6-islands/4.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/4.mdx
@@ -5,6 +5,9 @@ description: |-
   Tutoriel : Créer votre premier blog avec Astro —
   Convertissez votre blog d'un routage basé sur des fichiers en collections de contenu
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Créer une collection de contenu | Docs"
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Box from '~/components/tutorial/Box.astro';

--- a/src/content/docs/fr/tutorial/6-islands/index.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/index.mdx
@@ -6,6 +6,9 @@ description: |-
   Tutoriel : Créer votre premier blog avec Astro —
   Utilisez les îlots d'Astro pour intégrer des composants de framework frontend dans votre site Astro
 i18nReady: true
+head:
+  - tag: title
+    content: "Tutoriel de création d'un blog : Unité 6 - Îlots d'Astro | Docs"
 ---
 import Box from '~/components/tutorial/Box.astro';
 import Checklist from '~/components/Checklist.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #12012 to the French translations of the tutorial.

Note:
* I reused the label defined in `i18n/fr.yml` as title for consistency and for the same reasons explained in https://github.com/withastro/docs/pull/12012#discussion_r2198259104
* I haven't replaced `Docs` with `Documentation` because all the auto-generated titles use `Docs`, so consistency again.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
