### PR TITLE
Add open issues tip to contributing page

### DIFF
--- a/src/content/docs/en/contribute.mdx
+++ b/src/content/docs/en/contribute.mdx
@@ -8,7 +8,7 @@ import ContributorList from '~/components/ContributorList.astro'
 We welcome contributions of any size and contributors of any skill level. As an open-source project, we believe in giving back to our contributors. We are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
 :::tip[Open Issues]
-Want to know what we really need help with right now? Browse [all of Astro's open GitHub issues tagged `help wanted` and `good first issues`] for all the code repositories: Astro code, documentation, Starlight, Astro websites, language tools, GitHub Actions, bots, the compiler... there are lots of places to contribute!
+Want to know what we really need help with right now? Browse [all of Astro's open GitHub issues tagged `help wanted` and `good first issues`](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues) for all the code repositories: Astro code, documentation, Starlight, Astro websites, language tools, GitHub Actions, bots, the compiler... there are lots of places to contribute!
 :::
 
 Want to get even more involved? See our [Governance doc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) for detailed descriptions of different roles, maintainer nomination processes, code review processes, and Code of Conduct enforcement.

--- a/src/content/docs/en/contribute.mdx
+++ b/src/content/docs/en/contribute.mdx
@@ -7,6 +7,10 @@ import ContributorList from '~/components/ContributorList.astro'
 
 We welcome contributions of any size and contributors of any skill level. As an open-source project, we believe in giving back to our contributors. We are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
+:::tip[Open Issues]
+Want to know what we really need help with right now? Browse [all of Astro's open GitHub issues tagged `help wanted` and `good first issues`] for all the code repositories: Astro code, documentation, Starlight, Astro websites, language tools, GitHub Actions, bots, the compiler... there are lots of places to contribute!
+:::
+
 Want to get even more involved? See our [Governance doc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) for detailed descriptions of different roles, maintainer nomination processes, code review processes, and Code of Conduct enforcement.
 
 ## Ways to Contribute

--- a/src/content/docs/en/contribute.mdx
+++ b/src/content/docs/en/contribute.mdx
@@ -8,7 +8,7 @@ import ContributorList from '~/components/ContributorList.astro'
 We welcome contributions of any size and contributors of any skill level. As an open-source project, we believe in giving back to our contributors. We are happy to help with guidance on PRs, technical writing, and turning any feature idea into a reality.
 
 :::tip[Open Issues]
-Want to know what we really need help with right now? Browse [all of Astro's open GitHub issues tagged `help wanted` and `good first issues`](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues) for all the code repositories: Astro code, documentation, Starlight, Astro websites, language tools, GitHub Actions, bots, the compiler... there are lots of places to contribute!
+Browse [all of Astro's open GitHub issues tagged `help wanted` and `good first issues`](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues) for all the code repositories: Astro code, documentation, Starlight, Astro websites, language tools, GitHub Actions, bots, the compiler... there are lots of places to contribute!
 :::
 
 Want to get even more involved? See our [Governance doc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) for detailed descriptions of different roles, maintainer nomination processes, code review processes, and Code of Conduct enforcement.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This adds an advanced GitHub search link to the contributing page which will let readers see all open issues across all the GitHub repos in the withastro organization that are labelled either "help wanted" or "good first issue".


