### PR TITLE
context about limited full post content support in RSS

### DIFF
--- a/src/content/docs/en/recipes/rss.mdx
+++ b/src/content/docs/en/recipes/rss.mdx
@@ -163,7 +163,11 @@ This method is deprecated for all versions of Astro since v2.1.0, and cannot be 
 
 <p><Since v="1.6.14" /></p>
 
-The `content` key contains the full content of the post as HTML. This allows you to make your entire post content available to RSS feed readers.
+The `content` key contains the full content of a post as HTML. This allows `@astrojs/rss` to make the full Markdown text of your post available to RSS feed readers. Images and links with full URL paths are also supported. However, images and internal links to other pages using relative paths are not.
+
+When rendering full post content, you will have to consider images, relative links, styles, scripts, and other elements beyond standard Markdown text that you may have in your posts. You may need to include additional logic in your `src/pages/rss.xml.js` endpoint to account for these, or to remove elements that are unnecessary for an RSS feed (e.g. those that are used only for styling or interaction on your website).
+
+You can see [one specific community implementation](https://github.com/delucis/astro-blog-full-text-rss/blob/17c14db9b4fd68a20f097f5ad8ae66edb2da1815/src/pages/rss.xml.ts) that addresses some of these concerns for an example of how to proceed.
 
 :::tip
 A package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) will make sure that your content is properly sanitized, escaped, and encoded. In the process, such a package might also remove some harmless elements and attributes, so make sure to verify the output and configure the package according to your needs.

--- a/src/content/docs/en/recipes/rss.mdx
+++ b/src/content/docs/en/recipes/rss.mdx
@@ -163,11 +163,11 @@ This method is deprecated for all versions of Astro since v2.1.0, and cannot be 
 
 <p><Since v="1.6.14" /></p>
 
-The `content` key contains the full content of a post as HTML. This allows `@astrojs/rss` to make the full Markdown text of your post available to RSS feed readers. Images and links with full URL paths are also supported. However, images and internal links to other pages using relative paths are not.
+Set the `content` key on `rss.items` to provide the full content of a post as HTML. This allows `@astrojs/rss` to make the full Markdown text of your post available to RSS feed readers. Images and links with full URL paths are also supported. However, images and internal links to other pages using relative paths are not.
 
 When rendering full post content, you will have to consider images, relative links, styles, scripts, and other elements beyond standard Markdown text that you may have in your posts. You may need to include additional logic in your `src/pages/rss.xml.js` endpoint to account for these, or to remove elements that are unnecessary for an RSS feed (e.g. those that are used only for styling or interaction on your website).
 
-You can see [one specific community implementation](https://github.com/delucis/astro-blog-full-text-rss/blob/17c14db9b4fd68a20f097f5ad8ae66edb2da1815/src/pages/rss.xml.ts) that addresses some of these concerns for an example of how to proceed.
+You can see [one specific community implementation](https://github.com/delucis/astro-blog-full-text-rss/blob/latest/src/pages/rss.xml.ts) that addresses some of these concerns for an example of how to proceed.
 
 :::tip
 A package like [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) will make sure that your content is properly sanitized, escaped, and encoded. In the process, such a package might also remove some harmless elements and attributes, so make sure to verify the output and configure the package according to your needs.


### PR DESCRIPTION
Adds additional context and guidance re: full post content in RSS feeds (what kinds of images are/aren't supported; things to consider; example to consult)

#### Related issues & labels (optional)

- Closes #10946 