### PR TITLE
Updates CMS guide for Strapi 5

### DIFF
--- a/src/content/docs/en/guides/cms/strapi.mdx
+++ b/src/content/docs/en/guides/cms/strapi.mdx
@@ -117,16 +117,14 @@ If you are using TypeScript, create the following Article interface to correspon
 
 ```ts title="src/interfaces/article.ts"
 export default interface Article {
-  id: number;
-  attributes: {
-    title: string;
-    description: string;
-    content: string;
-    slug: string;
-    createdAt: string;
-    updatedAt: string;
-    publishedAt: string;
-  };
+  documentId: number;
+  title: string;
+  description: string;
+  content: string;
+  slug: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
 }
 ```
 
@@ -169,16 +167,14 @@ You can modify this interface, or create multiple interfaces, to correspond to y
     ```json
     [
       {
-        id: 1,
-        attributes: {
-          title: "What's inside a Black Hole",
-          description: "Maybe the answer is in this article, or not...",
-          content: "Well, we don't know yet...",
-          slug: "what-s-inside-a-black-hole",
-          createdAt: "2023-05-28T13:19:46.421Z",
-          updatedAt: "2023-05-28T13:19:46.421Z",
-          publishedAt: "2023-05-28T13:19:45.826Z"
-        }
+        documentId: 1,
+        title: "What's inside a Black Hole",
+        description: "Maybe the answer is in this article, or not...",
+        content: "Well, we don't know yet...",
+        slug: "what-s-inside-a-black-hole",
+        createdAt: "2023-05-28T13:19:46.421Z",
+        updatedAt: "2023-05-28T13:19:46.421Z",
+        publishedAt: "2023-05-28T13:19:45.826Z"
       },
       // ...
     ]
@@ -208,8 +204,8 @@ You can modify this interface, or create multiple interfaces, to correspond to y
             {
               articles.map((article) => (
                 <li>
-                  <a href={`/blog/${article.attributes.slug}/`}>
-                    {article.attributes.title}
+                  <a href={`/blog/${article.slug}/`}>
+                    {article.title}
                   </a>
                 </li>
               ))
@@ -257,7 +253,7 @@ export async function getStaticPaths() {
   });
 
   return articles.map((article) => ({
-    params: { slug: article.attributes.slug },
+    params: { slug: article.slug },
     props: article,
   }));
 }
@@ -281,7 +277,7 @@ export async function getStaticPaths() {
   });
 
   return articles.map((article) => ({
-    params: { slug: article.attributes.slug },
+    params: { slug: article.slug },
     props: article,
   }));
 }
@@ -293,23 +289,23 @@ const article = Astro.props;
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>{article.attributes.title}</title>
+    <title>{article.title}</title>
   </head>
 
   <body>
     <main>
-      <img src={import.meta.env.STRAPI_URL + article.attributes.image.data.attributes.url} />
+      <img src={import.meta.env.STRAPI_URL + article.image.data.url} />
 
-      <h1>{article.attributes.title}</h1>
+      <h1>{article.title}</h1>
 
       <!-- Render plain text -->
-      <p>{article.attributes.content}</p>
+      <p>{article.content}</p>
       <!-- Render markdown -->
       <MyMarkdownComponent>
-        {article.attributes.content}
+        {article.content}
       </MyMarkdownComponent>
       <!-- Render html -->
-      <Fragment set:html={article.attributes.content} />
+      <Fragment set:html={article.content} />
     </main>
   </body>
 </html>
@@ -350,23 +346,23 @@ try {
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>{article.attributes.title}</title>
+    <title>{article.title}</title>
   </head>
 
   <body>
     <main>
-      <img src={import.meta.env.STRAPI_URL + article.attributes.image.data.attributes.url} />
+      <img src={import.meta.env.STRAPI_URL + article.image.data.url} />
 
-      <h1>{article.attributes.title}</h1>
+      <h1>{article.title}</h1>
 
       <!-- Render plain text -->
-      <p>{article.attributes.content}</p>
+      <p>{article.content}</p>
       <!-- Render markdown -->
       <MyMarkdownComponent>
-        {article.attributes.content}
+        {article.content}
       </MyMarkdownComponent>
       <!-- Render html -->
-      <Fragment set:html={article.attributes.content} />
+      <Fragment set:html={article.content} />
     </main>
   </body>
 </html>


### PR DESCRIPTION
Updates the shape of the data returned from Strapi 5 per [Strapi's migration guide breaking changes](https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/use-document-id)

Specifically:
- `id` is replaced by `documentId`
- there is no longer a nested `attributes` object for other data

This PR update the code blocks that show returned data and types, and additionally updates using the data in component templates because data is no longer on an `attributes` object.

According to the issue, there are other improvements that could be made for using Strapi 5 with Astro, but this at least updates the code blocks to show correct data.

#### Related issues & labels (optional)

- Closes #11907 