### PR TITLE
not claim Prettier is included beyond the VSCode extension

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -77,7 +77,7 @@ Installation instructions, editor integration, and additional information can be
 
 ### Prettier
 
-[Prettier](https://prettier.io/) is a popular formatter for JavaScript, HTML, CSS, and more. If you're using the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) or [the Astro language server within another editor](#other-code-editors), code formatting with Prettier is included.
+[Prettier](https://prettier.io/) is a popular formatter for JavaScript, HTML, CSS, and more. If you're using the [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode), code formatting with Prettier is included.
 
 To add support for formatting `.astro` files outside of the editor (e.g. CLI) or inside editors that don't support our editor tooling, install [the official Astro Prettier plugin](https://github.com/withastro/prettier-plugin-astro).
 


### PR DESCRIPTION
Doesn't claim anything about Prettier being included beyond the Astro official VSCode extension itself.

#### Related issues & labels (optional)

- Closes #11313 