### PR TITLE
Disable Renovate `uses-with` for Node.js patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,13 @@
 			matchPackageNames: ['pnpm'],
 			matchDepTypes: ['packageManager'],
 			enabled: false,
+		},
+		{
+			description: 'Disable Node.js version patch updates with actions/setup-node',
+			matchDepNames: ['node'],
+			matchDepTypes: ['uses-with'],
+			matchUpdateTypes: ['patch'],
+			enabled: false,
 		}
 	],
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed on Discord, this PR disables Node.js version patch updates for `actions/setup-node` in Renovate (and any other potential actions having a `with` map accepting a Node.js version supported by Renovate).

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: ci

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
