### PR TITLE
docs: Update deutsch.md (i18n guide)

### DIFF
--- a/i18n-guides/deutsch.md
+++ b/i18n-guides/deutsch.md
@@ -2,44 +2,40 @@
 
 Hallo und herzlich willkommen! Wir freuen uns sehr, dass du dich dafür interessierst, bei der deutschen Übersetzung der Astro-Dokumentation mitzuwirken. 😊🚀
 
-
 ## Zielsetzung dieser Anleitung
 
 Wie bei Open Source-Projekten üblich wird unsere Dokumentation von vielen fleißigen Personen auf freiwilliger Basis übersetzt. Die aktuellen Übersetzungen stammen daher aus vielen unterschiedlichen Federn. Zudem ändert sich auch die Besetzung unseres Teams im Laufe der Zeit.
 
 Diese Anleitung soll dazu beitragen, dass sich das Ergebnis beim Lesen trotz aller verschiedenen Einflüsse wie ein Gesamtwerk mit gemeinsamem Schreibstil anfühlt.
 
-&nbsp;
-
-
 ## Übersetzungs-Glossar
 
 | Originalbegriff             | Übersetzung                          | Anmerkungen
 |:----------------------------|:-------------------------------------|:------------
 | asset                       | Asset                                | Wird nicht übersetzt (gängiger Domänenbegriff).
-| branch                      | der Branch                           | Wird nicht übersetzt (gängiger Domänenbegriff).
+| branch                      | der Branch                           | s.o.
 | build process               | Erzeugungs- / Erstellungsvorgang     | s.o.
 | build time                  | Erzeugungs- / Erstellungszeitpunkt   | s.o.
 | to build                    | erzeugen                             | Da die Alternativen "bauen" oder gar "builden" merkwürdig klingen, wird diese Übersetzung vermutlich so bleiben.
 | command line                | die Kommandozeile                    |
-| Commit                      | Commit                               | Siehe **Stilrichtlinien**
-| CLI                         | die Kommandozeilen&shy;schnittstelle | Beim ersten Vorkommen in einem Abschnitt kann `(CLI)` dahinter ergänzt werden. Aufgrund der Wortlänge wird die Aufnahme eines weichen Bindestrichs empfohlen: `Kommandozeilen&shy;schnittstelle`
-| CLI flag                    | die Kommandozeilen&shy;option        | Aufgrund der Wortlänge wird die Aufnahme eines weichen Bindestrichs empfohlen: `Kommandozeilen&shy;option`
-| configuration option        | die Konfigurations&shy;option        | Wenn klar ist, dass es um die Konfiguration geht, kann auch nur "Option" verwendet werden. Bei der Langversion wird die Aufnahme eines weichen Bindestrichs empfohlen: `Konfigurations&shy;option`
+| Commit                      | Commit                               | Siehe [Stilrichtlinien](#stilrichtlinien-style-guide)
+| CLI                         | die Kommandozeilen&shy;schnittstelle | Beim ersten Vorkommen in einem Abschnitt kann `(CLI)` dahinter ergänzt werden.
+| CLI flag                    | die Kommandozeilen&shy;option        |
+| configuration option        | die Konfigurations&shy;option        | Wenn klar ist, dass es um die Konfiguration geht, kann auch nur "Option" verwendet werden.
 | deployment provider         | der Hosting-Anbieter                 |
 | to deploy                   | veröffentlichen                      | Wir vermeiden "ausliefern" aufgrund der Zweideutigkeit.
-| dev toolbar                 | die Entwicklungswerkzeugleiste       | Aufgrund der Wortlänge wird die Aufnahme eines weichen Bindestrichs empfohlen: `Entwicklungs&shy;werkzeugleiste`
+| dev toolbar                 | die Entwicklungs&shy;werkzeugleiste  |
 | directory                   | das Verzeichnis                      |
 | domain                      | die Domäne                           |
 | frontmatter                 | das Frontmatter                      | Wird nicht übersetzt (gängiger Domänenbegriff).
 | frontmatter prop(erty)      | die Frontmatter-Eigenschaft          |
 | frontmatter value           | der Frontmatter-Wert                 |
 | to hydrate (an element)     | hydratisieren                        | Falsch hingegen wäre "hydrieren".
-| island(s)                   | die Astro-Insel(n)                   | Der Präfix "Astro-" wird davorgesetzt, sofern wir über Astros Umsetzung der Inselarchitektur sprechen.
+| island(s)                   | Island(s)                            | Da Islands ein Konzept sind, und nicht im Code beim Nutzer auftauchen, werden sie nicht übersetzt. "Astro" wird davorgesetzt, sofern wir über Astros Umsetzung der Islands sprechen. Beim ersten Vorkommen auf einer Seite sollte `(Insel(n))` dahinter ergänzt werden.
 | media query                 | Media Query                          | Wird nicht übersetzt (gängiger Domänenbegriff).
 | page                        | die Seite                            | Eine einzelne (HTML-)Seite. Wir vermeiden die längere Form "Webseite", um Verwechslungen mit "Website" zu vermeiden.
 | partial hydration           | die partielle Hydratation            | Falsch hingegen wäre "Hydrierung".
-| project root (directory)    | das Projektstamm&shy;verzeichnis     | Aufgrund der Wortlänge wird die Aufnahme eines weichen Bindestrichs empfohlen: `Projektstamm&shy;verzeichnis`
+| project root (directory)    | das Projektstamm&shy;verzeichnis     | 
 | recipe                      | das Beispiel                         |
 | repository                  | das Repository                       | Wird nicht übersetzt (gängiger Domänenbegriff).
 | request                     | die Anfrage                          |
@@ -52,9 +48,6 @@ Diese Anleitung soll dazu beitragen, dass sich das Ergebnis beim Lesen trotz all
 | ui                          | die Benutzeroberfläche               |
 | web                         | das Internet                         |
 
-&nbsp;
-
-
 ## Stilrichtlinien (Style Guide)
 
 - Wir halten uns hinsichtlich Grammatik und Rechtschreibung an die Empfehlungen des Dudens und verwenden die neue deutsche Rechtschreibung.
@@ -62,13 +55,11 @@ Diese Anleitung soll dazu beitragen, dass sich das Ergebnis beim Lesen trotz all
 - Wir bleiben möglichst nah am englischen Originaltext.
 	- Falls die Übersetzung sich aber nicht flüssig liest, weil z.B. im Deutschen übliche Überleitungen fehlen oder andere Formulierungen geläufiger sind, kann freier übersetzt werden, so lange die Bedeutung korrekt bleibt.
 - Wir übersetzen alle Kommentare in Code-Beispielen.
-- Wir übersetzen gerne auch Komponenten-, Klassen- und Variablennamen in Code-Beispielen. So signalisieren wir, dass diese Namen frei definierbar sind und keine "magischen Keywords" von Astro darstellen.
+- Komponenten-, Klassen- und Variablennamen in Code-Beispielen werden nicht übersetzt.
 - Wir haben uns gegen das Gendern in unserer Übersetzung entschieden, weil es die Lesbarkeit der Texte verschlechtert und noch keine Duden-Vorgaben dafür existieren. Wir vermeiden lieber geschlechtsspezifische Formulierungen in unseren Übersetzungen und formulieren die Texte so, dass niemand sich ausgeschlossen fühlen muss.
 - Wir vermeiden wertende Adjektive wie "einfach", "simpel" usw., da es immer Personen geben wird, denen das beschriebene Thema eben nicht "einfach" oder "simpel" vorkommt. Wir möchten niemandem den Eindruck vermitteln, fachlich "nicht gut genug" zu sein.
-- Wir übersetzen nicht zwanghaft Begriffe, die aus einem Ökosystem-spezifischen Kontext stammen. Eine Wort für Wort Übersetzung ist meistens nicht möglich, sodass eine ausführliche Erklärung folgen müsste, was wiederum die Lesbarkeit verschlechtert. Ein gutes Beispiel hierfür wären Begriffe, wie `Commit`, `Pull Request` und `merge`, die teils einen ganzen Prozess im Git-Ökosystem beschreiben. 
-
-&nbsp;
-
+- Wir übersetzen nicht zwanghaft Begriffe, die aus einem Ökosystem-spezifischen Kontext stammen. Eine Wort für Wort Übersetzung ist meistens nicht möglich, sodass eine ausführliche Erklärung folgen müsste, was wiederum die Lesbarkeit verschlechtert. Ein gutes Beispiel hierfür wären Begriffe, wie `Commit`, `Pull Request` und `merge`, die teils einen ganzen Prozess im Git-Ökosystem beschreiben.
+- Bei Wörtern, die länger als 20 Zeichen sind, fügen wir generell einen weichen Bindestrich (`&shy;`) ein. Um solche Wörter zu finden, kann der folgende reguläre Ausdruck zum Suchen im Code-Editor verwendet werden: `\b[A-Za-zÄäÖöÜüß]{20,}\b`
 
 ## Häufige Fehler
 
@@ -85,17 +76,13 @@ Diese Anleitung soll dazu beitragen, dass sich das Ergebnis beim Lesen trotz all
 	- mit Hilfe --> mithilfe
 - Falsch geschriebene Markennamen (wir halten uns an die offizielle Schreibweise auf der Hersteller-Website)
 	- Github --> GitHub
+	- Gitlab --> GitLab
 	- Javascript --> JavaScript
 	- Typescript --> TypeScript
 	- VSCode --> VS Code
-
-&nbsp;
-
 
 ## Hast du Ergänzungen oder Anregungen zu dieser Anleitung?
 
 Das ist super! Die Inhalte dieses Dokuments sind nämlich nicht als in Stein gemeißelte "Regeln von oben" zu verstehen, sondern bilden lediglich den aktuellen Konsens unseres deutschen Übersetzungsteams ab. 
 
 Solltest du Verbesserungsideen oder Änderungswünsche zu diesem Dokument haben, besuch uns gerne auf Discord und sprich mit uns darüber. Wir sind stets offen für neue Anregungen!
-
-&nbsp;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the German i18n guide:
- Astro Islands should no longer be translated.
- Component names, class names and variable names should no longer be translated in accordance to common best practices.

#### Related issues & labels (optional)

N/A
