### PR TITLE
clarify astro:before-swap example [i18nIgnore]

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -653,7 +653,8 @@ This event can be used to make changes before the swap occurs. The `newDocument`
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -651,17 +651,9 @@ An event that fires before the new document (which is populated during the prepa
 This event can be used to make changes before the swap occurs. The `newDocument` property on the event represents the incoming document. Here is an example of ensuring the browser's light or dark mode preference in `localStorage` is carried over to the new page:
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-  
-  setDarkMode(document);
-  
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // Pass the incoming document to set the theme on it
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -654,7 +654,7 @@ This event can be used to make changes before the swap occurs. The `newDocument`
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -648,7 +648,7 @@ Este evento puede ser usado para realizar cambios antes de que el intercambio oc
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -645,17 +645,9 @@ Un evento que es disparado antes de que el nuevo documento (que se completa dura
 Este evento puede ser usado para realizar cambios antes de que el intercambio ocurra. La propiedad `newDocument` en el evento representa el documento entrante. Aquí hay un ejempl para asegurar que la preferencia del modo claro u oscuro del navegador en `localStorage` se traslada a la nueva página:
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-  
-  setDarkMode(document);
-  
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // Pass the incoming document to set the theme on it
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/es/guides/view-transitions.mdx
+++ b/src/content/docs/es/guides/view-transitions.mdx
@@ -647,7 +647,8 @@ Este evento puede ser usado para realizar cambios antes de que el intercambio oc
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/fr/guides/view-transitions.mdx
+++ b/src/content/docs/fr/guides/view-transitions.mdx
@@ -653,7 +653,8 @@ Cet événement peut être utilisé pour effectuer des modifications avant que l
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/fr/guides/view-transitions.mdx
+++ b/src/content/docs/fr/guides/view-transitions.mdx
@@ -654,7 +654,7 @@ Cet événement peut être utilisé pour effectuer des modifications avant que l
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/fr/guides/view-transitions.mdx
+++ b/src/content/docs/fr/guides/view-transitions.mdx
@@ -651,17 +651,9 @@ Il s'agit d'une version plus simple du chargement d'un spinner que l'exemple ci-
 Cet événement peut être utilisé pour effectuer des modifications avant que la permutation ne se produise. La propriété `newDocument` de l'événement représente le document entrant. Voici un exemple permettant de s'assurer que les préférences du navigateur en matière de mode clair ou foncé dans `localStorage` sont reportées sur la nouvelle page :
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-
-  setDarkMode(document);
-
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // Transmettre le document entrant pour définir le thème sur celui-ci
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ja/guides/view-transitions.mdx
+++ b/src/content/docs/ja/guides/view-transitions.mdx
@@ -627,7 +627,7 @@ AstroのView Transition APIのライフサイクルイベントは、以下の�
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ja/guides/view-transitions.mdx
+++ b/src/content/docs/ja/guides/view-transitions.mdx
@@ -624,17 +624,9 @@ AstroのView Transition APIのライフサイクルイベントは、以下の�
 このイベントでは、スワップ前に変更を加えることができます。`event.newDocument`プロパティは、これから表示される新しいドキュメントを表します。以下は、`localStorage`のダークモード設定を新しいページにも適用する例です。
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-  
-  setDarkMode(document);
-  
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // 新しいドキュメントにもテーマを適用
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ja/guides/view-transitions.mdx
+++ b/src/content/docs/ja/guides/view-transitions.mdx
@@ -626,7 +626,8 @@ AstroのView Transition APIのライフサイクルイベントは、以下の�
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ko/guides/view-transitions.mdx
+++ b/src/content/docs/ko/guides/view-transitions.mdx
@@ -651,17 +651,9 @@ Astro의 뷰 전환 API 수명 주기 이벤트는 순서대로 다음과 같습
 이 이벤트는 교체 전에 변경 사항을 생성하는 데 사용할 수 있습니다. 이벤트의 `newDocument` 속성은 들어오는 문서를 나타냅니다. 다음은 `localStorage`의 브라우저 라이트 또는 다크 모드 기본 설정을 새 페이지로 전달하는 예시입니다.
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-  
-  setDarkMode(document);
-  
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // 들어오는 문서를 전달하여 테마를 설정합니다.
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ko/guides/view-transitions.mdx
+++ b/src/content/docs/ko/guides/view-transitions.mdx
@@ -653,7 +653,8 @@ Astro의 뷰 전환 API 수명 주기 이벤트는 순서대로 다음과 같습
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ko/guides/view-transitions.mdx
+++ b/src/content/docs/ko/guides/view-transitions.mdx
@@ -654,7 +654,7 @@ Astro의 뷰 전환 API 수명 주기 이벤트는 순서대로 다음과 같습
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/ru/guides/view-transitions.mdx
+++ b/src/content/docs/ru/guides/view-transitions.mdx
@@ -658,17 +658,10 @@ document.addEventListener("astro:page-load", () => {
 Это событие можно использовать для внесения изменений до того, как произойдет подмена. Свойство `newDocument` этого события представляет входящий документ. Вот пример того, как обеспечить перенос предпочтений светлого или тёмного режима браузера в `localStorage` на новую страницу:
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? 'dark' : 'light';
-    document.documentElement.dataset.theme = theme;
-  }
-
-  setDarkMode(document);
-
-  document.addEventListener('astro:before-swap', ev => {
-    // Передайте входящий документ, чтобы установить для него тему
-    setDarkMode(ev.newDocument);
+<script>
+  document.addEventListener("astro:before-swap", (event) => {
+    event.newDocument.documentElement.dataset.theme =
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/zh-cn/guides/view-transitions.mdx
+++ b/src/content/docs/zh-cn/guides/view-transitions.mdx
@@ -657,7 +657,8 @@ Astro 的视图过渡动画 API 生命周期事件顺序如下：
 ```astro
 <script>
   document.addEventListener("astro:before-swap", (event) => {
-    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
+    event.newDocument.documentElement.dataset.theme =
+    localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/zh-cn/guides/view-transitions.mdx
+++ b/src/content/docs/zh-cn/guides/view-transitions.mdx
@@ -655,17 +655,9 @@ Astro 的视图过渡动画 API 生命周期事件顺序如下：
 此事件可用于在交换发生之前进行更改。事件上的 `newDocument` 属性表示传入的文档。以下示例确保浏览器中的浅色或深色模式偏好设置在新页面中得到保留：
 
 ```astro
-<script is:inline>
-  function setDarkMode(document) {
-    let theme = localStorage.darkMode ? "dark" : "light";
-    document.documentElement.dataset.theme = theme;
-  }
-  
-  setDarkMode(document);
-  
+<script>
   document.addEventListener("astro:before-swap", (event) => {
-    // 传入新文档以设置主题
-    setDarkMode(event.newDocument);
+    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```

--- a/src/content/docs/zh-cn/guides/view-transitions.mdx
+++ b/src/content/docs/zh-cn/guides/view-transitions.mdx
@@ -658,7 +658,7 @@ Astro 的视图过渡动画 API 生命周期事件顺序如下：
 <script>
   document.addEventListener("astro:before-swap", (event) => {
     event.newDocument.documentElement.dataset.theme =
-    localStorage.getItem("darkMode") ? "dark" : "light";
+      localStorage.getItem("darkMode") ? "dark" : "light";
   });
 </script>
 ```


### PR DESCRIPTION
#### Description (required)

closes #12253

Uses the correct `localStorage.getItem()`.
Simplifies the `astro:before-swap` example in view-transitions to make it clearer and focused on the swap only.  
Removes `is:inline` and extra helper functions so readers can see the minimal working example.  

Old example:
```html
<script is:inline>
  function setDarkMode(document) {
    let theme = localStorage.darkMode ? "dark" : "light";
    document.documentElement.dataset.theme = theme;
  }

  setDarkMode(document);

  document.addEventListener("astro:before-swap", (event) => {
    // Pass the incoming document to set the theme on it
    setDarkMode(event.newDocument);
  });
</script>
```


Updated example:

```html
<script>
  document.addEventListener("astro:before-swap", (event) => {
    event.newDocument.documentElement.dataset.theme = localStorage.getItem("darkMode") ? "dark" : "light";
  });
</script>
```

discord: @sharqawycs