### PR TITLE
i18n(fr): improve the wording in the top-level `references` pages

### DIFF
--- a/src/content/docs/fr/reference/adapter-reference.mdx
+++ b/src/content/docs/fr/reference/adapter-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: API de l'Adaptateur d'Astro
+title: API de l'adaptateur d'Astro
 sidebar:
   label: API de l'adaptateur
 i18nReady: true
@@ -61,7 +61,7 @@ export interface AstroAdapterFeatures {
 	 */
 	edgeMiddleware: boolean;
 	/**
-	 * Détermine le type de sortie de construction pour lequel l'adaptateur est destiné. La valeur par défaut est `server`.
+	 * Détermine le type de sortie de compilation pour lequel l'adaptateur est destiné. La valeur par défaut est `server`.
 	 */
 	buildOutput?: 'static' | 'server';
 }
@@ -109,13 +109,13 @@ Les propriétés sont les suivantes :
 * __name__ : Un nom unique pour votre adaptateur, utilisé pour la journalisation.
 * __serverEntrypoint__ : Le point d'entrée pour le rendu du serveur à la demande.
 * __exports__ : Un tableau d'exportations nommées lorsqu'il est utilisé en conjonction avec `createExports` (expliqué ci-dessous).
-* __adapterFeatures__ : Un objet qui active des fonctionnalités spécifiques qui doivent être supportées par l'adaptateur.
-  Ces fonctionnalités vont changer la sortie construite, et l'adaptateur doit implémenter la logique appropriée pour gérer la sortie différente.
-* __supportedAstroFeatures__ : Une liste des caractéristiques intégrées d'Astro. Cela permet à Astro de déterminer quelles fonctionnalités un adaptateur ne peut pas ou ne veut pas supporter afin que les messages d'erreur appropriés puissent être fournis.
+* __adapterFeatures__ : Un objet qui active des fonctionnalités spécifiques qui doivent être prises en charge par l'adaptateur.
+  Ces fonctionnalités vont changer la sortie compilée, et l'adaptateur doit implémenter la logique appropriée pour gérer la sortie différente.
+* __supportedAstroFeatures__ : Une liste des fonctionnalités intégrées d'Astro. Cela permet à Astro de déterminer quelles fonctionnalités un adaptateur ne peut pas ou ne veut pas prendre en charge afin que les messages d'erreur appropriés puissent être fournis.
 
 ### Point d'entrée du serveur
 
-L'API de l'adaptateur Astro tente de fonctionner avec n'importe quel type d'hôte, et offre un moyen flexible de se conformer aux API de l'hôte.
+L'API de l'adaptateur d'Astro tente de fonctionner avec n'importe quel type d'hôte, et offre un moyen flexible de se conformer aux API de l'hôte.
 
 #### Exportations
 
@@ -162,9 +162,9 @@ export default function createIntegration() {
 }
 ```
 
-#### Start
+#### Démarrage
 
-Certains hôtes attendent que vous *démarriez* le serveur vous-mêmes, par exemple en écoutant un port. Pour ces types d'hôtes, l'API de l'adaptateur vous permet d'exporter une fonction `start` qui sera appelée lors de l'exécution du script bundle.
+Certains hôtes s'attendent à ce que vous *démarriez* le serveur vous-même, par exemple en écoutant un port. Pour ces types d'hôtes, l'API de l'adaptateur vous permet d'exporter une fonction `start` qui sera appelée lors de l'exécution du script du bundle.
 
 ```js
 import { App } from 'astro/app';
@@ -180,7 +180,7 @@ export function start(manifest) {
 
 #### `astro/app`
 
-Ce module est utilisé pour afficher les pages qui ont été pré-construites par `astro build`. Astro utilise les objets standards [Request](https://developer.mozilla.org/fr/docs/Web/API/Request) et [Response](https://developer.mozilla.org/fr/docs/Web/API/Response). Les hôtes qui ont une API différente pour les requêtes/réponses doivent convertir ces types dans leur adaptateur.
+Ce module est utilisé pour afficher les pages qui ont été pré-compilées par `astro build`. Astro utilise les objets standards [Request](https://developer.mozilla.org/fr/docs/Web/API/Request) et [Response](https://developer.mozilla.org/fr/docs/Web/API/Response). Les hôtes qui ont une API différente pour les requêtes/réponses doivent convertir ces types dans leur adaptateur.
 
 ```js
 import { App } from 'astro/app';
@@ -206,7 +206,7 @@ Les méthodes suivantes sont proposées :
 **Type :** `(request: Request, options?: RenderOptions) => Promise<Response>`
 </p>
 
-Cette méthode appelle la page Astro qui correspond à la demande, l'affiche et renvoie une promesse à un objet [Response](https://developer.mozilla.org/fr/docs/Web/API/Response). Cette méthode fonctionne également pour les routes API qui n'affichent pas de pages.
+Cette méthode appelle la page Astro qui correspond à la demande, l'affiche et renvoie une promesse à un objet [Response](https://developer.mozilla.org/fr/docs/Web/API/Response). Cette méthode fonctionne également pour les routes d'API qui n'affichent pas de pages.
 
 ```js
 const response = await app.render(request);
@@ -231,8 +231,8 @@ La méthode `app.render()` accepte un argument obligatoire `request`, et un obje
 
 Ajouter ou non automatiquement tous les cookies écrits par `Astro.cookie.set()` aux en-têtes de la réponse.
 
-Lorsqu'ils sont définis à `true`, ils seront ajoutés à l'en-tête `Set-Cookie` de la réponse sous forme de paires clé-valeur séparées par des virgules. Vous pouvez utiliser l'API standard `response.headers.getSetCookie()` pour les lire individuellement.
-Si la valeur est `false` (par défaut), les cookies ne seront disponibles qu'à partir de `App.getSetCookieFromResponse(response)`.
+Lorsque l'option est définie sur `true`, ils seront ajoutés à l'en-tête `Set-Cookie` de la réponse sous forme de paires clé-valeur séparées par des virgules. Vous pouvez utiliser l'API standard `response.headers.getSetCookie()` pour les lire individuellement.
+Lorsque l'option est définie sur `false` (par défaut), les cookies ne seront disponibles qu'à partir de `App.getSetCookieFromResponse(response)`.
 
 ```js
 const response = await app.render(request, { addCookieHeader: true });
@@ -246,7 +246,7 @@ const response = await app.render(request, { addCookieHeader: true });
 **Par défaut :** `request[Symbol.for("astro.clientAddress")]`
 </p>
 
-L'adresse IP du client qui sera disponible en tant que [`Astro.clientAddress`](/fr/reference/api-reference/#clientaddress) dans les pages, et en tant que `ctx.clientAddress` dans les routes de l'API et le middleware.
+L'adresse IP du client qui sera disponible en tant que [`Astro.clientAddress`](/fr/reference/api-reference/#clientaddress) dans les pages, et en tant que `ctx.clientAddress` dans les routes d'API et le middleware.
 
 L'exemple ci-dessous lit l'en-tête `x-forwarded-for` et le transmet comme `clientAddress`. Cette valeur devient disponible pour l'utilisateur en tant que `Astro.clientAddress`.
 
@@ -371,12 +371,12 @@ Une fois que vous avez [publié votre adaptateur sur npm](https://docs.npmjs.com
 Les fonctionnalités Astro permettent à un adaptateur d'indiquer à Astro s'il est en mesure de prendre en charge une fonctionnalité, ainsi que le niveau de prise en charge de l'adaptateur.
 
 Lors de l'utilisation de ces propriétés, Astro
-- exécute une validation spécifique ;
-- émet des informations contextuelles dans les journaux ;
+- exécute une validation spécifique,
+- émet des informations contextuelles dans les journaux.
 
 Ces opérations sont exécutées en fonction des fonctionnalités prises en charge ou non, de leur niveau de prise en charge, de la [quantité de journalisation souhaitée](#suppress) et de la configuration propre à l'utilisateur.
 
-La configuration suivante indique à Astro que cet adaptateur dispose d'un support expérimental pour le service d'image intégré optimisé par Sharp :
+La configuration suivante indique à Astro que cet adaptateur dispose d'une prise en charge expérimentale pour le service d'image intégré optimisé par Sharp :
 
 ```js title="my-adapter.mjs" ins={9-11}
 export default function createIntegration() {
@@ -419,7 +419,7 @@ export default function createIntegration() {
           supportedAstroFeatures: {
             sharpImageService: {
               support: 'limited',
-              message: 'This adapter has limited support for Sharp. Certain features may not work as expected.'
+              message: 'Cet adaptateur a une prise en charge limitée pour Sharp. Certaines fonctionnalités peuvent ne pas fonctionner comme prévu.'
             }
           } 
         });
@@ -500,9 +500,9 @@ Un ensemble de fonctionnalités qui modifient la sortie des fichiers émis. Lors
 **Type :** `boolean`
 </p>
 
-Définit si un code middleware de rendu à la demande sera regroupé lors de la construction.
+Définit si un code middleware de rendu à la demande sera regroupé lors de la compilation.
 
-Lorsque cette option est activée, elle empêche le code middleware d'être regroupé et importé par toutes les pages pendant la construction :
+Lorsque cette option est activée, elle empêche le code middleware d'être regroupé et importé par toutes les pages pendant la compilation :
 
 ```js title="my-adapter.mjs" ins={9-11}
 export default function createIntegration() {
@@ -639,7 +639,7 @@ export function createExports(manifest: SSRManifest) {
 <Since v="5.0.0" />
 </p>
 
-Cette propriété vous permet de forcer une forme de sortie spécifique pour la construction. Cela peut être utile pour les adaptateurs qui fonctionnent uniquement avec un type de sortie spécifique, par exemple, votre adaptateur peut s'attendre à un site web statique, mais utilise un adaptateur pour créer des fichiers spécifiques à l'hôte. La valeur par défaut est `server` si elle n'est pas spécifiée.
+Cette propriété vous permet de forcer une forme de sortie spécifique pour la compilation. Cela peut être utile pour les adaptateurs qui fonctionnent uniquement avec un type de sortie spécifique, par exemple, votre adaptateur peut s'attendre à un site web statique, mais utilise un adaptateur pour créer des fichiers spécifiques à l'hôte. La valeur par défaut est `server` si elle n'est pas spécifiée.
 
 ```js title="my-adapter.mjs" ins={9-11}
 export default function createIntegration() {

--- a/src/content/docs/fr/reference/api-reference.mdx
+++ b/src/content/docs/fr/reference/api-reference.mdx
@@ -21,7 +21,7 @@ L'objet global `Astro` est disponible pour tous les fichiers `.astro`. Utilisez 
 
 ## L'objet de contexte
 
-Les propriétés suivantes sont disponibles sur le global `Astro` (par exemple `Astro.props`, `Astro.redirect()`) et sont également disponibles sur l'objet de contexte (par exemple `context.props`, `context.redirect()`) passé aux fonctions de point de terminaison et au middleware.
+Les propriétés suivantes sont disponibles dans l'objet global `Astro` (par exemple `Astro.props`, `Astro.redirect()`) et sont également disponibles dans l'objet de contexte (par exemple `context.props`, `context.redirect()`) passé aux fonctions de point de terminaison et au middleware.
 
 ### `props`
 
@@ -46,10 +46,10 @@ import Heading from '../components/Heading.astro';
 <Heading title="Mon tout premier article" date="09 Août 2022" />
 ```
 
-<ReadMore>En savoir plus sur la façon dont les [Mises en page Markdown et MDX](/fr/guides/markdown-content/#propriété-layout-du-frontmatter) gèrent les propriétés.</ReadMore>
+<ReadMore>En savoir plus sur la façon dont les [mises en page Markdown et MDX](/fr/guides/markdown-content/#propriété-layout-du-frontmatter) gèrent les propriétés.</ReadMore>
 
 
-L'objet `props` contient également tous les `props` transmis depuis `getStaticPaths()` lors du rendu des routes statiques.
+L'objet `props` contient également toutes les `props` transmises depuis `getStaticPaths()` lors du rendu des routes statiques.
 
 <Tabs>
   <TabItem label="Astro.props">
@@ -93,7 +93,7 @@ Voir aussi : [Transmission de données avec `props`](/fr/reference/routing-refe
 
 ### `params`
 
-`params` est un objet contenant les valeurs des segments de route dynamiques correspondant à une requête. Ses clés doivent correspondre aux [paramètres](/fr/guides/routing/#routes-dynamiques) du chemin d'accès à la page ou au fichier de point de terminaison.
+`params` est un objet contenant les valeurs des segments de route dynamiques correspondant à une requête. Ses propriétés doivent correspondre aux [paramètres](/fr/guides/routing/#routes-dynamiques) du chemin d'accès à la page ou au fichier de point de terminaison.
 
 Dans les versions statiques, il s'agira des `params` renvoyés par `getStaticPaths()` utilisés pour le pré-rendu [des routes dynamiques](/fr/guides/routing/#routes-dynamiques).
 
@@ -167,7 +167,7 @@ Voir aussi : [`params`](/fr/reference/routing-reference/#params)
 
 `Astro.url` équivaut à faire `new URL(Astro.request.url)`.
 
-`url` sera une URL `localhost` en mode dev. Lors de la création d'un site, les routes pré-rendues recevront une URL basée sur les options [`site`](/fr/reference/configuration-reference/#site) et [`base`](/fr/reference/configuration-reference/#base). Si `site` n'est pas configuré, les pages pré-rendues recevront également une URL `localhost` pendant la construction.
+`url` sera une URL `localhost` en mode dev. Lors de la création d'un site, les routes pré-rendues recevront une URL basée sur les options [`site`](/fr/reference/configuration-reference/#site) et [`base`](/fr/reference/configuration-reference/#base). Si `site` n'est pas configuré, les pages pré-rendues recevront également une URL `localhost` pendant la compilation.
 
 ```astro title="src/pages/index.astro" "Astro.url"
 <h1>L'URL actuelle est : {Astro.url}</h1>
@@ -175,7 +175,7 @@ Voir aussi : [`params`](/fr/reference/routing-reference/#params)
 <h1>L'origine de l'URL actuelle est : {Astro.url.origin}</h1>
 ```
 
-Vous pouvez également utiliser `url` pour créer de nouvelles URL en le passant comme argument à [`new URL()`](https://developer.mozilla.org/fr/docs/Web/API/URL/URL).
+Vous pouvez également utiliser `url` pour créer de nouvelles URL en la passant comme argument à [`new URL()`](https://developer.mozilla.org/fr/docs/Web/API/URL/URL).
 
 ```astro title="src/pages/index.astro" "Astro.url"
 ---
@@ -317,7 +317,7 @@ Vous pouvez utiliser cette propriété pour exécuter une logique conditionnelle
 </Tabs>
 
 :::note
-Sur les pages pré-rendues, `request.url` ne contient pas de paramètres de recherche, comme `?type=new`, car il n'est pas possible de les déterminer à l'avance lors des constructions statiques. Cependant, `request.url` contient des paramètres de recherche pour les pages rendues à la demande car ils peuvent être déterminés à partir d'une requête serveur.
+Sur les pages pré-rendues, `request.url` ne contient pas de paramètres de recherche, comme `?type=new`, car il n'est pas possible de les déterminer à l'avance lors des générations statiques. Cependant, `request.url` contient des paramètres de recherche pour les pages rendues à la demande car ils peuvent être déterminés à partir d'une requête serveur.
 :::
 
 ### `response`
@@ -459,7 +459,7 @@ Utilisez un type `URL` lorsque vous devez construire le chemin de l'URL pour la 
   </TabItem>
 </Tabs>
 
-Utilisez un type `Request` pour un contrôle complet de la `Request` envoyée au serveur pour le nouveau chemin. L'exemple suivant envoie une requête pour afficher la page parent tout en fournissant des en-têtes :
+Utilisez un type `Request` pour un contrôle complet de la requête (`Request`) envoyée au serveur pour le nouveau chemin. L'exemple suivant envoie une requête pour afficher la page parent tout en fournissant des en-têtes :
 
 <Tabs syncKey="rewrite">
   <TabItem label="Astro.rewrite()">
@@ -572,7 +572,7 @@ Les composants Astro et les points de terminaison de l'API peuvent lire les vale
 
 `preferredLocale` est une valeur calculée pour trouver la meilleure correspondance entre les préférences linguistiques du navigateur de votre visiteur et les paramètres régionaux pris en charge par votre site.
 
-Elle est calculée en vérifiant les paramètres régionaux configurés dans votre tableau [`i18n.locales`](/fr/reference/configuration-reference/#i18nlocales) et les paramètres régionaux pris en charge par le navigateur de l'utilisateur via l'en-tête `Accept-Language`. Cette valeur a pour valeur `undefined` si aucune correspondance de ce type n'existe.
+Elle est calculée en vérifiant les paramètres régionaux configurés dans votre tableau [`i18n.locales`](/fr/reference/configuration-reference/#i18nlocales) et les paramètres régionaux pris en charge par le navigateur de l'utilisateur via l'en-tête `Accept-Language`. Cette valeur est `undefined` si aucune correspondance de ce type n'existe.
 
 Cette propriété est uniquement disponible pour les routes rendues à la demande et ne peut pas être utilisée sur des pages statiques pré-rendues.
 
@@ -702,9 +702,9 @@ Définit la clé du cookie (`key`) sur la valeur donnée. Cela tentera de conver
 **Type :** `(key: string, options?: AstroCookieDeleteOptions) => void`
 </p>
 
-Invalide un cookie en fixant la date d'expiration dans le passé (0 en temps Unix).
+Invalide un cookie en définissant la date d'expiration dans le passé (0 en temps Unix).
 
-Une fois qu'un cookie est « supprimé » (expiré), `Astro.cookies.has()` retournera `false` et `Astro.cookies.get()` retournera un [`AstroCookie`](#type-astrocookie) avec une `valeur` de `undefined`. Les options disponibles lors de la suppression d'un cookie sont : `domain`, `path`, `httpOnly`, `sameSite`, et `secure`.
+Une fois qu'un cookie est « supprimé » (expiré), `Astro.cookies.has()` retournera `false` et `Astro.cookies.get()` retournera un [`AstroCookie`](#type-astrocookie) avec une valeur (`value`) indéfinie (`undefined`). Les options disponibles lors de la suppression d'un cookie sont : `domain`, `path`, `httpOnly`, `sameSite`, et `secure`.
 
 ##### `cookies.merge()`
 
@@ -791,7 +791,7 @@ Permet de personnaliser la manière dont un cookie est désérialisé en une val
 **Type :** `string`
 </p>
 
-Spécifie le domaine. Si aucun domaine n'est défini, la plupart des clients interpréteront l'application au domaine actuel.
+Spécifie le domaine. Si aucun domaine n'est défini, la plupart des clients interpréteront cela comme s'appliquant au domaine actuel.
 
 ##### `expires`
 
@@ -1050,11 +1050,11 @@ Charge une session par identifiant. En utilisation normale, une session est char
 </Tabs>
 
 
-### Propriétés d'objet obsolètes
+### Propriétés d'objet dépréciées
 
 #### `Astro.glob()`
 
-:::caution[Obsolète depuis la version 5.0]
+:::caution[Dépréciée depuis la version 5.0]
 Utilisez [`import.meta.glob` de Vite](https://vite.dev/guide/features.html#glob-import) pour interroger les fichiers de projet.
 
 `Astro.glob('../pages/post/*.md')` peut être remplacé par :

--- a/src/content/docs/fr/reference/astro-syntax.mdx
+++ b/src/content/docs/fr/reference/astro-syntax.mdx
@@ -8,10 +8,10 @@ La syntaxe des composants Astro est un sur-ensemble de HTML. La syntaxe a été 
 
 ## Expressions type JSX
 
-Vous pouvez définir des variables JavaScript locales à l'intérieur du script du composant frontmatter entre les deux barrières de code (`---`) d'un composant Astro. Vous pouvez ensuite injecter ces variables dans le modèle HTML du composant à l'aide d'expressions de type JSX !
+Vous pouvez définir des variables JavaScript locales dans le script du composant à l'intérieur du frontmatter défini par les deux délimiteurs de code (`---`) d'un composant Astro. Vous pouvez ensuite injecter ces variables dans le modèle HTML du composant à l'aide d'expressions de type JSX !
 
 :::note[Dynamique vs réactif]
-En utilisant cette approche, vous pouvez inclure des valeurs **dynamiques** qui sont calculées dans le frontmatter. Mais une fois incluses, ces valeurs ne sont pas **réactives** et ne changeront jamais. Les composants Astro sont des templates qui ne s’exécutent qu’une seule fois, au moment de la compilation.
+En utilisant cette approche, vous pouvez inclure des valeurs **dynamiques** qui sont calculées dans le frontmatter. Mais une fois incluses, ces valeurs ne sont pas **réactives** et ne changeront jamais. Les composants Astro sont des modèles qui ne s’exécutent qu’une seule fois, lors de l'étape de rendu.
 
 Voir ci-dessous pour plus d’exemples de [différences entre Astro et JSX](#différences-entre-astro-et-jsx).
 :::
@@ -25,7 +25,7 @@ Des variables locales peuvent être ajoutées dans le HTML en utilisant la synta
 const name = "Astro";
 ---
 <div>
-  <h1>Bonjour {name}!</h1>  <!-- Affichera <h1>Bonjour Astro!</h1> -->
+  <h1>Bonjour {name} !</h1>  <!-- Affichera <h1>Bonjour Astro !</h1> -->
 </div>
 ```
 
@@ -37,7 +37,7 @@ Les variables locales peuvent être utilisées entre accolades pour transmettre 
 ---
 const name = "Astro";
 ---
-<h1 class={name}>Les expressions d'attributs sont supportées</h1>
+<h1 class={name}>Les expressions d'attributs sont prises en charge</h1>
 
 <MyComponent templateLiteralNameAttribute={`MonNomEst${name}`} />
 ```
@@ -46,7 +46,7 @@ const name = "Astro";
 Les attributs HTML seront convertis en chaînes de caractères, il n'est donc pas possible de passer des fonctions et des objets aux éléments HTML. 
 Par exemple, vous ne pouvez pas assigner un gestionnaire d'événements à un élément HTML dans un composant Astro :
 
-```astro title="dont-do-this.astro"
+```astro title="ne-faites-pas-ca.astro"
 ---
 function handleClick () {
     console.log("bouton cliqué !");
@@ -58,7 +58,7 @@ function handleClick () {
 
 À la place, utilisez un script côté client pour ajouter le gestionnaire d'événements, comme vous le feriez en JavaScipt pure :
 
-```astro title="do-this-instead.astro"
+```astro title="faites-ceci-a-la-place.astro"
 ---
 ---
 <button id="button">Cliquez</button>
@@ -117,7 +117,7 @@ Lors de l'utilisation de balises dynamiques :
 
 - **Les directives d'hydratation ne sont pas prises en charge.** Lorsque vous utilisez [les directives d'hydratation `client:*`](/fr/guides/framework-components/#hydratation-des-composants-interactifs), Astro doit savoir quels composants regrouper pour la production, et le modèle de balise dynamique empêche cela de fonctionner.
 
-- **La [directive `define:vars`](/fr/reference/directives-reference/#definevars) n'est pas supportée.** Si vous ne pouvez pas envelopper votre balise dans un élément conteneur (ex. `<div>`), alors vous pouvez ajouter ``style={`--maVariable:${valeur}`}`` à votre balise.
+- **La [directive `define:vars`](/fr/reference/directives-reference/#definevars) n'est pas prise en charge.** Si vous ne pouvez pas envelopper votre balise dans un élément conteneur (ex. `<div>`), alors vous pouvez ajouter ``style={`--maVariable:${valeur}`}`` à votre balise.
 
 ### Fragments
 
@@ -151,10 +151,10 @@ Contrairement au JavaScript et au JSX, un composant Astro peut afficher plusieur
 
 ```astro title="src/components/RootElements.astro"
 ---
-// Template avec plusieurs éléments
+// Modèle avec plusieurs éléments
 ---
 <p>Pas besoin d'envelopper les éléments dans un élément conteneur.</p>
-<p>Astro supporte plusieurs éléments racine dans un template</p>
+<p>Astro prend en charge plusieurs éléments racine dans un modèle</p>
 ```
 
 #### Commentaires
@@ -173,11 +173,11 @@ Les commentaires de type HTML seront inclus dans le DOM du navigateur, tandis qu
 :::
 
 
-## Component utilities
+## Utilitaires de composants
 
 ### `Astro.slots`
 
-`Astro.slots` contient des fonctions utilitaires pour modifier les enfants passés en tant que slots d'un composant Astro.
+`Astro.slots` contient des fonctions utilitaires pour modifier les enfants passés en tant que slots dans un composant Astro.
 
 #### `Astro.slots.has()`
 
@@ -208,7 +208,7 @@ Vous pouvez vérifier si le contenu d'un slot spécifique existe avec `Astro.slo
 **Type :** `(slotName: string, args?: any[]) => Promise<string>`
 </p>
 
-Vous pouvez restituer de manière asynchrone le contenu d'un emplacement dans une chaîne HTML à l'aide de `Astro.slots.render()`.
+Vous pouvez restituer de manière asynchrone le contenu d'un slot dans une chaîne HTML à l'aide de `Astro.slots.render()`.
 
 ```astro
 ---
@@ -218,12 +218,12 @@ const html = await Astro.slots.render('default');
 ```
 
 :::note
-Ceci est destiné aux cas d'utilisation avancés ! Dans la plupart des cas, il est plus simple de restituer le contenu des emplacements avec [l'élément `<slot />`](/fr/basics/astro-components/#les-slots).
+Ceci est destiné aux cas d'utilisation avancés ! Dans la plupart des cas, il est plus simple de restituer le contenu des slots avec [l'élément `<slot />`](/fr/basics/astro-components/#les-slots).
 :::
 
 `Astro.slots.render()` accepte éventuellement un second argument : un tableau de paramètres qui seront transmis à tous les enfants de la fonction. Cela peut être utile pour les composants utilitaires personnalisés.
 
-Par exemple, ce composant `<Shout />` convertit sa propriété `message` en majuscules et la transmet à l'emplacement par défaut :
+Par exemple, ce composant `<Shout />` convertit sa propriété `message` en majuscules et la transmet au slot par défaut :
 
 ```astro title="src/components/Shout.astro" "await Astro.slots.render('default', [message])"
 ---
@@ -249,7 +249,7 @@ import Shout from "../components/Shout.astro";
 <!-- rendu en tant que <div>SLOTS!</div> -->
 ```
 
-Les fonctions de rappel peuvent être transmises à des emplacements nommés à l'intérieur d'une balise d'élément HTML enveloppante avec un attribut `slot`. Cet élément est uniquement utilisé pour transférer la fonction de rappel à un emplacement nommé et ne sera pas rendu sur la page.
+Les fonctions de rappel peuvent être transmises à des slots nommés à l'intérieur d'une balise d'élément HTML enveloppante avec un attribut `slot`. Cet élément est uniquement utilisé pour transférer la fonction de rappel à un slot nommé et ne sera pas affiché sur la page.
 
 ```astro
 <Shout message="slots!">
@@ -273,7 +273,7 @@ const { items } = Astro.props;
 <ul class="nested-list">
   {items.map((item) => (
     <li>
-      <!-- S'il existe une structure de données imbriquée, nous rendons `<Astro.self>` -->
+      <!-- S'il existe une structure de données imbriquée, nous restituons `<Astro.self>` -->
       <!-- et pouvons transmettre des props avec l'appel récursif -->
       {Array.isArray(item) ? (
         <Astro.self items={item} />

--- a/src/content/docs/fr/reference/content-loader-reference.mdx
+++ b/src/content/docs/fr/reference/content-loader-reference.mdx
@@ -12,7 +12,7 @@ L'API du chargeur de contenu d'Astro (Content Loader) vous permet de charger vos
 
 Les chargeurs Astro vous permettent de charger des données dans des [collections de contenu](/fr/guides/content-collections/), qui peuvent ensuite être utilisées dans des pages et des composants. Les [chargeurs intégrés `glob()` et `file()`](/fr/guides/content-collections/#chargeurs-intégrés) sont utilisés pour charger le contenu du système de fichiers, et vous pouvez créer vos propres chargeurs pour charger le contenu à partir d'autres sources.
 
-Chaque collection a besoin [d'un chargeur défini dans son schéma](/fr/guides/content-collections/#définir-le-chargeur-de-collection-loader). Vous pouvez définir un chargeur en ligne dans le fichier `src/content.config.ts` de votre projet, partager un chargeur entre plusieurs collections, ou même [publier votre chargeur sur NPM en tant que paquet](/fr/reference/publish-to-npm/) à partager avec d'autres et à inclure dans notre bibliothèque d'intégrations.
+Chaque collection a besoin [d'un chargeur défini dans son schéma](/fr/guides/content-collections/#définir-le-chargeur-de-collection-loader). Vous pouvez définir un chargeur incorporé au fichier `src/content.config.ts` de votre projet, partager un chargeur entre plusieurs collections, ou même [publier votre chargeur sur NPM en tant que paquet](/fr/reference/publish-to-npm/) à partager avec d'autres et à inclure dans notre bibliothèque d'intégrations.
 
 ## Chargeurs intégrés
 
@@ -63,9 +63,9 @@ const authors = defineCollection({
 **Type :** `string | string[]`
 </p>
 
-La propriété `pattern` accepte une chaîne de caractères ou un tableau de chaînes de caractères utilisant la correspondance globale (par exemple, wildcards, globstars). Les motifs doivent être relatifs au répertoire de base des fichiers d'entrée à comparer.
+La propriété `pattern` accepte une chaîne de caractères ou un tableau de chaînes de caractères utilisant une correspondance glob (par exemple, des caractères génériques ou des caractères d'expansion glob). Les motifs doivent être relatifs au répertoire de base des fichiers d'entrée à comparer.
 
-Pour en savoir plus sur la syntaxe à utiliser, consultez la [documentation micromatch](https://github.com/micromatch/micromatch#matching-features). Vous pouvez également vérifier la validité de votre modèle à l'aide d'un outil en ligne tel que le [DigitalOcean Glob Tool](https://www.digitalocean.com/community/tools/glob).
+Pour en savoir plus sur la syntaxe à utiliser, consultez la [documentation de micromatch](https://github.com/micromatch/micromatch#matching-features). Vous pouvez également vérifier la validité de votre motif à l'aide d'un outil en ligne tel que l'[outil Glob de DigitalOcean](https://www.digitalocean.com/community/tools/glob).
 
 #### `base`
 
@@ -75,7 +75,7 @@ Pour en savoir plus sur la syntaxe à utiliser, consultez la [documentation micr
 **Par défaut :** `"."`
 </p>
 
-Un chemin relatif ou [URL](https://developer.mozilla.org/fr/docs/Web/API/URL) vers le répertoire à partir duquel résoudre le `pattern`.
+Un chemin relatif ou une [URL](https://developer.mozilla.org/fr/docs/Web/API/URL) vers le répertoire à partir duquel résoudre le `pattern`.
 
 #### `generateId()`
 
@@ -146,15 +146,15 @@ Un objet optionnel avec les propriétés suivantes :
 **Type :** `(text: string) => Record<string, Record<string, unknown>> | Array<Record<string, unknown>>`
 </p>
 
-Une fonction de rappel pour créer une collection à partir du contenu d'un fichier. Utilisez-la lorsque vous avez besoin de traiter des fichiers non supportés par défaut (par exemple `.csv`) ou lorsque vous utilisez des [documents `.json` imbriqués](/fr/guides/content-collections/#documents-json-imbriqués).
+Une fonction de rappel pour créer une collection à partir du contenu d'un fichier. Utilisez-la lorsque vous avez besoin de traiter des fichiers non pris en charge par défaut (par exemple `.csv`) ou lorsque vous utilisez des [documents `.json` imbriqués](/fr/guides/content-collections/#documents-json-imbriqués).
 
 ## Types de chargeurs
 
 Les chargeurs peuvent être définis soit comme une simple fonction qui renvoie un tableau d'entrées, soit avec l'API du chargeur de contenu sous forme d'objet plus puissante pour plus de contrôle sur le processus de chargement.
 
-### Chargeurs en ligne
+### Chargeurs incorporés
 
-Un chargeur en ligne est une fonction asynchrone qui renvoie un tableau ou un objet contenant des entrées. Utilisez-le pour les chargeurs simples, en particulier ceux qui sont définis en ligne dans le fichier `src/content.config.ts`.
+Un chargeur incorporé au document est une fonction asynchrone qui renvoie un tableau ou un objet contenant des entrées. Utilisez-le pour les chargeurs simples, en particulier ceux qui sont définis au sein du fichier `src/content.config.ts`.
 
 La fonction peut être asynchrone et doit renvoyer soit un tableau d'entrées contenant chacune un champ `id` unique, soit un objet où chaque clé est un ID unique et chaque valeur est l'entrée. Chaque fois que le chargeur est appelé, il efface le magasin et recharge toutes les entrées.
 
@@ -176,9 +176,9 @@ const countries = defineCollection({
 
 ### Chargeurs sous forme d'objet
 
-Un chargeur est un objet doté d'une méthode `load()` qui est appelée au moment de la construction pour récupérer des données et mettre à jour le magasin de données. Il permet de mettre à jour les entrées de manière incrémentielle ou de vider le magasin uniquement lorsque cela est nécessaire. Il peut également définir un schéma pour les entrées, qui peut être utilisé pour valider les données et générer des types statiques.
+Un chargeur est un objet doté d'une méthode `load()` qui est appelée au moment de la compilation pour récupérer des données et mettre à jour le magasin de données. Il permet de mettre à jour les entrées de manière incrémentielle ou de vider le magasin uniquement lorsque cela est nécessaire. Il peut également définir un schéma pour les entrées, qui peut être utilisé pour valider les données et générer des types statiques.
 
-Le modèle recommandé consiste à définir une fonction qui accepte les options de configuration et renvoie l'objet chargeur, de la même manière que vous définiriez normalement une intégration Astro ou un plugin Vite.
+Le modèle recommandé consiste à définir une fonction qui accepte les options de configuration et renvoie l'objet chargeur, de la même manière que vous définiriez normalement une intégration Astro ou un module d'extension Vite.
 
 
 ```ts title=loader.ts
@@ -222,9 +222,9 @@ const blog = defineCollection({
 });  
 ```
 
-## API du chargeur d'objets
+## API des chargeurs sous forme d'objet
 
-L'API pour les [chargeurs en ligne](#chargeurs-en-ligne) est très simple et est présentée ci-dessus. Cette section présente l'API permettant de définir un chargeur sous forme d'objet.
+L'API pour les [chargeurs incorporés](#chargeurs-incorporés) est très simple et est présentée ci-dessus. Cette section présente l'API permettant de définir un chargeur sous forme d'objet.
 
 ### L'objet `Loader`
 
@@ -246,7 +246,7 @@ Un nom unique pour le chargeur, utilisé dans les logs et [pour le chargement co
 **Type** : <code>(context: <a href="#loadercontext">LoaderContext</a>) => Promise&lt;void&gt;</code>
 </p>
 
-Une fonction asynchrone qui est appelée au moment de la construction pour charger les données et mettre à jour le magasin. Voir [`LoaderContext`](#loadercontext) pour plus d'informations.
+Une fonction asynchrone qui est appelée au moment de la compilation pour charger les données et mettre à jour le magasin. Voir [`LoaderContext`](#loadercontext) pour plus d'informations.
 
 #### `schema`
 
@@ -257,7 +257,7 @@ Une fonction asynchrone qui est appelée au moment de la construction pour charg
 
 Un [schéma Zod](/fr/guides/content-collections/#définition-des-types-de-données-avec-zod) facultatif qui définit la forme des entrées. Il est utilisé à la fois pour valider les données et pour générer des types TypeScript pour la collection.
 
-Si une fonction est fournie, elle sera appelée au moment de la construction avant `load()` pour générer le schéma. Vous pouvez l'utiliser pour générer dynamiquement le schéma en fonction des options de configuration ou en introspectant une API.
+Si une fonction est fournie, elle sera appelée au moment de la compilation avant `load()` pour générer le schéma. Vous pouvez l'utiliser pour générer dynamiquement le schéma en fonction des options de configuration ou en introspectant une API.
 
 ### `LoaderContext`
 
@@ -288,7 +288,7 @@ Une magasin de données pour stocker les données réelles. Utilisez-le pour met
 **Type** : `MetaStore`
 </p>
 
-Un magasin de clés-valeurs avec une portée limitée à la collection, conçu pour des choses comme la synchronisation des jetons et des heures de dernière modification. Ces métadonnées sont conservées entre les constructions avec les données de la collection, mais ne sont disponibles qu'à l'intérieur du chargeur.
+Un magasin de clés-valeurs avec une portée limitée à la collection, conçu pour des choses comme la synchronisation des jetons et des heures de dernière modification. Ces métadonnées sont conservées entre les compilations avec les données de la collection, mais ne sont disponibles qu'à l'intérieur du chargeur.
 
 ```ts
 const lastModified = meta.get("lastModified");
@@ -303,7 +303,7 @@ meta.set("lastModified", new Date().toISOString());
 **Type** : [`AstroIntegrationLogger`](/fr/reference/integrations-reference/#astrointegrationlogger)
 </p>
 
-Un enregistreur qui peut être utilisé pour enregistrer des messages sur la console. Utilisez-le à la place de `console.log` pour des journaux plus utiles qui incluent le nom du chargeur dans le message de journal. Voir [`AstroIntegrationLogger`](/fr/reference/integrations-reference/#astrointegrationlogger) pour plus d'informations.
+Un enregistreur qui peut être utilisé pour enregistrer des messages dans la console. Utilisez-le à la place de `console.log` pour des enregistrements plus utiles qui incluent le nom du chargeur dans le message affiché. Voir [`AstroIntegrationLogger`](/fr/reference/integrations-reference/#astrointegrationlogger) pour plus d'informations.
 
 #### `config`
 
@@ -312,7 +312,7 @@ Un enregistreur qui peut être utilisé pour enregistrer des messages sur la con
 **Type** : `AstroConfig`
 </p>
 
-L'objet de configuration Astro complet et résolu avec toutes les valeurs par défaut appliquées. Consultez [la référence de configuration](/fr/reference/configuration-reference/) pour plus d'informations.
+L'objet de configuration d'Astro complet et résolu avec toutes les valeurs par défaut appliquées. Consultez [la référence de configuration](/fr/reference/configuration-reference/) pour plus d'informations.
 
 #### `parseData`
 
@@ -363,7 +363,7 @@ Restitue une chaîne Markdown en HTML, renvoyant un objet `RenderedContent`.
 
 Cela vous permet de restituer le contenu Markdown directement dans vos chargeurs en utilisant le même traitement Markdown que le chargeur `glob` intégré d'Astro et donne accès à la fonction `render()` et au composant `<Content />` pour [la restitution du contenu](/fr/guides/content-collections/#restitution-du-contenu).
 
-Affecter cet objet au champ [renderer](#rendered) de l'objet [DataEntry](#dataentry) pour permettre aux utilisateurs d'[afficher le contenu dans une page](/fr/guides/content-collections/#restitution-du-contenu).
+Affecter cet objet au champ [`rendered`](#rendered) de l'objet [DataEntry](#dataentry) pour permettre aux utilisateurs d'[afficher le contenu dans une page](/fr/guides/content-collections/#restitution-du-contenu).
 
 ```ts title=loader.ts {16-17}
 import type { Loader } from 'astro/loaders';
@@ -440,7 +440,7 @@ export function feedLoader({ url }): Loader {
 
 En mode dev, il s'agit d'un observateur de système de fichiers qui peut être utilisé pour déclencher des mises à jour. Voir [`ViteDevServer`](https://vite.dev/guide/api-javascript.html#vitedevserver) pour plus d'informations.
 
-```ts title="Extraire du chargeur file()" {8-13}
+```ts title="Extrait du chargeur file()" {8-13}
 return {
   name: 'file-loader',
   load: async ({ config, store, watcher }) => {
@@ -661,7 +661,7 @@ Le format de l'objet `RenderedContent` est :
 		imagePaths?: Array<string>;
 		/** Tous les titres présents dans ce fichier. Renvoyé comme `headings` par `render()` */
 		headings?: MarkdownHeading[];
-		/** Frontmatter brut, analysé à partir du fichier. Cela peut inclure des données provenant de plugins Remark. */
+		/** Frontmatter brut, analysé à partir du fichier. Cela peut inclure des données provenant de modules d'extension Remark. */
 		frontmatter?: Record<string, any>;
 		/** Toute autre métadonnée présente dans ce fichier. */
 		[key: string]: unknown;

--- a/src/content/docs/fr/reference/image-service-reference.mdx
+++ b/src/content/docs/fr/reference/image-service-reference.mdx
@@ -1,29 +1,29 @@
 ---
-title: API de Service d'images
+title: API des services d'images
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
 
-`astro:assets` a été conçu pour permettre à n'importe quel service d'optimisation d'images de construire facilement un service au-dessus d'Astro.
+`astro:assets` a été conçu pour permettre à tout service d'optimisation d'images de créer facilement un service reposant sur Astro.
 
 ## Qu'est-ce qu'un service d'images ?
 
 Astro propose deux types de services d'images : Local et Externe.
 
-- **Les services locaux** gèrent les transformations d'image directement lors de la création pour les sites statiques, ou lors de l'exécution, à la fois en mode développement et pour le rendu à la demande. Il s'agit souvent de wrappers autour de bibliothèques telles que Sharp, ImageMagick ou Squoosh. En mode développement et dans les routes de production rendues à la demande, les services locaux utilisent un point de terminaison API pour effectuer la transformation.
-- Les **services externes** pointent vers des URL et peuvent ajouter la prise en charge de services tels que Cloudinary, Vercel ou tout autre serveur conforme à [RIAPI](https://github.com/riapi/riapi).
+- **Les services locaux** gèrent les transformations d'image directement lors de la compilation pour les sites statiques, ou lors de l'exécution, à la fois en mode développement et pour le rendu à la demande. Il s'agit souvent d'enveloppes autour de bibliothèques telles que Sharp, ImageMagick ou Squoosh. En mode développement et pour les routes de production rendues à la demande, les services locaux utilisent un point de terminaison d'API pour effectuer la transformation.
+- Les **services externes** pointent vers des URL et peuvent ajouter la prise en charge de services tels que Cloudinary, Vercel ou tout autre serveur compatible avec [RIAPI](https://github.com/riapi/riapi).
 
-## Construire à l'aide de l'API d'un service d'image
+## Construire à l'aide de l'API des services d'images
 
 Les définitions de service prennent la forme d'un objet par défaut exporté avec diverses méthodes requises ("hooks").
 
-Les services externes fournissent un `getURL()` qui pointe vers le `src` de la balise `<img>` de sortie.
+Les services externes fournissent une méthode `getURL()` qui pointe vers la `src` de la balise `<img>` après compilation.
 
 Les services locaux fournissent une méthode `transform()` pour effectuer des transformations sur votre image, et les méthodes `getURL()` et `parseURL()` pour utiliser un point de terminaison pour le mode dev et lors du rendu à la demande.
 
-Les deux types de services peuvent fournir `getHTMLAttributes()` pour déterminer les autres attributs de la sortie `<img>` et `validateOptions()` pour valider et augmenter les options passées.
+Les deux types de services peuvent fournir `getHTMLAttributes()` pour déterminer les autres attributs de la sortie `<img>` et `validateOptions()` pour valider et augmenter les options transmises.
 
-### Services Externes
+### Services externes
 
 Un service externe pointe vers une URL distante à utiliser comme attribut `src` de la balise `<img>` finale. Cette URL distante est responsable du téléchargement, de la transformation et du renvoi de l'image.
 
@@ -59,9 +59,9 @@ const service: ExternalImageService = {
 export default service;
 ```
 
-### Services Local
+### Services locaux
 
-Pour créer votre propre service local, vous pouvez pointer vers le [built-in point de terminaison](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/endpoint/generic.ts) (`/_image`), ou vous pouvez également créer votre propre point de terminaison qui peut appeler les méthodes du service.
+Pour créer votre propre service local, vous pouvez pointer vers le [point de terminaison intégré](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/endpoint/generic.ts) (`/_image`), ou vous pouvez également créer votre propre point de terminaison qui peut appeler les méthodes du service.
 
 ```js
 import type { LocalImageService, AstroConfig } from "astro";
@@ -74,9 +74,9 @@ const service: LocalImageService = {
 		options.height && searchParams.append('h', options.height.toString());
 		options.quality && searchParams.append('q', options.quality.toString());
 		options.format && searchParams.append('f', options.format);
-    return `/my_custom_endpoint_that_transforms_images?${searchParams}`;
-    // Vous pouvez également utiliser le point de terminaison intégré, qui appellera vos fonctions parseURL et transform :
-    // retourne `/_image?${searchParams}`;
+    return `/mon_point_de_terminaison_personnalise_qui_transforme_les_images?${searchParams}`;
+    // Ou utilisez le point de terminaison intégré, qui appellera vos fonctions parseURL et transform :
+    // return `/_image?${searchParams}`;
   },
   parseURL(url: URL, imageConfig) {
     return {
@@ -122,17 +122,17 @@ const service: LocalImageService = {
 export default service;
 ```
 
-Au moment de la construction des sites statiques et des routes pré-rendues, `<Image />` et `getImage(options)` appellent la fonction `transform()`. Ces derniers transmettent les options soit par les attributs du composant, soit par un argument `options`, respectivement. Les images transformées seront compilées dans un dossier `dist/_astro`. Leurs noms de fichiers contiendront un hachage des propriétés passées à `propertiesToHash`. Cette propriété est optionnelle et sera par défaut `['src', 'width', 'height', 'format', 'quality']`. Si votre service d'image personnalisé a plus d'options qui modifient les images générées, ajoutez-les dans le tableau.
+Au moment de la compilation des sites statiques et des routes pré-rendues, `<Image />` et `getImage(options)` appellent la fonction `transform()`. Ces derniers transmettent des options soit par les attributs du composant, soit par un argument `options`, respectivement. Les images transformées seront générées dans un dossier `dist/_astro`. Leurs noms de fichier contiendront un hachage des propriétés transmises à `propertiesToHash`. Cette propriété est optionnelle et sera définie par défaut sur `['src', 'width', 'height', 'format', 'quality']`. Si votre service d'images personnalisé dispose d’autres options qui modifient les images générées, ajoutez-les au tableau.
 
-En mode développement et lors de l'utilisation d'un adaptateur pour effectuer le rendu à la demande, Astro ne sait pas à l'avance quelles images doivent être optimisées. Astro utilise un point d'accès GET (par défaut, `/_image`) pour traiter les images au moment de l'exécution. `<Image />` et `getImage()` transmettent leurs options à `getURL()`, qui renvoie l'URL du point d'accès. Ensuite, le point d'accès appelle `parseURL()` et transmet les propriétés résultantes à `transform()`.
+En mode développement et lors de l'utilisation d'un adaptateur pour effectuer le rendu à la demande, Astro ne sait pas à l'avance quelles images doivent être optimisées. Astro utilise un point de terminaison GET (par défaut, `/_image`) pour traiter les images au moment de l'exécution. `<Image />` et `getImage()` transmettent leurs options à `getURL()`, qui renvoie l'URL du point de terminaison. Ensuite, le point de terminaison appelle `parseURL()` et transmet les propriétés résultantes à `transform()`.
 
 #### getConfiguredImageService & imageConfig
 
-Si vous implémentez votre propre point d'accès comme point d'accès Astro, vous pouvez utiliser `getConfiguredImageService` et `imageConfig` pour appeler les méthodes `parseURL` et `transform` de votre service et fournir la configuration de l'image.
+Si vous implémentez votre propre point de terminaison en tant que point de terminaison Astro, vous pouvez utiliser `getConfiguredImageService` et `imageConfig` pour appeler les méthodes `parseURL` et `transform` de votre service et fournir la configuration de l'image.
 
 Pour accéder à la configuration du service d'image ([`image.service.config`](/fr/reference/configuration-reference/#imageservice)), vous pouvez utiliser `imageConfig.service.config`.
 
-```ts title="src/api/my_custom_endpoint_that_transforms_images.ts"
+```ts title="src/api/mon_point_de_terminaison_personnalise_qui_transforme_les_images.ts"
 import type { APIRoute } from "astro";
 import { getConfiguredImageService, imageConfig } from 'astro:assets';
 

--- a/src/content/docs/fr/reference/legacy-flags.mdx
+++ b/src/content/docs/fr/reference/legacy-flags.mdx
@@ -30,15 +30,15 @@ export default defineConfig({
 });
 ```
 
-Si cette option est activée, les collections de données et de contenus (uniquement) sont gérées à l'aide de l'implémentation des collections de contenu héritées. Les collections avec un `loader` (uniquement) continueront à utiliser l'API Content Layer à la place. Les deux types de collections peuvent exister dans le même projet, chacune utilisant leurs implémentations respectives.
+Si cette option est activée, les collections de données et de contenus (uniquement) sont gérées à l'aide de l'implémentation des collections de contenu héritées. Les collections avec un `loader` (uniquement) continueront à utiliser l'API de la couche de contenu à la place. Les deux types de collections peuvent exister dans le même projet, chacune utilisant leurs implémentations respectives.
  
 Les limitations suivantes subsistent :
 
 - Toutes les collections héritées (`type: 'content'` ou `type: 'data'`) doivent continuer à être situées dans le répertoire `src/content/`.
 - Ces collections héritées ne seront pas transformées pour utiliser implicitement le chargeur `glob()` et seront plutôt gérées par le code hérité.
-- Les collections utilisant l'API Content Layer (avec un `loader` défini) sont interdites dans `src/content/`, mais peuvent exister n'importe où ailleurs dans votre projet.
+- Les collections utilisant l'API de la couche de contenu (avec un `loader` défini) sont interdites dans `src/content/`, mais peuvent exister n'importe où ailleurs dans votre projet.
 
-Lorsque vous êtes prêt à supprimer cette option et à migrer vers la nouvelle API Content Layer pour vos collections héritées, vous devez définir une collection pour tous les répertoires de `src/content/` que vous souhaitez continuer à utiliser comme collection. Il suffit de déclarer une collection vide et Astro générera implicitement une définition appropriée pour vos collections héritées :
+Lorsque vous êtes prêt à supprimer cette option et à migrer vers la nouvelle API de la couche de contenu pour vos collections héritées, vous devez définir une collection pour tous les répertoires de `src/content/` que vous souhaitez continuer à utiliser comme collection. Il suffit de déclarer une collection vide et Astro générera implicitement une définition appropriée pour vos collections héritées :
  
 ```js
 // src/content/config.ts

--- a/src/content/docs/fr/reference/programmatic-reference.mdx
+++ b/src/content/docs/fr/reference/programmatic-reference.mdx
@@ -36,7 +36,7 @@ Si un chemin relatif est défini, il sera résolu en fonction de l'option `root`
 
 Définissez la valeur sur `false` pour désactiver le chargement des fichiers de configuration.
 
-La configuration en ligne transmise dans cet objet aura la priorité la plus élevée lors de la fusion avec la configuration utilisateur chargée.
+La configuration transmise dans cet objet aura la priorité la plus élevée lors de la fusion avec la configuration utilisateur chargée.
 
 ### `mode`
 
@@ -47,7 +47,7 @@ La configuration en ligne transmise dans cet objet aura la priorité la plus él
 <Since v="5.0.0" />
 </p>
 
-Le mode utilisé lors du développement ou de la construction de votre site (par exemple `"production"`, `"test"`).
+Le mode utilisé lors du développement ou de la compilation de votre site (par exemple `"production"`, `"test"`).
 
 Cette valeur est transmise à Vite à l'aide de [l'option `--mode`](/fr/reference/cli-reference/#--mode-string) lorsque les commandes `astro build` ou `astro dev` sont exécutées pour déterminer la valeur de `import.meta.env.MODE`. Cela détermine également quels fichiers `.env` sont chargés, et donc les valeurs de `astro:env`. Consultez la [page des variables d'environnement](/fr/guides/environment-variables/) pour plus de détails.
 
@@ -147,13 +147,13 @@ Renvoie une `Promise` qui se résout une fois que toutes les demandes en attente
 **Type :** `(inlineConfig: AstroInlineConfig, options?: BuildOptions) => Promise<void>`
 </p>
 
-Similaire à [`astro build`](/fr/reference/cli-reference/#astro-build), il construit votre site pour le déploiement.
+Similaire à [`astro build`](/fr/reference/cli-reference/#astro-build), il compile votre site pour le déploiement.
 
 ```js
 import { build } from "astro";
 
 await build({
-  root: "./my-project",
+  root: "./mon-projet",
 });
 ```
 
@@ -186,7 +186,7 @@ Génère une version basée sur le développement similaire au code transformé 
 <Since v="5.4.0" />
 </p>
 
-Supprime l'instance WASM du compilateur après la construction. Cela peut améliorer les performances lors d'une construction unique, mais peut entraîner une baisse des performances en cas de construction plusieurs fois de suite.
+Supprime l'instance WASM du compilateur après la compilation. Cela peut améliorer les performances lors d'une compilation unique, mais peut entraîner une baisse des performances en cas de compilation plusieurs fois de suite.
 
 Lors de la création de plusieurs projets dans la même exécution (par exemple pendant les tests), la désactivation de cette option peut augmenter considérablement les performances et réduire l'utilisation maximale de la mémoire au détriment d'une utilisation soutenue de la mémoire plus élevée.
 
@@ -197,7 +197,7 @@ Lors de la création de plusieurs projets dans la même exécution (par exemple 
 **Type :** `(inlineConfig: AstroInlineConfig) => Promise<PreviewServer>`
 </p>
 
-Similaire à [`astro preview`](/fr/reference/cli-reference/#astro-preview), il démarre un serveur local pour servir la sortie de votre construction.
+Similaire à [`astro preview`](/fr/reference/cli-reference/#astro-preview), il démarre un serveur local pour servir la sortie de votre compilation.
 
 Si aucun adaptateur n'est défini dans la configuration, le serveur d'aperçu ne servira que les fichiers statiques créés.
 Si un adaptateur est défini dans la configuration, le serveur d'aperçu est fourni par l'adaptateur. Les adaptateurs ne sont pas tenus de fournir un serveur d'aperçu, cette fonctionnalité peut donc ne pas être disponible en fonction de l'adaptateur choisi.
@@ -293,7 +293,7 @@ Importé depuis `astro/config`, fusionne une configuration Astro partielle avec 
 
 `mergeConfig()` accepte un objet de configuration Astro et une configuration partielle (tout ensemble d'options de configuration Astro valides) et renvoie une configuration Astro valide combinant les deux valeurs telles que :
 
-- Les tableaux sont concaténés (y compris les intégrations et les plugins Remark).
+- Les tableaux sont concaténés (y compris les intégrations et les modules d'extension Remark).
 - Les objets sont fusionnés de manière récursive.
 - Les options de Vite sont fusionnées à l'aide de [la fonction `mergeConfig` de Vite](https://vite.dev/guide/api-javascript#mergeconfig) avec l'option `isRoot` par défaut.
 - Les options qui peuvent être fournies sous forme de fonctions sont encapsulées dans de nouvelles fonctions qui fusionnent de manière récursive les valeurs de retour des deux configurations avec ces mêmes règles.
@@ -367,7 +367,7 @@ import { validateConfig } from "astro/config";
 
 const config = await validateConfig({
   integrations: [partytown()],
-}, "./my-project", "build");
+}, "./mon-projet", "build");
 
 // les valeurs par défaut sont appliquées
 await rm(config.outDir, { recursive: true, force: true });

--- a/src/content/docs/fr/reference/publish-to-npm.mdx
+++ b/src/content/docs/fr/reference/publish-to-npm.mdx
@@ -9,10 +9,10 @@ Vous développez un nouveau composant Astro ? **Publiez-le sur [NPM](https://npm
 
 Publier un composant Astro est une excellente façon de réutiliser votre travail existant dans vos projets et de le partager avec la communauté d'Astro à grande échelle. Les composants Astro peuvent être publiés directement et installés depuis NPM, comme tout autre paquet JavaScript.
 
-Vous cherchez de l'inspiration ? Regardez quelques-uns de nos [thèmes](https://astro.build/themes/) et [composants](https://astro.build/integrations/) préférés issus la communauté d'Astro. Vous pouvez aussi [rechercher sur NPM](https://www.npmjs.com/search?q=keywords:astro-component) pour voir l'ensemble du catalogue public.
+Vous cherchez de l'inspiration ? Regardez quelques-uns de nos [thèmes](https://astro.build/themes/) et [composants](https://astro.build/integrations/) préférés de la communauté d'Astro. Vous pouvez aussi [rechercher sur NPM](https://www.npmjs.com/search?q=keywords:astro-component) pour voir l'ensemble du catalogue public.
 
 :::tip[Besoin d'aide ?]
-Regardez [le modèle de composant de la communauté Astro](https://github.com/astro-community/component-template) pour un modèle de composant prêt à l'emploi et supporté par la communauté !
+Regardez [le modèle de composant de la communauté Astro](https://github.com/astro-community/component-template) pour un modèle prêt à l'emploi pris en charge par la communauté !
 :::
 
 ## Démarrage rapide
@@ -34,7 +34,7 @@ pnpm create astro@latest my-new-component-directory -- --template component
 Avant de se lancer, avoir une compréhension basique des sujets suivants vous sera d'une grande aide :
 
 - [Modules Node](https://docs.npmjs.com/creating-node-js-modules)
-- [Manifeste de Paquet (`package.json`)](https://docs.npmjs.com/creating-a-package-json-file)
+- [Manifeste du paquet (`package.json`)](https://docs.npmjs.com/creating-a-package-json-file)
 - [Espaces de travail](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#workspaces)
 :::
 
@@ -171,7 +171,7 @@ Ajoutez `astro-component` ou `withastro` comme mot-clé spécial pour maximiser 
 ```
 
 :::tip
-Les mots-clés sont également utilisés par notre [bibliothèque d'intégration](https://astro.build/integrations)! [Voir ci-dessous](#bibliothèque-dintégrations) pour une liste complète des mots-clés que nous utilisons dans NPM.
+Les mots-clés sont également utilisés par notre [bibliothèque d'intégration](https://astro.build/integrations) ! [Voir ci-dessous](#bibliothèque-dintégrations) pour une liste complète des mots-clés que nous utilisons dans NPM.
 :::
 
 ---
@@ -199,7 +199,7 @@ import { MyReactComponent } from 'my-component';
 <MyReactComponent />
 ```
 
-#### Exemple : Utilisation des importations de Namespace (Espace de Noms)
+#### Exemple : Utilisation des importations d'espaces de noms
 
 ```astro
 ---
@@ -230,7 +230,7 @@ Si vous voulez extraire des composants d'un projet existant, vous pouvez aussi c
 
 ## Tester votre composant
 
-Astro ne livre actuellement pas de suites de tests. _(Si vous êtes intéressé·e·s pour aider, [rejoignez-nous dans notre Discord !](https://astro.build/chat))_
+Astro ne livre actuellement aucun exécuteur de tests. _(Si vous êtes intéressé·e·s pour aider, [rejoignez-nous sur Discord !](https://astro.build/chat))_
 
 En attendant, nos recommandations actuelles pour les tests sont :
 
@@ -241,7 +241,7 @@ En attendant, nos recommandations actuelles pour les tests sont :
   
 3. Chaque page devrait inclure un usage de composant différent que vous souhaitez tester.
   
-4. Exécutez `astro build` pour construire vos fixtures, puis comparez le résultat de `dist/__fixtures__/` à ce que vous attendiez.
+4. Exécutez `astro build` pour compiler vos fixtures, puis comparez le résultat de `dist/__fixtures__/` à ce que vous attendiez.
    <FileTree>
    - my-project/demo/src/pages/\_\_fixtures\_\_/
      - test-name-01.astro
@@ -255,9 +255,9 @@ En attendant, nos recommandations actuelles pour les tests sont :
 
 Une fois que votre paquet est prêt, vous pouvez le publier sur npm en utilisant la commande `npm publish`. Si cela échoue, assurez-vous que vous vous êtes connecté via `npm login` et que votre `package.json` est correct. Si cela réussit, vous avez fini !
 
-Notez que il n'y avait pas de étape `build` pour les paquets Astro. Tout type de fichier pris en charge nativement par Astro, tel que `.astro`, `.ts`, `.jsx`, et `.css`, peut être publié directement sans étape de construction.
+Notez que il n'y avait pas d'étape de compilation (`build`) pour les paquets Astro. Tout type de fichier pris en charge nativement par Astro, tel que `.astro`, `.ts`, `.jsx`, et `.css`, peut être publié directement sans étape de compilation.
 
-Si vous avez besoin d'un autre type de fichier qui n'est pas pris en charge nativement par Astro, ajoutez une étape de construction à votre paquet. Cet exercice avancé est laissé à votre discrétion.
+Si vous avez besoin d'un autre type de fichier qui n'est pas pris en charge nativement par Astro, ajoutez une étape de compilation à votre paquet. Cet exercice avancé est laissé à votre discrétion.
 
 ## Bibliothèque d'intégrations
 
@@ -269,7 +269,7 @@ Vous avez besoin d'aide pour construire votre intégration, ou vous voulez simpl
 
 ### Données du fichier `package.json`
 
-La bibliothèque est automatiquement mise à jour chaque semaine ; chaque paquet publié sur NPM avec le mot-clé `astro-component` ou `withastro` est extrait.
+La bibliothèque est automatiquement mise à jour chaque semaine, récupérant chaque paquet publié sur NPM avec le mot-clé `astro-component` ou `withastro`.
 
 La bibliothèque d'intégration lit les données `name`, `description`, `repository`, et `homepage` de votre `package.json`.
 
@@ -298,6 +298,6 @@ En plus du mot-clé obligatoire `astro-component` ou `withastro`, des mots-clés
 
 Les paquets qui n'incluent aucun mot-clé correspondant à une catégorie seront affichés comme `Uncategorized`.
 
-## Partagez
+## Partager
 
-Nous vous encourageons à partager votre travail, nous apprécions vraiment de voir ce que nos talentueux Astronautes créent. Venez partager vos créations avec nous sur notre [Discord](https://astro.build/chat) ou mentionnez [@astrodotbuild](https://twitter.com/astrodotbuild) dans un Tweet !
+Nous vous encourageons à partager votre travail et nous apprécions vraiment voir ce que nos talentueux Astronautes créent. Venez partager vos créations avec nous sur notre [Discord](https://astro.build/chat) ou mentionnez [@astrodotbuild](https://twitter.com/astrodotbuild) dans un Tweet !

--- a/src/content/docs/fr/reference/routing-reference.mdx
+++ b/src/content/docs/fr/reference/routing-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: Référence de routage
+title: Référence du routage
 i18nReady: true
 tableOfContents:
   minHeadingLevel: 2
@@ -13,7 +13,7 @@ Il n'y a pas de configuration de routage séparée dans Astro.
 
 Chaque [fichier de page pris en charge](/fr/basics/astro-pages/#fichiers-de-page-pris-en-charge) situé dans le répertoire spécial `src/pages/` crée une route. Lorsque le nom du fichier contient un [paramètre](#params), une route peut créer plusieurs pages de manière dynamique, sinon elle crée une seule page.
 
-Par défaut, toutes les routes et tous les points de terminaison des pages Astro sont générés et pré-rendus au moment de la construction. Le [rendu du serveur à la demande](/fr/guides/on-demand-rendering/) peut être défini pour des routes individuelles ou par défaut.
+Par défaut, toutes les routes de pages et tous les points de terminaison d'Astro sont générés et pré-rendus au moment de la compilation. Le [rendu du serveur à la demande](/fr/guides/on-demand-rendering/) peut être défini pour des routes individuelles ou par défaut.
 
 ## `prerender`
 
@@ -32,7 +32,7 @@ Par défaut, toutes les pages et tous les points de terminaison sont pré-rendus
 
 Vous pouvez remplacer la valeur par défaut pour activer [le rendu à la demande](/fr/guides/on-demand-rendering/) pour une route individuelle en exportant `prerender` avec la valeur `false` à partir de ce fichier :
 
-```astro title="src/pages/rendered-on-demand.astro" {2}
+```astro title="src/pages/rendu-a-la-demande.astro" {2}
 ---
 export const prerender = false
 ---
@@ -46,7 +46,7 @@ Vous pouvez remplacer la valeur par défaut pour toutes les routes en configuran
 
 En mode `server`, activez le pré-rendu pour une route individuelle en exportant `prerender` avec la valeur `true` à partir de ce fichier :
 
-```astro title="src/pages/static-about-page.astro" {3}
+```astro title="src/pages/page-a-propos-statique.astro" {3}
 ---
 // avec `output: 'server'` configuré
 export const prerender = true
@@ -70,7 +70,7 @@ Par défaut, tous les fichiers situés dans le répertoire réservé `src/pages/
 
 Vous pouvez remplacer la valeur par défaut pour désigner le contenu comme une [partie de page](/fr/basics/astro-pages/#pages-partielles) pour une route individuelle en exportant une valeur pour `partial` à partir de ce fichier :
 
-```astro title="src/pages/my-page-partial.astro" {2}
+```astro title="src/pages/ma-page-partielle.astro" {2}
 ---
 export const partial = true
 ---
@@ -90,7 +90,7 @@ La déclaration `export const partial` doit être identifiable de manière stati
 <Since v="1.0.0" />
 </p>
 
-Une fonction permettant de générer plusieurs routes de pages pré-rendues à partir d'un seul composant de page `.astro` avec un ou plusieurs [paramètres](#params) dans son chemin de fichier. Utilisez-le pour les routes qui seront créées au moment de la construction, également appelées création de site statique.
+Une fonction permettant de générer plusieurs routes de pages pré-rendues à partir d'un seul composant de page `.astro` avec un ou plusieurs [paramètres](#params) dans son chemin de fichier. Utilisez-le pour les routes qui seront créées au moment de la compilation, également appelées création de site statique.
 
 La fonction `getStaticPaths()` doit renvoyer un tableau d'objets pour déterminer quels chemins d'URL seront pré-rendus par Astro. Chaque objet doit inclure un objet `params` pour spécifier les chemins d'accès. L'objet peut éventuellement contenir un objet `props` avec des [données à transmettre](#transmission-de-données-avec-props) à chaque modèle de page.
 
@@ -114,7 +114,7 @@ export async function getStaticPaths() {
 `getStaticPaths()` peut également être utilisé dans les points de terminaison de fichiers statiques pour [le routage dynamique](/fr/guides/endpoints/#params-et-routage-dynamique).
 
 :::tip
-Lorsque vous utilisez TypeScript, utilisez l'utilitaire de type [`GetStaticPaths`](/fr/guides/typescript/#inférer-les-types-de-getstaticpaths) pour garantir un accès sécurisé à vos `params` et `props`.
+Lorsque vous utilisez TypeScript, utilisez l'utilitaire de type [`GetStaticPaths`](/fr/guides/typescript/#inférer-les-types-de-getstaticpaths) pour garantir un accès à vos `params` et `props` avec la sûreté du typage.
 :::
 
 :::caution
@@ -123,11 +123,11 @@ La fonction `getStaticPaths()` s'exécute une fois dans sa propre portée isolé
 
 ### `params`
 
-La clé `params` de chaque objet du tableau renvoyée par `getStaticPaths()` indique à Astro quelles routes construire.
+La propriété `params` de chaque objet du tableau renvoyée par `getStaticPaths()` indique à Astro quelles routes générer.
 
-Les clés dans `params` doivent correspondre aux paramètres définis dans le chemin d'accès de votre fichier de composants. La valeur de chaque objet `params` doit correspondre aux paramètres utilisés dans le nom de la page. Les `params` sont codés dans l'URL, donc seules les chaînes de caractères sont prises en charge comme valeurs.
+Les propriétés dans `params` doivent correspondre aux paramètres définis dans le chemin d'accès de votre fichier de composants. La valeur de chaque objet `params` doit correspondre aux paramètres utilisés dans le nom de la page. Les `params` sont codés dans l'URL, donc seules les chaînes de caractères sont prises en charge comme valeurs.
 
-Par exemple, `src/pages/posts/[id].astro` a un paramètre `id` dans son nom de fichier. La fonction `getStaticPaths()` suivante dans ce composant `.astro` indique à Astro de générer statiquement `posts/1`, `posts/2` et `posts/3` au moment de la construction.
+Par exemple, `src/pages/posts/[id].astro` a un paramètre `id` dans son nom de fichier. La fonction `getStaticPaths()` suivante dans ce composant `.astro` indique à Astro de générer statiquement `posts/1`, `posts/2` et `posts/3` au moment de la compilation.
 
 ```astro title="src/pages/posts/[id].astro"
 ---
@@ -146,7 +146,7 @@ const { id } = Astro.params;
 
 ### Transmission de données avec `props`
 
-Pour transmettre des données supplémentaires à chaque page générée, vous pouvez définir une valeur `props` sur chaque objet du tableau renvoyé par `getStaticPaths()`. Contrairement à `params`, les `props` ne sont pas encodées dans l'URL et ne sont donc pas limitées aux seules chaînes.
+Pour transmettre des données supplémentaires à chaque page générée, vous pouvez définir une valeur `props` sur chaque objet du tableau renvoyé par `getStaticPaths()`. Contrairement à `params`, les `props` ne sont pas encodées dans l'URL et ne sont donc pas limitées uniquement aux chaînes de caractères.
 
 Par exemple, si vous générez des pages avec des données extraites d'une API distante, vous pouvez transmettre l'objet de données complet au composant de page à l'intérieur de `getStaticPaths()`. Le modèle de page peut référencer les données de chaque publication à l'aide de `Astro.props`.
 
@@ -181,7 +181,7 @@ Une fonction qui peut être renvoyée par [`getStaticPaths()`](#getstaticpaths) 
 
 `paginate()` génèrera automatiquement le tableau nécessaire à renvoyer depuis `getStaticPaths()` pour créer une URL pour chaque page de votre collection paginée. Le numéro de page sera transmis comme un `param` et les données de la page seront transmises en tant que propriété `page`.
 
-L'exemple suivant récupère et transmet 150 éléments à la fonction `paginate` et crée des pages statiques pré-rendues au moment de la construction qui afficheront 10 éléments par page :
+L'exemple suivant récupère et transmet 150 éléments à la fonction `paginate` et crée des pages statiques pré-rendues au moment de la compilation qui afficheront 10 éléments par page :
 
 ```astro title="src/pages/pokemon/[page].astro"
 ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translations of the remaining top-level `references` pages (I'll check `errors` and `experimental-flags` separately) to improve the wording based on the French i18n guide:
* replace `construction` with `compilation` or `génération` where more appropriate
* replace `supporté` with `pris en charge`
* replace the translation of `deprecated` (`obsolète` > `déprécié`)
* translate `template`
* translate some examples
* translate some untranslated headings
* replace the translation of `inline` (`incorporé`/`au sein de`)
* translate `plugin`
* do not translate `slot` when referring to Astro slots
* do not translate `glob`
* replace `barrières` with `délimiteurs` for `code fences`
* replace `point d'accès` with `point de terminaison`
* replace the translation of `type safety` with `sûreté du typage`
* fix some grammar/typo (ie. in French we use comma and not semicolon at the end of list items)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
