### PR TITLE
new: Document `failOnPrerenderConflict` experimental flag

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -151,6 +151,7 @@ export const sidebar = [
 					'reference/experimental-flags/heading-id-compat',
 					'reference/experimental-flags/static-import-meta-env',
 					'reference/experimental-flags/chrome-devtools-workspace',
+					'reference/experimental-flags/fail-on-prerender-conflict',
 				],
 			}),
 			'reference/legacy-flags',

--- a/src/content/docs/en/reference/experimental-flags/fail-on-prerender-conflict.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fail-on-prerender-conflict.mdx
@@ -1,0 +1,32 @@
+---
+title: Experimental prerender conflict error
+sidebar:
+  label: Prerender conflict error
+i18nReady: true
+---
+
+import Since from '~/components/Since.astro'
+
+<p>
+
+**Type:** `boolean`<br />
+**Default:** `false`<br />
+<Since v="5.14.0" />
+</p>
+
+Turns prerender conflict warnings into errors during the build process.
+
+Multiple dynamic routes can result in the same output path, for example `/blog/[slug]` and `/blog/[...all]` both could try to prerender the `/blog/post-1` path. In such cases, Astro will warn you about the conflict during build and render only the [highest priority route](/en/guides/routing/#route-priority-order) for the conflicting path. With this flag set, the build will instead fail immediately with an error.
+
+This will be the default behavior in Astro 6.
+
+Enable it in your `astro.config.mjs`:
+
+```js
+// astro.config.mjs
+defineConfig({
+	experimental: {
+		failOnPrerenderConflict: true,
+	},
+});
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Document new experimental flag to fail on multiple routes prerendering the same page instead of showing a warning.

#### For Astro version: `5.14`. See astro PR [#14206](https://github.com/withastro/astro/pull/14206). -->
