### PR TITLE
docs: add Hacktoberfest participation information

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,6 @@
 
 <!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
 <!-- https://astro.build/chat -->
+
+<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
+<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Submitting an Issue is usually the first step to making a change. After an Issue
 
 Larger contributions to the docs are encouraged after participating in Issues and Discussions, as unsolicited material may not fit into our existing plans.
 
+**Participating in Hacktoberfest?** See how you can get recognized for your translation PRs and PR reviews in our [Hacktoberfest guide](https://contribute.docs.astro.build/guides/hacktoberfest/).
+
 ### Examples of Helpful GitHub New Issues
 
 - a particular explanation is confusing (with explanation)


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
[Hacktoberfest](https://hacktoberfest.com/) is back for this year!

This PR add Hacktoberfest participation information to contributing guidelines and PR template (a revert revert of #9905)
<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: docs<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->


Hacktoberfest participation 🎃 