### PR TITLE
feat(sitemap): add configurable XML namespaces support

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -486,7 +486,7 @@ The given configuration will generate sitemap files at `https://example.com/astr
 
 Controls which XML namespaces are included in the sitemap generation.
 
-By default, all namespaces default to `true` and you must explicitly set each one you want to change to `false`.
+By default, all configurable namespaces  (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude a namespace from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
 
 ```js title="astro.config.mjs" ins={8-14}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -475,6 +475,31 @@ export default defineConfig({
 
 The given configuration will generate sitemap files at `https://example.com/astronomy-sitemap-0.xml` and `https://example.com/astronomy-sitemap-index.xml`.
 
+### `namespaces`
+
+**Type:** `{ news?: boolean; xhtml?: boolean; image?: boolean; video?: boolean; }`  
+**Default:** `{ news: true, xhtml: true, image: true, video: true }`
+
+Controls which XML namespaces are included in the sitemap generation.
+
+```js title="astro.config.mjs" ins={8}
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://example.com',
+  integrations: [
+    sitemap({
+      namespaces: {
+        news: true,
+        xhtml: true, 
+        image: true,
+        video: true,
+      },
+    }),
+  ],
+});
+
 ## Examples
 
 * The official Astro website uses Astro Sitemap to generate [its sitemap](https://astro.build/sitemap-index.xml).

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -486,7 +486,7 @@ The given configuration will generate sitemap files at `https://example.com/astr
 
 An object of XML namespaces to exclude from the generated sitemap.
 
-Excluding unused namespaces can help create cleaner, more focused sitemaps that are faster for search engines to parse and use less bandwidth. For example, if your site doesn't have news content, videos, or multiple languages, you can exclude those namespaces to reduce XML bloat.
+Excluding unused namespaces can help create more focused sitemaps that are faster for search engines to parse and use less bandwidth. For example, if your site doesn't have news content, videos, or multiple languages, you can exclude those namespaces to reduce XML bloat.
 
 By default, all configurable namespaces (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude one or more of these namespaces from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
 

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -498,11 +498,9 @@ export default defineConfig({
   site: 'https://example.com',
   integrations: [
     sitemap({
-      // Only include image and video namespaces
       namespaces: {
         news: false,
         xhtml: false, 
-        // image and video will be true by default
       }
     })
   ]

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -482,7 +482,9 @@ The given configuration will generate sitemap files at `https://example.com/astr
 
 Controls which XML namespaces are included in the sitemap generation.
 
-```js title="astro.config.mjs" ins={8}
+By default, all namespaces default to `true` and you must explicitly set each one you want to include to `false`.
+
+```js title="astro.config.mjs" ins={8-14}
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
@@ -490,11 +492,11 @@ export default defineConfig({
   site: 'https://example.com',
   integrations: [
     sitemap({
+      // Only include image and video namespaces
       namespaces: {
-        news: true,
-        xhtml: true, 
-        image: true,
-        video: true,
+        news: false,
+        xhtml: false, 
+        // image and video will be true by default
       },
     }),
   ],

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -501,6 +501,7 @@ export default defineConfig({
     })
   ]
 });
+```
 
 ## Examples
 

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -497,9 +497,9 @@ export default defineConfig({
         news: false,
         xhtml: false, 
         // image and video will be true by default
-      },
-    }),
-  ],
+      }
+    })
+  ]
 });
 
 ## Examples

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -482,7 +482,7 @@ The given configuration will generate sitemap files at `https://example.com/astr
 
 Controls which XML namespaces are included in the sitemap generation.
 
-By default, all namespaces default to `true` and you must explicitly set each one you want to include to `false`.
+By default, all namespaces default to `true` and you must explicitly set each one you want to change to `false`.
 
 ```js title="astro.config.mjs" ins={8-14}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -477,8 +477,12 @@ The given configuration will generate sitemap files at `https://example.com/astr
 
 ### `namespaces`
 
-**Type:** `{ news?: boolean; xhtml?: boolean; image?: boolean; video?: boolean; }`  
-**Default:** `{ news: true, xhtml: true, image: true, video: true }`
+<p>
+
+**Type:** `{ news?: boolean; xhtml?: boolean; image?: boolean; video?: boolean; }` <br />
+**Default:** `{ news: true, xhtml: true, image: true, video: true }` <br />
+<Since v="3.6.0" pkg="@astrojs/sitemap" />
+</p>
 
 Controls which XML namespaces are included in the sitemap generation.
 

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -490,7 +490,7 @@ Excluding unused namespaces can help create more focused sitemaps that are faste
 
 By default, all configurable namespaces (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude one or more of these namespaces from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
 
-```js title="astro.config.mjs" ins={8-14}
+```js title="astro.config.mjs" ins={8-11}
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -488,7 +488,7 @@ An object of XML namespaces to exclude from the generated sitemap.
 
 Excluding unused namespaces can help create cleaner, more focused sitemaps that are faster for search engines to parse and use less bandwidth. For example, if your site doesn't have news content, videos, or multiple languages, you can exclude those namespaces to reduce XML bloat.
 
-By default, all configurable namespaces  (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude a namespace from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
+By default, all configurable namespaces (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude one or more of these namespaces from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
 
 ```js title="astro.config.mjs" ins={8-14}
 import { defineConfig } from 'astro/config';

--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -484,7 +484,9 @@ The given configuration will generate sitemap files at `https://example.com/astr
 <Since v="3.6.0" pkg="@astrojs/sitemap" />
 </p>
 
-Controls which XML namespaces are included in the sitemap generation.
+An object of XML namespaces to exclude from the generated sitemap.
+
+Excluding unused namespaces can help create cleaner, more focused sitemaps that are faster for search engines to parse and use less bandwidth. For example, if your site doesn't have news content, videos, or multiple languages, you can exclude those namespaces to reduce XML bloat.
 
 By default, all configurable namespaces  (`news`, `xhtml`, `image`, and `video`) are included in your generated sitemap XML. To exclude a namespace from your sitemap generation, add a `namespaces` configuration object and set individual options to `false`:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

This pull request adds documentation for the new `namespaces` configuration option to the sitemap integration guide. The update explains the purpose, type, and default values for this option, and provides a usage example.

**Sitemap integration documentation update:**

* Added a section describing the `namespaces` option, including its type, default values, and its role in controlling which XML namespaces are included during sitemap generation.
* Provided a code example in `astro.config.mjs` showing how to configure the `namespaces` option for the sitemap integration.

Updated docs for https://github.com/withastro/astro/pull/14285

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
