### PR TITLE
[v6] clean deprecated APIs

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -279,6 +279,72 @@ const integration = () => {
 }
 ```
 
+### Removed: old `app.render()` signature (Adapter API)
+
+<SourcePR number="14462" title="feat: clean deprecated APIs"/>
+
+In Astro 4.0, the `app.render()` signature allowing to pass `routeData` and `locals` as optional arguments was deprecated in favor of a single optional `renderOptions` argument.
+
+Astro 6.0 removes this signature entirely.
+
+#### What should I do?
+
+Review your `app.render` calls and pass `routeData` and `locals` as properties of an object instead of as multiple independent arguments:
+
+```ts title="my-adapter/entrypoint.ts" del={1} ins={2}
+app.render(request, routeData, locals)
+app.render(request, { routeData, locals })
+```
+
+<ReadMore>Learn more about the [Adapter API](/en/reference/adapter-reference/).</ReadMore>
+
+### Removed: `handleForms` prop for the `<ClientRouter />` component
+
+<SourcePR number="14462" title="feat: clean deprecated APIs"/>
+
+In Astro 4.0, the `handleForms` prop of the `<ClientRouter />` component was deprecated.
+
+Astro 6.0 removes this prop entirely, as it had no impact on form submission anymore.
+
+#### What should I do?
+
+Remove the `handleForms` property from your `<ClientRouter />` component. It is no longer necessary.
+
+```astro title="src/pages/index.astro" del="handleForms"
+---
+import { ViewTransitions } from "astro:transitions";
+---
+<html>
+  <head>
+    <ViewTransitions handleForms />
+  </head>
+  <body>
+    <!-- stuff here -->
+  </body>
+</html>
+```
+
+<ReadMore>Learn more about [transitions with forms](/en/guides/view-transitions/#transitions-with-forms).</ReadMore>
+
+### Removed: `prefetch()` `with` option
+
+<SourcePR number="14462" title="feat: clean deprecated APIs"/>
+
+In Astro 4.8.4, the `with` option of the programmatic `prefetch()` function was deprecated.
+
+Astro 6.0 removes this option entirely, defaulting to `link` preloading.
+
+#### What should I do?
+
+Review your `prefetch()` calls and remove the `with` option:
+
+```ts
+prefetch('/about', { with: 'fetch' });
+prefetch('/about');
+```
+
+<ReadMore>Learn more about [prefetching](/en/guides/prefetch/).</ReadMore>
+
 ## Changed Defaults
 
 Some default behavior has changed in Astro v5.0 and your project code may need updating to account for these changes.

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -312,11 +312,11 @@ Remove the `handleForms` property from your `<ClientRouter />` component. It is 
 
 ```astro title="src/pages/index.astro" del="handleForms"
 ---
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 ---
 <html>
   <head>
-    <ViewTransitions handleForms />
+    <ClientRouter handleForms />
   </head>
   <body>
     <!-- stuff here -->

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -283,7 +283,7 @@ const integration = () => {
 
 <SourcePR number="14462" title="feat: clean deprecated APIs"/>
 
-In Astro 4.0, the `app.render()` signature allowing to pass `routeData` and `locals` as optional arguments was deprecated in favor of a single optional `renderOptions` argument.
+In Astro 4.0, the `app.render()` signature that allowed passing `routeData` and `locals` as optional arguments was deprecated in favor of a single optional `renderOptions` argument.
 
 Astro 6.0 removes this signature entirely.
 
@@ -302,13 +302,13 @@ app.render(request, { routeData, locals })
 
 <SourcePR number="14462" title="feat: clean deprecated APIs"/>
 
-In Astro 4.0, the `handleForms` prop of the `<ClientRouter />` component was deprecated.
+In Astro 4.0, the `handleForms` prop of the `<ClientRouter />` component was deprecated, as it was no longer necessary to opt in to handling `submit` events for `form` elements. This functionality has been built-in by default and the property, if still included in your project, silently had no impact on form submission.
 
-Astro 6.0 removes this prop entirely, as it had no impact on form submission anymore.
+Astro 6.0 removes this prop entirely and it now must be removed to avoid errors in your project.
 
 #### What should I do?
 
-Remove the `handleForms` property from your `<ClientRouter />` component. It is no longer necessary.
+Remove the `handleForms` property from your `<ClientRouter />` component if it exists. It has provided no additional functionality, and so removing it should not change any behavior in your project:
 
 ```astro title="src/pages/index.astro" del="handleForms"
 ---
@@ -330,13 +330,15 @@ import { ClientRouter } from "astro:transitions";
 
 <SourcePR number="14462" title="feat: clean deprecated APIs"/>
 
-In Astro 4.8.4, the `with` option of the programmatic `prefetch()` function was deprecated.
+In Astro 4.8.4, the `with` option of the programmatic `prefetch()` function was deprecated in favor of a more sensible default behavior that no longer required specifying the priority of prefetching for each page.
 
-Astro 6.0 removes this option entirely, defaulting to `link` preloading.
+Astro 6.0 removes this option entirely and it is no longer possible to configure the priority of prefetching by passing the `with` option. Attempting to do so will now cause errors.
+
+By default, Astro's prefetching now uses an automatic approach that will always try to use `<link rel="prefetch>` if supported, or will fall back to `fetch()`.
 
 #### What should I do?
 
-Review your `prefetch()` calls and remove the `with` option:
+Review your `prefetch()` calls and remove the `with` option if it still exists:
 
 ```ts
 prefetch('/about', { with: 'fetch' });

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -285,7 +285,7 @@ const integration = () => {
 
 In Astro 4.0, the `app.render()` signature that allowed passing `routeData` and `locals` as optional arguments was deprecated in favor of a single optional `renderOptions` argument.
 
-Astro 6.0 removes this signature entirely.
+Astro 6.0 removes this signature entirely. Attempting to pass these separate arguments will now cause an error in your project.
 
 #### What should I do?
 


### PR DESCRIPTION
Co-authored-by: Sarah Rainsberger <5098874+sarah11918@users.noreply.github.com><!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
I don't think docs need to be updated elsewhere because the things getting deprecated were already not documented anymore

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `6.0`. See astro PR [#14462](https://github.com/withastro/astro/pull/14462).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
