### PR TITLE
simplify experimental flags section

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -424,7 +424,7 @@ export default defineConfig({
 
 #### Experimental features now stable:
 
-- `liveContentCollections` (See the updated [content collections docs](/en/guides/content-collections/#live-collections) to learn more about live collections.)
+- `liveContentCollections` (See the updated [content collections docs](/en/guides/content-collections/) to learn more about live collections.)
 
 #### New default or recommended behavior:
 


### PR DESCRIPTION
This makes the Experimental Flags section more concise for readability, plus adds:

- live collections 
- a link for `headingIdCompat`