### PR TITLE
Add "Function prototype methods" section to Actions guide

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -163,6 +163,12 @@ Now, all of your user actions are callable from the `actions.user` object:
 - `actions.user.createUser()`
 
 
+## Function prototype methods
+
+Action functions only support a limited set of JavaScript function prototype methods: `.toString()`, `.valueOf()`, and `.bind()`.  
+Methods like `.apply()` and `.call()` are not available. This allows you to safely name actions `apply` or `call` without conflicts.
+
+
 ## Handling returned data
 
 Actions return an object containing either `data` with the type-safe return value of your `handler()`, or an `error` with any backend errors. Errors may come from validation errors on the `input` property or thrown errors within the `handler()`.


### PR DESCRIPTION
#### Description (required)

Adds a new "Function prototype methods" section to the Actions guide.

This describes the restrictions introduced by https://github.com/withastro/astro/pull/14248.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: new content 

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
