### PR TITLE
i18n(fr): update `errors/only-response-can-be-returned.mdx`

### DIFF
--- a/src/content/docs/fr/reference/errors/only-response-can-be-returned.mdx
+++ b/src/content/docs/fr/reference/errors/only-response-can-be-returned.mdx
@@ -22,5 +22,3 @@ return Astro.redirect('/login');
 
 **Voir aussi :**
 -  [Response](/fr/guides/on-demand-rendering/#response)
-
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `errors/only-response-can-be-returned.mdx` to mark it as up to date. A link has been updated in #9240 both in the English and the French versions, so the file do not need changes.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
