### PR TITLE
fix(imports): update aliases to match Typescript guide

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -174,21 +174,16 @@ In this example, a developer would need to understand the tree relationship betw
 
 You can add import aliases in `tsconfig.json`.
 
-```json title="tsconfig.json" ins={5-6}
+```json title="tsconfig.json" ins={4-5}
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@components/*": ["src/components/*"],
-      "@assets/*": ["src/assets/*"]
+      "@components/*": ["./src/components/*"],
+      "@assets/*": ["./src/assets/*"]
     }
   }
 }
 ```
-
-:::note
-Make sure `compilerOptions.baseUrl` is set so the aliased paths can be resolved.
-:::
 
 The development server will automatically restart after this configuration change. You can now import using the aliases anywhere in your project:
 
@@ -198,9 +193,6 @@ import Button from '@components/controls/Button.astro';
 import logoUrl from '@assets/logo.png?url';
 ---
 ```
-
-These aliases are also integrated automatically into [VS Code](https://code.visualstudio.com/docs/languages/jsconfig) and other editors.
-
 
 ## `import.meta.glob()`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Updates `guides/imports.mdx`:
  * to make "Aliases" matches what we describe in the Typescript guide (`baseUrl` is no longer necessary, the Typescript guide was updated in #12026 and #12358 but not the Imports guide section)
  
  * to remove `jsconfig` mention (see #8782 and we've removed a similar sentence in https://github.com/withastro/docs/pull/8818#pullrequestreview-2180074954)

#### Related issues & labels (optional)

- Suggested label: `improve or update documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
