### PR TITLE
i18n(fr): improve the wording in `guides/middleware.mdx`

### DIFF
--- a/src/content/docs/fr/guides/internationalization.mdx
+++ b/src/content/docs/fr/guides/internationalization.mdx
@@ -15,7 +15,7 @@ Le routage i18n d'Astro vous permet de proposer du contenu multilingue en prenan
 
 ## Logique de routage
 
-Astro utilise un [middleware](/fr/guides/middleware/) pour mettre en œuvre sa logique de routage. Cette fonction middleware est placée en [première position](/fr/guides/middleware/#enchaînement-middleware) où il attend chaque `Response` provenant de tout middleware supplémentaire et des routes de chaque page avant d'exécuter finalement sa propre logique.
+Astro utilise un [middleware](/fr/guides/middleware/) pour mettre en œuvre sa logique de routage. Cette fonction middleware est placée en [première position](/fr/guides/middleware/#enchaînement-de-middlewares) où il attend chaque `Response` provenant de tout middleware supplémentaire et des routes de chaque page avant d'exécuter finalement sa propre logique.
 
 Cela signifie que les opérations (par exemple les redirections) de votre propre middleware et de la logique de votre page sont exécutées en premier, vos routes sont restituées, puis le middleware i18n effectue ses propres actions, comme vérifier qu'une URL localisée correspond à une route valide.
 

--- a/src/content/docs/fr/guides/middleware.mdx
+++ b/src/content/docs/fr/guides/middleware.mdx
@@ -1,22 +1,22 @@
 ---
-title: Le Middleware
-description: Apprendre à utiliser le middleware dans Astro.
+title: Middleware
+description: Apprendre à utiliser un middleware dans Astro.
 i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { Steps } from '@astrojs/starlight/components';
 import Since from '~/components/Since.astro';
 
-**Middleware** vous permet d'intercepter les demandes et les réponses et d'injecter des comportements de manière dynamique chaque fois qu'une page ou un point de terminaison est sur le point d'être rendu. Ce rendu a lieu au moment de la construction pour toutes les pages pré-rendues, mais il a lieu lorsque la route est demandée pour les pages rendues à la demande, rendant disponible [des fonctionnalités SSR supplémentaires telles que les cookies et les en-têtes](/fr/guides/on-demand-rendering/#fonctionnalités-de-rendu-à-la-demande).
+Un **middleware** vous permet d'intercepter les demandes et les réponses et d'injecter des comportements de manière dynamique chaque fois qu'une page ou un point de terminaison est sur le point d'être rendu. Ce rendu a lieu au moment de la compilation pour toutes les pages pré-rendues, mais il a lieu lorsque la route est demandée pour les pages rendues à la demande, rendant disponibles [des fonctionnalités SSR supplémentaires telles que les cookies et les en-têtes](/fr/guides/on-demand-rendering/#fonctionnalités-de-rendu-à-la-demande).
 
-Le middleware vous permet également de définir et de partager des informations spécifiques aux requêtes entre les points de terminaison et les pages en modifiant un objet `locals` disponible dans tous les composants Astro et les points de terminaison de l'API. Cet objet est disponible même lorsque ce middleware s'exécute au moment de la construction.
+Un middleware vous permet également de définir et de partager des informations spécifiques aux requêtes entre les points de terminaison et les pages en modifiant un objet `locals` disponible dans tous les composants Astro et les points de terminaison de l'API. Cet objet est disponible même lorsque ce middleware s'exécute au moment de la compilation.
 
 ## Utilisation basique
 
 <Steps>
 1. Créez `src/middleware.js|ts` (Alternativement, vous pouvez créer `src/middleware/index.js|ts`.)
 
-2. Dans ce fichier, exportez une fonction [`onRequest()`](/fr/reference/modules/astro-middleware/#onrequest) à laquelle on peut passer un objet [`context`](#objet-context) et une fonction `next()`. Il ne doit pas s'agir d'une exportation par défaut.
+2. Dans ce fichier, exportez une fonction [`onRequest()`](/fr/reference/modules/astro-middleware/#onrequest) à laquelle il est possible de transmettre un objet [`context`](#objet-context) et une fonction `next()`. Il ne doit pas s'agir d'une exportation par défaut.
 
     ```js title="src/middleware.js"
     export function onRequest (context, next) {
@@ -24,27 +24,27 @@ Le middleware vous permet également de définir et de partager des informations
          // optionnellement, modifie la propriété dans `locals`
          context.locals.title = "Nouveau titre";
 
-         // renvoie une Réponse ou le résultat de l'appel à `next()`
+         // renvoie une réponse (Response) ou le résultat de l'appel à `next()`
          return next();
     };
     ```
 
-3. Dans n'importe quel fichier `.astro`, accédez aux données de réponse en utilisant `Astro.locals`.
+3. Dans n'importe quel fichier `.astro`, accédez aux données de la réponse en utilisant `Astro.locals`.
 
     ```astro title="src/components/Component.astro"
     ---
     const data = Astro.locals;
     ---
     <h1>{data.title}</h1>
-    <p>This {data.property} provient du middleware.</p>
+    <p>Cette {data.property} provient du middleware.</p>
     ```
 </Steps>
 
 ### Objet `context`
 
-L'objet [`context`](/fr/reference/api-reference/) inclut des informations à mettre à disposition d'autres middleware, routes API et routes `.astro` pendant le processus de rendu.
+L'objet [`context`](/fr/reference/api-reference/) inclut des informations à mettre à disposition d'autres middlewares, routes d'API et routes `.astro` pendant le processus de rendu.
 
-C'est un argument optionnel passé à `onRequest()` qui peut contenir l'objet `locals` ainsi que toutes les propriétés additionnelles à partager pendant le rendu.Par exemple, l'objet `context` peut inclure les cookies utilisés pour l'authentification.
+C'est un argument optionnel passé à `onRequest()` qui peut contenir l'objet `locals` ainsi que toutes les propriétés additionnelles à partager pendant le rendu. Par exemple, l'objet `context` peut inclure les cookies utilisés pour l'authentification.
 
 ### Stocker des données dans `context.locals`
 
@@ -52,11 +52,11 @@ C'est un argument optionnel passé à `onRequest()` qui peut contenir l'objet `l
 
 Cet objet `locals` est transmis à travers le processus de traitement des requêtes et est disponible en tant que propriété pour [`APIContext`](/fr/reference/api-reference/#locals) et [`AstroGlobal`](/fr/reference/api-reference/#locals). Cela permet de partager des données entre les middlewares, les routes API et les pages `.astro`. Ceci est utile pour stocker des données spécifiques à une requête, telles que les données de l'utilisateur, à travers l'étape de rendu.
 
-:::tip[Propriétés de l'intégration]
-Les [Integrations](/fr/guides/integrations-guide/) peuvent définir des propriétés et fournir des fonctionnalités à travers l'objet `locals`. Si vous utilisez une intégration, vérifiez sa documentation pour vous assurer que vous ne surchargez aucune de ses propriétés et que vous ne faites pas de travail inutile.
+:::tip[Propriétés des intégrations]
+Les [intégrations](/fr/guides/integrations-guide/) peuvent définir des propriétés et fournir des fonctionnalités à travers l'objet `locals`. Si vous utilisez une intégration, vérifiez sa documentation pour vous assurer que vous ne surchargez aucune de ses propriétés et que vous ne faites pas de travail inutile.
 :::
 
-Vous pouvez stocker n'importe quel type de données dans `locals` : des chaînes, des nombres, et même des types de données complexes tels que des fonctions et des cartes.
+Vous pouvez stocker n'importe quel type de données dans `locals` : des chaînes de caractères, des nombres, et même des types de données complexes tels que des fonctions et des cartes.
 
 ```js title="src/middleware.js"
 export function onRequest (context, next) {
@@ -67,7 +67,7 @@ export function onRequest (context, next) {
         return "Welcome back " + locals.user.name;
     };
 
-    // renvoie une Réponse ou le résultat de l'appel à `next()`
+    // renvoie une réponse (`Response`) ou le résultat de l'appel à `next()`
     return next();
 };
 ```
@@ -92,12 +92,12 @@ const data = Astro.locals;
 `locals` est un objet qui vit et meurt au sein d'une seule route Astro ; lorsque la page de votre route est rendue, `locals` n'existera plus et un nouvel objet sera créé. Les informations qui doivent persister à travers plusieurs requêtes de pages doivent être stockées ailleurs.
 
 :::note
-La valeur de `locals` ne peut pas être modifiée à l'exécution. Cela risquerait d'effacer toutes les informations stockées par l'utilisateur.  Astro effectue des vérifications et génère une erreur si la valeur de `locals` est remplacée.
+La valeur de `locals` ne peut pas être modifiée au moment de l'exécution. Cela risquerait d'effacer toutes les informations stockées par l'utilisateur.  Astro effectue des vérifications et génère une erreur si la valeur de `locals` est remplacée.
 :::
 
-### Exemple : Supprimer des informations sensibles
+### Exemple : supprimer des informations sensibles
 
-L'exemple ci-dessous utilise un middleware pour remplacer "PRIVATE INFO" par le mot "REDACTED" afin de vous permettre d'afficher le code HTML modifié sur votre page :
+L'exemple ci-dessous utilise un middleware pour remplacer « PRIVATE INFO » par le mot « REDACTED » afin de vous permettre d'afficher le code HTML modifié sur votre page :
 
 ```js title="src/middleware.js"
 export const onRequest = async (context, next) => {
@@ -112,9 +112,9 @@ export const onRequest = async (context, next) => {
 };
 ```
 
-### Type de middleware
+### Types du middleware
 
-Vous pouvez importer et utiliser la fonction utilitaire `defineMiddleware()` pour bénéficier de la sécurité de type :
+Vous pouvez importer et utiliser la fonction utilitaire `defineMiddleware()` pour bénéficier de la sûreté du typage :
 
 ```ts
 // src/middleware.ts
@@ -126,7 +126,7 @@ export const onRequest = defineMiddleware((context, next) => {
 });
 ```
 
-A la place, si vous utilisez JsDoc pour profiter de la sécurité des types, vous pouvez utiliser `MiddlewareHandler` :
+A la place, si vous utilisez JsDoc pour profiter de la sûreté du typage, vous pouvez utiliser `MiddlewareHandler` :
 
 ```js
 // src/middleware.js
@@ -139,7 +139,7 @@ export const onRequest = (context, next) => {
 };
 ```
 
-Pour activer les types pour les informations contenues dans `Astro.locals`, ce qui vous donne l'autocomplétion dans les fichiers `.astro` et le code middleware, déclarez un espace de noms global dans le fichier `env.d.ts` :
+Pour ajouter des types aux informations contenues dans `Astro.locals`, ce qui vous donne l'autocomplétion dans les fichiers `.astro` et le code du middleware, déclarez un espace de noms global dans le fichier `env.d.ts` :
 
 ```ts title="src/env.d.ts"
 type User = {
@@ -157,33 +157,33 @@ declare namespace App {
 }
 ```
 
-Ensuite, dans le fichier du middleware, vous pouvez tirer parti de l'autocomplétion et de la sécurité des types.
+Ensuite, dans le fichier du middleware, vous pouvez tirer parti de l'autocomplétion et de la sûreté du typage.
 
-## Enchaînement middleware
+## Enchaînement de middlewares
 
-Plusieurs middlewares peuvent être reliés dans un ordre précis à l'aide de [`séquence()`](/fr/reference/modules/astro-middleware/#sequence) :
+Plusieurs middlewares peuvent être reliés dans un ordre précis à l'aide de [`sequence()`](/fr/reference/modules/astro-middleware/#sequence) :
 
 ```js title="src/middleware.js"
 import { sequence } from "astro/middleware";
 
 async function validation(_, next) {
-    console.log("validation request");
+    console.log("demande de validation");
     const response = await next();
-    console.log("validation response");
+    console.log("réponse de validation");
     return response;
 }
 
 async function auth(_, next) {
-    console.log("auth request");
+    console.log("demande d'authentification");
     const response = await next();
-    console.log("auth response");
+    console.log("réponse d'authentification");
     return response;
 }
 
 async function greeting(_, next) {
-    console.log("greeting request");
+    console.log("demande de salutation");
     const response = await next();
-    console.log("greeting response");
+    console.log("réponse de salutation");
     return response;
 }
 
@@ -193,12 +193,12 @@ export const onRequest = sequence(validation, auth, greeting);
 L'ordre de la console sera alors le suivant :
 
 ```sh
-validation request
-auth request
-greeting request
-greeting response
-auth response
-validation response
+demande de validation
+demande d'authentification
+demande de salutation
+réponse de salutation
+réponse d'authentification
+réponse de validation
 ```
 
 ## Réécriture
@@ -227,7 +227,7 @@ export function onRequest (context, next) {
 };
 ```
 
-Vous pouvez également passer à la fonction `next()` un paramètre optionnel de chemin URL pour réécrire la `Request` courante sans réenclencher une nouvelle phase de rendu. L'emplacement du chemin de réécriture peut être fourni sous la forme d'une chaîne, d'une URL ou d'une `Request` :
+Vous pouvez également passer à la fonction `next()` un paramètre optionnel de chemin URL pour réécrire la requête (`Request`) actuelle sans réenclencher une nouvelle phase de rendu. L'emplacement du chemin de réécriture peut être fourni sous la forme d'une chaîne de caractères, d'une URL ou d'une requête (`Request`) :
 
 ```js title="src/middleware.js"
 import { isLoggedIn } from "~/auth.js"
@@ -235,7 +235,7 @@ export function onRequest (context, next) {
   if (!isLoggedIn(context) {
     // Si l'utilisateur n'est pas connecté, mettre à jour la requête pour afficher la route `/login` et
     // ajouter un en-tête pour indiquer où l'utilisateur doit être envoyé après une connexion réussie.
-    // Renvoyer un nouveau `contexte` à tous les middlewares suivants.
+    // Renvoyer un nouveau contexte (`context`) à tous les middlewares suivants.
     return next(new Request("/login", {
       headers: {
         "x-redirect-to": context.url.pathname
@@ -247,14 +247,14 @@ export function onRequest (context, next) {
 };
 ```
 
-La fonction `next()` accepte la même charge utile que [la fonction `Astro.rewrite()`](/fr/reference/api-reference/#rewrite). L'emplacement du chemin de réécriture peut être fourni sous la forme d'une chaîne, d'une URL ou d'une `Request`.
+La fonction `next()` accepte la même charge utile que [la fonction `Astro.rewrite()`](/fr/reference/api-reference/#rewrite). L'emplacement du chemin de réécriture peut être fourni sous la forme d'une chaîne de caractères, d'une URL ou d'une requête (`Request`).
 
-Quand vous avez plusieurs fonctions middleware enchaînées via [sequence()](#enchaînement-middleware), soumettre un chemin à `next()` réécrira la `Request` en place et le middleware ne s'exécutera pas à nouveau. Le middleware suivant dans la chaîne recevra la nouvelle `Request` avec son `context` mis à jour :
+Quand vous avez plusieurs fonctions middleware enchaînées via [sequence()](#enchaînement-de-middlewares), soumettre un chemin à `next()` réécrira la requête (`Request`) en place et le middleware ne s'exécutera pas à nouveau. Le middleware suivant dans la chaîne recevra la nouvelle requête (`Request`) avec son contexte (`context`) mis à jour :
 
-L'appel de `next()` avec cette signature créera un nouvel objet `Request` en utilisant l'ancien `ctx.request`. Cela signifie que toute tentative de consommation de `Request.body`, avant ou après cette réécriture, générera une erreur d'exécution. Cette erreur est souvent générée avec [les actions Astro qui utilisent des formulaires HTML](/fr/guides/actions/#appeler-des-actions-depuis-une-action-de-formulaire-html). Dans ces cas, nous vous recommandons de gérer les réécritures de vos modèles Astro à l'aide de `Astro.rewrite()` au lieu d'utiliser un middleware.
+L'appel de `next()` avec cette signature créera un nouvel objet `Request` en utilisant l'ancien contexte de requête (`ctx.request`). Cela signifie que toute tentative de consommation de `Request.body`, avant ou après cette réécriture, générera une erreur d'exécution. Cette erreur est souvent générée avec [les actions Astro qui utilisent des formulaires HTML](/fr/guides/actions/#appeler-des-actions-depuis-une-action-de-formulaire-html). Dans ces cas, nous vous recommandons de gérer les réécritures de vos modèles Astro à l'aide de `Astro.rewrite()` au lieu d'utiliser un middleware.
 
 ```js title="src/middleware.js"
-// L'URL actuel est https://example.com/blog
+// L'URL actuelle est https://example.com/blog
 
 // Première fonction du middleware
 async function first(_, next) {
@@ -269,7 +269,7 @@ async function first(_, next) {
 // Deuxième fonction du middleware
 async function second(context, next) {
   // Reçoit la mise à jour du `context`
-  console.log(context.url.pathname) // Cela sera affiché dans les logs "/"    
+  console.log(context.url.pathname) // Cela affichera dans la console « / »    
   return next()
 }
 
@@ -278,6 +278,6 @@ export const onRequest = sequence(first, second);
 
 ## Pages d'erreur
 
-Le middleware tentera de s'exécuter pour toutes les pages rendues à la demande, même lorsqu'un itinéraire correspondant ne peut être trouvé. Cela inclut la page 404 par défaut (vide) d'Astro et toutes les pages 404 personnalisées. Cependant, c'est à l'[adaptateur](/fr/guides/on-demand-rendering/) de décider si ce code s'exécute. Certains adaptateurs peuvent servir une page d'erreur spécifique à la plate-forme à la place.
+Un middleware tentera de s'exécuter pour toutes les pages rendues à la demande, même lorsqu'une route correspondante ne peut être trouvée. Cela inclut la page 404 par défaut (vide) d'Astro et toutes les pages 404 personnalisées. Cependant, c'est à l'[adaptateur](/fr/guides/on-demand-rendering/) de décider si ce code s'exécute. Certains adaptateurs peuvent servir une page d'erreur spécifique à la plate-forme à la place.
 
-Le middleware tentera également de s'exécuter avant de servir une page d'erreur 500, y compris une page 500 personnalisée, sauf si l'erreur du serveur s'est produite lors de l'exécution du middleware lui-même. Si votre middleware ne s'exécute pas correctement, vous n'aurez pas accès à `Astro.locals` pour rendre votre page 500.
+Un middleware tentera également de s'exécuter avant de servir une page d'erreur 500, y compris une page 500 personnalisée, sauf si l'erreur du serveur s'est produite lors de l'exécution du middleware lui-même. Si votre middleware ne s'exécute pas correctement, vous n'aurez pas accès à `Astro.locals` pour générer votre page 500.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/middleware` to bring changes from the French i18n guide updates:
* replace `construction` with `compilation` where more appropriate
* replace `rendre` with `générer`
* replace `itinéraire` with `route`
* replace the translation for `type safety` (`sûreté du typage`)
* translate some examples
* use French quotes
* fix some mismatches with the English version (including the use of `on` when the original version do not use `we`)
* slightly reword some sentences to make the reading smoother (e.g. use the french word and the code version in parenthesis)

I also made some changes around the use of `middleware` (indefinite/definite article, plural). For example, middleware was the only one using an article in the nav so for consistency I removed it:
![French nav of Astro Docs showing "Le Middleware"](https://github.com/user-attachments/assets/3c147a21-dda6-4913-9d61-f5cacdc5177e)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
