### PR TITLE
i18n(fr): improve the wording in `client-side-scripts` & `configuring-astro`

### DIFF
--- a/src/content/docs/fr/basics/astro-components.mdx
+++ b/src/content/docs/fr/basics/astro-components.mdx
@@ -73,7 +73,7 @@ Le modèle de composant se trouve sous le délimiteur de code et détermine la s
 
 Si vous écrivez du HTML brut ici, votre composant affichera ce HTML dans n'importe quelle page Astro où il est importé et utilisé.
 
-Cependant, la [syntaxe du modèle de composant d'Astro](/fr/reference/astro-syntax/) prend également en charge les **expressions JavaScript**, les balises [`<style>`](/fr/guides/styling/#mettre-en-forme-avec-astro) et [`<script>`](/fr/guides/client-side-scripts/#utilisation-du-script-dans-astro) d'Astro, les **composants importés** et les [**directives spéciales d'Astro**](/fr/reference/directives-reference/). Les données et valeurs définies dans le script du composant peuvent être utilisées dans le modèle de composant pour produire du HTML créé dynamiquement.
+Cependant, la [syntaxe du modèle de composant d'Astro](/fr/reference/astro-syntax/) prend également en charge les **expressions JavaScript**, les balises [`<style>`](/fr/guides/styling/#mettre-en-forme-avec-astro) et [`<script>`](/fr/guides/client-side-scripts/#utilisation-de-script-dans-astro) d'Astro, les **composants importés** et les [**directives spéciales d'Astro**](/fr/reference/directives-reference/). Les données et valeurs définies dans le script du composant peuvent être utilisées dans le modèle de composant pour produire du HTML créé dynamiquement.
 
 ```astro title="src/components/MyFavoritePokemon.astro"
 ---

--- a/src/content/docs/fr/guides/client-side-scripts.mdx
+++ b/src/content/docs/fr/guides/client-side-scripts.mdx
@@ -9,9 +9,9 @@ import ReadMore from '~/components/ReadMore.astro'
 
 Vous pouvez ajouter de l'interactivité à vos composants Astro sans [utiliser un framework UI](/fr/guides/framework-components/) comme React, Svelte, Vue, etc, en utilisant les balises HTML `<script>` standard. Cela vous permet d'exécuter du JavaScript dans le navigateur et d'ajouter des fonctionnalités à vos composants Astro.
 
-## Script côté client
+## Scripts côté client
 
-Les scripts peuvent être utilisés pour écouter des événements envoyer des données analytiques, jouer des animations et tout ce que JavaScript permet de faire sur le web.
+Les scripts peuvent être utilisés pour écouter des événements, envoyer des données analytiques, jouer des animations et tout ce que JavaScript permet de faire sur le web.
 
 ```astro
 <!-- src/components/ConfettiButton.astro -->
@@ -33,7 +33,7 @@ Les scripts peuvent être utilisés pour écouter des événements envoyer des d
 
 Par défaut, Astro traite et regroupe les balises `<script>`, ce qui permet d'importer des modules npm, d'écrire du TypeScript, etc.
 
-## Utilisation du `<script>` dans Astro
+## Utilisation de `<script>` dans Astro
 
 Dans les fichiers `.astro`, vous pouvez ajouter du JavaScript côté client en ajoutant une (ou plusieurs) balises `<script>`.
 
@@ -53,13 +53,13 @@ Par défaut, les balises `<script>` sont optimisées par Astro.
 
 - Toutes les importations seront regroupées, ce qui vous permettra d'importer des fichiers locaux ou des modules Node.
 - Le script optimisé sera injecté à l'endroit où il est déclaré avec [`type="module"`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Guide/Modules).
-- TypeScript est entièrement supporté, y compris l'import de fichiers TypeScript.
+- TypeScript est entièrement pris en charge, y compris l'importation de fichiers TypeScript.
 - Si votre composant est utilisé plusieurs fois sur une page, le script ne sera inclus qu'une seule fois.
 
 ```astro title="src/components/Example.astro"
 <script>
   // Optimisé ! Regroupé ! Compatible avec TypeScript !
-  // L'importation de fichiers locaux et de modules Node est supportée.
+  // L'importation de fichiers locaux et de modules Node fonctionne.
 </script>
 ```
 
@@ -80,7 +80,7 @@ Pour empêcher Astro de traiter un script, ajoutez la directive `is:inline`.
 <script is:inline>
   // Sera rendu dans le code HTML exactement comme il est écrit !
   // Les importations locales ne sont pas résolues et ne fonctionneront pas.
-  // Si elle se trouve dans un composant, elle se répète chaque fois que le composant est utilisé.
+  // Si le script se trouve dans un composant, il se répète chaque fois que le composant est utilisé.
 </script>
 ```
 
@@ -99,7 +99,7 @@ Vous pouvez vouloir écrire vos scripts comme des fichiers `.js`/`.ts` séparés
 
 **Quand l'utiliser :** Si votre script se trouve dans `src/`.
 
-Astro construira, optimisera et ajoutera ces scripts à la page pour vous, en suivant ses [règles de traitement des scripts](#traitement-des-scripts).
+Astro compilera, optimisera et ajoutera ces scripts à la page pour vous, en suivant ses [règles de traitement des scripts](#traitement-des-scripts).
 
 ```astro title="src/components/LocalScripts.astro"
 <!-- chemin relatif du script dans `src/scripts/local.js` -->
@@ -191,12 +191,12 @@ L'utilisation d'un élément personnalisé présente deux avantages :
 
 2. Bien qu'un `<script>` ne s'exécute qu'une seule fois, le navigateur exécutera la méthode `connectedCallback()` de notre élément personnalisé chaque fois qu'il trouvera `<astro-heart>` sur la page.  Cela signifie que vous pouvez écrire en toute sécurité du code pour un seul composant à la fois, même si vous avez l'intention d'utiliser ce composant plusieurs fois sur une page.
 
-<ReadMore>Pour en savoir plus sur les éléments personnalisés, consultez [le guide des composants Web réutilisables de web.dev (EN)](https://web.dev/custom-elements-v1/) et [l'introduction aux éléments personnalisés de MDN](https://developer.mozilla.org/fr/docs/Web/API/Web_components/Using_custom_elements).</ReadMore>
+<ReadMore>Pour en savoir plus sur les éléments personnalisés, consultez [le guide des composants Web réutilisables de web.dev (Anglais)](https://web.dev/custom-elements-v1/) et [l'introduction aux éléments personnalisés de MDN](https://developer.mozilla.org/fr/docs/Web/API/Web_components/Using_custom_elements).</ReadMore>
 
 
 ### Transmettre les variables du frontmatter aux scripts
 
-Dans les composants Astro, le code dans [le frontmatter](/fr/basics/astro-components/#le-script-du-composant) entre les barrières `---` s'exécute sur le serveur et n'est pas disponible dans le navigateur. Pour envoyer des variables du serveur au client, nous avons besoin d'un moyen de stocker nos variables, puis de les lire lorsque le JavaScript s'exécute dans le navigateur.
+Dans les composants Astro, le code dans [le frontmatter](/fr/basics/astro-components/#le-script-du-composant) entre les délimiteurs `---` s'exécute sur le serveur et n'est pas disponible dans le navigateur. Pour envoyer des variables du serveur au client, nous avons besoin d'un moyen de stocker nos variables, puis de les lire lorsque le JavaScript s'exécute dans le navigateur.
 
 Une façon d'y parvenir est d'utiliser les attributs [`data-*`](https://developer.mozilla.org/fr/docs/Learn/HTML/Howto/Use_data_attributes) pour stocker la valeur des variables dans votre sortie HTML. Les scripts, y compris les éléments personnalisés, peuvent alors lire ces attributs en utilisant la propriété `dataset` d'un élément une fois que votre HTML se charge dans le navigateur.
 
@@ -239,7 +239,7 @@ import AstroGreet from '../components/AstroGreet.astro';
 <AstroGreet />
 
 <!-- Utiliser des messages personnalisés passés comme props. -->
-<AstroGreet message="Belle journée pour construire des composants !" />
+<AstroGreet message="Belle journée pour créer des composants !" />
 <AstroGreet message="Content que tu sois là ! 👋" />
 ```
 
@@ -247,6 +247,6 @@ import AstroGreet from '../components/AstroGreet.astro';
 C'est en fait ce qu'Astro fait dans les coulisses lorsque vous passez des props à un composant écrit avec un framework d'interface utilisateur comme React ! Pour les composants avec une directive `client:*`, Astro crée un élément personnalisé `<astro-island>` avec un attribut `props` qui stocke vos paramètres côté serveur dans la sortie HTML.
 :::
 
-### Combinaison de scripts et de Frameworks UI
+### Combinaison de scripts et de frameworks UI
 
-Les éléments rendus par un framework UI peuvent ne pas être disponibles au moment de l'exécution d'une balise `<script>`. Si votre script doit également gérer les [composants du framework UI](/fr/guides/framework-components/), il est recommandé d'utiliser un élément personnalisé.
+Les éléments rendus par un framework UI peuvent ne pas être disponibles au moment de l'exécution d'une balise `<script>`. Si votre script doit également gérer les [composants d'un framework UI](/fr/guides/framework-components/), il est recommandé d'utiliser un élément personnalisé.

--- a/src/content/docs/fr/guides/configuring-astro.mdx
+++ b/src/content/docs/fr/guides/configuring-astro.mdx
@@ -24,19 +24,19 @@ export default defineConfig({
 });
 ```
 
-Il n'est nécessaire que si vous avez quelque chose à configurer, mais la plupart des projets utiliseront ce fichier. L'aide `defineConfig()` fournit une IntelliSense automatique dans votre IDE et est l'endroit où vous ajouterez toutes vos options de configuration pour dire à Astro comment construire et rendre votre projet en HTML.
+Il n'est nécessaire que si vous avez quelque chose à configurer, mais la plupart des projets utiliseront ce fichier. L'aide `defineConfig()` fournit une IntelliSense automatique dans votre IDE et est l'endroit où vous ajouterez toutes vos options de configuration pour dire à Astro comment compiler et effectuer le rendu de votre projet en HTML.
 
-Nous recommandons d'utiliser le format de fichier par défaut `.mjs` dans la plupart des cas, ou `.ts` si vous voulez écrire du TypeScript dans votre fichier de configuration. Cependant, `astro.config.js` et `astro.config.cjs` sont également supportés.
+Nous recommandons d'utiliser le format de fichier par défaut `.mjs` dans la plupart des cas, ou `.ts` si vous voulez écrire du TypeScript dans votre fichier de configuration. Cependant, `astro.config.js` et `astro.config.cjs` sont également pris en charge.
 
 <ReadMore>Lisez la [référence de configuration](/fr/reference/configuration-reference/) d'Astro pour un aperçu complet de toutes les options de configuration prises en charge.</ReadMore>
 
 ## Le fichier de configuration TypeScript
 
-Chaque projet de démarrage Astro inclut un fichier `tsconfig.json` dans votre projet. Le [script du composant](/fr/basics/astro-components/#le-script-du-composant) d'Astro est Typescript, qui fournit l'outil d'édition d'Astro et vous permet d'ajouter optionnellement une syntaxe à votre JavaScript pour la vérification du type du code de votre propre projet.
+Chaque projet de démarrage Astro inclut un fichier `tsconfig.json` dans votre projet. Le [script du composant](/fr/basics/astro-components/#le-script-du-composant) d'Astro est Typescript, ce qui fournit les outils d'édition d'Astro et vous permet d'ajouter optionnellement une syntaxe à votre JavaScript pour la vérification des types dans le code de votre propre projet.
 
-Utilisez le fichier `tsconfig.json` pour configurer le modèle TypeScript qui effectuera les vérifications de type sur votre code, configurer les plugins TypeScript, définir les alias d'importation, et plus encore.
+Utilisez le fichier `tsconfig.json` pour configurer le modèle TypeScript qui effectuera les vérifications de type sur votre code, configurer les modules d'extension de TypeScript, définir les alias d'importation, et plus encore.
 
-<ReadMore>Veuillez lire le [Guide TypeScript](/fr/guides/typescript/) d'Astro pour une présentation complète des options TypeScript et des types d'utilitaires intégrés à Astro.</ReadMore>
+<ReadMore>Veuillez lire le [guide TypeScript](/fr/guides/typescript/) d'Astro pour une présentation complète des options TypeScript et des types d'utilitaires intégrés à Astro.</ReadMore>
 
 ## Expérience de développement
 
@@ -54,7 +54,7 @@ Voici quelques premières étapes que vous pourriez choisir de suivre avec un no
 
 Pour générer votre sitemap et créer des URL canoniques, configurez votre URL de déploiement dans l'option [`site`](/fr/reference/configuration-reference/#site). Si vous déployez vers un chemin (par exemple `www.example.com/docs`), vous pouvez également configurer une [`base`](/fr/reference/configuration-reference/#base) pour la racine de votre projet.
 
-De plus, les différents hôtes de déploiement peuvent avoir un comportement différent en ce qui concerne les barres obliques à la fin de vos URLs. (par exemple, `example.com/about` vs `example.com/about/`). Une fois que votre site est déployé, vous pouvez avoir besoin de configurer votre préférence [`trailingSlash`](/fr/reference/configuration-reference/#trailingslash).
+De plus, les différents hôtes de déploiement peuvent avoir un comportement différent en ce qui concerne les barres obliques à la fin de vos URLs. (par exemple, `example.com/about` vs `example.com/about/`). Une fois que votre site est déployé, vous pouvez avoir besoin de configurer votre valeur préférée pour [`trailingSlash`](/fr/reference/configuration-reference/#trailingslash).
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -68,7 +68,7 @@ export default defineConfig({
 
 ### Ajouter les métadonnées du site
 
-Astro n'utilise pas son fichier de configuration pour les données de référencement ou les métadonnées, mais seulement pour les informations nécessaires à la construction du code de votre projet et à son rendu en HTML.
+Astro n'utilise pas son fichier de configuration pour les données de référencement ou les métadonnées, mais seulement pour les informations nécessaires à la compilation du code de votre projet et à son rendu en HTML.
 
 Au lieu de cela, ces informations sont ajoutées au `<head>` de votre page en utilisant les balises HTML standard `<link>` et `<meta>`, comme si vous écriviez des pages HTML simples.
 

--- a/src/content/docs/fr/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v5.mdx
@@ -603,7 +603,7 @@ const { afficherAlerte } = Astro.props;
 }
 ```
 
-<ReadMore>En savoir plus sur [l'utilisation des balises `script` dans Astro](/fr/guides/client-side-scripts/#utilisation-du-script-dans-astro).</ReadMore>
+<ReadMore>En savoir plus sur [l'utilisation des balises `script` dans Astro](/fr/guides/client-side-scripts/#utilisation-de-script-dans-astro).</ReadMore>
 
 ## Changements non rétrocompatibles
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations of `guides/client-side-scripts` and `guides/configuring-astro` with changes added to the French i18n guides:
* replace `construire` with `compiler` or `créer` where more appropriate
* replace `rendre` with `effectuer le rendu`
* replace `plugin` with `module d'extension`
* replace `supporté` with `pris en charge`
* replace `import` with `importation`
* replace `barrières` with `délimiteurs`
* fix some mismatches with the English version (e.g. plural)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
