### PR TITLE
add SvgComponent type docs

### DIFF
--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -433,6 +433,29 @@ import Logo from '../assets/logo.svg';
 <Logo width={64} height={64} fill="currentColor" />
 ```
 
+#### `SvgComponent` Type
+
+You can also enforce type safety for your `.svg` assets using the `SvgComponent` type:
+
+```astro title="src/components/Logo.astro"
+import type { SvgComponent } from "astro/types";
+import HomeIcon from './Home.svg'
+
+interface Link {
+	url: string
+	text: string
+	icon: SvgComponent
+}
+
+const links: Link[] = [
+	{
+		url: '/',
+		text: 'Home',
+		icon: HomeIcon
+	}
+]
+```
+
 ### Creating custom image components
 
 You can create a custom, reusable image component by wrapping the `<Image />`  or `<Picture/>` component in another Astro component. This allows you to set default attributes and styles only once.

--- a/src/content/docs/en/guides/images.mdx
+++ b/src/content/docs/en/guides/images.mdx
@@ -435,9 +435,12 @@ import Logo from '../assets/logo.svg';
 
 #### `SvgComponent` Type
 
+<Since v="5.14.0" />
+
 You can also enforce type safety for your `.svg` assets using the `SvgComponent` type:
 
 ```astro title="src/components/Logo.astro"
+---
 import type { SvgComponent } from "astro/types";
 import HomeIcon from './Home.svg'
 
@@ -454,6 +457,7 @@ const links: Link[] = [
 		icon: HomeIcon
 	}
 ]
+---
 ```
 
 ### Creating custom image components


### PR DESCRIPTION
#### Description (required)

This PR adds a section to the Images guide for the new `SvgComponent` type

#### Related issues & labels (optional)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.14.0`. See astro PR [#13651](https://github.com/withastro/astro/pull/13651). -->

