### PR TITLE
feat(astro:i18n): add docs for some missing public utilities

### DIFF
--- a/src/content/docs/en/reference/modules/astro-i18n.mdx
+++ b/src/content/docs/en/reference/modules/astro-i18n.mdx
@@ -40,6 +40,10 @@ import {
   notFound,
   middleware,
   requestHasLocale,
+  normalizeTheLocale,
+  pathHasLocale,
+  toCodes,
+  toPaths
  } from 'astro:i18n';
 ```
 
@@ -336,4 +340,112 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
   return new Response("Not found", { status: 404 });
 })
+```
+
+### `normalizeTheLocale()`
+
+<p>
+
+**Type:** `(locale: string) => string`
+</p>
+
+Replaces underscores (`_`) with hyphens (`-`) in the given locale before returning a lowercase version.
+
+```astro title="src/pages/index.astro"
+---
+normalizeTheLocale("it_VT") // returns `it-vt`
+---
+```
+
+### `pathHasLocale()`
+
+<p>
+
+**Type:** `(path: string) => boolean`<br />
+<Since v="4.6.0" />
+</p>
+
+Checks whether the given path contains a configured locale.
+
+This is useful to prevent errors before using an i18n utility that relies on a locale from a URL path.
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  i18n: {
+    locales: [
+      { codes: ["it-VT", "it"], path: "italiano" },
+      "es"
+    ]
+  }
+})
+```
+
+```astro title="src/pages/index.astro"
+---
+import { pathHasLocale } from "astro:i18n";
+
+pathHasLocale("italiano"); // returns `true`
+pathHasLocale("es"); // returns `true`
+pathHasLocale("it-VT"); // returns `false`
+---
+```
+
+### `toCodes()`
+
+<p>
+
+**Type:** `(locales: Locales) => string[]`<br />
+<Since v="4.0.0" />
+</p>
+
+Retrieves the configured locale codes for each locale defined in your configuration. When multiple codes are associated to a locale, only the first one will be added to the array.
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  i18n: {
+    locales: [
+      { codes: ["it-VT", "it"], path: "italiano" },
+      "es"
+    ]
+  }
+})
+```
+
+```astro title="src/pages/index.astro"
+---
+import { i18n } from "astro:config/client";
+import { toCodes } from "astro:i18n";
+
+toCodes(i18n!.locales); // ["it-VT", "es"]
+---
+```
+
+### `toPaths()`
+
+<p>
+
+**Type:** `(locales: Locales) => string[]`<br />
+<Since v="4.0.0" />
+</p>
+
+Retrieves the configured locale paths for each locale defined in your configuration.
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  i18n: {
+    locales: [
+      { codes: ["it-VT", "it"], path: "italiano" },
+      "es"
+    ]
+  }
+})
+```
+
+```astro title="src/pages/index.astro"
+---
+import { i18n } from "astro:config/client";
+import { toPaths } from "astro:i18n";
+
+toPaths(i18n!.locales); // ["italiano", "es"]
+---
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The [`i18nNoLocaleFoundInPath` error](https://docs.astro.build/en/reference/errors/i18n-no-locale-found-in-path/) suggests to use the `pathHasLocale` helper... but I couldn't find it in the docs. Actually we're missing a few utilities in the `astro:i18n` reference.

Adds documentation for:
* `normalizeTheLocale()` (since `astro:i18n` release? Maybe this was made public later but I couldn't find a PR suggesting this)
* `pathHasLocale()` (added in 4.6.0, https://github.com/withastro/astro/pull/10193)
* `toCodes()` (added in 4.0.0, https://github.com/withastro/astro/pull/9200)
* `toPaths()` (added in 4.0.0, https://github.com/withastro/astro/pull/9200)

I'm not quite sure about the use cases, so I added examples based on the [`getPathByLocale()`](https://docs.astro.build/en/reference/modules/astro-i18n/#getpathbylocale) one.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: add new content

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
