### PR TITLE
Shown CMD syntax throws a warning

### DIFF
--- a/src/content/docs/en/recipes/docker.mdx
+++ b/src/content/docs/en/recipes/docker.mdx
@@ -37,7 +37,7 @@ RUN npm run build
 ENV HOST=0.0.0.0
 ENV PORT=4321
 EXPOSE 4321
-CMD node ./dist/server/entry.mjs
+CMD ["node", "./dist/server/entry.mjs"]
 ```
 
 :::tip[Keep this in mind]
@@ -164,7 +164,7 @@ COPY --from=build /app/dist ./dist
 ENV HOST=0.0.0.0
 ENV PORT=4321
 EXPOSE 4321
-CMD node ./dist/server/entry.mjs
+CMD ["node", "./dist/server/entry.mjs"]
 ```
 
 ## Recipe


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When following the guide, docker will show the following warning upon building the image:

```txt
 1 warning found:
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 26)
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
Dockerfile:26
--------------------
  24 |     ENV PORT=4321
  25 |     EXPOSE 4321
  26 | >>> CMD node ./dist/server/entry.mjs
  27 |     
--------------------
```

This PR prevents the warning by following the suggestions from https://docs.docker.com/go/dockerfile/rule/json-args-recommended/.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)


<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

You can find me on Discord with the username `openscript`.

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

I've signed up for Hacktoberfest.
