### PR TITLE
i18n(fr): improve the wording in `data-fetching` & `dev-toolbar`

### DIFF
--- a/src/content/docs/fr/guides/data-fetching.mdx
+++ b/src/content/docs/fr/guides/data-fetching.mdx
@@ -10,11 +10,11 @@ Les fichiers `.astro` peuvent récupérer des données distantes pour vous aider
 Tous les [composants Astro](/fr/basics/astro-components/) ont accès à la [fonction globale `fetch()`](https://developer.mozilla.org/fr/docs/Web/API/fetch) dans le script de leur composant pour effectuer des requêtes HTTP aux API en utilisant l'URL complète (par exemple `https://example.com/api`).
 En outre, vous pouvez construire une URL vers les pages et les points de terminaison de votre projet qui sont affichés à la demande sur le serveur en utilisant [`new URL("/api", Astro.url)`](/fr/reference/api-reference/#url).
 
-Cet appel sera exécuté au moment de la construction (Build), et les données seront disponibles pour le modèle de composant afin de générer du HTML dynamique. Si le mode [SSR](/fr/guides/on-demand-rendering/) est activé, tous les appels de recherche seront exécutés au moment de l'exécution.
+Cet appel de récupération sera exécuté au moment de la compilation et les données seront disponibles dans le modèle du composant pour générer du HTML dynamique. Si le mode [SSR](/fr/guides/on-demand-rendering/) est activé, tous les appels de récupération seront exécutés au moment de l'exécution.
 
-💡 Profitez de la fonctionnalité "[**top-level `await` (EN)**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await)" à l'intérieur de votre Script de composant Astro.
+💡 Profitez de la fonctionnalité "[**top-level `await` (Anglais)**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await)" à l'intérieur de votre script de composant Astro.
 
-💡 Transmettez les données récupérées aux composants Astro et aux composants du framework, en tant que props.
+💡 Transmettez les données récupérées aux composants Astro et aux composants de framework, en tant que props.
 
 ```astro /await fetch\\(.*?\\);/
 ---
@@ -26,11 +26,11 @@ const response = await fetch("https://randomuser.me/api/");
 const data = await response.json();
 const randomUser = data.results[0];
 ---
-<!-- Les données récupérées lors de la construction peuvent être rendues en HTML -->
+<!-- Les données récupérées lors de la compilation peuvent être rendues en HTML -->
 <h1>Utilisateur</h1>
 <h2>{randomUser.name.first} {randomUser.name.last}</h2>
 
-<!-- Les données récupérées lors de la construction peuvent être transmises aux composants en tant que props -->
+<!-- Les données récupérées lors de la compilation peuvent être transmises aux composants en tant que props -->
 <Contact client:load email={randomUser.email} />
 <Location city={randomUser.location.city} />
 ```
@@ -38,20 +38,20 @@ const randomUser = data.results[0];
 :::note
 N'oubliez pas que toutes les données des composants Astro sont récupérées lors du rendu du composant.
 
-Votre site Astro déployé récupérera les données **une seule fois, au moment de la construction (Build)**. En développement, vous verrez les données récupérées lors du rafraîchissement des composants. Si vous avez besoin de récupérer des données plusieurs fois côté client, utilisez un [composant de Framework](/fr/guides/framework-components/) ou un [script coté client](/fr/guides/client-side-scripts/) dans un composant Astro.
+Votre site Astro déployé récupérera les données **une seule fois, au moment de la compilation**. En développement, vous verrez les données récupérées lors du rafraîchissement des composants. Si vous avez besoin de récupérer des données plusieurs fois côté client, utilisez un [composant de framework](/fr/guides/framework-components/) ou un [script coté client](/fr/guides/client-side-scripts/) dans un composant Astro.
 :::
 
-## `fetch()` dans les Composants de Framework
+## `fetch()` dans les composants de framework
 
-La fonction `fetch()` est également disponible globalement dans tous les [composants de Framework](/fr/guides/framework-components/) :
+La fonction `fetch()` est également disponible globalement dans tous les [composants de framework](/fr/guides/framework-components/) :
 
 ```tsx title="src/components/Movies.tsx" /await fetch\\(.*?\\)/
 import type { FunctionalComponent } from 'preact';
 
 const data = await fetch('https://example.com/movies.json').then((response) => response.json());
 
-// Les composants dont le rendu est effectué au moment de la construction se connectent également à la console (CLI).
-// Lorsqu'ils sont rendus avec une directive `client:*`, ils se connectent également à la console du navigateur.
+// Les composants dont le rendu est effectué au moment de la compilation écrivent également dans la console du serveur.
+// Lorsqu'ils sont rendus avec une directive `client:*`, ils écrivent également dans la console du navigateur.
 console.log(data);
 
 const Movies: FunctionalComponent = () => {
@@ -98,12 +98,12 @@ const { film } = json.data;
 <p>Année : {film.releaseDate}</p>
 ```
 
-## Récupérer à partir d'un Headless CMS
+## Récupérer à partir d'un CMS headless
 
 Les composants Astro peuvent récupérer des données de votre CMS préféré et les restituer sous forme de contenu de page. Grâce aux [routes dynamiques](/fr/guides/routing/#routes-dynamiques), les composants peuvent même générer des pages basées sur le contenu de votre CMS.
 
-Consultez nos [Guides CMS](/fr/guides/cms/) pour plus de détails sur l'intégration d'Astro avec des CMS headless comme Storyblok, Contentful et WordPress.
+Consultez nos [guides CMS](/fr/guides/cms/) pour plus de détails sur l'intégration d'Astro avec des CMS headless comme Storyblok, Contentful et WordPress.
 
 ## Ressources communautaires
 
-- [Créer une application fullstack avec Astro + GraphQL (EN)](https://robkendal.co.uk/blog/how-to-build-astro-site-with-graphql/)
+- [Créer une application fullstack avec Astro + GraphQL (Anglais)](https://robkendal.co.uk/blog/how-to-build-astro-site-with-graphql/)

--- a/src/content/docs/fr/guides/dev-toolbar.mdx
+++ b/src/content/docs/fr/guides/dev-toolbar.mdx
@@ -21,7 +21,7 @@ Cette application comprend également un bouton « Copy debug info » qui lanc
 
 ### Inspect
 
-L'application Inspect fournit des informations sur toutes les [îles](/fr/concepts/islands/) de la page en cours. Elle vous montrera les propriétés transmises à chaque île, ainsi que la directive client utilisée pour les afficher.
+L'application Inspect fournit des informations sur tous les [îlots](/fr/concepts/islands/) de la page en cours. Elle vous montrera les propriétés transmises à chaque îlot, ainsi que la directive client utilisée pour les afficher.
 
 ### Audit
 
@@ -51,7 +51,7 @@ La barre d'outils de développement est activée par défaut pour chaque site. V
 
 ### Par projet
 
-Pour désactiver la barre d'outils de développement pour tous ceux qui travaillent sur un projet, définissez `devToolbar: false` dans le [fichier de configuration Astro](/fr/reference/configuration-reference/#devtoolbarenabled).
+Pour désactiver la barre d'outils de développement pour tous ceux qui travaillent sur un projet, définissez `devToolbar: false` dans le [fichier de configuration d'Astro](/fr/reference/configuration-reference/#devtoolbarenabled).
 
 ```js title="astro.config.mjs" ins={4-6}
 import { defineConfig } from "astro/config";
@@ -73,7 +73,7 @@ Pour désactiver la barre d'outils de développement pour vous-même sur un proj
 astro preferences disable devToolbar
 ```
 
-Pour désactiver la barre d'outils de développement dans tous les projets Astro pour un utilisateur sur la machine courante, ajoutez le drapeau `--global` lors de l'exécution de `astro-preferences` :
+Pour désactiver la barre d'outils de développement dans tous les projets Astro pour un utilisateur sur la machine courante, ajoutez l'option `--global` lors de l'exécution de `astro-preferences` :
 
 ```shell
 astro preferences disable --global devToolbar


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations of `guides/data-fetching.mdx` and `guides/dev-toolbar.mdx` to bring changes from the French i18n guide updates:
* replace `île` with `îlot`
* replace `construction` with `compilation` where more appropriate
* replace the translation for `fetch` (`recherche` > `récupération`)
* replace the translation for `to log` (ie. `se connecter` sounded odd)
* replace `drapeau` (`flag`) with `option`
* replace `(EN)` with `(Anglais)` for non translated links
* lowercase some words
* slightly rewords some sentences to make the reading smoother

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
