### PR TITLE
[v6] trailing slash never for endpoints with file extension

### DIFF
--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -47,6 +47,8 @@ import type { APIRoute } from "astro";
 export const GET: APIRoute = async ({ params, request }) => {...}
 ```
 
+Note that these endpoints can only be accessed without a trailing slash, regardless of your [`build.trailingSlash`](/en/reference/configuration-reference/#trailingslash) configuration.
+
 ### `params` and Dynamic routing
 
 Endpoints support the same [dynamic routing](/en/guides/routing/#dynamic-routes) features that pages do. Name your file with a bracketed parameter name and export a [`getStaticPaths()` function](/en/reference/routing-reference/#getstaticpaths). Then, you can access the parameter using the `params` property passed to the endpoint function:

--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -47,7 +47,7 @@ import type { APIRoute } from "astro";
 export const GET: APIRoute = async ({ params, request }) => {...}
 ```
 
-Note that these endpoints can only be accessed without a trailing slash, regardless of your [`build.trailingSlash`](/en/reference/configuration-reference/#trailingslash) configuration.
+Note that endpoints whose URLs include a file extension (e.g. `src/pages/sitemap.xml.ts`) can only be accessed without a trailing slash (e.g. `/sitemap.xml`), regardless of your [`build.trailingSlash`](/en/reference/configuration-reference/#trailingslash) configuration.
 
 ### `params` and Dynamic routing
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -89,6 +89,8 @@ Check that both your development environment and your deployment environment are
 
 ### Vite 7.0
 
+<SourcePR number="14445" title="feat: update vite"/>
+
 Astro v6.0 upgrades to Vite v7.0 as the development server and production bundler.
 
 #### What should I do?
@@ -287,6 +289,8 @@ In most cases, the only action needed is to review your existing project's deplo
 
 ### Changed: `i18n.routing.redirectToDefaultLocale` default value
 
+<SourcePR number="14406" title="feat(astro)!: update i18n.redirectToDefaultLocale default"/>
+
 In Astro v5.0, the `i18n.routing.redirectToDefaultLocale` default value was `true`. When combined with the `i18n.routing.prefixDefaultLocale` default value of `false`, the resulting redirects could cause infinite loops.
 
 In Astro v6.0, `i18n.routing.redirectToDefaultLocale` now defaults to `false`. Additionally, it can now only be used if `i18n.routing.prefixDefaultLocale` is set to `true`.
@@ -309,6 +313,26 @@ export default defineConfig({
 ```
 
 <ReadMore>Learn more about [Internationalization routing](/en/guides/internationalization/#routing).</ReadMore>
+value
+
+### Changed: endpoints with a file extension cannot be accessed with a trailing slash
+
+<SourcePR number="14457" title="feat!: trailing slash never for endpoints with file extension"/>
+
+In Astro v5.0, endpoints with a pathname ending with a file extension (eg. `/src/pages/sitemap.xml.ts`) could be accessed with a trailing slash (`/sitemap.xml/`) or without (`/sitemap.xml`), no matter the value of `build.trailingSlash`.
+
+In Astro v6.0, these endpoints can only be accessed without a trailing slash.
+
+#### What should I do?
+
+Review your links and remove any referencing an endpoint ending witha file a file extension and a trailing slash:
+
+```html del={1} ins={2} title="src/pages/index.astro"
+<a href="/sitemap.xml/">Sitemap</a>
+<a href="/sitemap.xml">Sitemap</a>
+```
+
+<ReadMore>Learn more about [`build.trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash).</ReadMore>
 
 ## Breaking Changes
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -313,7 +313,6 @@ export default defineConfig({
 ```
 
 <ReadMore>Learn more about [Internationalization routing](/en/guides/internationalization/#routing).</ReadMore>
-value
 
 ### Changed: endpoints with a file extension cannot be accessed with a trailing slash
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -331,7 +331,7 @@ Review your links and remove any referencing an endpoint ending with a file exte
 <a href="/sitemap.xml">Sitemap</a>
 ```
 
-<ReadMore>Learn more about [`build.trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash).</ReadMore>
+<ReadMore>Learn more about [`build.trailingSlash`](/en/reference/configuration-reference/#trailingslash).</ReadMore>
 
 ## Breaking Changes
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -324,7 +324,7 @@ In Astro v6.0, these endpoints can only be accessed without a trailing slash. Th
 
 #### What should I do?
 
-Review your links and remove any referencing an endpoint ending with a file extension and a trailing slash:
+Review your links to your custom endpoints that include a file extension in the URL and remove any trailing slashes:
 
 ```html del={1} ins={2} title="src/pages/index.astro"
 <a href="/sitemap.xml/">Sitemap</a>

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -331,7 +331,7 @@ Review your links to your custom endpoints that include a file extension in the 
 <a href="/sitemap.xml">Sitemap</a>
 ```
 
-<ReadMore>Learn more about [`build.trailingSlash`](/en/reference/configuration-reference/#trailingslash).</ReadMore>
+<ReadMore>Learn more about [custom endpoints](/en/guides/endpoints/).</ReadMore>
 
 ## Breaking Changes
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -320,7 +320,7 @@ export default defineConfig({
 
 In Astro v5.0, endpoints with a pathname ending with a file extension (eg. `/src/pages/sitemap.xml.ts`) could be accessed with a trailing slash (`/sitemap.xml/`) or without (`/sitemap.xml`), no matter the value of `build.trailingSlash`.
 
-In Astro v6.0, these endpoints can only be accessed without a trailing slash.
+In Astro v6.0, these endpoints can only be accessed without a trailing slash. This is true regardless of your `build.trailingSlash` configuration.
 
 #### What should I do?
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -324,7 +324,7 @@ In Astro v6.0, these endpoints can only be accessed without a trailing slash.
 
 #### What should I do?
 
-Review your links and remove any referencing an endpoint ending witha file a file extension and a trailing slash:
+Review your links and remove any referencing an endpoint ending with a file extension and a trailing slash:
 
 ```html del={1} ins={2} title="src/pages/index.astro"
 <a href="/sitemap.xml/">Sitemap</a>

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -314,6 +314,10 @@ export default defineConfig({
 
 <ReadMore>Learn more about [Internationalization routing](/en/guides/internationalization/#routing).</ReadMore>
 
+## Breaking Changes
+
+The following changes are considered breaking changes in Astro v5.0. Breaking changes may or may not provide temporary backwards compatibility. If you were using these features, you may have to update your code as recommended in each entry.
+
 ### Changed: endpoints with a file extension cannot be accessed with a trailing slash
 
 <SourcePR number="14457" title="feat!: trailing slash never for endpoints with file extension"/>
@@ -332,10 +336,6 @@ Review your links to your custom endpoints that include a file extension in the 
 ```
 
 <ReadMore>Learn more about [custom endpoints](/en/guides/endpoints/).</ReadMore>
-
-## Breaking Changes
-
-The following changes are considered breaking changes in Astro v5.0. Breaking changes may or may not provide temporary backwards compatibility. If you were using these features, you may have to update your code as recommended in each entry.
 
 ## Community Resources
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -318,7 +318,7 @@ export default defineConfig({
 
 <SourcePR number="14457" title="feat!: trailing slash never for endpoints with file extension"/>
 
-In Astro v5.0, endpoints with a pathname ending with a file extension (eg. `/src/pages/sitemap.xml.ts`) could be accessed with a trailing slash (`/sitemap.xml/`) or without (`/sitemap.xml`), no matter the value of `build.trailingSlash`.
+In Astro v5.0, custom endpoints whose URL ended in a file extension (e.g. `/src/pages/sitemap.xml.ts` ) could be accessed with a trailing slash (`/sitemap.xml/`) or without (`/sitemap.xml`), regardless of the value configured for `build.trailingSlash`.
 
 In Astro v6.0, these endpoints can only be accessed without a trailing slash. This is true regardless of your `build.trailingSlash` configuration.
 


### PR DESCRIPTION
Co-authored-by: Sarah Rainsberger <5098874+sarah11918@users.noreply.github.com><!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `6.0`. See astro PR [#14457](https://github.com/withastro/astro/pull/14457).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
