### PR TITLE
Added Gudupao Astro I18n plugin configuration method

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -52,6 +52,7 @@ export const sidebar = [
 					'guides/endpoints',
 					'guides/middleware',
 					'guides/internationalization',
+					'guides/gudupaointernationalization',
 					'guides/prefetch',
 					'guides/view-transitions',
 				],

--- a/src/content/docs/ar/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/ar/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: البرنامج المساعد Gudupao Astro I18n
+sidebar:
+ label: البرنامج المساعد Gudupao Astro I18n
+description: البرنامج المساعد i18n لـ Astro مع دعم لـ {{t.xxx}} وحزم اللغات المحلية وتبديل اللغة والتوافق مع SSR وSSG.
+i18nReady: true
+---
+
+يوفر مكوننا الإضافي حلاً كاملاً لـ i18n لمشاريع Astro، مصمم ليكون بديهيًا وقويًا:
+
+- توجيه متعدد اللغات مرن: يدعم التوجيه القائم على المسار وبدون مسار.
+- كشف اللغة التلقائي: يكتشف لغة متصفح المستخدم مع عمليات تراجع أنيقة.
+- حزم لغات قابلة للتخصيص: تسمح للمطورين بتعريف وتنظيم الترجمات في ملفات JSON المحلية.
+- بناء جملة ترجمة بسيطة: يمكن الوصول إلى الترجمات باستخدام \{\{t.xxx\}\} للوضوح وسهولة الصيانة.
+- تبديل اللغة السلس: يتيح تغييرات اللغة في وقت التشغيل دون تعقيد.
+- توافق الأوضاع: يدعم كليًا أوضاع SSR (الديناميكية) وSSG (الثابتة) الخاصة بـ Astro.
+- دعم عبر الأطر: يعمل مع لغات التأليف الثلاث الرئيسية الخاصة بـ Astro — Astro وReact وVue.
+
+## التثبيت
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## التكوين
+
+### نظرة عامة
+
+يمكن تكوين Astro-i18n مع خيارات متنوعة لتخصيص سلوكه. يوضح هذا المستند كل خيار تكوين وغرضه والقيمة الافتراضية.
+
+يدعم Astro-i18n طريقتين رئيسيتين للتشغيل:
+- **قائم على المسار**: تُحدد اللغات بواسطة مسارات URL (على سبيل المثال، `/en/about`، `/zh/about`). يتم التحكم في هذا بواسطة خيار `pathBasedRouting`.
+- **بدون مسار**: تُحدد اللغة بوسائل أخرى (ملف تعريف الارتباط، رأس Accept-Language) دون تغيير مسار URL. يتم التحكم في هذا أيضًا بواسطة خيار `pathBasedRouting`.
+
+### خيارات التكوين الشائعة
+
+هذه الخيارات متوفرة لكل من الوضع القائم على المسار والوضع بدون مسار.
+
+#### `localesDir`
+
+- **النوع**: `string`
+- **الوصف**: الدليل الذي يتم فيه تخزين ملفات الإعدادات المحلية الخاصة بك.
+- **الافتراضي**: `'locales'`
+
+مثال:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **النوع**: `string`
+- **الوصف**: اللغة التي يتم التراجع إليها إذا لم يتم العثور على ترجمة للغة الحالية.
+- **الافتراضي**: `'en'`
+
+مثال:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **النوع**: `boolean`
+- **الوصف**: ما إذا كان سيتم اكتشاف لغة المستخدم تلقائيًا من رأس Accept-Language.
+- **الافتراضي**: `true`
+
+مثال (مع الكشف التلقائي):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+مثال (بدون الكشف التلقائي):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **النوع**: `boolean`
+- **الوصف**: ما إذا كان سيتم استخدام التوجيه القائم على المسار. إذا كان `true`، تُحدد اللغات بواسطة مسارات URL (على سبيل المثال، `/en/about`، `/zh/about`). إذا كان `false`، تُحدد اللغة بوسائل أخرى (ملف تعريف الارتباط، رأس Accept-Language) دون تغيير مسار URL.
+- **الافتراضي**: `true`
+
+يحدد هذا الخيار وضع التشغيل:
+- `true` (الافتراضي): الوضع القائم على المسار.
+- `false`: الوضع بدون مسار.
+
+مثال (قائم على المسار):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+مثال (بدون مسار):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### تكوين الوضع القائم على المسار (pathBasedRouting: true)
+
+عندما يكون `pathBasedRouting` `true`، يعمل Astro-i18n في الوضع القائم على المسار. تنطبق جميع خيارات التكوين الشائعة.
+
+### تكوين الوضع بدون مسار (pathBasedRouting: false)
+
+عندما يكون `pathBasedRouting` `false`، يعمل Astro-i18n في الوضع بدون مسار. تنطبق جميع خيارات التكوين الشائعة.
+
+الفرق الرئيسي هو في كيفية تحديد اللغة وكيفية التعامل مع عناوين URL:
+- في الوضع القائم على المسار، تكون اللغة جزءًا من مسار URL.
+- في الوضع بدون مسار، تُحدد اللغة بوسائل أخرى (ملف تعريف الارتباط، رأس Accept-Language) ويظل مسار URL دون تغيير.
+
+## الاستخدام
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// الحصول على اللغة من المعلمات
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>اختبار Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>اختبار React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>اختبار Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## أمثلة محوّل اللغة
+
+### الإصدار القائم على المسار
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // تعيين ملف تعريف الارتباط للغة
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] تعيين ملف تعريف الارتباط للغة:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### الإصدار بدون مسار
+
+```astro
+---
+// الحصول على جميع اللغات المتوفرة
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // ما إذا كان سيتم استخدام وضع التوجيه القائم على المسار
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// دالة للكشف عن اللغة الحالية
+function detectCurrentLanguage() {
+  // التحقق من معلمات URL أولاً
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // ثم التحقق من ملف تعريف الارتباط
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // إرجاع اللغة الافتراضية
+  return 'en';
+}
+
+// الحصول على اللغة الحالية
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>محوّل اللغة (الإصدار الجديد)</h3>
+  <p>الوضع الحالي: {pathBasedRouting ? 'التوجيه القائم على المسار' : 'التوجيه بدون مسار'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // دالة لتبديل اللغة
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // وضع التوجيه القائم على المسار
+      // تعيين ملف تعريف الارتباط للغة
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] تعيين ملف تعريف الارتباط للغة:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // وضع التوجيه بدون مسار
+      // تعيين ملف تعريف الارتباط للغة
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // تعيين localStorage
+      localStorage.setItem('lang', language);
+      // إعادة تحميل الصفحة لتطبيق اللغة الجديدة
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## الروابط
+
+- مستودع الكود المصدر: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- الوثائق الأصلية: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/de/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/de/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Gudupao Astro I18n Plugin
+sidebar:
+ label: Gudupao Astro I18n Plugin
+description: Astro i18n Plugin mit Unterstützung für {{t.xxx}}, lokale Sprachpakete, Sprachumschaltung und Kompatibilität mit SSR und SSG.
+i18nReady: true
+---
+
+Unser Plugin bietet eine vollständige i18n-Lösung für Astro-Projekte, die intuitiv und dennoch leistungsstark konzipiert ist:
+
+- Flexible mehrsprachige Weiterleitung: unterstützt pfadbasierte und pfadlose Weiterleitung.
+- Automatische Spracherkennung: erkennt die Browsersprache des Benutzers mit eleganten Fallbacks.
+- Anpassbare Sprachpakete: ermöglichen Entwicklern das Definieren und Organisieren von Übersetzungen in lokalen JSON-Dateien.
+- Einfache Übersetzungssyntax: Übersetzungen können mit \{\{t.xxx\}\} für Klarheit und Wartbarkeit aufgerufen werden.
+- Nahtloser Sprachwechsel: ermöglicht Laufzeitsprachänderungen ohne Komplexität.
+- Moduskompatibilität: unterstützt vollständig Astros SSR- (dynamische) und SSG- (statische) Modi.
+- Framework-übergreifende Unterstützung: funktioniert mit Astros drei primären Autorensprachen — Astro, React und Vue.
+
+## Installation
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Konfiguration
+
+### Überblick
+
+Astro-i18n kann mit verschiedenen Optionen konfiguriert werden, um sein Verhalten anzupassen. Dieses Dokument beschreibt jede Konfigurationsoption, ihren Zweck und ihren Standardwert.
+
+Astro-i18n unterstützt zwei Hauptbetriebsmodi:
+- **Pfadbasiert**: Sprachen werden durch URL-Pfade identifiziert (z. B. `/en/about`, `/zh/about`). Dies wird durch die Option `pathBasedRouting` gesteuert.
+- **Pfadlos**: Die Sprache wird durch andere Mittel (Cookie, Accept-Language-Header) bestimmt, ohne den URL-Pfad zu ändern. Dies wird ebenfalls durch die Option `pathBasedRouting` gesteuert.
+
+### Allgemeine Konfigurationsoptionen
+
+Diese Optionen sind für beide Modi, pfadbasiert und pfadlos, verfügbar.
+
+#### `localesDir`
+
+- **Typ**: `string`
+- **Beschreibung**: Das Verzeichnis, in dem Ihre Gebietsschemadateien gespeichert sind.
+- **Standard**: `'locales'`
+
+Beispiel:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Typ**: `string`
+- **Beschreibung**: Die Sprache, auf die zurückgegriffen wird, wenn keine Übersetzung für die aktuelle Sprache gefunden wird.
+- **Standard**: `'en'`
+
+Beispiel:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Typ**: `boolean`
+- **Beschreibung**: Ob die Benutzersprache automatisch aus dem Accept-Language-Header erkannt werden soll.
+- **Standard**: `true`
+
+Beispiel (mit automatischer Erkennung):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Beispiel (ohne automatische Erkennung):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Typ**: `boolean`
+- **Beschreibung**: Ob pfadbasiertes Routing verwendet werden soll. Wenn `true`, werden Sprachen durch URL-Pfade identifiziert (z. B. `/en/about`, `/zh/about`). Wenn `false`, wird die Sprache durch andere Mittel (Cookie, Accept-Language-Header) bestimmt, ohne den URL-Pfad zu ändern.
+- **Standard**: `true`
+
+Diese Option bestimmt den Betriebsmodus:
+- `true` (Standard): Pfadbasiert-Modus.
+- `false`: Pfadlos-Modus.
+
+Beispiel (Pfadbasiert):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Beispiel (Pfadlos):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Konfiguration des pfadbasierten Modus (pathBasedRouting: true)
+
+Wenn `pathBasedRouting` `true` ist, arbeitet Astro-i18n im pfadbasierten Modus. Alle allgemeinen Konfigurationsoptionen gelten.
+
+### Konfiguration des pfadlosen Modus (pathBasedRouting: false)
+
+Wenn `pathBasedRouting` `false` ist, arbeitet Astro-i18n im pfadlosen Modus. Alle allgemeinen Konfigurationsoptionen gelten.
+
+Der Hauptunterschied liegt darin, wie die Sprache bestimmt wird und wie URLs behandelt werden:
+- Im pfadbasierten Modus ist die Sprache Teil des URL-Pfades.
+- Im pfadlosen Modus wird die Sprache durch andere Mittel (Cookie, Accept-Language-Header) bestimmt, und der URL-Pfad bleibt unverändert.
+
+## Verwendung
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Sprache aus Parametern abrufen
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astro Test: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>React Test: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Vue Test: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Beispiele für Sprachumschalter
+
+### Pfadbasierte Version
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Sprach-Cookie setzen
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Sprach-Cookie setzen:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Pfadlose Version
+
+```astro
+---
+// Alle verfügbaren Sprachen abrufen
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Ob der pfadbasierte Routing-Modus verwendet werden soll
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Funktion zur Erkennung der aktuellen Sprache
+function detectCurrentLanguage() {
+  // Zuerst URL-Parameter prüfen
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Dann Cookie prüfen
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Standardsprache zurückgeben
+  return 'en';
+}
+
+// Aktuelle Sprache abrufen
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Sprachumschalter (Neue Version)</h3>
+  <p>Aktueller Modus: {pathBasedRouting ? 'Pfadbasiertes Routing' : 'Pfadloses Routing'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Funktion zum Wechseln der Sprache
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Pfadbasiertes Routing-Modus
+      // Sprach-Cookie setzen
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Sprach-Cookie setzen:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Pfadloses Routing-Modus
+      // Sprach-Cookie setzen
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // localStorage setzen
+      localStorage.setItem('lang', language);
+      // Seite neu laden, um die neue Sprache anzuwenden
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Links
+
+- Quellcode-Repository: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Originaldokumentation: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/en/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/en/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Gudupao Astro I18n Plugin
+sidebar:
+  label: Gudupao Astro I18n Plugin
+description: Astro i18n plugin with support for {{t.xxx}}, local language packs, language switching, and compatibility with both SSR and SSG.
+i18nReady: true
+---
+
+Our plugin provides a full-featured i18n solution for Astro projects, designed to be intuitive yet powerful:
+
+- Flexible multilingual routing: supports both path-based and pathless routing.
+- Automatic language detection: detects the user's browser language with graceful fallbacks.
+- Customizable language packs: allows developers to define and organize translations in local JSON files.
+- Simple translation syntax: translations can be accessed using \{\{t.xxx\}\} for clarity and maintainability.
+- Seamless language switching: enables runtime language changes without complexity.
+- Mode compatibility: fully supports Astro's SSR (dynamic) and SSG (static) modes.
+- Cross-framework support: works with Astro's three primary authoring languages — Astro, React, and Vue.
+
+## Installation
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Configuration
+
+### Overview
+
+Astro-i18n can be configured with various options to customize its behavior. This document details each configuration option, its purpose, and default value.
+
+Astro-i18n supports two main modes of operation:
+- **Path-based**: Languages are identified by URL paths (e.g., `/en/about`, `/zh/about`). This is controlled by the `pathBasedRouting` option.
+- **Path-less**: Language is determined by other means (cookie, Accept-Language header) without changing the URL path. This is also controlled by the `pathBasedRouting` option.
+
+### Common Configuration Options
+
+These options are available for both path-based and path-less modes.
+
+#### `localesDir`
+
+- **Type**: `string`
+- **Description**: The directory where your locale files are stored.
+- **Default**: `'locales'`
+
+Example:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Type**: `string`
+- **Description**: The language to fall back to if a translation is not found for the current language.
+- **Default**: `'en'`
+
+Example:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Type**: `boolean`
+- **Description**: Whether to automatically detect the user's language from the Accept-Language header.
+- **Default**: `true`
+
+Example (with auto-detect):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Example (without auto-detect):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Type**: `boolean`
+- **Description**: Whether to use path-based routing. If `true`, languages are identified by URL paths (e.g., `/en/about`, `/zh/about`). If `false`, language is determined by other means (cookie, Accept-Language header) without changing the URL path.
+- **Default**: `true`
+
+This option determines the mode of operation:
+- `true` (default): Path-based mode.
+- `false`: Path-less mode.
+
+Example (Path-based):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Example (Path-less):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Path-based Mode Configuration (pathBasedRouting: true)
+
+When `pathBasedRouting` is `true`, Astro-i18n operates in path-based mode. All the common configuration options apply.
+
+### Path-less Mode Configuration (pathBasedRouting: false)
+
+When `pathBasedRouting` is `false`, Astro-i18n operates in path-less mode. All the common configuration options apply.
+
+The main difference is in how the language is determined and how URLs are handled:
+- In path-based mode, the language is part of the URL path.
+- In path-less mode, the language is determined by other means (cookie, Accept-Language header) and the URL path remains unchanged.
+
+## Usage
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Get language from params
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astro Test: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>React Test: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Vue Test: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Language Switcher Examples
+
+### Path-based Version
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Set language Cookie
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Set language Cookie:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Path-less Version
+
+```astro
+---
+// Get all available languages
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Whether to use path-based routing mode
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Function to detect current language
+function detectCurrentLanguage() {
+  // First check URL parameters
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Then check Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Return default language
+  return 'en';
+}
+
+// Get current language
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Language Switcher (New Version)</h3>
+  <p>Current Mode: {pathBasedRouting ? 'Path-based Routing' : 'Path-less Routing'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Function to switch language
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Path-based routing mode
+      // Set language Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Set language Cookie:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Path-less routing mode
+      // Set language Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Set localStorage
+      localStorage.setItem('lang', language);
+      // Reload the page to apply the new language
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Links
+
+- Source Code Repository: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Original Documentation: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)
+

--- a/src/content/docs/es/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/es/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Plugin Gudupao Astro I18n
+sidebar:
+ label: Plugin Gudupao Astro I18n
+description: Plugin i18n para Astro con soporte para {{t.xxx}}, paquetes de idioma locales, cambio de idioma y compatibilidad con SSR y SSG.
+i18nReady: true
+---
+
+Nuestro plugin proporciona una solución i18n completa para proyectos Astro, diseñada para ser intuitiva y potente:
+
+- Enrutamiento multilingüe flexible: admite enrutamiento basado en rutas y sin rutas.
+- Detección automática de idioma: detecta el idioma del navegador del usuario con alternativas elegantes.
+- Paquetes de idioma personalizables: permiten a los desarrolladores definir y organizar traducciones en archivos JSON locales.
+- Sintaxis de traducción simple: se puede acceder a las traducciones mediante \{\{t.xxx\}\} para mayor claridad y mantenibilidad.
+- Cambio de idioma fluido: permite cambios de idioma en tiempo de ejecución sin complejidad.
+- Compatibilidad con modos: es totalmente compatible con los modos SSR (dinámico) y SSG (estático) de Astro.
+- Soporte multiplataforma: funciona con los tres lenguajes de autoría principales de Astro: Astro, React y Vue.
+
+## Instalación
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Configuración
+
+### Descripción general
+
+Astro-i18n se puede configurar con varias opciones para personalizar su comportamiento. Este documento detalla cada opción de configuración, su propósito y su valor predeterminado.
+
+Astro-i18n admite dos modos principales de funcionamiento:
+- **Basado en rutas**: los idiomas se identifican mediante rutas URL (por ejemplo, `/en/about`, `/zh/about`). Esto se controla mediante la opción `pathBasedRouting`.
+- **Sin rutas**: el idioma se determina por otros medios (cookie, encabezado Accept-Language) sin cambiar la ruta URL. Esto también se controla mediante la opción `pathBasedRouting`.
+
+### Opciones de configuración comunes
+
+Estas opciones están disponibles tanto para el modo basado en rutas como para el modo sin rutas.
+
+#### `localesDir`
+
+- **Tipo**: `string`
+- **Descripción**: El directorio donde se almacenan los archivos de configuración regional.
+- **Predeterminado**: `'locales'`
+
+Ejemplo:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Tipo**: `string`
+- **Descripción**: El idioma al que se recurre si no se encuentra una traducción para el idioma actual.
+- **Predeterminado**: `'en'`
+
+Ejemplo:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Tipo**: `boolean`
+- **Descripción**: Si se debe detectar automáticamente el idioma del usuario desde el encabezado Accept-Language.
+- **Predeterminado**: `true`
+
+Ejemplo (con detección automática):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Ejemplo (sin detección automática):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Tipo**: `boolean`
+- **Descripción**: Si se debe utilizar el enrutamiento basado en rutas. Si es `true`, los idiomas se identifican mediante rutas URL (por ejemplo, `/en/about`, `/zh/about`). Si es `false`, el idioma se determina por otros medios (cookie, encabezado Accept-Language) sin cambiar la ruta URL.
+- **Predeterminado**: `true`
+
+Esta opción determina el modo de funcionamiento:
+- `true` (predeterminado): Modo basado en rutas.
+- `false`: Modo sin rutas.
+
+Ejemplo (Basado en rutas):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Ejemplo (Sin rutas):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Configuración del modo basado en rutas (pathBasedRouting: true)
+
+Cuando `pathBasedRouting` es `true`, Astro-i18n funciona en modo basado en rutas. Se aplican todas las opciones de configuración comunes.
+
+### Configuración del modo sin rutas (pathBasedRouting: false)
+
+Cuando `pathBasedRouting` es `false`, Astro-i18n funciona en modo sin rutas. Se aplican todas las opciones de configuración comunes.
+
+La principal diferencia radica en cómo se determina el idioma y cómo se gestionan las URL:
+- En el modo basado en rutas, el idioma forma parte de la ruta URL.
+- En el modo sin rutas, el idioma se determina por otros medios (cookie, encabezado Accept-Language) y la ruta URL permanece sin cambios.
+
+## Uso
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Obtener el idioma de los parámetros
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Prueba de Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Prueba de React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Prueba de Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Ejemplos de selector de idioma
+
+### Versión basada en rutas
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Establecer la cookie de idioma
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Establecer la cookie de idioma:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Versión sin rutas
+
+```astro
+---
+// Obtener todos los idiomas disponibles
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Si se debe utilizar el modo de enrutamiento basado en rutas
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Función para detectar el idioma actual
+function detectCurrentLanguage() {
+  // Primero comprobar los parámetros de la URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Luego comprobar la Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Devolver el idioma predeterminado
+  return 'en';
+}
+
+// Obtener el idioma actual
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Selector de idioma (Nueva versión)</h3>
+  <p>Modo actual: {pathBasedRouting ? 'Enrutamiento basado en rutas' : 'Enrutamiento sin rutas'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Función para cambiar de idioma
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Modo de enrutamiento basado en rutas
+      // Establecer la cookie de idioma
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Establecer la cookie de idioma:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Modo de enrutamiento sin rutas
+      // Establecer la cookie de idioma
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Establecer localStorage
+      localStorage.setItem('lang', language);
+      // Recargar la página para aplicar el nuevo idioma
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Enlaces
+
+- Repositorio de código fuente: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Documentación original: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/fr/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/fr/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Plugin Gudupao Astro I18n
+sidebar:
+ label: Plugin Gudupao Astro I18n
+description: Plugin i18n pour Astro avec prise en charge de {{t.xxx}}, de packs de langues locaux, de changement de langue et de compatibilité avec SSR et SSG.
+i18nReady: true
+---
+
+Notre plugin fournit une solution i18n complète pour les projets Astro, conçue pour être intuitive et puissante :
+
+- Routage multilingue flexible : prend en charge le routage basé sur le chemin et sans chemin.
+- Détection automatique de la langue : détecte la langue du navigateur de l'utilisateur avec des replis élégants.
+- Packs de langues personnalisables : permet aux développeurs de définir et d'organiser les traductions dans des fichiers JSON locaux.
+- Syntaxe de traduction simple : les traductions sont accessibles via \{\{t.xxx\}\} pour plus de clarté et de maintenabilité.
+- Changement de langue transparent : permet de changer la langue à l'exécution sans complexité.
+- Compatibilité des modes : prend entièrement en charge les modes SSR (dynamique) et SSG (statique) d'Astro.
+- Prise en charge multi-cadres : fonctionne avec les trois langages d'écriture principaux d'Astro — Astro, React et Vue.
+
+## Installation
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Configuration
+
+### Aperçu
+
+Astro-i18n peut être configuré avec diverses options pour personnaliser son comportement. Ce document détaille chaque option de configuration, son objectif et sa valeur par défaut.
+
+Astro-i18n prend en charge deux modes principaux de fonctionnement :
+- **Basé sur le chemin **: Les langues sont identifiées par les chemins d'URL (par exemple, `/en/about`, `/zh/about`). Ceci est contrôlé par l'option `pathBasedRouting`.
+- **Sans chemin **: La langue est déterminée par d'autres moyens (cookie, en-tête Accept-Language) sans modifier le chemin d'URL. Ceci est également contrôlé par l'option `pathBasedRouting`.
+
+### Options de configuration communes
+
+Ces options sont disponibles pour les modes basés sur le chemin et sans chemin.
+
+#### `localesDir`
+
+- **Type **: `string`
+- **Description **: Le répertoire où vos fichiers de paramètres régionaux sont stockés.
+- **Par défaut **: `'locales'`
+
+Exemple :
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Type **: `string`
+- **Description **: La langue de secours si une traduction n'est pas trouvée pour la langue actuelle.
+- **Par défaut **: `'en'`
+
+Exemple :
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Type **: `boolean`
+- **Description **: Indique s'il faut détecter automatiquement la langue de l'utilisateur à partir de l'en-tête Accept-Language.
+- **Par défaut **: `true`
+
+Exemple (avec détection automatique) :
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Exemple (sans détection automatique) :
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Type **: `boolean`
+- **Description **: Indique s'il faut utiliser le routage basé sur le chemin. Si `true`, les langues sont identifiées par les chemins d'URL (par exemple, `/en/about`, `/zh/about`). Si `false`, la langue est déterminée par d'autres moyens (cookie, en-tête Accept-Language) sans modifier le chemin d'URL.
+- **Par défaut **: `true`
+
+Cette option détermine le mode de fonctionnement :
+- `true` (par défaut) : Mode basé sur le chemin.
+- `false` : Mode sans chemin.
+
+Exemple (Basé sur le chemin) :
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Exemple (Sans chemin) :
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Configuration du mode basé sur le chemin (pathBasedRouting : true)
+
+Lorsque `pathBasedRouting` est `true`, Astro-i18n fonctionne en mode basé sur le chemin. Toutes les options de configuration communes s'appliquent.
+
+### Configuration du mode sans chemin (pathBasedRouting : false)
+
+Lorsque `pathBasedRouting` est `false`, Astro-i18n fonctionne en mode sans chemin. Toutes les options de configuration communes s'appliquent.
+
+La principale différence réside dans la façon dont la langue est déterminée et comment les URL sont gérées :
+- En mode basé sur le chemin, la langue fait partie du chemin d'URL.
+- En mode sans chemin, la langue est déterminée par d'autres moyens (cookie, en-tête Accept-Language) et le chemin d'URL reste inchangé.
+
+## Utilisation
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Obtenir la langue à partir des paramètres
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Test Astro : {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Test React : {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Test Vue : {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Exemples de sélecteur de langue
+
+### Version basée sur le chemin
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Définir le cookie de langue
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Définir le cookie de langue :', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Version sans chemin
+
+```astro
+---
+// Obtenir toutes les langues disponibles
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Indique s'il faut utiliser le mode de routage basé sur le chemin
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Fonction pour détecter la langue actuelle
+function detectCurrentLanguage() {
+  // Vérifier d'abord les paramètres d'URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Ensuite, vérifier le Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Retourner la langue par défaut
+  return 'en';
+}
+
+// Obtenir la langue actuelle
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Sélecteur de langue (Nouvelle version)</h3>
+  <p>Mode actuel : {pathBasedRouting ? 'Routage basé sur le chemin' : 'Routage sans chemin'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Fonction pour changer de langue
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Mode de routage basé sur le chemin
+      // Définir le cookie de langue
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Définir le cookie de langue :', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Mode de routage sans chemin
+      // Définir le cookie de langue
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Définir localStorage
+      localStorage.setItem('lang', language);
+      // Recharger la page pour appliquer la nouvelle langue
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Liens
+
+- Dépôt de code source : [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs : [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Documentation originale : [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/hi/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/hi/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: गुडूपाओ एस्ट्रो आई 18 एन प्लगइन
+sidebar:
+ label: गुडूपाओ एस्ट्रो आई 18 एन प्लगइन
+description: "{{t.xxx}}, स्थानीय भाषा पैक, भाषा स्विचिंग और एसएसआर और एसएसजी के साथ संगतता के समर्थन के साथ एस्ट्रो आई 18 एन प्लगइन।"
+i18nReady: true
+---
+
+हमारा प्लगइन एस्ट्रो प्रोजेक्ट्स के लिए एक पूर्ण-विशेषता वाला आई 18 एन समाधान प्रदान करता है, जिसे सहज और शक्तिशाली होने के लिए डिज़ाइन किया गया है:
+
+- लचीला बहुभाषी रूटिंग: पथ-आधारित और पथहीन रूटिंग दोनों का समर्थन करता है।
+- स्वचालित भाषा का पता लगाना: उपयोगकर्ता की ब्राउज़र भाषा का पता लगाता है और सुंदर रूप से फ़ॉलबैक करता है।
+- अनुकूलनीय भाषा पैक: डेवलपर्स को स्थानीय जेएसओएन फ़ाइलों में अनुवाद परिभाषित और व्यवस्थित करने की अनुमति देता है।
+- सरल अनुवाद वाक्यविन्यास: \{\{t.xxx\}\} का उपयोग करके अनुवाद की पहुंच की जा सकती है, जिससे स्पष्टता और रखरखाव में सुधार होता है।
+- निर्बाध भाषा स्विचिंग: जटिलता के बिना रनटाइम भाषा परिवर्तन सक्षम करता है।
+- मोड संगतता: एस्ट्रो के एसएसआर (गतिशील) और एसएसजी (स्थिर) मोड का पूरी तरह से समर्थन करता है।
+- क्रॉस-फ्रेमवर्क समर्थन: एस्ट्रो की तीन प्राथमिक लेखन भाषाओं—एस्ट्रो, प्रतिक्रिया और व्यू के साथ काम करता है।
+
+## स्थापना
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## विन्यास
+
+### अवलोकन
+
+एस्ट्रो-आई 18 एन को विभिन्न विकल्पों के साथ कॉन्फ़िगर किया जा सकता है ताकि इसके व्यवहार को अनुकूलित किया जा सके। यह दस्तावेज़ प्रत्येक विन्यास विकल्प, इसके उद्देश्य और डिफ़ॉल्ट मान का विस्तृत वर्णन करता है।
+
+एस्ट्रो-आई 18 एन ऑपरेशन के दो मुख्य मोड का समर्थन करता है:
+- **पथ-आधारित**: भाषाओं की पहचान यूआरएल पथ (जैसे `/en/about`, `/zh/about`) द्वारा की जाती है। यह `pathBasedRouting` विकल्प द्वारा नियंत्रित होता है।
+- **पथहीन**: यूआरएल पथ को बदले बिना भाषा को अन्य साधनों (कुकी, स्वीकृत-भाषा हेडर) द्वारा निर्धारित किया जाता है। यह `pathBasedRouting` विकल्प द्वारा भी नियंत्रित होता है।
+
+### सामान्य विन्यास विकल्प
+
+ये विकल्प पथ-आधारित और पथहीन मोड दोनों के लिए उपलब्ध हैं।
+
+#### `localesDir`
+
+- **प्रकार**: `string`
+- **विवरण**: वह निर्देशिका जहां आपकी स्थानीय फ़ाइलें संग्रहीत हैं।
+- **डिफ़ॉल्ट**: `'locales'`
+
+उदाहरण:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **प्रकार**: `string`
+- **विवरण**: वह भाषा जिसका उपयोग वर्तमान भाषा के लिए अनुवाद नहीं मिलने पर फ़ॉलबैक के रूप में किया जाता है।
+- **डिफ़ॉल्ट**: `'en'`
+
+उदाहरण:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **प्रकार**: `boolean`
+- **विवरण**: क्या स्वीकृत-भाषा हेडर से उपयोगकर्ता की भाषा का स्वचालित रूप से पता लगाना है।
+- **डिफ़ॉल्ट**: `true`
+
+उदाहरण (ऑटो-डिटेक्ट के साथ):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+उदाहरण (ऑटो-डिटेक्ट के बिना):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **प्रकार**: `boolean`
+- **विवरण**: क्या पथ-आधारित रूटिंग का उपयोग करना है। यदि `true` है, तो भाषाओं की पहचान यूआरएल पथ (जैसे `/en/about`, `/zh/about`) द्वारा की जाती है। यदि `false` है, तो भाषा को अन्य साधनों (कुकी, स्वीकृत-भाषा हेडर) द्वारा निर्धारित किया जाता है, बिना यूआरएल पथ को बदले।
+- **डिफ़ॉल्ट**: `true`
+
+यह विकल्प ऑपरेशन के मोड को निर्धारित करता है:
+- `true` (डिफ़ॉल्ट): पथ-आधारित मोड।
+- `false`: पथहीन मोड।
+
+उदाहरण (पथ-आधारित):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+उदाहरण (पथहीन):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### पथ-आधारित मोड विन्यास (pathBasedRouting: true)
+
+जब `pathBasedRouting` `true` होता है, तो एस्ट्रो-आई 18 एन पथ-आधारित मोड में काम करता है। सभी सामान्य विन्यास विकल्प लागू होते हैं।
+
+### पथहीन मोड विन्यास (pathBasedRouting: false)
+
+जब `pathBasedRouting` `false` होता है, तो एस्ट्रो-आई 18 एन पथहीन मोड में काम करता है। सभी सामान्य विन्यास विकल्प लागू होते हैं।
+
+मुख्य अंतर यह है कि भाषा कैसे निर्धारित की जाती है और यूआरएल कैसे संभाले जाते हैं:
+- पथ-आधारित मोड में, भाषा यूआरएल पथ का हिस्सा होती है।
+- पथहीन मोड में, भाषा को अन्य साधनों (कुकी, स्वीकृत-भाषा हेडर) द्वारा निर्धारित किया जाता है और यूआरएल पथ अपरिवर्तित रहता है।
+
+## उपयोग
+
+
+### एस्ट्रो
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// पैराम से भाषा प्राप्त करें
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>एस्ट्रो परीक्षण: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### प्रतिक्रिया
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>प्रतिक्रिया परीक्षण: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### व्यू
+
+```vue
+<template>
+ <div>
+    <h1>व्यू परीक्षण: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## भाषा स्विचर उदाहरण
+
+### पथ-आधारित संस्करण
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // भाषा कुकी सेट करें
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] भाषा कुकी सेट करें:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### पथहीन संस्करण
+
+```astro
+---
+// सभी उपलब्ध भाषाएं प्राप्त करें
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // क्या पथ-आधारित रूटिंग मोड का उपयोग करना है
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// वर्तमान भाषा का पता लगाने के लिए फ़ंक्शन
+function detectCurrentLanguage() {
+  // सबसे पहले यूआरएल पैरामीटर की जांच करें
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // फिर कुकी की जांच करें
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // डिफ़ॉल्ट भाषा लौटाएं
+  return 'en';
+}
+
+// वर्तमान भाषा प्राप्त करें
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>भाषा स्विचर (नया संस्करण)</h3>
+  <p>वर्तमान मोड: {pathBasedRouting ? 'पथ-आधारित रूटिंग' : 'पथहीन रूटिंग'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // भाषा बदलने के लिए फ़ंक्शन
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // पथ-आधारित रूटिंग मोड
+      // भाषा कुकी सेट करें
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] भाषा कुकी सेट करें:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // पथहीन रूटिंग मोड
+      // भाषा कुकी सेट करें
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // लोकलस्टोरेज सेट करें
+      localStorage.setItem('lang', language);
+      // नई भाषा लागू करने के लिए पृष्ठ को पुनः लोड करें
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## लिंक
+
+- स्रोत कोड रिपॉजिटरी: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- मूल दस्तावेज़: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/it/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/it/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Plugin Gudupao Astro I18n
+sidebar:
+ label: Plugin Gudupao Astro I18n
+description: Plugin i18n per Astro con supporto per {{t.xxx}}, pacchetti linguistici locali, cambio lingua e compatibilità con SSR e SSG.
+i18nReady: true
+---
+
+Il nostro plugin fornisce una soluzione i18n completa per i progetti Astro, progettata per essere intuitiva e potente:
+
+- Routing multilingue flessibile: supporta sia il routing basato su percorso che quello senza percorso.
+- Rilevamento automatico della lingua: rileva la lingua del browser dell'utente con fallback eleganti.
+- Pacchetti linguistici personalizzabili: consente agli sviluppatori di definire e organizzare le traduzioni in file JSON locali.
+- Sintassi di traduzione semplice: le traduzioni sono accessibili utilizzando \{\{t.xxx\}\} per chiarezza e manutenibilità.
+- Cambio lingua senza soluzione di continuità: consente modifiche alla lingua in fase di esecuzione senza complessità.
+- Compatibilità delle modalità: supporta pienamente le modalità SSR (dinamica) e SSG (statica) di Astro.
+- Supporto multipiattaforma: funziona con le tre principali lingue di authoring di Astro: Astro, React e Vue.
+
+## Installazione
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Configurazione
+
+### Panoramica
+
+Astro-i18n può essere configurato con varie opzioni per personalizzarne il comportamento. Questo documento descrive in dettaglio ogni opzione di configurazione, il suo scopo e il valore predefinito.
+
+Astro-i18n supporta due modalità principali di funzionamento:
+- **Basato su percorso**: le lingue sono identificate dai percorsi degli URL (ad esempio, `/en/about`, `/zh/about`). Questo è controllato dall'opzione `pathBasedRouting`.
+- **Senza percorso**: la lingua è determinata da altri mezzi (cookie, intestazione Accept-Language) senza modificare il percorso dell'URL. Questo è controllato anche dall'opzione `pathBasedRouting`.
+
+### Opzioni di configurazione comuni
+
+Queste opzioni sono disponibili sia per la modalità basata su percorso che per quella senza percorso.
+
+#### `localesDir`
+
+- **Tipo**: `string`
+- **Descrizione**: La directory in cui sono memorizzati i file delle impostazioni locali.
+- **Predefinito**: `'locales'`
+
+Esempio:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Tipo**: `string`
+- **Descrizione**: La lingua di fallback se non viene trovata una traduzione per la lingua corrente.
+- **Predefinito**: `'en'`
+
+Esempio:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Tipo**: `boolean`
+- **Descrizione**: Se rilevare automaticamente la lingua dell'utente dall'intestazione Accept-Language.
+- **Predefinito**: `true`
+
+Esempio (con rilevamento automatico):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Esempio (senza rilevamento automatico):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Tipo**: `boolean`
+- **Descrizione**: Se utilizzare il routing basato su percorso. Se `true`, le lingue sono identificate dai percorsi degli URL (ad esempio, `/en/about`, `/zh/about`). Se `false`, la lingua è determinata da altri mezzi (cookie, intestazione Accept-Language) senza modificare il percorso dell'URL.
+- **Predefinito**: `true`
+
+Questa opzione determina la modalità operativa:
+- `true` (predefinito): Modalità basata su percorso.
+- `false`: Modalità senza percorso.
+
+Esempio (Basato su percorso):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Esempio (Senza percorso):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Configurazione della modalità basata su percorso (pathBasedRouting: true)
+
+Quando `pathBasedRouting` è `true`, Astro-i18n opera in modalità basata su percorso. Si applicano tutte le opzioni di configurazione comuni.
+
+### Configurazione della modalità senza percorso (pathBasedRouting: false)
+
+Quando `pathBasedRouting` è `false`, Astro-i18n opera in modalità senza percorso. Si applicano tutte le opzioni di configurazione comuni.
+
+La differenza principale sta nel modo in cui viene determinata la lingua e come vengono gestiti gli URL:
+- Nella modalità basata su percorso, la lingua fa parte del percorso dell'URL.
+- Nella modalità senza percorso, la lingua è determinata da altri mezzi (cookie, intestazione Accept-Language) e il percorso dell'URL rimane invariato.
+
+## Utilizzo
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Ottieni la lingua dai parametri
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Test Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Test React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Test Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Esempi di selettore lingua
+
+### Versione basata su percorso
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Imposta il cookie della lingua
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Imposta il cookie della lingua:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Versione senza percorso
+
+```astro
+---
+// Ottieni tutte le lingue disponibili
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Se utilizzare la modalità di routing basata su percorso
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Funzione per rilevare la lingua corrente
+function detectCurrentLanguage() {
+  // Controlla prima i parametri dell'URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Poi controlla il Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Restituisci la lingua predefinita
+  return 'en';
+}
+
+// Ottieni la lingua corrente
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Selettore lingua (Nuova versione)</h3>
+  <p>Modalità corrente: {pathBasedRouting ? 'Routing basato su percorso' : 'Routing senza percorso'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Funzione per cambiare lingua
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Modalità di routing basata su percorso
+      // Imposta il cookie della lingua
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Imposta il cookie della lingua:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Modalità di routing senza percorso
+      // Imposta il cookie della lingua
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Imposta localStorage
+      localStorage.setItem('lang', language);
+      // Ricarica la pagina per applicare la nuova lingua
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Collegamenti
+
+- Repository del codice sorgente: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Documentazione originale: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/ja/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/ja/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: グドゥパオ・アストロ・アイ18nプラグイン
+sidebar:
+ label: グドゥパオ・アストロ・アイ18nプラグイン
+description: "{{t.xxx}}、ローカル言語パック、言語切り替え、およびSSRとSSGとの互換性をサポートするAstro i18nプラグイン。"
+i18nReady: true
+---
+
+当社のプラグインは、直感的で強力なAstroプロジェクト用のフル機能のi18nソリューションを提供します。
+
+- 柔軟な多言語ルーティング: パスベースとパスレスの両方のルーティングをサポートします。
+- 自動言語検出: ユーザーのブラウザ言語を検出し、適切なフォールバックを行います。
+- カスタマイズ可能な言語パック: 開発者がローカルのJSONファイルで翻訳を定義および整理できるようにします。
+- 単純な翻訳構文: 明確さと保守性のために\{\{t.xxx\}\}を使用して翻訳にアクセスできます。
+- シームレスな言語切り替え: 複雑さなしにランタイムでの言語変更を可能にします。
+- モード互換性: AstroのSSR（動的）およびSSG（静的）モードを完全にサポートします。
+- クロスフレームワークサポート: Astroの3つの主要なオーサリング言語（Astro、React、Vue）で動作します。
+
+## インストール
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## 構成
+
+### 概要
+
+Astro-i18nは、その動作をカスタマイズするためにさまざまなオプションで構成できます。このドキュメントでは、各構成オプション、その目的、およびデフォルト値について詳しく説明します。
+
+Astro-i18nは、次の2つの主要な操作モードをサポートしています。
+- **パスベース**: 言語はURLパス（例: `/en/about`、`/zh/about`）によって識別されます。これは `pathBasedRouting` オプションによって制御されます。
+- **パスレス**: URLパスを変更せずに、他の手段（クッキー、Accept-Languageヘッダー）によって言語が決定されます。これも `pathBasedRouting` オプションによって制御されます。
+
+### 一般的な構成オプション
+
+これらのオプションは、パスベースモードとパスレスモードの両方で使用できます。
+
+#### `localesDir`
+
+- **タイプ**: `string`
+- **説明**: ロケールファイルが保存されているディレクトリ。
+- **デフォルト**: `'locales'`
+
+例:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **タイプ**: `string`
+- **説明**: 現在の言語の翻訳が見つからない場合にフォールバックする言語。
+- **デフォルト**: `'en'`
+
+例:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **タイプ**: `boolean`
+- **説明**: Accept-Languageヘッダーからユーザーの言語を自動検出するかどうか。
+- **デフォルト**: `true`
+
+例（自動検出あり）:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+例（自動検出なし）:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **タイプ**: `boolean`
+- **説明**: パスベースのルーティングを使用するかどうか。 `true`の場合、言語はURLパス（例: `/en/about`、`/zh/about`）によって識別されます。 `false`の場合、言語は他の手段（クッキー、Accept-Languageヘッダー）によって決定され、URLパスは変更されません。
+- **デフォルト**: `true`
+
+このオプションは操作モードを決定します。
+- `true`（デフォルト）: パスベースモード。
+- `false`: パスレスモード。
+
+例（パスベース）:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+例（パスレス）:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### パスベースモードの構成（pathBasedRouting: true）
+
+`pathBasedRouting`が`true`の場合、Astro-i18nはパスベースモードで動作します。すべての一般的な構成オプションが適用されます。
+
+### パスレスモードの構成（pathBasedRouting: false）
+
+`pathBasedRouting`が`false`の場合、Astro-i18nはパスレスモードで動作します。すべての一般的な構成オプションが適用されます。
+
+主な違いは、言語の決定方法とURLの処理方法にあります。
+- パスベースモードでは、言語はURLパスの一部です。
+- パスレスモードでは、言語は他の手段（クッキー、Accept-Languageヘッダー）によって決定され、URLパスは変更されません。
+
+## 使用方法
+
+
+### アストロ
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// パラメータから言語を取得
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astroテスト: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### リアクション
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Reactテスト: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### ヴュー
+
+```vue
+<template>
+ <div>
+    <h1>Vueテスト: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## 言語スイッチャーの例
+
+### パスベースバージョン
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // 言語クッキーを設定
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] 言語クッキーを設定:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### パスレスバージョン
+
+```astro
+---
+// 利用可能なすべての言語を取得
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // パスベースのルーティングモードを使用するかどうか
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// 現在の言語を検出する関数
+function detectCurrentLanguage() {
+  // 最初にURLパラメータを確認
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // 次にクッキーを確認
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // デフォルト言語を返す
+  return 'en';
+}
+
+// 現在の言語を取得
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+ <h3>言語スイッチャー（新バージョン）</h3>
+  <p>現在のモード: {pathBasedRouting ? 'パスベースのルーティング' : 'パスレスルーティング'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // 言語を切り替える関数
+ function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // パスベースのルーティングモード
+      // 言語クッキーを設定
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] 言語クッキーを設定:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // パスレスルーティングモード
+      // 言語クッキーを設定
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // ローカルストレージを設定
+      localStorage.setItem('lang', language);
+      // 新しい言語を適用するためにページを再読み込み
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## リンク
+
+- ソースコードリポジトリ: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- 元のドキュメント: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/ko/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/ko/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: 구두파오 아스트로 i18n 플러그인
+sidebar:
+ label: 구두파오 아스트로 i18n 플러그인
+description: "{{t.xxx}}, 로컬 언어 팩, 언어 전환 및 SSR 및 SSG와의 호환성을 지원하는 Astro i18n 플러그인입니다."
+i18nReady: true
+---
+
+저희 플러그인은 직관적이면서도 강력하도록 설계된 Astro 프로젝트를 위한 완전한 기능의 i18n 솔루션을 제공합니다:
+
+- 유연한 다국어 라우팅: 경로 기반 및 경로 없는 라우팅을 모두 지원합니다.
+- 자동 언어 감지: 사용자의 브라우저 언어를 감지하고 우아하게 대체합니다.
+- 맞춤형 언어 팩: 개발자가 로컬 JSON 파일에서 번역을 정의하고 구성할 수 있습니다.
+- 간단한 번역 구문: 명확성과 유지 관리 용이성을 위해 \{\{t.xxx\}\}를 사용하여 번역에 액세스할 수 있습니다.
+- 원활한 언어 전환: 복잡성 없이 런타임 언어 변경을 가능하게 합니다.
+- 모드 호환성: Astro의 SSR(동적) 및 SSG(정적) 모드를 완전히 지원합니다.
+- 크로스 프레임워크 지원: Astro의 세 가지 주요 작성 언어인 Astro, React 및 Vue에서 작동합니다.
+
+## 설치
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## 구성
+
+### 개요
+
+Astro-i18n은 다양한 옵션으로 구성되어 동작을 사용자 정의할 수 있습니다. 이 문서에서는 각 구성 옵션, 그 목적 및 기본값에 대해 자세히 설명합니다.
+
+Astro-i18n은 두 가지 주요 작동 모드를 지원합니다:
+- **경로 기반**: 언어는 URL 경로(예: `/en/about`, `/zh/about`)로 식별됩니다. 이는 `pathBasedRouting` 옵션에 의해 제어됩니다.
+- **경로 없음**: URL 경로를 변경하지 않고 다른 수단(쿠키, Accept-Language 헤더)에 의해 언어가 결정됩니다. 이는 `pathBasedRouting` 옵션에 의해 제어됩니다.
+
+### 공통 구성 옵션
+
+이러한 옵션은 경로 기반 및 경로 없는 모드 모두에서 사용할 수 있습니다.
+
+#### `localesDir`
+
+- **유형**: `string`
+- **설명**: 로케일 파일이 저장되는 디렉터리입니다.
+- **기본값**: `'locales'`
+
+예시:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **유형**: `string`
+- **설명**: 현재 언어에 대한 번역을 찾을 수 없는 경우 대체할 언어입니다.
+- **기본값**: `'en'`
+
+예시:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **유형**: `boolean`
+- **설명**: Accept-Language 헤더에서 사용자 언어를 자동으로 감지할지 여부입니다.
+- **기본값**: `true`
+
+예시(자동 감지 포함):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+예시(자동 감지 제외):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **유형**: `boolean`
+- **설명**: 경로 기반 라우팅을 사용할지 여부입니다. `true`이면 언어는 URL 경로(예: `/en/about`, `/zh/about`)로 식별됩니다. `false`이면 URL 경로를 변경하지 않고 다른 수단(쿠키, Accept-Language 헤더)에 의해 언어가 결정됩니다.
+- **기본값**: `true`
+
+이 옵션은 작동 모드를 결정합니다:
+- `true`(기본값): 경로 기반 모드.
+- `false`: 경로 없는 모드.
+
+예시(경로 기반):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+예시(경로 없음):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### 경로 기반 모드 구성(pathBasedRouting: true)
+
+`pathBasedRouting`이 `true`이면 Astro-i18n은 경로 기반 모드에서 작동합니다. 모든 공통 구성 옵션이 적용됩니다.
+
+### 경로 없는 모드 구성(pathBasedRouting: false)
+
+`pathBasedRouting`이 `false`이면 Astro-i18n은 경로 없는 모드에서 작동합니다. 모든 공통 구성 옵션이 적용됩니다.
+
+주요 차이점은 언어를 결정하는 방법과 URL을 처리하는 방법에 있습니다:
+- 경로 기반 모드에서 언어는 URL 경로의 일부입니다.
+- 경로 없는 모드에서 언어는 다른 수단(쿠키, Accept-Language 헤더)에 의해 결정되며 URL 경로는 변경되지 않습니다.
+
+## 사용법
+
+
+### 아스트로
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// 매개변수에서 언어 가져오기
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astro 테스트: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### 반응
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>React 테스트: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### 뷰
+
+```vue
+<template>
+ <div>
+    <h1>Vue 테스트: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## 언어 전환기 예제
+
+### 경로 기반 버전
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // 언어 쿠키 설정
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] 언어 쿠키 설정:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### 경로 없는 버전
+
+```astro
+---
+// 사용 가능한 모든 언어 가져오기
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // 경로 기반 라우팅 모드를 사용할지 여부
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// 현재 언어를 감지하는 함수
+function detectCurrentLanguage() {
+  // 먼저 URL 매개변수 확인
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // 그런 다음 쿠키 확인
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // 기본 언어 반환
+  return 'en';
+}
+
+// 현재 언어 가져오기
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>언어 전환기 (새 버전)</h3>
+  <p>현재 모드: {pathBasedRouting ? '경로 기반 라우팅' : '경로 없는 라우팅'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // 언어를 전환하는 함수
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // 경로 기반 라우팅 모드
+      // 언어 쿠키 설정
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] 언어 쿠키 설정:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // 경로 없는 라우팅 모드
+      // 언어 쿠키 설정
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // 로컬스토리지 설정
+      localStorage.setItem('lang', language);
+      // 새 언어를 적용하기 위해 페이지 새로 고침
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## 링크
+
+- 소스 코드 저장소: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- 원본 문서: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/pl/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/pl/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Wtyczka Gudupao Astro I18n
+sidebar:
+ label: Wtyczka Gudupao Astro I18n
+description: Wtyczka i18n dla Astro z obsługą {{t.xxx}}, lokalnych pakietów językowych, przełączania języka i zgodności z SSR i SSG.
+i18nReady: true
+---
+
+Nasza wtyczka zapewnia kompleksowe rozwiązanie i18n dla projektów Astro, zaprojektowane tak, aby było intuicyjne i potężne:
+
+- Elastyczne routowanie wielojęzyczne: obsługuje routowanie oparte na ścieżkach i bez ścieżek.
+- Automatyczne wykrywanie języka: wykrywa język przeglądarki użytkownika z eleganckimi zastępnikami.
+- Konfigurowalne pakiety językowe: umożliwiają programistom definiowanie i organizowanie tłumaczeń w lokalnych plikach JSON.
+- Prosta składnia tłumaczenia: tłumaczenia są dostępne za pomocą \{\{t.xxx\}\} dla przejrzystości i łatwości konserwacji.
+- Bezproblemowe przełączanie języka: umożliwia zmiany języka w czasie wykonywania bez złożoności.
+- Zgodność trybów: w pełni obsługuje tryby SSR (dynamiczny) i SSG (statyczny) Astro.
+- Obsługa wielu platform: działa z trzema głównymi językami tworzenia Astro — Astro, React i Vue.
+
+## Instalacja
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Konfiguracja
+
+### Przegląd
+
+Astro-i18n można skonfigurować za pomocą różnych opcji, aby dostosować jego zachowanie. Ten dokument szczegółowo opisuje każdą opcję konfiguracji, jej cel i wartość domyślną.
+
+Astro-i18n obsługuje dwa główne tryby działania:
+- **Oparte na ścieżce**: języki są identyfikowane przez ścieżki URL (np. `/en/about`, `/zh/about`). Jest to kontrolowane przez opcję `pathBasedRouting`.
+- **Bez ścieżki**: język jest określany przez inne środki (plik cookie, nagłówek Accept-Language) bez zmiany ścieżki URL. Jest to również kontrolowane przez opcję `pathBasedRouting`.
+
+### Wspólne opcje konfiguracji
+
+Te opcje są dostępne zarówno dla trybu opartego na ścieżce, jak i bez ścieżki.
+
+#### `localesDir`
+
+- **Typ**: `string`
+- **Opis**: Katalog, w którym przechowywane są pliki ustawień regionalnych.
+- **Domyślnie**: `'locales'`
+
+Przykład:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Typ**: `string`
+- **Opis**: Język zastępczy, jeśli nie zostanie znalezione tłumaczenie dla bieżącego języka.
+- **Domyślnie**: `'en'`
+
+Przykład:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Typ**: `boolean`
+- **Opis**: Czy automatycznie wykrywać język użytkownika na podstawie nagłówka Accept-Language.
+- **Domyślnie**: `true`
+
+Przykład (z automatycznym wykrywaniem):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Przykład (bez automatycznego wykrywania):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Typ**: `boolean`
+- **Opis**: Czy używać routingu opartego na ścieżce. Jeśli `true`, języki są identyfikowane przez ścieżki URL (np. `/en/about`, `/zh/about`). Jeśli `false`, język jest określany przez inne środki (plik cookie, nagłówek Accept-Language) bez zmiany ścieżki URL.
+- **Domyślnie**: `true`
+
+Ta opcja określa tryb działania:
+- `true` (domyślnie): Tryb oparty na ścieżce.
+- `false`: Tryb bez ścieżki.
+
+Przykład (Oparty na ścieżce):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Przykład (Bez ścieżki):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Konfiguracja trybu opartego na ścieżce (pathBasedRouting: true)
+
+Gdy `pathBasedRouting` ma wartość `true`, Astro-i18n działa w trybie opartym na ścieżce. Wszystkie wspólne opcje konfiguracji mają zastosowanie.
+
+### Konfiguracja trybu bez ścieżki (pathBasedRouting: false)
+
+Gdy `pathBasedRouting` ma wartość `false`, Astro-i18n działa w trybie bez ścieżki. Wszystkie wspólne opcje konfiguracji mają zastosowanie.
+
+Główną różnicą jest sposób określania języka i obsługi adresów URL:
+- W trybie opartym na ścieżce język jest częścią ścieżki URL.
+- W trybie bez ścieżki język jest określany przez inne środki (plik cookie, nagłówek Accept-Language), a ścieżka URL pozostaje niezmieniona.
+
+## Użycie
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Pobierz język z parametrów
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Test Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### Reagować
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Test React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Widok
+
+```vue
+<template>
+ <div>
+    <h1>Test Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Przykłady przełącznika języka
+
+### Wersja oparta na ścieżce
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Ustaw plik cookie języka
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Ustaw plik cookie języka:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Wersja bez ścieżki
+
+```astro
+---
+// Pobierz wszystkie dostępne języki
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Czy używać trybu routingu opartego na ścieżce
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Funkcja do wykrywania bieżącego języka
+function detectCurrentLanguage() {
+  // Najpierw sprawdź parametry adresu URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Następnie sprawdź plik cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Zwróć domyślny język
+  return 'en';
+}
+
+// Pobierz bieżący język
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Przełącznik języka (Nowa wersja)</h3>
+  <p>Bieżący tryb: {pathBasedRouting ? 'Routing oparty na ścieżce' : 'Routing bez ścieżki'}</p>
+ <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Funkcja do przełączania języka
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Tryb routingu oparty na ścieżce
+      // Ustaw plik cookie języka
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Ustaw plik cookie języka:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Tryb routingu bez ścieżki
+      // Ustaw plik cookie języka
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Ustaw localStorage
+      localStorage.setItem('lang', language);
+      // Załaduj ponownie stronę, aby zastosować nowy język
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Spinki do mankietów
+
+- Repozytorium kodu źródłowego: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Oryginalna dokumentacja: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/pt-br/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/pt-br/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Plugin Gudupao Astro I18n
+sidebar:
+ label: Plugin Gudupao Astro I18n
+description: Plugin i18n para Astro com suporte para {{t.xxx}}, pacotes de idiomas locais, troca de idioma e compatibilidade com SSR e SSG.
+i18nReady: true
+---
+
+Nosso plugin fornece uma solução i18n completa para projetos Astro, projetada para ser intuitiva e poderosa:
+
+- Roteamento multilíngue flexível: suporta roteamento baseado em caminho e sem caminho.
+- Detecção automática de idioma: detecta o idioma do navegador do usuário com fallbacks elegantes.
+- Pacotes de idiomas personalizáveis: permitem que os desenvolvedores definam e organizem traduções em arquivos JSON locais.
+- Sintaxe de tradução simples: as traduções podem ser acessadas usando \{\{t.xxx\}\} para clareza e manutenibilidade.
+- Troca de idioma perfeita: permite alterações de idioma em tempo de execução sem complexidade.
+- Compatibilidade de modos: suporta totalmente os modos SSR (dinâmico) e SSG (estático) do Astro.
+- Suporte a múltiplos frameworks: funciona com as três principais linguagens de autoria do Astro — Astro, React e Vue.
+
+## Instalação
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Configuração
+
+### Visão geral
+
+O Astro-i18n pode ser configurado com várias opções para personalizar seu comportamento. Este documento detalha cada opção de configuração, sua finalidade e valor padrão.
+
+O Astro-i18n suporta dois modos principais de operação:
+- **Baseado em caminho**: os idiomas são identificados por caminhos de URL (por exemplo, `/en/about`, `/zh/about`). Isso é controlado pela opção `pathBasedRouting`.
+- **Sem caminho**: o idioma é determinado por outros meios (cookie, cabeçalho Accept-Language) sem alterar o caminho da URL. Isso também é controlado pela opção `pathBasedRouting`.
+
+### Opções de configuração comuns
+
+Essas opções estão disponíveis para os modos baseado em caminho e sem caminho.
+
+#### `localesDir`
+
+- **Tipo**: `string`
+- **Descrição**: O diretório onde seus arquivos de localidade são armazenados.
+- **Padrão**: `'locales'`
+
+Exemplo:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Tipo**: `string`
+- **Descrição**: O idioma para o qual retornar se uma tradução não for encontrada para o idioma atual.
+- **Padrão**: `'en'`
+
+Exemplo:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Tipo**: `boolean`
+- **Descrição**: Se deve detectar automaticamente o idioma do usuário a partir do cabeçalho Accept-Language.
+- **Padrão**: `true`
+
+Exemplo (com detecção automática):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Exemplo (sem detecção automática):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Tipo**: `boolean`
+- **Descrição**: Se deve usar roteamento baseado em caminho. Se `true`, os idiomas são identificados por caminhos de URL (por exemplo, `/en/about`, `/zh/about`). Se `false`, o idioma é determinado por outros meios (cookie, cabeçalho Accept-Language) sem alterar o caminho da URL.
+- **Padrão**: `true`
+
+Esta opção determina o modo de operação:
+- `true` (padrão): Modo baseado em caminho.
+- `false`: Modo sem caminho.
+
+Exemplo (Baseado em caminho):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Exemplo (Sem caminho):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Configuração do modo baseado em caminho (pathBasedRouting: true)
+
+Quando `pathBasedRouting` é `true`, o Astro-i18n opera no modo baseado em caminho. Todas as opções de configuração comuns se aplicam.
+
+### Configuração do modo sem caminho (pathBasedRouting: false)
+
+Quando `pathBasedRouting` é `false`, o Astro-i18n opera no modo sem caminho. Todas as opções de configuração comuns se aplicam.
+
+A principal diferença está em como o idioma é determinado e como as URLs são tratadas:
+- No modo baseado em caminho, o idioma faz parte do caminho da URL.
+- No modo sem caminho, o idioma é determinado por outros meios (cookie, cabeçalho Accept-Language) e o caminho da URL permanece inalterado.
+
+## Uso
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Obter idioma dos parâmetros
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Teste Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Teste React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Teste Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Exemplos de seletor de idioma
+
+### Versão baseada em caminho
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Definir Cookie de idioma
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Definir Cookie de idioma:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Versão sem caminho
+
+```astro
+---
+// Obter todos os idiomas disponíveis
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Se deve usar o modo de roteamento baseado em caminho
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Função para detectar o idioma atual
+function detectCurrentLanguage() {
+  // Primeiro verificar os parâmetros da URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Depois verificar o Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Retornar o idioma padrão
+  return 'en';
+}
+
+// Obter o idioma atual
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Seletor de Idioma (Nova Versão)</h3>
+  <p>Modo Atual: {pathBasedRouting ? 'Roteamento Baseado em Caminho' : 'Roteamento Sem Caminho'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Função para trocar o idioma
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Modo de roteamento baseado em caminho
+      // Definir Cookie de idioma
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Definir Cookie de idioma:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Modo de roteamento sem caminho
+      // Definir Cookie de idioma
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Definir localStorage
+      localStorage.setItem('lang', language);
+      // Recarregar a página para aplicar o novo idioma
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Links
+
+- Repositório de código-fonte: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Documentação original: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/ru/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/ru/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Плагин Gudupao Astro I18n
+sidebar:
+ label: Плагин Gudupao Astro I18n
+description: Плагин i18n для Astro с поддержкой {{t.xxx}}, локальных языковых пакетов, переключения языка и совместимости с SSR и SSG.
+i18nReady: true
+---
+
+Наш плагин предоставляет полнофункциональное решение i18n для проектов Astro, разработанное так, чтобы быть интуитивно понятным и мощным:
+
+- Гибкая маршрутизация на нескольких языках: поддерживает маршрутизацию на основе путей и без путей.
+- Автоматическое определение языка: определяет язык браузера пользователя с элегантными запасными вариантами.
+- Настраиваемые языковые пакеты: позволяют разработчикам определять и организовывать переводы в локальных файлах JSON.
+- Простой синтаксис перевода: переводы можно получить с помощью \{\{t.xxx\}\} для ясности и удобства обслуживания.
+- Бесшовное переключение языка: позволяет изменять язык во время выполнения без сложностей.
+- Совместимость режимов: полностью поддерживает динамический (SSR) и статический (SSG) режимы Astro.
+- Поддержка нескольких фреймворков: работает с тремя основными языками создания Astro — Astro, React и Vue.
+
+## Установка
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## Конфигурация
+
+### Обзор
+
+Astro-i18n можно настроить с помощью различных опций для настройки его поведения. В этом документе подробно описана каждая опция конфигурации, её назначение и значение по умолчанию.
+
+Astro-i18n поддерживает два основных режима работы:
+- **На основе пути**: языки определяются по путям URL (например, `/en/about`, `/zh/about`). Это контролируется опцией `pathBasedRouting`.
+- **Без пути**: язык определяется другими средствами (cookie, заголовок Accept-Language) без изменения пути URL. Это также контролируется опцией `pathBasedRouting`.
+
+### Общие параметры конфигурации
+
+Эти параметры доступны как для режима на основе пути, так и для режима без пути.
+
+#### `localesDir`
+
+- **Тип**: `string`
+- **Описание**: Каталог, в котором хранятся ваши файлы локали.
+- **По умолчанию**: `'locales'`
+
+Пример:
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **Тип**: `string`
+- **Описание**: Язык, на который следует переключиться, если перевод для текущего языка не найден.
+- **По умолчанию**: `'en'`
+
+Пример:
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **Тип**: `boolean`
+- **Описание**: Следует ли автоматически определять язык пользователя по заголовку Accept-Language.
+- **По умолчанию**: `true`
+
+Пример (с автоматическим определением):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+Пример (без автоматического определения):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **Тип**: `boolean`
+- **Описание**: Следует ли использовать маршрутизацию на основе пути. Если `true`, языки определяются по путям URL (например, `/en/about`, `/zh/about`). Если `false`, язык определяется другими средствами (cookie, заголовок Accept-Language) без изменения пути URL.
+- **По умолчанию**: `true`
+
+Эта опция определяет режим работы:
+- `true` (по умолчанию): Режим на основе пути.
+- `false`: Режим без пути.
+
+Пример (На основе пути):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+Пример (Без пути):
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### Конфигурация режима на основе пути (pathBasedRouting: true)
+
+Когда `pathBasedRouting` равно `true`, Astro-i18n работает в режиме на основе пути. Применяются все общие параметры конфигурации.
+
+### Конфигурация режима без пути (pathBasedRouting: false)
+
+Когда `pathBasedRouting` равно `false`, Astro-i18n работает в режиме без пути. Применяются все общие параметры конфигурации.
+
+Основное отличие заключается в том, как определяется язык и как обрабатываются URL-адреса:
+- В режиме на основе пути язык является частью пути URL.
+- В режиме без пути язык определяется другими средствами (cookie, заголовок Accept-Language), а путь URL остается неизменным.
+
+## Использование
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// Получить язык из параметров
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Тест Astro: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>Тест React: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Тест Vue: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## Примеры переключателя языка
+
+### Версия на основе пути
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // Установить Cookie языка
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] Установить Cookie языка:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### Версия без пути
+
+```astro
+---
+// Получить все доступные языки
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // Следует ли использовать режим маршрутизации на основе пути
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// Функция для определения текущего языка
+function detectCurrentLanguage() {
+  // Сначала проверить параметры URL
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+  if (langParam) return langParam;
+
+  // Затем проверить Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // Вернуть язык по умолчанию
+  return 'en';
+}
+
+// Получить текущий язык
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>Переключатель языка (Новая версия)</h3>
+  <p>Текущий режим: {pathBasedRouting ? 'Маршрутизация на основе пути' : 'Маршрутизация без пути'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // Функция для переключения языка
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // Режим маршрутизации на основе пути
+      // Установить Cookie языка
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] Установить Cookie языка:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // Режим маршрутизации без пути
+      // Установить Cookie языка
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // Установить localStorage
+      localStorage.setItem('lang', language);
+      // Перезагрузить страницу, чтобы применить новый язык
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## Ссылки
+
+- Репозиторий исходного кода: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- Оригинальная документация: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/zh-cn/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/zh-cn/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Gudupao Astro I18n 插件
+sidebar:
+ label: Gudupao Astro I18n 插件
+description: 支持 {{t.xxx}}、本地语言包、语言切换以及与 SSR 和 SSG 兼容的 Astro i18n 插件。
+i18nReady: true
+---
+
+我们的插件为 Astro 项目提供了一个功能齐全的 i18n 解决方案，设计直观且功能强大：
+
+- 灵活的多语言路由：支持基于路径和无路径的路由。
+- 自动语言检测：检测用户的浏览器语言并优雅地回退。
+- 可自定义的语言包：允许开发人员在本地 JSON 文件中定义和组织翻译。
+- 简单的翻译语法：可以使用 \{\{t.xxx\}\} 访问翻译，以提高清晰度和可维护性。
+- 无缝语言切换：支持在运行时切换语言，无需复杂操作。
+- 模式兼容性：完全支持 Astro 的 SSR（动态）和 SSG（静态）模式。
+- 跨框架支持：适用于 Astro 的三种主要创作语言——Astro、React 和 Vue。
+
+## 安装
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## 配置
+
+### 概述
+
+Astro-i18n 可以通过各种选项进行配置，以自定义其行为。本文档详细说明每个配置选项、其目的和默认值。
+
+Astro-i18n 支持两种主要的操作模式：
+- **基于路径**：语言由 URL 路径识别（例如 `/en/about`、`/zh/about`）。这由 `pathBasedRouting` 选项控制。
+- **无路径**：语言由其他方式（Cookie、Accept-Language 标头）确定，而无需更改 URL 路径。这也由 `pathBasedRouting` 选项控制。
+
+### 通用配置选项
+
+这些选项适用于基于路径和无路径模式。
+
+#### `localesDir`
+
+- **类型**：`string`
+- **说明**：存放地区设置文件的目录。
+- **默认**：`'locales'`
+
+示例：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **类型**：`string`
+- **说明**：如果找不到当前语言的翻译，则回退到的语言。
+- **默认**：`'en'`
+
+示例：
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **类型**：`boolean`
+- **说明**：是否从 Accept-Language 标头自动检测用户语言。
+- **默认**：`true`
+
+示例（启用自动检测）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+示例（停用自动检测）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **类型**：`boolean`
+- **说明**：是否使用基于路径的路由。如果为 `true`，语言由 URL 路径识别（例如 `/en/about`、`/zh/about`）。如果为 `false`，语言由其他方式（Cookie、Accept-Language 标头）确定，而无需更改 URL 路径。
+- **默认**：`true`
+
+此选项决定操作模式：
+- `true`（默认）：基于路径的模式。
+- `false`：无路径模式。
+
+示例（基于路径）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+示例（无路径）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### 基于路径模式配置 (pathBasedRouting: true)
+
+当 `pathBasedRouting` 为 `true` 时，Astro-i18n 以基于路径的模式运作。所有通用配置选项都适用。
+
+### 无路径模式配置 (pathBasedRouting: false)
+
+当 `pathBasedRouting` 为 `false` 时，Astro-i18n 以无路径模式运作。所有通用配置选项都适用。
+
+主要差异在于语言的判定方式以及 URL 的处理方式：
+- 在基于路径的模式中，语言是 URL 路径的一部分。
+- 在无路径模式中，语言由其他方式（Cookie、Accept-Language 标头）确定，而 URL 路径保持不变。
+
+## 用法
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// 从参数取得语言
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astro 测试: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>React 测试: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Vue 测试: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## 语言切换器示例
+
+### 基于路径的版本
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // 设定语言 Cookie
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] 设定语言 Cookie:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### 无路径版本
+
+```astro
+---
+// 取得所有可用语言
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // 是否使用基于路径的路由模式
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// 检测当前语言的函数
+function detectCurrentLanguage() {
+  // 首先检查 URL 参数
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+ if (langParam) return langParam;
+
+  // 然后检查 Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // 返回默认语言
+  return 'en';
+}
+
+// 取得当前语言
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>语言切换器 (新版本)</h3>
+  <p>当前模式: {pathBasedRouting ? '基于路径的路由' : '无路径路由'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // 切换语言的函数
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // 基于路径的路由模式
+      // 设定语言 Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] 设定语言 Cookie:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // 无路径路由模式
+      // 设定语言 Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // 设定 localStorage
+      localStorage.setItem('lang', language);
+      // 重新载入页面以套用新语言
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## 链接
+
+- 源代码存储库: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- 原始文档: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)

--- a/src/content/docs/zh-tw/guides/gudupaointernationalization.mdx
+++ b/src/content/docs/zh-tw/guides/gudupaointernationalization.mdx
@@ -1,0 +1,405 @@
+---
+title: Gudupao Astro I18n 插件
+sidebar:
+ label: Gudupao Astro I18n 插件
+description: 支援 {{t.xxx}}、本地語言包、語言切換以及與 SSR 和 SSG 相容的 Astro i18n 插件。
+i18nReady: true
+---
+
+我們的插件為 Astro 專案提供了一個功能完整的 i18n 解決方案，設計直觀且功能強大：
+
+- 靈活的多語言路由：支援基於路徑和無路徑的路由。
+- 自動語言偵測：偵測使用者的瀏覽器語言並優雅地回退。
+- 可自訂的語言包：允許開發人員在本地 JSON 檔案中定義和組織翻譯。
+- 簡單的翻譯語法：可以使用 \{\{t.xxx\}\} 存取翻譯，以提高清晰度和可維護性。
+- 無縫語言切換：支援在執行時切換語言，無需複雜操作。
+- 模式相容性：完全支援 Astro 的 SSR（動態）和 SSG（靜態）模式。
+- 跨框架支援：適用於 Astro 的三種主要創作語言——Astro、React 和 Vue。
+
+## 安裝
+
+```
+pnpm add @gudupao/astro-i18n
+```
+
+
+
+## 設定
+
+### 概述
+
+Astro-i18n 可以透過各種選項進行設定，以自訂其行為。本文件詳細說明每個設定選項、其目的和預設值。
+
+Astro-i18n 支援兩種主要的操作模式：
+- **基於路徑**：語言由 URL 路徑識別（例如 `/en/about`、`/zh/about`）。這由 `pathBasedRouting` 選項控制。
+- **無路徑**：語言由其他方式（Cookie、Accept-Language 標頭）確定，而無需更改 URL 路徑。這也由 `pathBasedRouting` 選項控制。
+
+### 通用設定選項
+
+這些選項適用於基於路徑和無路徑模式。
+
+#### `localesDir`
+
+- **類型**：`string`
+- **說明**：存放地區設定檔案的目錄。
+- **預設**：`'locales'`
+
+範例：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    localesDir: './my-locales'
+ })
+]
+```
+
+#### `fallbackLang`
+
+- **類型**：`string`
+- **說明**：如果找不到目前語言的翻譯，則回退到的語言。
+- **預設**：`'en'`
+
+範例：
+```typescript
+integrations: [
+ astroI18nPlugin({
+    fallbackLang: 'zh'
+  })
+]
+```
+
+#### `autoDetectLanguage`
+
+- **類型**：`boolean`
+- **說明**：是否從 Accept-Language 標頭自動偵測使用者語言。
+- **預設**：`true`
+
+範例（啟用自動偵測）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: true
+  })
+]
+```
+
+範例（停用自動偵測）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    autoDetectLanguage: false
+  })
+]
+```
+
+#### `pathBasedRouting`
+
+- **類型**：`boolean`
+- **說明**：是否使用基於路徑的路由。如果為 `true`，語言由 URL 路徑識別（例如 `/en/about`、`/zh/about`）。如果為 `false`，語言由其他方式（Cookie、Accept-Language 標頭）確定，而無需更改 URL 路徑。
+- **預設**：`true`
+
+此選項決定操作模式：
+- `true`（預設）：基於路徑的模式。
+- `false`：無路徑模式。
+
+範例（基於路徑）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: true
+  })
+]
+```
+
+範例（無路徑）：
+```typescript
+integrations: [
+  astroI18nPlugin({
+    pathBasedRouting: false
+  })
+]
+```
+
+### 基於路徑模式設定 (pathBasedRouting: true)
+
+當 `pathBasedRouting` 為 `true` 時，Astro-i18n 以基於路徑的模式運作。所有通用設定選項都適用。
+
+### 無路徑模式設定 (pathBasedRouting: false)
+
+當 `pathBasedRouting` 為 `false` 時，Astro-i18n 以無路徑模式運作。所有通用設定選項都適用。
+
+主要差異在於語言的判定方式以及 URL 的處理方式：
+- 在基於路徑的模式中，語言是 URL 路徑的一部分。
+- 在無路徑模式中，語言由其他方式（Cookie、Accept-Language 標頭）確定，而 URL 路徑保持不變。
+
+## 用法
+
+
+### Astro
+
+```astro
+---
+import { getTranslator } from '@gudupao/astro-i18n';
+
+// 從參數取得語言
+const lang = Astro.params.lang || 'en';
+const t = getTranslator(lang);
+---
+
+<div>
+  <h1>Astro 測試: {t('hello')} {t('123.a')}</h1>
+</div>
+```
+
+### React
+
+```jsx
+import React from 'react';
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+const TestComponent = ({ translations }: { translations: Translations }) => {
+  const t = createClientTranslator(translations);
+  
+  return (
+    <div>
+      <h1>React 測試: {t('hello')} {t('123.a')}</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+```
+
+### Vue
+
+```vue
+<template>
+ <div>
+    <h1>Vue 測試: {{ t('hello') }} {{ t('123.a') }}</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClientTranslator } from '@gudupao/astro-i18n';
+import type { Translations } from '@gudupao/astro-i18n';
+
+interface Props {
+  translations: Translations;
+}
+
+const props = defineProps<Props>();
+const t = createClientTranslator(props.translations);
+</script>
+```
+
+## 語言切換器範例
+
+### 基於路徑的版本
+
+```astro
+---
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+---
+
+<script is:inline>
+ function switchLanguage(language) {
+    // 設定語言 Cookie
+    document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+    console.log('[LanguageSwitcher] 設定語言 Cookie:', language);
+    
+    const urlParts = window.location.pathname.split('/');
+    urlParts[1] = language;
+    window.location.href = urlParts.join('/');
+  }
+
+  const currentPath = window.location.pathname;
+  const urlParts = currentPath.split('/');
+</script>
+
+<div class="language-switcher">
+  <button
+    onclick="switchLanguage('en')"
+    class={lang === 'en' ? 'active' : ''}
+  >
+    English
+  </button>
+  <button
+    onclick="switchLanguage('zh')"
+    class={lang === 'zh' ? 'active' : ''}
+  >
+    中文
+  </button>
+    <button
+    onclick="switchLanguage('jp')"
+    class={lang === 'jp' ? 'active' : ''}
+  >
+    日本語
+  </button>
+</div>
+
+<style>
+.language-switcher {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.language-switcher button {
+  padding: 5px 10px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+</style>
+```
+
+### 無路徑版本
+
+```astro
+---
+// 取得所有可用語言
+const { getAvailableLanguages } = await import('@gudupao/astro-i18n');
+const availableLanguages = getAvailableLanguages();
+
+interface Props {
+  pathBasedRouting?: boolean; // 是否使用基於路徑的路由模式
+}
+
+const { pathBasedRouting = true } = Astro.props;
+
+// 偵測目前語言的函數
+function detectCurrentLanguage() {
+  // 首先檢查 URL 參數
+  const urlParams = new URLSearchParams(Astro.url.search);
+  const langParam = urlParams.get('lang');
+ if (langParam) return langParam;
+
+  // 然後檢查 Cookie
+  const cookies = Astro.request.headers.get('cookie');
+  if (cookies) {
+    const cookieObj = Object.fromEntries(
+      cookies.split(';').map(cookie => {
+        const [name, value] = cookie.trim().split('=');
+        return [name, decodeURIComponent(value)];
+      })
+    );
+    if (cookieObj.lang) return cookieObj.lang;
+ }
+
+  // 回傳預設語言
+  return 'en';
+}
+
+// 取得目前語言
+const currentLang = detectCurrentLanguage();
+---
+
+<div class="language-switcher">
+  <h3>語言切換器 (新版本)</h3>
+  <p>目前模式: {pathBasedRouting ? '基於路徑的路由' : '無路徑路由'}</p>
+  <div class="switcher-buttons">
+    {availableLanguages.map((language) => (
+      <button
+        data-lang={language}
+        class={language === currentLang ? 'active' : ''}
+        onclick={`switchLanguage('${language}', ${pathBasedRouting})`}
+      >
+        {language === 'en' && 'English'}
+        {language === 'zh' && '中文'}
+        {language === 'jp' && '日本語'}
+        {language !== 'en' && language !== 'zh' && language !== 'jp' && language}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script is:inline>
+  // 切換語言的函數
+  function switchLanguage(language, pathBasedRouting) {
+    if (pathBasedRouting) {
+      // 基於路徑的路由模式
+      // 設定語言 Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      console.log('[LanguageSwitcher] 設定語言 Cookie:', language);
+      
+      const urlParts = window.location.pathname.split('/');
+      urlParts[1] = language;
+      window.location.href = urlParts.join('/');
+    } else {
+      // 無路徑路由模式
+      // 設定語言 Cookie
+      document.cookie = `lang=${language}; path=/; max-age=31536000; samesite=lax`;
+      // 設定 localStorage
+      localStorage.setItem('lang', language);
+      // 重新載入頁面以套用新語言
+      window.location.reload();
+    }
+  }
+</script>
+
+<style>
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9;
+}
+
+.switcher-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.language-switcher button {
+  padding: 8px 12px;
+  border: none;
+  background: #f0f0f0;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.language-switcher button:hover {
+  background: #e0e0e0;
+}
+
+.language-switcher button.active {
+  background: #007bff;
+  color: white;
+}
+
+.language-switcher h3 {
+  margin: 0 0 10px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.language-switcher p {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  color: #666;
+}
+</style>
+```
+
+## 連結
+
+- 原始碼儲存庫: [https://github.com/GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)
+- npmjs: [https://www.npmjs.com/package/@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)
+- 原始文件: [https://astro-i18n.gudupao.top](https://astro-i18n.gudupao.top)


### PR DESCRIPTION
## Summary

This PR introduces a new **internationalization (i18n) plugin for Astro**, developed by Gudupao Spark Inc. since July.  
The plugin provides a full-featured and developer-friendly i18n solution with the following features:

- **Flexible multilingual routing** — supports both path-based and pathless routing  
- **Automatic language detection** — detects browser language with graceful fallbacks  
- **Customizable language packs** — manage translations in local JSON files  
- **Simple translation syntax** — use `{{t.xxx}}` for clarity and maintainability  
- **Seamless language switching** — runtime language changes without complexity  
- **Mode compatibility** — works in both SSR (dynamic) and SSG (static) modes  
- **Cross-framework support** — compatible with Astro, React, and Vue  

✅ All features have been fully tested and verified.  
✅ The plugin is already being used in production websites with smooth and stable performance.  

---

## Resources

- **GitHub**: [GudupaoSpark/Astro-i18n](https://github.com/GudupaoSpark/Astro-i18n)  
- **NPM**: [@gudupao/astro-i18n](https://www.npmjs.com/package/@gudupao/astro-i18n)  
- **Documentation**: [astro-i18n.gudupao.top](https://astro-i18n.gudupao.top/)  

---

## Motivation

We believe this plugin fills a gap in the Astro ecosystem by offering an intuitive yet powerful i18n solution.  
It would be great if the Astro team could consider featuring it in the official documentation so developers can easily discover and benefit from it.  
