### PR TITLE
docs: add note about environment variables with output: 'server'

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -285,6 +285,10 @@ There are three kinds of environment variables, determined by the combination of
 **Secret client variables** are not supported because there is no safe way to send this data to the client. Therefore, it is not possible to configure both `context: "client"` and `access: "secret"` in your schema.
 :::
 
+:::note
+When using `output: 'server'`, `process.env` variables are bundled (hardcoded) into the server bundle during the `npm run build` phase. This means environment variables become part of the compiled server code rather than being read from the environment at runtime. You will need to rebuild to have fresh `.env` values.
+:::
+
 ### Data types
 
 There are currently four data types supported: strings, numbers, enums, and booleans:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

I have added a missing note about bundling the environment variables during output: 'server' build, because it's unclear when you read the docs.

Example of the server output:
<img width="1679" height="460" alt="Image" src="https://github.com/user-attachments/assets/161a13de-34a7-4ecf-b075-06f8495704a5" />

Code what does it:
https://github.com/withastro/astro/blob/be566b3476260529645e92021957dd0ed502ce4b/packages/astro/src/env/vite-plugin-env.ts#L175

<!--#### Related issues & labels (optional)-->

<!--- Closes # Add an issue number if this PR will close it. -->
<!--- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
