### PR TITLE
Install tailwindcss rather than deprecated tailwind package

### DIFF
--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -447,17 +447,17 @@ In Astro `>=5.2.0`, use the `astro add tailwind` command for your package manage
 <PackageManagerTabs>
   <Fragment slot="npm">
     ```shell
-    npx astro add tailwind
+    npx astro add tailwindcss
     ```
   </Fragment>
   <Fragment slot="pnpm">
     ```shell
-    pnpm astro add tailwind
+    pnpm astro add tailwindcss
     ```
   </Fragment>
   <Fragment slot="yarn">
     ```shell
-    yarn astro add tailwind
+    yarn astro add tailwindcss
     ```
   </Fragment>
 </PackageManagerTabs>


### PR DESCRIPTION
#### Description

When I followed these instructions I got this message in the terminal: 

>  WARN  deprecated tailwind@4.0.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.

Should use tailwindcss instead!