### PR TITLE
Docs for deployment on GitHub Pages: bump dependencies

### DIFF
--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -41,13 +41,14 @@ Follow the instructions below to use the GitHub Action to deploy your Astro site
         runs-on: ubuntu-latest
         steps:
           - name: Checkout your repository using git
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
           - name: Install, build, and upload your site
-            uses: withastro/action@v3
+            uses: withastro/action@v5
             # with:
               # path: . # The root location of your Astro project inside the repository. (optional)
-              # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+              # node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
               # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+              # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
             # env:
               # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
 


### PR DESCRIPTION
This PR bumps dependencies in the documentation describing deployment on GitHub Pages.
I tested these changes with a GitHub repo of mine, and deployment still worked as expected.