### PR TITLE
fix(astro-i18n): update wrong locale code

### DIFF
--- a/src/content/docs/en/reference/modules/astro-i18n.mdx
+++ b/src/content/docs/en/reference/modules/astro-i18n.mdx
@@ -356,7 +356,7 @@ Replaces underscores (`_`) with hyphens (`-`) in the given locale before returni
 import { normalizeTheLocale } from "astro:i18n";
 
 normalizeTheLocale("it_VT") // returns `it-vt`
-// Assuming the current locale is `"pt-PR"`:
+// Assuming the current locale is `"pt-PT"`:
 normalizeTheLocale(Astro.currentLocale) // returns `pt-pt`
 ---
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

The locale code `pt-PR` does not seem to exist.

Based on my findings, the locales `pt-PT` and `pt-BR` exist, and given that the return value of the `normalizeTheLocale` function is `pt-pt`, it is assumed that `pt-PR` is a typo for `pt-PT`, and thus it is corrected.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
