### PR TITLE
Remove outdated ‘hybrid’ explanation from Spanish docs (configuration-reference.mdx)

### DIFF
--- a/src/content/docs/es/reference/configuration-reference.mdx
+++ b/src/content/docs/es/reference/configuration-reference.mdx
@@ -141,7 +141,7 @@ Puedes personalizar el [código de estado de redirección](https://developer.moz
 ### output
 
 <p>
-**Tipo:** `'static' | 'server' | 'hybrid'`<br />
+**Tipo:** `'static' | 'server'`<br />
 **Por defecto:** `'static'`
 </p>
 
@@ -149,7 +149,6 @@ Especifica el tipo de la compilación.
 
 - `'static'`: Construye un sitio estático para ser implementado en cualquier host estático.
 - `'server'`: Construye una aplicación que se implementará en un host compatible con SSR (renderizado en el servidor).
-- `'hybrid'` : Construye un sitio estático con algunas páginas renderizadas en el lado del servidor.
 
 ```js
 import { defineConfig } from 'astro/config';


### PR DESCRIPTION
#### Description (required)

This PR removes the explanation about the `hybrid` mode in the Spanish documentation.

That content was removed from the Astro framework but was still present in the Spanish docs, which could cause confusion for readers.

This update aligns the Spanish documentation with the current English version.

Changes made **only in the Spanish documentation**.

---

#### Related issues & labels (optional)

- Suggested label: `i18n`, `docs`, `bug`

---

#### First-time contributor to Astro Docs?

Yes, first-time contributor! 😊  
**Astro Discord:** @Dinotaurent
