### PR TITLE
Remove `"default"` from `workerEntrypoint.namedExports` type

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -295,7 +295,7 @@ To support other [Cloudflare invocation handlers](https://developers.cloudflare.
 <p>
 
 **Type:** `[]`<br />
-**Default:** `['default']`
+**Default:** `[]`
 <Since v="12.6.0" pkg="@astrojs/cloudflare" />
 </p>
 


### PR DESCRIPTION
#### Description (required)

This removes `"default"` from being part of `namedExports`' type, which wasn't correct. The `"default"` export is added *outside* of this array, which could confuse people into beliving that setting a custom `namedExports` meant adding `"default"` manually.

#### Related issues & labels (optional)

