### PR TITLE
perf: exclude llms plugin during smoke tests

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -69,7 +69,10 @@ export default defineConfig({
 				},
 			],
 			disable404Route: true,
-			plugins: [starlightPluginSmokeTest(), starlightPluginLlmsTxt()],
+			plugins: [
+				starlightPluginSmokeTest(),
+				...(process.env.PUBLIC_TWO_LANG ? [] : [starlightPluginLlmsTxt()]),
+			],
 		}),
 		sitemap(),
 	],

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -4,7 +4,7 @@ import { localesConfig, twoLocalesConfig } from '../config/locales';
 /** The current Starlight i18n configuration depending if we are running smoke tests or not. */
 const currentLocalesConfig = process.env.PUBLIC_TWO_LANG ? twoLocalesConfig : localesConfig;
 
-/** An array of all language currently configured. */
+/** An array of all languages currently configured. */
 export const allLanguages = Object.keys(currentLocalesConfig);
 
 /** The pages to generate for `/[lang]/` dynamic routes. */


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Disable the llms plugin during Astro's smoke tests (as @HiDeoo hints in #12602)
And fix a small typo.

Performance improvement (deleted `.cache/` and `.astro/` folder before both smoke runs):

| Before (with llms plugin)     | After (without llms plugin)      |
| ------------- | ------------- |
| <img width="702" height="92" alt="image" src="https://github.com/user-attachments/assets/da317f44-ccd1-42bb-8801-20bc30282040" /> | <img width="685" height="100" alt="image" src="https://github.com/user-attachments/assets/03c09086-09a9-40b0-bac1-bd21b5a5260b" /> |

_I also noticed that the `▶ @astrojs/starlight/routes/static/index.astro` route builds for all languages no matter if `PUBLIC_TWO_LANG` is set to `true` or not, probably because its config (where it fetches the docs collection) is probably not configurable here. But that is just my assumption, I didn't look more closely into it_

#### Related issues & labels (optional)

- "Follow-up" #12602
- Suggested label: low effort
