### PR TITLE
i18n(fr): add `experimental-flags/chrome-devtools-workspace.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/chrome-devtools-workspace.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/chrome-devtools-workspace.mdx
@@ -1,0 +1,51 @@
+---
+title: Espace de travail expérimental dans Chrome DevTools
+sidebar:
+  label: Espace de travail dans Chrome DevTools
+i18nReady: true
+---
+
+import Since from '~/components/Since.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+
+<p>
+
+**Type :** `boolean`<br />
+**Par défaut :** `false`<br />
+<Since v="5.13.0" />
+</p>
+
+Active l'[intégration expérimentale d'un espace de travail dans Chrome DevTools](https://developer.chrome.com/docs/devtools/workspaces) pour le serveur de développement Astro.
+
+Cette fonctionnalité vous permet de modifier des fichiers directement dans Chrome DevTools et de répercuter ces modifications dans votre système de fichiers local via un dossier d'espace de travail connecté. Ceci est utile pour appliquer des modifications, comme l'ajustement des valeurs CSS, sans quitter l'onglet de votre navigateur.
+
+Avec cette fonctionnalité activée, l'exécution de `astro dev` configurera automatiquement un espace de travail dans Chrome DevTools pour votre projet. Ce dernier apparaîtra alors comme une [source d'espace de travail disponible à laquelle vous pouvez vous connecter](#connecter-votre-projet). Les modifications apportées dans le panneau « Sources » seront alors automatiquement enregistrées dans le code source de votre projet.
+
+Pour activer cette fonctionnalité, ajoutez l'option expérimentale `chromeDevtoolsWorkspace` à votre configuration Astro :
+
+```js title="astro.config.mjs" ins={4-6}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  experimental: {
+    chromeDevtoolsWorkspace: true,
+  },
+});
+```
+
+## Connecter votre projet
+
+Astro créera le fichier de configuration nécessaire à la prise en charge des espaces de travail dans Chrome DevTools. Cependant, votre projet doit également être [connecté en tant que source](https://developer.chrome.com/docs/devtools/workspaces#manual-connection) pour permettre l'enregistrement des fichiers.
+
+<Steps>
+
+1. [Démarrez le serveur de développement d'Astro](/fr/develop-and-build/#démarrer-le-serveur-de-développement-dastro) avec la commande CLI appropriée pour votre gestionnaire de paquets.
+
+2. Accédez à l'aperçu de votre site (par exemple `http://localhost:4321/`) dans Chrome et ouvrez DevTools.
+
+3. Sous l'onglet **Sources** > **Espace de travail**, vous trouverez le dossier de votre projet Astro. Cliquez sur **Connecter** pour ajouter votre répertoire comme espace de travail.
+
+</Steps>
+
+Consultez la [documentation des espaces de travail dans Chrome DevTools](https://developer.chrome.com/docs/devtools/workspaces#connect) pour plus d'informations.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translates in French the new `experimental-flags/chrome-devtools-workspace` file added in #12144

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
