### PR TITLE
i18n(zh-TW): Revise glossary

### DIFF
--- a/i18n-guides/正體中文.md
+++ b/i18n-guides/正體中文.md
@@ -69,7 +69,7 @@
 | reactive              | 反應式       |                       |
 | recipe                | 操作指南     |                       |
 | reference             | 參考         |                       |
-| repository            | 儲存庫       |                       |
+| repository            | 版本庫       |                       |
 | responsive            | 響應式       |                       |
 | routing               | 路由         |                       |
 | server-side rendering | 伺服器端算繪 |                       |

--- a/src/content/docs/zh-tw/contribute.mdx
+++ b/src/content/docs/zh-tw/contribute.mdx
@@ -8,18 +8,18 @@ import ContributorList from '~/components/ContributorList.astro'
 我們歡迎任何規模的貢獻，無論你是初學者或專家。身為開源專案，我們相信應該要回饋貢獻者，因此很樂意對 PR、技術寫作、功能、想法提供指導。
 
 :::tip[未解決的 Issue]
-請瀏覽 [Astro 所有標記為 `help wanted` 及 `good first issues`，且未解決的 GitHub issue](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues)，這些程式碼儲存庫包含：Astro 程式碼、文件、Starlight、Astro 網站、語言工具、GitHub Action、機器人、編譯工具……有很多地方可以貢獻！
+請瀏覽 [Astro 所有標記為 `help wanted` 及 `good first issues`，且未解決的 GitHub issue](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues)，這些程式碼版本庫包含：Astro 程式碼、文件、Starlight、Astro 網站、語言工具、GitHub Action、機器人、編譯工具……有很多地方可以貢獻！
 :::
 
 想要更深入參與嗎？請參閱我們的[治理文件](https://github.com/withastro/.github/blob/main/GOVERNANCE.md)，其中詳細描述了不同角色、維護者提名流程、程式碼審查流程，以及行為準則。
 
 ## 貢獻的方法
 
-### 專案儲存庫
+### 專案版本庫
 
-為 Astro 專案貢獻的方法很多！每個 Astro 儲存庫都有說明文件，連結到專案根目錄的 `CONTRIBUTING.md` 檔案。
+為 Astro 專案貢獻的方法很多！每個 Astro 版本庫都有說明文件，連結到專案根目錄的 `CONTRIBUTING.md` 檔案。
 
-[Astro 的 GitHub 簡介](https://github.com/withastro)包含下列儲存庫：
+[Astro 的 GitHub 簡介](https://github.com/withastro)包含下列版本庫：
 
 - [Astro 主要 codebase](https://github.com/withastro/astro)，包含官方整合和起始模板。
 

--- a/src/content/docs/zh-tw/guides/deploy/github.mdx
+++ b/src/content/docs/zh-tw/guides/deploy/github.mdx
@@ -8,7 +8,7 @@ i18nReady: true
 ---
 import { Steps } from '@astrojs/starlight/components';
 
-你可以透過 [GitHub Pages](https://pages.github.com/) 直接從 [GitHub](https://github.com/) 的儲存庫中部署你的 Astro 網站。
+你可以透過 [GitHub Pages](https://pages.github.com/) 直接從 [GitHub](https://github.com/) 的版本庫中部署你的 Astro 網站。
 
 ## 如何部署
 
@@ -40,16 +40,16 @@ export default defineConfig({
 
 #### `base`
 
-你可能需要設定 `base`，這樣 Astro 才會將儲存庫名稱（例如 `/my-repo`）視為網站的根目錄。
+你可能需要設定 `base`，這樣 Astro 才會將版本庫名稱（例如 `/my-repo`）視為網站的根目錄。
 
 :::note
   如果你的情況符合以下其中之一，請不要設定 `base` 參數：
 
 - 如果你的頁面由根資料夾所提供。
-- 如果你的原始碼儲存庫在 `https://github.com/<USERNAME>/<USERNAME>.github.io`。
+- 如果你的原始碼版本庫在 `https://github.com/<USERNAME>/<USERNAME>.github.io`。
 :::
 
-`base` 的內容應該是你的儲存庫名稱，並以正斜線開頭，例如 `/my-blog`。這樣做是為了讓 Astro 理解你的網站根目錄是 `/my-repo`，而不是預設的 `/`。
+`base` 的內容應該是你的版本庫名稱，並以正斜線開頭，例如 `/my-blog`。這樣做是為了讓 Astro 理解你的網站根目錄是 `/my-repo`，而不是預設的 `/`。
 
 :::caution
     當設定了這個值後，你所有的內部頁面連結都必須以所設定的 `base` 值作為前綴：
@@ -99,7 +99,7 @@ export default defineConfig({
       # 允許你在 GitHub 上的 Actions 分頁中手動觸發此部署
       workflow_dispatch:
       
-    # 允許這個工作複製儲存庫並建立頁面部署
+    # 允許這個工作複製版本庫並建立頁面部署
     permissions:
       contents: read
       pages: write
@@ -114,9 +114,9 @@ export default defineConfig({
           - name: Install, build, and upload your site
             uses: withastro/action@v3
             # with:
-              # path: . # 儲存庫中 Astro 專案的根位置。（可選）
+              # path: . # 版本庫中 Astro 專案的根位置。（可選）
               # node-version: 20 # 用於建置網站的特定 Node.js 版本，預設為 20。（可選）
-              # package-manager: pnpm@latest # 應該使用哪個 Node.js 套件管理器來安裝相依套件和建置網站，會根據儲存庫中的 lockfile 自動檢測。（可選）
+              # package-manager: pnpm@latest # 應該使用哪個 Node.js 套件管理器來安裝相依套件和建置網站，會根據版本庫中的 lockfile 自動檢測。（可選）
 
       deploy:
         needs: build
@@ -135,7 +135,7 @@ export default defineConfig({
     :::
     
     :::caution
-    官方提供的 Astro [GitHub Action](https://github.com/withastro/action) 會透過掃描根目錄下的 lockfile 來檢查你所使用的套件管理器（如 `npm`、`yarn`、`pnpm` 或 `bun`）。正因如此，你應該將套件管理器自動產生的 `package-lock.json`、`yarn.lock`、`pnpm-lock.yaml` 或是 `bun.lockb` 檔案一起提交至你的儲存庫中。
+    官方提供的 Astro [GitHub Action](https://github.com/withastro/action) 會透過掃描根目錄下的 lockfile 來檢查你所使用的套件管理器（如 `npm`、`yarn`、`pnpm` 或 `bun`）。正因如此，你應該將套件管理器自動產生的 `package-lock.json`、`yarn.lock`、`pnpm-lock.yaml` 或是 `bun.lockb` 檔案一起提交至你的版本庫中。
     :::
 
 2. （可選）如果你要在本地開發或預覽建置時傳遞環境變數到 Astro 專案，你需要在 `deploy.yml` 檔案定義所有公開的變數，這樣它們才會在部署至 GitHub Pages 時被處理。（要新增不公開的環境變數，請參閱 [GitHub 文件中關於設定秘密的部分](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository)。）
@@ -155,14 +155,14 @@ export default defineConfig({
    ```
 
 
-3. 在 GitHub 網站上，請切換到儲存庫中的 **Settings** 分頁，並找到 **Pages** 部分。
+3. 在 GitHub 網站上，請切換到版本庫中的 **Settings** 分頁，並找到 **Pages** 部分。
 
 4. 選擇 **GitHub Actions** 作為設定中的 **Source**。
 
 5. 將先前設定好的 workflow file 提交（Commit）並推送（Push）到 GitHub。 
 </Steps>
   
-恭喜你！如此一來，你的 Astro 網站就會自動部署到 GitHub Pages 上了。如果你更改了你的網站原始碼並推送到前述的儲存庫，GitHub Actions 也會自動重新構建並部署你的網站，你不需要手動構建和部署。
+恭喜你！如此一來，你的 Astro 網站就會自動部署到 GitHub Pages 上了。如果你更改了你的網站原始碼並推送到前述的版本庫，GitHub Actions 也會自動重新構建並部署你的網站，你不需要手動構建和部署。
 
 ## 範例
 

--- a/src/content/docs/zh-tw/install-and-setup.mdx
+++ b/src/content/docs/zh-tw/install-and-setup.mdx
@@ -119,9 +119,9 @@ Astro 是使用 Vite 建構的，預設支援具有現代 JavaScript 功能的�
 
 ### 使用主題或起始模板
 
-使用 `create astro` 命令時，你可以加上 `--template` 參數來基於[官方範例](https://github.com/withastro/astro/tree/main/examples)或任何 GitHub 儲存庫的 `main` 分支建立新的 Astro 專案。
+使用 `create astro` 命令時，你可以加上 `--template` 參數來基於[官方範例](https://github.com/withastro/astro/tree/main/examples)或任何 GitHub 版本庫的 `main` 分支建立新的 Astro 專案。
 
-在你的終端機中執行以下指令，將官方的 Astro 模板名稱或你想使用的主題的 GitHub 使用者名稱和儲存庫名稱替換進去：
+在你的終端機中執行以下指令，將官方的 Astro 模板名稱或你想使用的主題的 GitHub 使用者名稱和版本庫名稱替換進去：
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -129,7 +129,7 @@ Astro 是使用 Vite 建構的，預設支援具有現代 JavaScript 功能的�
   # 使用官方範例建立新專案
   npm create astro@latest -- --template <example-name>
 
-  # 基於 GitHub 儲存庫的 main 分支建立新專案
+  # 基於 GitHub 版本庫的 main 分支建立新專案
   npm create astro@latest -- --template <github-username>/<github-repo>
   ```
   </Fragment>
@@ -138,7 +138,7 @@ Astro 是使用 Vite 建構的，預設支援具有現代 JavaScript 功能的�
   # 使用官方範例建立新專案
   pnpm create astro@latest --template <example-name>
 
-  # 基於 GitHub 儲存庫的 main 分支建立新專案
+  # 基於 GitHub 版本庫的 main 分支建立新專案
   pnpm create astro@latest --template <github-username>/<github-repo>
   ```
   </Fragment>
@@ -147,13 +147,13 @@ Astro 是使用 Vite 建構的，預設支援具有現代 JavaScript 功能的�
   # 使用官方範例建立新專案
   yarn create astro --template <example-name>
 
-  # 基於 GitHub 儲存庫的 main 分支建立新專案
+  # 基於 GitHub 版本庫的 main 分支建立新專案
   yarn create astro --template <github-username>/<github-repo>
   ```
   </Fragment>
 </PackageManagerTabs>
 
-預設情況下，此指令會使用模板儲存庫的 `main` 分支。若要使用不同的分支名稱，請將其作為 `--template` 參數的一部分傳遞：`<github-username>/<github-repo>#<branch>`。
+預設情況下，此指令會使用模板版本庫的 `main` 分支。若要使用不同的分支名稱，請將其作為 `--template` 參數的一部分傳遞：`<github-username>/<github-repo>#<branch>`。
 
 ## 手動安裝
 


### PR DESCRIPTION
#### Description (required)

This adds some mistakable terms to the glossary to draw translators' attention and changes some translations.

There is a plan to change more, such as 水合 (hydration) due to its difficulty to understand, but discussion is needed.

Changes:
- 儲存庫 -> 版本庫 (repository): Use Git CLI translation.
- Adds 隨需算繪 (on-demand render)
- Adds 非完整頁面 (page partial)

Cc: @mingjunlu, @vrabe