### PR TITLE
i18n(ko-KR): create `fail-on-prerender-conflict.mdx`

### DIFF
--- a/src/content/docs/ko/reference/experimental-flags/fail-on-prerender-conflict.mdx
+++ b/src/content/docs/ko/reference/experimental-flags/fail-on-prerender-conflict.mdx
@@ -1,0 +1,37 @@
+---
+title: 실험적 사전 렌더링 충돌 오류
+sidebar:
+  label: 사전 렌더링 충돌 오류
+i18nReady: true
+---
+
+import Since from '~/components/Since.astro'
+
+<p>
+
+**타입:** `boolean`<br />
+**기본값:** `false`<br />
+<Since v="5.14.0" />
+</p>
+
+빌드 과정에서 사전 렌더링 충돌 경고를 오류로 전환합니다.
+
+Astro는 빌드 과정에서 동일한 출력 경로를 생성할 수 있는 여러 동적 라우트 간 충돌에 대해 경고합니다. 예를 들어 `/blog/[slug]`와 `/blog/[...all]` 모두 `/blog/post-1` 경로를 사전 렌더링하려고 시도합니다. 이러한 경우 Astro는 충돌하는 경로에 대해 [가장 높은 우선순위의 라우트](/ko/guides/routing/#라우트-우선-순위)만 렌더링합니다. 이를 통해 사이트는 성공적으로 빌드되지만, 일부 페이지가 예상치 못한 라우트로 렌더링된다는 사실을 발견할 수 있습니다.
+
+이 실험적 플래그가 설정되면, 빌드는 즉시 실패하며, 오류가 발생합니다. 이로 인해 라우팅 충돌을 즉시 해결해야 하며, Astro가 라우트를 의도한 대로 빌드하도록 보장합니다.
+
+이 동작을 활성화하려면 Astro 구성에 `experimental.failOnPrerenderConflict` 기능 플래그를 추가하세요.
+
+```js title="astro.config.mjs" ins={4-6}
+import { defineConfig } from "astro/config"
+
+defineConfig({
+	experimental: {
+		failOnPrerenderConflict: true,
+	},
+});
+```
+
+## 사용하기
+
+이 플래그를 활성화한 후에는 프로젝트 빌드 시 사전 렌더링된 라우트 충돌에 대한 오류가 발생할 수 있습니다. 이 경우 모호한 라우팅을 방지하기 위해 하나 이상의 [동적 라우트](/ko/guides/routing/#동적-라우트)를 업데이트해야 합니다.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

- #12413

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
