### PR TITLE
Refresh CloudCannon CMS guide

### DIFF
--- a/src/content/docs/en/guides/cms/cloudcannon.mdx
+++ b/src/content/docs/en/guides/cms/cloudcannon.mdx
@@ -24,7 +24,7 @@ If you're starting a project from scratch, you can use the [CloudCannon Astro St
 
 This guide will describe the process of configuring CloudCannon as a CMS for Astro using the CloudCannon Site Dashboard.
 
-The Site Dashbaord provides you with an organized view of your Astro files and the ability to edit them using:
+The Site Dashboard provides you with an organized view of your Astro files and the ability to edit them using:
 
 - A [Data Editor](https://cloudcannon.com/documentation/articles/the-data-editor/) for managing structured data files and markup.
 - A [Content Editor](https://cloudcannon.com/documentation/articles/the-content-editor/) for WYSIWYG rich text editing in a minimal view.
@@ -33,8 +33,6 @@ The Site Dashbaord provides you with an organized view of your Astro files and t
 You can also configure role-based access to a minimal [Source Editor](https://cloudcannon.com/documentation/articles/the-source-editor/), an in-browser code editor for making minor changes to the source code of your files.
 
 ## Prerequisites
-
-{/* TODO: Does CloudCannon want a particular UTM link? */}
 
 1. A CloudCannon account. If you don’t have an account, you can [sign up with CloudCannon](https://app.cloudcannon.com/register).
 2. An existing Astro project stored locally, or on one of CloudCannon's supported Git providers: GitHub, GitLab, or Bitbucket. If you do not have an existing project, you can start with CloudCannon's [Astro Starter Template](https://cloudcannon.com/templates/astro-starter/).
@@ -55,7 +53,7 @@ The following steps will configure a new CloudCannon Site from your dashboard. T
 
 You can now explore your Site Dashboard to see your Astro files and edit them with the Content Editor.
 
-You may also want to take advantage of some CloudCannon features such as [organizing your files into collections](#cloudcannon-collections-and-schemas), [creating CloudCannon schemas](#create-a-cloudcannon-schema-for-a-collection), and setting up your project for [visual editing](#configure-visual-editing).
+You may also want to take advantage of some CloudCannon features, such as [organizing your files into collections](#cloudcannon-collections-and-schemas), [creating CloudCannon schemas](#create-a-cloudcannon-schema-for-a-collection), and setting up your project for [visual editing](#configure-visual-editing).
 
 For more detailed instructions, see [CloudCannon's Getting Started Guide](https://cloudcannon.com/documentation/guides/getting-started-with-cloudcannon/).
 
@@ -67,7 +65,7 @@ Your CloudCannon Site Dashboard allows you to organize your Astro project's page
 
 ### Create a CloudCannon schema for a collection
 
-To ensure that the data properties of your CloudCannon entries match the Zod validation `schema` defined in your content collection, you can create a [CloudCannon schema](https://cloudcannon.com/documentation/articles/what-is-a-schema/) (a blank template document for creating a new entry). Creating a template schema can ensure that any new documents created in CloudCannon will have the properties required by your content collection and avoid type errors in your project. Your CloudCannon schema can also include default values to start new documents, such as an author name for a single person blog.
+To ensure that the data properties of your CloudCannon entries match the Zod validation `schema` defined in your content collection, you can create a [CloudCannon schema](https://cloudcannon.com/documentation/articles/what-is-a-schema/) (a blank template document for creating a new entry). Creating a template schema can ensure that any new documents created in CloudCannon will have the properties required by your content collection and avoid type errors in your project. Your CloudCannon schema can also include default values to start new documents, such as an author name for a single-person blog.
 
 The following example will create a CloudCannon schema based on an Astro content collection (`blog`) for blog posts written in Markdown. This schema will be available when [creating a new entry](#creating-a-new-entry) from the CloudCannon "Posts" collection:
 
@@ -87,7 +85,7 @@ The following example will create a CloudCannon schema based on an Astro content
       ---
       
       ```
-4. In your Cloudflare configuration file's `collections_config` property, add the file path to your schema under the CloudCannon collection under the "Posts" collection.
+4. In your CloudCannon configuration file's `collections_config` property, add the file path to your schema under the CloudCannon collection under the "Posts" collection.
 
       ```yml title="cloudcannon.config.yml" ins={6-9}
       collections_config:
@@ -104,22 +102,22 @@ The following example will create a CloudCannon schema based on an Astro content
 
 ## Creating a new entry
 
-In your CloudCannon Site Dashboard, you can create new content using the "Add" button. You will be able to select a an entry type from the schemas you have defined in `cloudcannon.config.yml` depending on which collection you are currently in.
+In your CloudCannon Site Dashboard, you can create new content using the "Add" button. You will be able to select an entry type from the schemas you have defined in `cloudcannon.config.yml`, depending on which collection you are currently in.
 
 You can also upload files to CloudCannon, or create new files directly in your Astro project. When you save your Site changes, new files created in either location will be synchronized and available in both CloudCannon and your Astro project.
 
 The following example will create a new blog post from the CloudCannon Site Dashboard "Posts" collection using the `post.md` template schema created to satisfy the `blog` Astro content collection:
 
 <Steps>
-1. In the CloudCannon Site Dashbaord, navigate to the collection representing the kind of content you want to add. For example, navigate to the "Posts" collection to add a new blog post.
+1. In the CloudCannon Site Dashboard, navigate to the collection representing the kind of content you want to add. For example, navigate to the "Posts" collection to add a new blog post.
 
-2. Use the "Add" button to create a new post. If you have configured CloudCannon `post.md` schema, then you can choose the default blog post entry to create a new post.
+2. Use the "Add" button to create a new post. If you have configured CloudCannon's `post.md` schema, then you can choose the default blog post entry to create a new post.
 
 3. Fill the necessary fields in the sidebar of your Content Editor (e.g. `title`, `author`, `date`), and post content and save your post.
 
 3. This post is saved locally in CloudCannon and should now be visible from your Site Dashboard in your "Posts" collection. You can view and edit all your individual posts from this dashboard page.
 
-4. When you are ready to commit this new post back to your Astro repository, select save in the Site navigation sidebar from your Site Dashboard. This will show you all unsaved changes made to your site since your last commit back to your repository and allow you to review and select which ones to save or discard.
+4. When you are ready to commit this new post back to your Astro repository, select "Save" in the Site navigation sidebar from your Site Dashboard. This will show you all unsaved changes made to your site since your last commit back to your repository and allow you to review and select which ones to save or discard.
 
 5. Return to view your Astro project files and pull new changes from git. You will now find a new `.md` file inside the specified directory for this new post, for example:
     <FileTree title="Project Structure">
@@ -151,9 +149,9 @@ The following example displays a list of each post title, with a link to an indi
 
 ```astro title="src/pages/blog.astro" {4}
 ---
-import { getCollection } from 'astro:content'
+import { getCollection } from 'astro:content';
 
-const posts = await getCollection('blog')
+const posts = await getCollection('blog');
 ---
 <ul>
   {posts.map(post => (
@@ -170,10 +168,10 @@ To display content from an individual post, you can import and use the `<Content
 
 ```astro title="src/pages/blog/my-first-post.astro" {4-5}
 ---
-import { getEntry, render } from 'astro:content'
+import { getEntry, render } from 'astro:content';
 
-const entry = await getEntry('blog', 'my-first-post')
-const { Content } = await render(entry)
+const entry = await getEntry('blog', 'my-first-post');
+const { Content } = await render(entry);
 ---
 
 <main>
@@ -184,7 +182,7 @@ const { Content } = await render(entry)
 
 ```
 
-For more information on querying, filtering, displaying your collections content and more, see the full content [collections documentation](/en/guides/content-collections/).
+For more information on querying, filtering, displaying your collections content, and more, see the full content [collections documentation](/en/guides/content-collections/).
 
 ## Deploying CloudCannon + Astro
 
@@ -242,7 +240,7 @@ CloudCannon allows you to [define Component Editable Regions](https://cloudcanno
 
 3. Follow [CloudCannon's instructions to register your components](https://cloudcannon.com/documentation/guides/set-up-visual-editing/visual-editing-for-components/#register-your-components). This tells CloudCannon that those components should be bundled for client-side use in the Visual Editor.
 
-4. Add the appropriate attributes to your components for visual editing. For example, the following `CTA.astro` component properties such as description and button color can be updated in CloudCannon's Visual Editor:
+4. Add the appropriate attributes to your components for visual editing. For example, the following `CTA.astro` component properties, such as description and button color, can be updated in CloudCannon's Visual Editor:
 
     ```astro title="src/components/CTA.astro"
     ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updating CloudCannon CMS guide to coincide with more / better Astro support. (e.g. Editable components)

Focuses on the parts relevant to using with Astro.

Direct link to deploy preview of the guide: https://deploy-preview-12698--astro-docs-2.netlify.app/en/guides/cms/cloudcannon/