### PR TITLE
Update Vitest reference type in testing guide

### DIFF
--- a/src/content/docs/en/guides/testing.mdx
+++ b/src/content/docs/en/guides/testing.mdx
@@ -21,7 +21,7 @@ Use Astro’s `getViteConfig()` helper in your [`vitest.config.ts` configuration
 
 ```js
 // vitest.config.ts
-/// <reference types="vitest" />
+/// <reference types="vitest/config" />
 import { getViteConfig } from 'astro/config';
 
 export default getViteConfig({


### PR DESCRIPTION
#### Description

Update [Testing doc](https://docs.astro.build/en/guides/testing/#vitest) to reflect [changes in Vitest config](https://vitest.dev/guide/#configuring-vitest).

#### Related issue

- Closes #12584
