### PR TITLE
i18n(fr): improve the wording in `guides/markdown-content.mdx`

### DIFF
--- a/src/content/docs/fr/guides/markdown-content.mdx
+++ b/src/content/docs/fr/guides/markdown-content.mdx
@@ -11,7 +11,7 @@ import RecipeLinks from "~/components/RecipeLinks.astro";
 import ReadMore from '~/components/ReadMore.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Le [Markdown](https://daringfireball.net/projects/markdown/) est couramment utilisé pour créer des contenus à forte teneur en texte, tels que des articles de blog et de la documentation. Astro inclut une prise en charge intégrée des fichiers Markdown qui peuvent également inclure un [frontmatter YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) (ou [TOML](https://toml.io)) pour définir des propriétés personnalisées telles qu'un titre, une description et des balises.
+[Markdown](https://daringfireball.net/projects/markdown/) est couramment utilisé pour créer des contenus à forte teneur en texte, tels que des articles de blog et de la documentation. Astro inclut une prise en charge intégrée des fichiers Markdown qui peuvent également inclure un [frontmatter en YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) (ou [TOML](https://toml.io)) pour définir des propriétés personnalisées telles qu'un titre, une description et des étiquettes.
 
 Dans Astro, vous pouvez créer du contenu en utilisant [GitHub Flavored Markdown](https://github.github.com/gfm/), puis l'afficher dans des composants `.astro`. Cela combine un format d'écriture familier conçu pour le contenu avec la flexibilité de la syntaxe et de l'architecture des composants d'Astro.
 
@@ -37,9 +37,9 @@ Les collections utilisent des API optimisées et spécifiques au contenu pour [i
 
 ## Expressions dynamiques de type JSX
 
-Après avoir importé ou analysé des fichiers Markdown, vous pouvez écrire des modèles HTML dynamiques dans vos composants `.astro` qui incluent les données du frontmatter et le contenu du corps du texte.
+Après avoir importé ou interrogé des fichiers Markdown, vous pouvez écrire des modèles HTML dynamiques dans vos composants `.astro` qui incluent les données du frontmatter et le contenu du corps du texte.
 
-```md title="src/pages/posts/great-post.md"
+```md title="src/pages/posts/article-incroyable.md"
 ---
 title: 'Le meilleur article de tous les temps'
 author: 'Ben'
@@ -48,16 +48,16 @@ author: 'Ben'
 Voici mon _incroyable_ billet !
 ```
 
-```astro title="src/pages/my-posts.astro"
+```astro title="src/pages/mes-articles.astro"
 ---
-import * as greatPost from './posts/great-post.md';
+import * as greatPost from './posts/article-incroyable.md';
 const posts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
 ---
 
 <p>{greatPost.frontmatter.title}</p>
 <p>Écrit par : {greatPost.frontmatter.author}</p>
 
-<p>Archives d'articles :</p>
+<p>Archive des articles :</p>
 <ul>
   {posts.map(post => <li><a href={post.url}>{post.frontmatter.title}</a></li>)}
 </ul>
@@ -69,7 +69,7 @@ const posts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
 
 Lorsque vous récupérez des données de vos collections avec les fonctions d'aide `getCollection()` ou `getEntry()`, les propriétés du frontmatter de votre Markdown sont disponibles dans un objet `data` (par exemple `post.data.title`). De plus, `body` contient le contenu brut, non compilé, sous forme de chaîne de caractères.
 
-La fonction [`render()`](/fr/reference/modules/astro-content/#render) renvoie le contenu du corps de votre Markdown, une liste de titres générée, ainsi qu'un objet frontmatter modifié après l'application de tout plugin Remark ou Rehype.
+La fonction [`render()`](/fr/reference/modules/astro-content/#render) renvoie le contenu du corps de votre Markdown, une liste de titres générée, ainsi qu'un objet frontmatter modifié après l'application de tout module d'extension Remark ou Rehype.
 
 <ReadMore>En savoir plus sur [l'utilisation du contenu renvoyé par une requête de collection](/fr/guides/content-collections/#utilisation-du-contenu-dans-les-modèles-astro).</ReadMore>
 
@@ -77,13 +77,13 @@ La fonction [`render()`](/fr/reference/modules/astro-content/#render) renvoie le
 
 Les propriétés exportées suivantes sont disponibles dans votre composant `.astro` lors de l'importation de Markdown en utilisant `import` ou `import.meta.glob()` :
 
-- **`file`** - Le chemin absolu du fichier (par exemple `/home/user/projects/.../file.md`).
+- **`file`** - Le chemin absolu du fichier (par exemple `/home/utilisateur/projets/.../fichier.md`).
 - **`url`** - L'URL de la page (par exemple `/fr/guides/markdown-content`).
-- **`frontmatter`** - Contient toutes les données spécifiées dans le frontmatter YAML (ou TOML) du fichier.
-- **`<Content />`** - Un composant qui renvoie le contenu complet et affiché du fichier.
+- **`frontmatter`** - Contient toutes les données spécifiées dans le frontmatter en YAML (ou TOML) du fichier.
+- **`<Content />`** - Un composant qui renvoie le contenu complet du fichier après rendu.
 - **`RawContent()`** - Une fonction qui renvoie le document Markdown brut sous forme de chaîne de caractères.
 - **`compiledContent()`** - Une fonction asynchrone qui retourne le document Markdown compilé en une chaîne HTML.
-- **`getHeadings()`** - Une fonction asynchrone qui retourne un tableau de tous les titres (`<h1>` à `<h6>`) dans le fichier avec le type : `{ depth: number ; slug: string ; text: string }[]`. Le `slug` de chaque titre correspond à l'identifiant généré pour un titre donné et peut être utilisé pour les liens d'ancrage.
+- **`getHeadings()`** - Une fonction asynchrone qui retourne un tableau de tous les titres (`<h1>` à `<h6>`) dans le fichier avec le type : `{ depth: number; slug: string; text: string }[]`. Le `slug` de chaque titre correspond à l'identifiant généré pour un titre donné et peut être utilisé pour les liens d'ancrage.
 
 Un exemple de billet de blog en Markdown peut passer l'objet `Astro.props` suivant :
 
@@ -111,9 +111,9 @@ Astro.props = {
 
 ## Le composant `<Content />`
 
-Le composant `<Content />` est disponible en important `Content` à partir d'un fichier Markdown. Ce composant renvoie le contenu complet du fichier, affiché en HTML. Vous pouvez optionnellement renommer `Content` en n'importe quel nom de composant que vous préférez.
+Le composant `<Content />` est disponible en important `Content` à partir d'un fichier Markdown. Ce composant renvoie le contenu complet du fichier, converti en HTML. Vous pouvez éventuellement renommer `Content` avec le nom de composant de votre choix.
 
-Vous pouvez également [rendre le contenu HTML d'une entrée de collection Markdown](/fr/guides/content-collections/#restitution-du-contenu) en affichant un composant `<Content />`.
+Vous pouvez également [afficher le contenu HTML d'une entrée de collection en Markdown](/fr/guides/content-collections/#restitution-du-contenu) en effectuant le rendu d'un composant `<Content />`.
 
 ```astro title="src/pages/content.astro" "Content"
 ---
@@ -150,15 +150,15 @@ Je peux créer un lien interne vers [ma conclusion](#conclusion) sur la même pa
 Je peux visiter `https://example.com/page-1/#introduction` dans un navigateur pour naviguer directement vers mon Introduction.
 ```
 
-Astro génère des `id`s d'en-tête basés sur `github-slugger`. Vous pouvez trouver plus d'exemples dans [la documentation de github-slugger](https://github.com/Flet/github-slugger#usage).
+Astro génère des `id` de titres à l'aide `github-slugger`. Vous pouvez trouver plus d'exemples dans [la documentation de github-slugger](https://github.com/Flet/github-slugger#usage).
 
-### ID des titres et plugins
+### ID de titres et modules d'extension
 
-Astro injecte un attribut `id` dans tous les éléments d'en-tête (`<h1>` à `<h6>`) dans les fichiers Markdown et MDX. Vous pouvez récupérer ces données à partir de l'utilitaire `getHeadings()` disponible en tant que [propriété exportée Markdown](#propriétés-disponibles) à partir d'un fichier importé, ou à partir de la fonction `render()` lorsque [vous utilisez du Markdown renvoyé à partir d'une requête de collections de contenu](#markdown-à-partir-des-requêtes-de-collections-de-contenu).
+Astro injecte un attribut `id` dans tous les éléments de titre (`<h1>` à `<h6>`) dans les fichiers Markdown et MDX. Vous pouvez récupérer ces données à partir de l'utilitaire `getHeadings()` disponible en tant que [propriété exportée Markdown](#propriétés-disponibles) à partir d'un fichier importé, ou à partir de la fonction `render()` lorsque [vous utilisez du Markdown renvoyé à partir d'une requête de collections de contenu](#markdown-à-partir-des-requêtes-de-collections-de-contenu).
 
-Vous pouvez personnaliser ces ID en ajoutant un plugin rehype qui injecte les attributs `id` (par exemple `rehype-slug`). Vos ID personnalisés, au lieu des valeurs par défaut d'Astro, seront reflétés dans la sortie HTML et les éléments retournés par `getHeadings()`.
+Vous pouvez personnaliser ces ID en ajoutant un module d'extension rehype qui injecte les attributs `id` (par exemple `rehype-slug`). Vos ID personnalisés, au lieu des valeurs par défaut d'Astro, seront reflétés dans la sortie HTML et les éléments retournés par `getHeadings()`.
 
-Par défaut, Astro injecte les attributs `id` après l'exécution de vos plugins rehype. Si l'un de vos plugins rehype personnalisés a besoin d'accéder aux ID injectés par Astro, vous pouvez importer et utiliser directement le plugin `rehypeHeadingIds` d'Astro. Assurez-vous d'ajouter `rehypeHeadingIds` avant tous les plugins qui en dépendent :
+Par défaut, Astro injecte les attributs `id` après l'exécution de vos modules d'extension rehype. Si l'un de vos modules d'extension rehype personnalisés a besoin d'accéder aux ID injectés par Astro, vous pouvez importer et utiliser directement le module d'extension `rehypeHeadingIds` d'Astro. Assurez-vous d'ajouter `rehypeHeadingIds` avant tous les modules d'extension qui en dépendent :
 
 ```js title="astro.config.mjs" ins={2, 8}
 import { defineConfig } from 'astro/config';
@@ -175,19 +175,19 @@ export default defineConfig({
 });
 ```
 
-## Plugins Markdown
+## Modules d'extension Markdown
 
-La prise en charge de Markdown dans Astro est assurée par [remark](https://remark.js.org/), un puissant outil d'analyse et de traitement doté d'un écosystème actif. D'autres analyseurs Markdown comme Pandoc et markdown-it ne sont pas supportés actuellement.
+La prise en charge de Markdown dans Astro est assurée par [remark](https://remark.js.org/), un puissant outil d'analyse et de traitement doté d'un écosystème actif. D'autres analyseurs Markdown comme Pandoc et markdown-it ne sont pas pris en charge actuellement.
 
-Astro applique par défaut les plugins [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) et [SmartyPants](https://github.com/silvenon/remark-smartypants). Cela permet de générer des liens cliquables à partir du texte et de formater les [citations et les tirets cadratins](https://daringfireball.net/projects/smartypants/).
+Astro applique par défaut les modules d'extension [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm) et [SmartyPants](https://github.com/silvenon/remark-smartypants). Cela permet de générer des liens cliquables à partir du texte et de formater les [citations et les tirets cadratins](https://daringfireball.net/projects/smartypants/).
 
 Vous pouvez personnaliser la façon dont remark analyse votre Markdown dans `astro.config.mjs`. Voir la liste complète des [options de configuration Markdown](/fr/reference/configuration-reference/#options-de-markdown).
 
-### Ajouter des plugins remark et rehype
+### Ajouter des modules d'extension remark et rehype
 
-Astro prend en charge l'ajout de plugins tiers [remark](https://github.com/remarkjs/remark) et [rehype](https://github.com/rehypejs/rehype) pour Markdown. Ces plugins vous permettent d'étendre votre Markdown avec de nouvelles fonctionnalités, comme [générer automatiquement une table des matières](https://github.com/remarkjs/remark-toc), [appliquer des étiquettes accessibles aux émojis](https://github.com/florianeckerstorfer/remark-a11y-emoji) et [styliser votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown).
+Astro prend en charge l'ajout de modules d'extension tiers [remark](https://github.com/remarkjs/remark) et [rehype](https://github.com/rehypejs/rehype) pour Markdown. Ces modules d'extension vous permettent d'étendre votre Markdown avec de nouvelles fonctionnalités, comme [générer automatiquement une table des matières](https://github.com/remarkjs/remark-toc), [appliquer des étiquettes accessibles aux émojis](https://github.com/florianeckerstorfer/remark-a11y-emoji) et [mettre en forme votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown).
 
-Nous vous encourageons à consulter [awesome-remark](https://github.com/remarkjs/awesome-remark) et [awesome-rehype](https://github.com/rehypejs/awesome-rehype) parmi les plugins populaires ! Consultez le fichier README de chaque plugin pour obtenir des instructions d'installation spécifiques.
+Nous vous encourageons à consulter [awesome-remark](https://github.com/remarkjs/awesome-remark) et [awesome-rehype](https://github.com/rehypejs/awesome-rehype) parmi les modules d'extension populaires ! Consultez le fichier README de chaque module d'extension pour obtenir des instructions d'installation spécifiques.
 
 Cet exemple applique [`remark-toc`](https://github.com/remarkjs/remark-toc) et [`rehype-accessible-emojis`](https://www.npmjs.com/package/rehype-accessible-emojis) aux fichiers Markdown :
 
@@ -204,11 +204,11 @@ export default defineConfig({
 });
 ```
 
-### Personnaliser un plugin
+### Personnaliser un module d'extension
 
-Pour personnaliser un plugin, il faut lui ajouter un objet d'options dans un tableau imbriqué.
+Pour personnaliser un module d'extension, il faut lui ajouter un objet d'options dans un tableau imbriqué.
 
-L'exemple ci-dessous ajoute l'option [`heading` au plugin `remarkToc`](https://github.com/remarkjs/remark-toc#options) pour modifier l'emplacement de la table des matières, et l'option [`behavior` au plugin `rehype-autolink-headings`](https://github.com/rehypejs/rehype-autolink-headings#options) afin d'ajouter la balise d'ancrage après le texte du titre.
+L'exemple ci-dessous ajoute l'option [`heading` au module d'extension `remarkToc`](https://github.com/remarkjs/remark-toc#options) pour modifier l'emplacement de la table des matières, et l'option [`behavior` au module d'extension `rehype-autolink-headings`](https://github.com/rehypejs/rehype-autolink-headings#options) afin d'ajouter la balise d'ancrage après le texte du titre.
 
 ```js title="astro.config.mjs"
 import remarkToc from 'remark-toc';
@@ -225,14 +225,14 @@ export default {
 
 ### Modification programmatique du frontmatter
 
-Vous pouvez ajouter des propriétés au frontmatter de tous vos fichiers Markdown et MDX en utilisant un [plugin remark ou rehype](#plugins-markdown).
+Vous pouvez ajouter des propriétés au frontmatter de tous vos fichiers Markdown et MDX en utilisant un [module d'extension remark ou rehype](#plugins-markdown).
 
 <Steps>
-  1. Ajoutez une propriété `customProperty` à l'objet `data.astro.frontmatter` présent dans l'argument `file` de votre plugin :
+  1. Ajoutez une propriété `customProperty` à l'objet `data.astro.frontmatter` présent dans l'argument `file` de votre module d'extension :
 
       ```js title="example-remark-plugin.mjs"
       export function exampleRemarkPlugin() {
-        // Tous les plugins remark et rehype renvoient une fonction distincte
+        // Tous les modules d'extension remark et rehype renvoient une fonction distincte
         return function (tree, file) {
           file.data.astro.frontmatter.customProperty = 'Propriété générée';
         }
@@ -245,7 +245,7 @@ Vous pouvez ajouter des propriétés au frontmatter de tous vos fichiers Markdow
       `data.astro.frontmatter` contient toutes les propriétés d'un document Markdown ou MDX donné. Cela vous permet de modifier les propriétés existantes du frontmatter, ou de calculer de nouvelles propriétés à partir de ce frontmatter existant.
       :::
 
-  2. Appliquez ce plugin à votre configuration d'intégration `markdown` ou `mdx` :
+  2. Appliquez ce module d'extension à votre configuration d'intégration `markdown` ou `mdx` :
 
       ```js title="astro.config.mjs" "import { exampleRemarkPlugin } from './example-remark-plugin.mjs';" "remarkPlugins: [exampleRemarkPlugin],"
       import { defineConfig } from 'astro/config';
@@ -282,7 +282,7 @@ Maintenant, chaque fichier Markdown ou MDX aura une propriété `customProperty`
 
 L'intégration MDX d'Astro étend par défaut [la configuration Markdown existante de votre projet](/fr/reference/configuration-reference/#options-de-markdown). Pour remplacer des options individuelles, vous pouvez spécifier leur équivalent dans votre configuration MDX.
 
-L'exemple suivant désactive l'option GitHub-Flavored Markdown et applique un ensemble différent de plugins Remark pour les fichiers MDX :
+L'exemple suivant désactive l'option GitHub-Flavored Markdown et applique un ensemble différent de modules d'extension Remark pour les fichiers MDX :
 
 ```ts title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -308,7 +308,7 @@ export default defineConfig({
 });
 ```
 
-Pour éviter d'étendre votre configuration Markdown depuis MDX, mettez [l'option `extendMarkdownConfig`](/fr/guides/integrations-guide/mdx/#extendmarkdownconfig) (activée par défaut) sur `false` :
+Pour éviter d'étendre votre configuration Markdown depuis MDX, définissez [l'option `extendMarkdownConfig`](/fr/guides/integrations-guide/mdx/#extendmarkdownconfig) (activée par défaut) sur `false` :
 
 ```ts title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -322,7 +322,7 @@ export default defineConfig({
     mdx({
       // La configuration Markdown est désormais ignorée
       extendMarkdownConfig: false,
-      // Pas de `remarkPlugins` appliqué
+      // Aucun `remarkPlugins` appliqué
     })
   ]
 });
@@ -334,9 +334,9 @@ export default defineConfig({
 Les [collections de contenu](/fr/guides/content-collections/) et l'[importation de Markdown dans les composants `.astro`](#expressions-dynamiques-de-type-jsx) offrent davantage de fonctionnalités pour le rendu de votre Markdown et constituent le moyen recommandé pour gérer la plupart de votre contenu. Cependant, il peut arriver que vous souhaitiez simplement ajouter un fichier à `src/pages/` et avoir une page simple créée automatiquement pour vous.
 :::
 
-Astro traite [tout fichier supporté dans le répertoire `/src/pages/`](/fr/basics/astro-pages/#fichiers-de-page-pris-en-charge) comme une page, y compris `.md` et d'autres types de fichiers Markdown.
+Astro traite [tout fichier pris en charge dans le répertoire `/src/pages/`](/fr/basics/astro-pages/#fichiers-de-page-pris-en-charge) comme une page, y compris `.md` et d'autres types de fichiers Markdown.
 
-Placer un fichier dans ce répertoire, ou n'importe quel sous-répertoire, construira automatiquement une route de page en utilisant le nom de chemin du fichier et affichera le contenu Markdown affiché en HTML. Astro ajoutera automatiquement une balise `<meta charset="utf-8">` ​​à votre page pour permettre une création plus facile de contenu non ASCII.
+Placer un fichier dans ce répertoire, ou n'importe quel sous-répertoire, génèrera automatiquement une route de page en utilisant le nom de chemin du fichier et affichera le contenu Markdown converti en HTML. Astro ajoutera automatiquement une balise `<meta charset="utf-8">` ​​à votre page pour permettre une création plus facile de contenu non ASCII.
 
 ```markdown title="src/pages/page-1.md"
 ---
@@ -347,11 +347,11 @@ titre: Bonjour, le monde
 
 Ce fichier Markdown crée une page à `votre-domaine.com/page-1/`
 
-Il n'est probablement pas très stylé, mais Markdown prend en charge :
-- **gras** et _italique_.
-- listes
-- [liens](https://astro.build)
-- <p>éléments HTML</p>
+Elle n'est probablement pas très élégante, mais Markdown prend en charge :
+- le **gras** et l'_italique_.
+- les listes
+- les [liens](https://astro.build)
+- <p>les éléments HTML</p>
 - et bien d'autres choses encore !
 ```
 
@@ -391,22 +391,22 @@ const {frontmatter} = Astro.props;
 </html>
 ```
 
-Lorsque vous utilisez la propriété frontmatter `layout`, vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement. Vous pouvez désormais également [styliser votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown) dans votre composant de mise en page.
+Lorsque vous utilisez la propriété frontmatter `layout`, vous devez inclure la balise `<meta charset="utf-8">` dans votre mise en page car Astro ne l'ajoutera plus automatiquement. Vous pouvez désormais également [mettre en forme votre Markdown](/fr/guides/styling/#mettre-en-forme-markdown) dans votre composant de mise en page.
 
-<ReadMore>En savoir plus sur les [Mises en page Markdown](/fr/basics/layouts/#mises-en-page-markdown).</ReadMore>
+<ReadMore>En savoir plus sur les [mises en page Markdown](/fr/basics/layouts/#mises-en-page-markdown).</ReadMore>
 
 ## Récupérer du Markdown à distance
 
-Astro n'inclut pas de support intégré pour Markdown à distance en dehors des [collections de contenu](/fr/guides/content-collections/).
+Astro n'inclut pas de prise en charge intégrée pour le contenu Markdown distant en dehors des [collections de contenu](/fr/guides/content-collections/).
 
-Pour récupérer directement du Markdown distant et le rendre au format HTML, vous devrez installer et configurer votre propre interpréteur de Markdown à partir de NPM. Celui-ci n'héritera pas des paramètres Markdown intégrés d'Astro que vous avez configurés.
+Pour récupérer directement du Markdown distant et le restituer au format HTML, vous devrez installer et configurer votre propre interpréteur de Markdown à partir de NPM. Celui-ci n'héritera pas des paramètres Markdown intégrés d'Astro que vous avez configurés.
 
 Assurez-vous de bien comprendre ces limitations avant d'implémenter ceci dans votre projet, et envisagez de récupérer votre Markdown distant en utilisant un chargeur de collections de contenu à la place.
 
 ```astro title="src/pages/remote-example.astro"
 ---
 // Exemple : Récupération du contenu Markdown depuis une API distante
-// et le rendre au format HTML, au moment de l'exécution.
+// et le restituer au format HTML, au moment de l'exécution.
 // En utilisant "marked" (https://github.com/markedjs/marked)
 import { marked } from 'marked';
 const response = await fetch('https://raw.githubusercontent.com/wiki/adam-p/markdown-here/Markdown-Cheatsheet.md');

--- a/src/content/docs/fr/guides/migrate-to-astro/index.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/index.mdx
@@ -27,7 +27,7 @@ En fonction de votre projet existant, vous pourrez peut-être réutiliser :
 
 - vos [feuilles de style ou bibliothèques CSS](/fr/guides/styling/), y compris Tailwind.
 
-- vos [fichiers Markdown/MDX](/fr/guides/markdown-content/), configuré en utilisant vos [modules d'extension remark et rehype](/fr/guides/markdown-content/#plugins-markdown) existants.
+- vos [fichiers Markdown/MDX](/fr/guides/markdown-content/), configuré en utilisant vos [modules d'extension remark et rehype](/fr/guides/markdown-content/#modules-dextension-markdown) existants.
 
 - votre [contenu depuis un CMS](/fr/guides/cms/) à travers une intégration ou une API.
 

--- a/src/content/docs/fr/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/fr/guides/upgrade-to/v5.mdx
@@ -881,7 +881,7 @@ Les types de `imagePaths` ont également été mis à jour de `Set<string>` à `
 
 Bien que nous ne considérions pas ces API comme publiques, elles sont accessibles aux modules d'extension remark et rehype qui souhaitent réutiliser les métadonnées d'Astro. Si vous utilisez ces API, assurez-vous d'y accéder dans les nouveaux emplacements.
 
-<ReadMore>En savoir plus sur [l'utilisation des modules d'extension de Markdown dans Astro](/fr/guides/markdown-content/#plugins-markdown).</ReadMore>
+<ReadMore>En savoir plus sur [l'utilisation des modules d'extension de Markdown dans Astro](/fr/guides/markdown-content/#modules-dextension-markdown).</ReadMore>
 
 ### Modifié : configuration du point de terminaison de l'image
 

--- a/src/content/docs/fr/reference/experimental-flags/heading-id-compat.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/heading-id-compat.mdx
@@ -56,7 +56,7 @@ Dans une future version majeure, Astro utilisera par défaut le style d'identifi
 
 ## Utilisation avec le plugin `rehypeHeadingIds`
 
-Si vous [utilisez directement le plugin `rehypeHeadingIds`](/fr/guides/markdown-content/#id-des-titres-et-plugins), activez le mode de compatibilité lorsque vous transmettez le plugin dans votre configuration Astro :
+Si vous [utilisez directement le plugin `rehypeHeadingIds`](/fr/guides/markdown-content/#id-des-titres-et-modules-dextension), activez le mode de compatibilité lorsque vous transmettez le plugin dans votre configuration Astro :
 
 
 ```js title="astro.config.mjs" {8}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `guides/markdown-content` to improve the wording based on the French i18n guide updates:
* replace `plugin` with `module d'extension`
* fix `tags` translation according to the context
* fix typo in inline codes (no space before semicolon)
* replace the translation of `render`/`rendering` where more appropriate
* replace the translation for `to style`/`styling`
* replace `supporté` with `pris en charge`
* use a consistent translation of `headings` (in Astro Docs we use `titres`)
* translate some examples/code snippet file paths (not all, not sure long translated plugin names would be better than the English version)
* small rewording to make the reading smoother

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
