### PR TITLE
feat: highlight active backend service with logo border

### DIFF
--- a/src/components/BrandLogo.astro
+++ b/src/components/BrandLogo.astro
@@ -5,9 +5,10 @@ export interface Props {
 	size?: `${number}rem` | `${number}px`;
 	shape?: 'circle' | 'rounded';
 	brand: LogoKey;
+	'data-current'?: boolean;
 }
 
-const { brand, size = '4rem', shape = 'circle' } = Astro.props as Props;
+const { brand, size = '4rem', shape = 'circle', 'data-current': dataCurrent } = Astro.props as Props;
 const { file, padding } = logos[brand] || {};
 
 // Make a rough guess at the pixel size to use as width/height attributes
@@ -18,7 +19,7 @@ const pixelSize = unit === 'px' ? valueAsNumber : valueAsNumber * 16;
 
 {
 	file && (
-		<div class:list={['logo', shape]} style={`--logo-size: ${size}; --logo-padding: ${padding};`}>
+		<div class:list={['logo', shape]} style={`--logo-size: ${size}; --logo-padding: ${padding};`} data-current={dataCurrent}>
 			<img
 				src={`/logos/${file}`}
 				alt=""
@@ -58,5 +59,11 @@ const pixelSize = unit === 'px' ? valueAsNumber : valueAsNumber * 16;
 		padding: var(--logo-padding);
 		width: 100%;
 		height: 100%;
+	}
+
+	/* Active state styling */
+	.logo[data-current="true"] {
+		border: 4px solid var(--sl-color-text-accent);
+		transform: scale(1.05);
 	}
 </style>

--- a/src/components/NavGrid/Card.astro
+++ b/src/components/NavGrid/Card.astro
@@ -13,8 +13,8 @@ export interface Props extends HTMLAttributes<'li'> {
 const { href, logo, current, minimal, class: classes, ...attrs } = Astro.props as Props;
 ---
 
-<li class:list={['card', minimal && 'card--minimal', classes]} {...attrs}>
-	{logo && <BrandLogo brand={logo} />}
+<li class:list={['card', minimal && 'card--minimal', current && 'card--current', classes]} {...attrs}>
+	{logo && <BrandLogo brand={logo} data-current={current} />}
 	<div class="stack sl-flex">
 		<h3>
 			<a href={href} aria-current={current ? 'page' : 'false'}>

--- a/src/components/NavGrid/CardsNav.astro
+++ b/src/components/NavGrid/CardsNav.astro
@@ -31,7 +31,7 @@ const currentPage = new URL(Astro.request.url).pathname;
 			links.map(({ description, href, logo, title, tags, lang }) => (
 				<Card
 					{...{ minimal, logo, href, lang }}
-					current={currentPage.includes(href)}
+					current={currentPage === href || currentPage.startsWith(href + '/')}
 					class={Object.keys(tags || {}).join(' ')}
 				>
 					<Fragment slot="title" set:html={title} />


### PR DESCRIPTION
#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Improves user experience by providing clear visual feedback about which backend service page the user is currently viewing.
As my previous comment: https://github.com/withastro/docs/pull/12055#issuecomment-3097712814 
Netlify Preview Deploy Demo: [Here](https://deploy-preview-12540--astro-docs-2.netlify.app/en/guides/backend/prisma-postgres/#official-resources)

#### Related issues & labels (optional)
hacktoberfest-accepted

 #### First-time contributor to Astro Docs?
No, 2nd time. 

 If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! 
<!-- https://astro.build/chat -->
`2u841r`

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->