### PR TITLE
feat: clarify partytown config

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -189,13 +189,13 @@ const proxyMap = {
 ---
 
 <script is:inline set:html={`
-window.partytown = {
-  resolveUrl: (url) => {
-    const proxyMap = ${JSON.stringify(proxyMap)};
-    url.hostname = proxyMap[url.hostname] || url.hostname;
-    return url;
-  },
-};
+  window.partytown = {
+    resolveUrl: (url) => {
+      const proxyMap = ${JSON.stringify(proxyMap)};
+      url.hostname = proxyMap[url.hostname] || url.hostname;
+      return url;
+    },
+  };
 `} />
 ```
 

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -10,7 +10,7 @@ i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-This **[Astro integration][astro-integration]** enables [Partytown](https://partytown.builder.io/) in your Astro project.
+This **[Astro integration][astro-integration]** enables [Partytown](https://partytown.qwik.dev/) in your Astro project.
 
 ## Why Astro Partytown
 
@@ -109,35 +109,11 @@ export default defineConfig({
 
 This mirrors the [Partytown config object](https://partytown.qwik.dev/configuration/).
 
-:::caution
-The `config` object is serialized and sent to the client. That means functions like `config.resolveUrl()` cannot use TypeScript, nor access anything outside of their scope.
-:::
-
-If you need to pass external data to functions when Partytown is initialized on the client, you can set the configuration through `window.partytown`:
-
-```astro title="Head.astro"
----
-const proxyMap = {
-  "connect.facebook.net": "my-proxy.com"
-};
----
-
-<script is:inline set:html={`
-window.partytown = {
-  resolveUrl: (url) => {
-    const proxyMap = ${JSON.stringify(proxyMap)};
-    url.hostname = proxyMap[url.hostname] || url.hostname;
-    return url;
-  },
-};
-`} />
-```
-
-It will be overriden by any config option coming from the integration.
+The `config` object is serialized, even [`config.resolveUrl()`](#configresolveurl), because it is sent to the client.
 
 ### config.debug
 
-Partytown ships with a `debug` mode; enable or disable it by passing `true` or `false` to `config.debug`. If [`debug` mode](https://partytown.builder.io/debugging) is enabled, it will output detailed logs to the browser console.
+Partytown ships with a `debug` mode; enable or disable it by passing `true` or `false` to `config.debug`. If [`debug` mode](https://partytown.qwik.dev/debugging) is enabled, it will output detailed logs to the browser console.
 
 If this option isn't set, `debug` mode will be on by default in [dev](/en/reference/cli-reference/#astro-dev) or [preview](/en/reference/cli-reference/#astro-preview) mode.
 
@@ -159,7 +135,7 @@ Third-party scripts typically add variables to the `window` object so that you c
 
 To solve this, Partytown can "patch" variables to the global window object and forward them to the appropriate script.
 
-You can specify which variables to forward with the `config.forward` option. [Read more in Partytown's documentation.](https://partytown.builder.io/forwarding-events)
+You can specify which variables to forward with the `config.forward` option. [Read more in Partytown's documentation.](https://partytown.qwik.dev/forwarding-events)
 
 ```js title="astro.config.mjs" {7}
 export default defineConfig({
@@ -174,6 +150,38 @@ export default defineConfig({
   ],
 });
 ```
+
+### config.resolveUrl
+
+Some third-party scripts may require proxying through `config.resolveUrl()`, which runs inside the service worker. [Read more in Partytown's documentation.](https://partytown.qwik.dev/forwarding-events)
+
+However since `config` is serialized (even functions), it has limitations:
+
+- It cannot reference anything outside of the function scope
+- It can only use JavaScript
+
+For advanced use cases, you may need to pass data to this function while initializing Partytown. To do so, you can set `resolveUrl()` on `window.partytown` instead of the integration config:
+
+```astro title="Head.astro"
+---
+const proxyMap = {
+  "connect.facebook.net": "my-proxy.com"
+};
+---
+
+<script is:inline set:html={`
+window.partytown = {
+  resolveUrl: (url) => {
+    const proxyMap = ${JSON.stringify(proxyMap)};
+    url.hostname = proxyMap[url.hostname] || url.hostname;
+    return url;
+  },
+};
+`} />
+```
+
+Note that the integration config will override `window.partytown` if you set a property in both.
+
 
 ## Examples
 

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -152,12 +152,32 @@ export default defineConfig({
 
 ### config.resolveUrl
 
-Some third-party scripts may require proxying through `config.resolveUrl()`, which runs inside the service worker. [Read more in Partytown's documentation.](https://partytown.qwik.dev/forwarding-events)
+Some third-party scripts may require [proxying](https://partytown.qwik.dev/proxying-requests/) through `config.resolveUrl()`, which runs inside the service worker. You can set this configuration option to check for a specific URL, and optionally return a proxied URL instead:
 
-However since `config` is serialized (even functions), it has limitations:
+```js title="astro.config.mjs" {7-13}
+export default defineConfig({
+  // ...
+  integrations: [
+    partytown({
+      // Example: proxy Facebook's analytics script
+      config: {
+        resolveUrl: (url) => {
+          const proxyMap = {
+            "connect.facebook.net": "my-proxy.com"
+          }
+          url.hostname = proxyMap[url.hostname] || url.hostname;
+          return url;
+        },
+      }
+    }),
+  ],
+});
+```
 
-- It cannot reference anything outside of the function scope
-- It can only use JavaScript
+However since `config` is serialized, some limitations apply:
+
+- Functions passed to the `config` object cannot reference anything outside of the function scope.
+- Functions passed to the `config` object can only be written in JavaScript.
 
 In some advanced use cases, you may need to pass data to this function while initializing Partytown. To do so, you can set `resolveUrl()` on `window.partytown` instead of the integration config:
 

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -201,7 +201,6 @@ window.partytown = {
 
 Note that the integration config will override `window.partytown` if you set a property in both.
 
-
 ## Examples
 
 * [Browse projects with Astro Partytown on GitHub](https://github.com/search?q=%22%40astrojs%2Fpartytown%22+path%3A**%2Fpackage.json\&type=code) for more examples!

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -109,6 +109,32 @@ export default defineConfig({
 
 This mirrors the [Partytown config object](https://partytown.builder.io/configuration).
 
+:::caution
+The `config` object is serialized and sent to the client. That means functions like `config.resolveUrl()` cannot use TypeScript, nor access anything outside of their scope.
+:::
+
+If you need to pass external data to functions when Partytown is initialized on the client, you can set the configuration through `window.partytown`:
+
+```astro title="Head.astro"
+---
+const proxyMap = {
+  "connect.facebook.net": "my-proxy.com"
+};
+---
+
+<script is:inline set:html={`
+window.partytown = {
+  resolveUrl: (url) => {
+    const proxyMap = ${JSON.stringify(proxyMap)};
+    url.hostname = proxyMap[url.hostname] || url.hostname;
+    return url;
+  },
+};
+`} />
+```
+
+It will be overriden by any config option coming from the integration.
+
 ### config.debug
 
 Partytown ships with a `debug` mode; enable or disable it by passing `true` or `false` to `config.debug`. If [`debug` mode](https://partytown.builder.io/debugging) is enabled, it will output detailed logs to the browser console.

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -109,7 +109,6 @@ export default defineConfig({
 
 This mirrors the [Partytown config object](https://partytown.qwik.dev/configuration/).
 
-The `config` object is serialized, even [`config.resolveUrl()`](#configresolveurl), because it is sent to the client.
 
 ### config.debug
 
@@ -160,9 +159,9 @@ However since `config` is serialized (even functions), it has limitations:
 - It cannot reference anything outside of the function scope
 - It can only use JavaScript
 
-For advanced use cases, you may need to pass data to this function while initializing Partytown. To do so, you can set `resolveUrl()` on `window.partytown` instead of the integration config:
+In some advanced use cases, you may need to pass data to this function while initializing Partytown. To do so, you can set `resolveUrl()` on `window.partytown` instead of the integration config:
 
-```astro title="Head.astro"
+```astro title="Head.astro" {8-14}
 ---
 const proxyMap = {
   "connect.facebook.net": "my-proxy.com"

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -107,7 +107,7 @@ export default defineConfig({
 });
 ```
 
-This mirrors the [Partytown config object](https://partytown.builder.io/configuration).
+This mirrors the [Partytown config object](https://partytown.qwik.dev/configuration/).
 
 :::caution
 The `config` object is serialized and sent to the client. That means functions like `config.resolveUrl()` cannot use TypeScript, nor access anything outside of their scope.

--- a/src/content/docs/en/guides/integrations-guide/partytown.mdx
+++ b/src/content/docs/en/guides/integrations-guide/partytown.mdx
@@ -174,10 +174,10 @@ export default defineConfig({
 });
 ```
 
-However since `config` is serialized, some limitations apply:
+However since the `config` object is serialized when sent to the client, some limitations on functions passed to your configuration apply:
 
-- Functions passed to the `config` object cannot reference anything outside of the function scope.
-- Functions passed to the `config` object can only be written in JavaScript.
+- Functions cannot reference anything outside of the function scope.
+- Functions can only be written in JavaScript.
 
 In some advanced use cases, you may need to pass data to this function while initializing Partytown. To do so, you can set `resolveUrl()` on `window.partytown` instead of the integration config:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When working on a complex site using Partytown, we found the need for proxying based on environment variables. We struggled a lot because we thought everything had to be passed through the integration config, but it turns out it can also come from `window.partytown`.

Anyways, here are the additions:

- Document that `config` is serialized which means you can't access things outside functions scopes. Not sure how to convey that functions are also serialized (ie. not converted to `null`)
- Document that you can also use `window.partytown`, with a real world example

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
