### PR TITLE
Update Content Layer API page for TOML support

### DIFF
--- a/src/content/docs/en/reference/content-loader-reference.mdx
+++ b/src/content/docs/en/reference/content-loader-reference.mdx
@@ -26,7 +26,7 @@ Astro provides two built-in loaders to help you fetch your collections. Both off
 <Since v="5.0.0" />
 </p>
 
-The `glob()` loader creates entries from directories of files from anywhere on the filesystem. The supported file types are Markdown, MDX, Markdoc, JSON, and YAML files.
+The `glob()` loader creates entries from directories of files from anywhere on the filesystem. The supported file types are Markdown, MDX, Markdoc, JSON, YAML, and TOML files.
 
 This loader accepts an object with the following properties: `pattern`, `base` (optional), and `generateId` (optional).
 
@@ -99,7 +99,7 @@ By default it uses [`github-slugger`](https://github.com/Flet/github-slugger) to
 <Since v="5.0.0" />
 </p>
 
-The `file()` loader creates entries from a single file that contains an array of objects with a unique `id` field, or an object with IDs as keys and entries as values. It supports JSON or YAML, and you can provide a custom `parser` for data files it cannot parse by default.
+The `file()` loader creates entries from a single file that contains an array of objects with a unique `id` field, or an object with IDs as keys and entries as values. It supports JSON, YAML, or TOML files and you can provide a custom `parser` for data files it cannot parse by default.
 
 This loader accepts a `fileName` property and an optional object as second argument:
 


### PR DESCRIPTION
When we added TOML support to the built-in `glob()` and `file()` loaders, we updated the content collections guide page but we didn't also update the Conent Layer API page content about these loaders.

This adds mention of TOML files being supported.

#### Related issues & labels (optional)

- Closes #12087 