### PR TITLE
Use proper header in troubleshooting page

### DIFF
--- a/src/content/docs/en/guides/troubleshooting.mdx
+++ b/src/content/docs/en/guides/troubleshooting.mdx
@@ -186,7 +186,7 @@ You may notice an imported component's `<style>` tag included in your HTML sourc
 
 Astro's build process works on the module graph: once a component is included in the template, its `<style>` tag is processed, optimized, and bundled, whether it appears in the final output or not.
 
-## Escaping special characters in Markdown
+### Escaping special characters in Markdown
 
 Certain characters have a special meaning in Markdown. You may need to use a different syntax if you want to display them. To do this, you can use [HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) for these characters instead.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The Troubleshooting doc has "Escaping special characters in Markdown" as a top-level section, which doesn't make sense to me. My guess is that this was meant to be sub-section of "Common gotchas".
