### PR TITLE
Add instructions on date serialization at astro-actions.mdx

### DIFF
--- a/src/content/docs/en/reference/modules/astro-actions.mdx
+++ b/src/content/docs/en/reference/modules/astro-actions.mdx
@@ -78,11 +78,10 @@ If `input` is omitted, the `handler` will receive an input of type `unknown` for
 
 ##### Use with `accept: 'form'`
 
-If your action accepts form inputs, use the `z.object()` validator to automatically parse form data to a typed object. The following validators are supported for form data fields:
+If your action accepts form inputs, use the `z.object()` validator to automatically parse form data to a typed object. All Zod validators are supported for form data fields (e.g. `z.coerce.date()`). Astro additionally provides special handling under the hood for your convenience for validating the following types of field inputs:
 
 - Inputs of type `number` can be validated using `z.number()`
 - Inputs of type `checkbox` can be validated using `z.coerce.boolean()`
-- Inputs of type `date` can be validated using `z.coerce.date()`
 - Inputs of type `file` can be validated using `z.instanceof(File)`
 - Multiple inputs of the same `name` can be validated using `z.array(/* validator */)`
 - All other inputs can be validated using `z.string()`

--- a/src/content/docs/en/reference/modules/astro-actions.mdx
+++ b/src/content/docs/en/reference/modules/astro-actions.mdx
@@ -82,6 +82,7 @@ If your action accepts form inputs, use the `z.object()` validator to automatica
 
 - Inputs of type `number` can be validated using `z.number()`
 - Inputs of type `checkbox` can be validated using `z.coerce.boolean()`
+- Inputs of type `date` can be validated using `z.coerce.date()`
 - Inputs of type `file` can be validated using `z.instanceof(File)`
 - Multiple inputs of the same `name` can be validated using `z.array(/* validator */)`
 - All other inputs can be validated using `z.string()`


### PR DESCRIPTION
## Description

<!-- Please describe the change you are proposing, and why -->

This PR adds documentation regarding date serialization in Astro actions, including an example for the following description:

_Actions use `JSON.stringify()` under the hood, which turns dates into their string representation. You can use z.coerce.date() instead._ 

Including this new example will help guide developers when they encounter issues with date interpolation.

<!-- Please make changes in **one language** only -->

## Related issues & labels (optional)

- Closes #11644
- Suggested label: `improve or update documentation`
