### PR TITLE
i18n(fr): fix missing updates, typo and wording in `reference/modules`

### DIFF
--- a/src/content/docs/fr/reference/modules/astro-actions.mdx
+++ b/src/content/docs/fr/reference/modules/astro-actions.mdx
@@ -86,7 +86,7 @@ Si votre action accepte les entrées de formulaire, utilisez le validateur `z.ob
 - Plusieurs entrées du même nom (`name`) peuvent être validées à l'aide de `z.array(/* validateur */)`
 - Toutes les autres entrées peuvent être validées à l'aide de `z.string()`
 
-Les fonctions d'extension, notamment `.refine()`, `.transform()` et `.pipe()`, sont également prises en charge sur cet objet. Les validateurs suivants sont pris en charge pour les champs de données de formulaire :
+Les fonctions d'extension, notamment `.refine()`, `.transform()` et `.pipe()`, sont également prises en charge sur le validateur `z.object()`.
 
 Pour appliquer une union de différents validateurs, utilisez le wrapper `z.discriminatedUnion()` pour affiner le type en fonction d'un champ de formulaire spécifique. Cet exemple accepte une soumission de formulaire pour créer (`create`) ou mettre à jour (`update`) un utilisateur, en utilisant le champ de formulaire avec le nom `type` pour déterminer l'objet à valider :
 

--- a/src/content/docs/fr/reference/modules/astro-assets.mdx
+++ b/src/content/docs/fr/reference/modules/astro-assets.mdx
@@ -57,7 +57,7 @@ import monImage from "../assets/mon_image.png"; // Image a une résolution de 16
 
 #### Propriétés d'Image
 
-Le composant `<Image />` accepte toutes les propriétés acceptées par la balise HTML `<img>` en plus des propriétés décrites ci-dessous.
+Le composant `<Image />` accepte les propriétés listées ci-dessous et les [propriétés d'image adaptatives](#propriétés-des-images-adaptatives) en plus de toutes les propriétés acceptées par la balise HTML `<img>`.
 
 ##### src (obligatoire)
 
@@ -117,7 +117,7 @@ Utilisez l'attribut `alt` requis pour fournir un [texte alternatif descriptif](h
 
 Si une image est simplement décorative (c'est-à-dire qu'elle ne contribue pas à la compréhension de la page), définissez `alt=""` pour que les lecteurs d'écran et autres technologies d'assistance sachent qu'il faut ignorer l'image.
 
-##### width et height (obligatoire pour les images dans `public/`)
+##### width et height (obligatoires pour les images dans `public/`)
 
 <p>
 
@@ -284,7 +284,7 @@ Par défaut, cette valeur est définie sur `false` et vous devez spécifier manu
 
 Ajoutez `inferSize` au composant `<Image />` (ou `inferSize: true` à `getImage()`) pour déduire ces valeurs du contenu de l'image lors de la récupération. Cela est utile si vous ne connaissez pas les dimensions de l'image distante ou si elles peuvent changer :
 
-```astro mark="inferSize"
+```astro title="src/components/MonComposant.astro" "inferSize"
 ---
 import { Image } from 'astro:assets';
 ---
@@ -497,7 +497,7 @@ Définit une [image adaptative](#propriétés-des-images-adaptatives) et déterm
 
   Ceci est utile si vous avez activé une mise en page par défaut, mais que vous souhaitez la désactiver pour une image spécifique.
 
-Par exemple, avec la valeur « contraint » (`constrained`) définie comme mise en page par défaut, vous pouvez remplacer la propriété `layout` de n'importe quelle image individuelle :
+Par exemple, avec la valeur `constrained` définie comme mise en page par défaut, vous pouvez remplacer la propriété `layout` de n'importe quelle image individuelle :
 
 ```astro title="src/components/MonComposant.astro"
 ---
@@ -518,9 +518,9 @@ import monImage from '../assets/mon_image.png';
 <Since v="5.10.0" />
 </p>
 
-Activé lorsque la propriété [`layout`](#layout) est définie ou configurée. Définit comment une image adaptative doit être recadrée si son rapport hauteur/largeur est modifié.
+Activée lorsque la propriété [`layout`](#layout) est définie ou configurée. Définit comment une image adaptative doit être recadrée si son rapport hauteur/largeur est modifié.
 
-Les valeurs correspondent à celles de la propriété CSS `object-fit`. La valeur par défaut est `cover` ou la valeur de [`image.objectFit`](/fr/reference/configuration-reference/#imageobjectfit) si elle est définie. Peut être utilisé pour remplacer les styles par défaut de `object-fit`.
+Les valeurs correspondent à celles de la propriété CSS `object-fit`. La valeur par défaut est `cover` ou la valeur de [`image.objectFit`](/fr/reference/configuration-reference/#imageobjectfit) si elle est définie. Peut être utilisée pour remplacer les styles par défaut de `object-fit`.
 
 ##### position
 
@@ -531,9 +531,9 @@ Les valeurs correspondent à celles de la propriété CSS `object-fit`. La valeu
 <Since v="5.10.0" />
 </p>
 
-Activé lorsque la propriété [`layout`](#layout) est définie ou configurée. Définit la position du recadrage de l'image pour une image adaptative si le rapport hauteur/largeur est modifié.
+Activée lorsque la propriété [`layout`](#layout) est définie ou configurée. Définit la position du recadrage de l'image pour une image adaptative si le rapport hauteur/largeur est modifié.
 
-Les valeurs correspondent à celles de la propriété CSS `object-position`. La valeur par défaut est `center` ou la valeur de [`image.objectPosition`](/fr/reference/configuration-reference/#imageobjectposition) si elle est définie. Peut être utilisé pour remplacer les styles par défaut de la propriété `object-position`.
+Les valeurs correspondent à celles de la propriété CSS `object-position`. La valeur par défaut est `center` ou la valeur de [`image.objectPosition`](/fr/reference/configuration-reference/#imageobjectposition) si elle est définie. Peut être utilisée pour remplacer les styles par défaut de la propriété `object-position`.
 
 ### `getImage()`
 

--- a/src/content/docs/fr/reference/modules/astro-content.mdx
+++ b/src/content/docs/fr/reference/modules/astro-content.mdx
@@ -133,7 +133,7 @@ const relatedPosts = await getEntries(blogPost.data.relatedPosts);
 
 `getCollection()` est une fonction qui récupère une liste d'entrées de collection de contenu par nom de collection.
 
-Il renvoie tous les éléments de la collection par défaut et accepte une fonction facultative `filter` pour affiner les propriétés d'entrée. Cela vous permet d'interroger uniquement certains éléments d'une collection en fonction de `id` ou des valeurs du frontmatter via l'objet `data`.
+Elle renvoie tous les éléments de la collection par défaut et accepte une fonction facultative `filter` pour affiner les propriétés d'entrée. Cela vous permet d'interroger uniquement certains éléments d'une collection en fonction de `id` ou des valeurs du frontmatter via l'objet `data`.
 
 ```astro
 ---
@@ -170,7 +170,7 @@ import { getEntry } from 'astro:content';
 // Récupère `src/content/blog/enterprise.md`
 const enterprisePost = await getEntry('blog', 'enterprise');
 
-// Get `src/content/captains/picard.json`
+// Récupère `src/content/captains/picard.json`
 const picardProfile = await getEntry('captains', 'picard');
 
 // Récupère le profil référencé par `data.captain`
@@ -213,7 +213,7 @@ Une fonction permettant de compiler une entrée donnée pour le rendu. Elle renv
 
 - `<Content />` - Un composant utilisé pour restituer le contenu du document dans un fichier Astro.
 - `headings` - Une liste générée de titres, [reflétant l'utilitaire `getHeadings()` d'Astro](/fr/guides/markdown-content/#propriétés-disponibles) sur les importations Markdown et MDX.
-- `remarkPluginFrontmatter ` - L'objet frontmatter modifié après que tous les [plugins Remark ou Rehype ont été appliqués](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter). Définit sur le type `any`.
+- `remarkPluginFrontmatter ` - L'objet frontmatter modifié après que tous les [modules d'extension Remark ou Rehype ont été appliqués](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter). Définit sur le type `any`.
 
 ```astro
 ---

--- a/src/content/docs/fr/reference/modules/astro-env.mdx
+++ b/src/content/docs/fr/reference/modules/astro-env.mdx
@@ -12,7 +12,7 @@ import ReadMore from '~/components/ReadMore.astro';
 
 <p><Since v="5.0.0" /></p>
 
-L'API `astro:env` vous permet de configurer un schéma de type sécurisé pour les variables d'environnement que vous avez définies. Cela vous permet d'indiquer si elles doivent être disponibles sur le serveur ou le client, et de définir leur type de données et leurs propriétés supplémentaires. Pour des exemples et des instructions d'utilisation, [consultez le guide `astro:env`](/fr/guides/environment-variables/#variables-denvironnement-avec-sûreté-du-typage).
+L'API `astro:env` vous permet de configurer un schéma avec sûreté du typage pour les variables d'environnement que vous avez définies. Cela vous permet d'indiquer si elles doivent être disponibles sur le serveur ou le client, et de définir leur type de données et leurs propriétés supplémentaires. Pour des exemples et des instructions d'utilisation, [consultez le guide `astro:env`](/fr/guides/environment-variables/#variables-denvironnement-avec-sûreté-du-typage).
 
 ## Importations depuis `astro:env`
 
@@ -30,7 +30,7 @@ import {
 
 La fonction d'aide `getSecret()` permet de récupérer la valeur brute d'une variable d'environnement par sa clé.
 
-Par exemple, vous pouvez récupérer une valeur booléenne sous forme de chaîne :
+Par exemple, vous pouvez récupérer une valeur booléenne sous forme de chaîne de caractères :
 
 ```js
 import {

--- a/src/content/docs/fr/reference/modules/astro-i18n.mdx
+++ b/src/content/docs/fr/reference/modules/astro-i18n.mdx
@@ -204,7 +204,7 @@ getLocaleByPath("french"); // renvoie "fr" car c'est le premier code configuré
 Disponible uniquement lorsque `i18n.routing` est défini sur `"manual"`
 :::
 
-Une fonction qui renvoie une `Response` qui redirige vers les paramètres régionaux utilisés par défaut (`defaultLocale`). Il accepte un code d’état de redirection valide facultatif.
+Une fonction qui renvoie une `Response` qui redirige vers les paramètres régionaux utilisés par défaut (`defaultLocale`). Elle accepte un code d’état de redirection valide facultatif.
 
 ```js title="middleware.js"
 import { defineMiddleware } from "astro:middleware";
@@ -291,7 +291,7 @@ Disponible uniquement lorsque `i18n.routing` est défini sur `"manual"`
 
 Une fonction qui vous permet de créer par programmation le middleware i18n d'Astro.
 
-Cette function est utile lorsque vous souhaitez continuer à utiliser la logique i18n par défaut tout en ajoutant quelques exceptions pour votre site.
+Cette fonction est utile lorsque vous souhaitez continuer à utiliser la logique i18n par défaut tout en ajoutant quelques exceptions pour votre site.
   
 ```js title="middleware.js"
 import { middleware } from "astro:i18n";

--- a/src/content/docs/fr/reference/modules/astro-middleware.mdx
+++ b/src/content/docs/fr/reference/modules/astro-middleware.mdx
@@ -33,7 +33,7 @@ Vous pouvez importer et utiliser la fonction utilitaire `defineMiddleware()` pou
 // src/middleware.ts
 import { defineMiddleware } from "astro:middleware";
 
-// `context` et `next` sont automatiquement saisis
+// `context` et `next` sont automatiquement typés
 export const onRequest = defineMiddleware((context, next) => {
 
 });
@@ -46,7 +46,7 @@ export const onRequest = defineMiddleware((context, next) => {
 **Type :** `(...handlers: MiddlewareHandler[]) => MiddlewareHandler`
 </p>
 
-Une fonction qui accepte les fonctions middleware comme arguments et les exécutera dans l'ordre dans lequel elles sont transmises.
+Une fonction qui accepte des fonctions de middleware comme arguments et les exécutera dans l'ordre dans lequel elles sont transmises.
 
 ```js title="src/middleware.js"
 import { sequence } from "astro:middleware";
@@ -66,9 +66,9 @@ export const onRequest = sequence(validation, auth, greeting);
 <Since v="2.8.0" />
 </p>
 
-Une API de bas niveau pour créer un objet [`APIContext`](/fr/reference/api-reference/) à transmettre à une fonction `onRequest()` du middleware Astro.
+Une API de bas niveau pour créer un objet [`APIContext`](/fr/reference/api-reference/) à transmettre à une fonction `onRequest()` du middleware d'Astro.
 
-Cette fonction peut être utilisée par les intégrations/adaptateurs pour exécuter par programmation le middleware Astro.
+Cette fonction peut être utilisée par les intégrations/adaptateurs pour exécuter par programmation le middleware d'Astro.
 
 ### `trySerializeLocals()`
 
@@ -80,15 +80,15 @@ Cette fonction peut être utilisée par les intégrations/adaptateurs pour exéc
 
 Une API de bas niveau qui prend n'importe quelle valeur et tente d'en renvoyer une version sérialisée (une chaîne de caractères). Si la valeur ne peut pas être sérialisée, la fonction générera une erreur d'exécution.
 
-## Middleware exports
+## Exportations de middleware
 
-Lors de la définition du middleware de votre projet dans `src/middleware.js`, il exporte les fonctions définies par l'utilisateur suivantes :
+Lors de la définition du middleware de votre projet dans `src/middleware.js`, exportez les fonctions définies par l'utilisateur suivantes :
 
 ### `onRequest()`
 
 **Type :** `(context: APIContext, next: MiddlewareNext) => Promise<Response> | Response | Promise<void> | void`
 
-Une fonction exportée requise depuis `src/middleware.js` qui sera appelée avant le rendu de chaque page ou route API. Elle reçoit deux arguments : [context](#context) et [next()](#next). `onRequest()` doit renvoyer une réponse (`Response`) : soit directement, soit en appelant `next()`.
+Une fonction requise exportée depuis `src/middleware.js` qui sera appelée avant le rendu de chaque page ou route d'API. Elle reçoit deux arguments : [context](#context) et [next()](#next). `onRequest()` doit renvoyer une réponse (`Response`) : soit directement, soit en appelant `next()`.
 
 ```js title="src/middleware.js"
 export function onRequest (context, next) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations in `reference/modules` to:
* add some missing updates in `astro:actions` and `astro:assets`
* fix some grammar errors (e.g. `une propriété`, so we should use `activée` not `activé`)
* replace `plugins` with `modules d'extension`, according the French i18n guide
* replace `de type sécurisé` with `avec sûreté du typage`, according the French i18n guide
* fix some typo

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
