### PR TITLE
fix(adapter-reference): small nitpicks (verb tense, indentation...)

### DIFF
--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -166,7 +166,7 @@ export default function createIntegration() {
 **Type:** `URLSearchParams`
 </p>
 
-Defines the query parameters to append to all asset URLs (images, stylesheets, scripts, etc.). This is useful for adapters that need to track deployment versions or other metadata.
+Defines the query parameters to append to all asset URLs (e.g. images, stylesheets, scripts). This is useful for adapters that need to track deployment versions or other metadata.
 
 The following example retrieves a `DEPLOY_ID` from the environment variables and, if provided, returns an object with a custom search parameter name as key and the deploy id as value:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

While translating in French, I noticed a few more fixes for the Adapter reference:
* verb tense in two locations
* redundant `.e.g.` with `etc.`
* consistent use of backticks for code
* consistent use of parenthesis for functions as inline code
* a code snippet was malformed
* the indentation in code snippets was inconsistent (some used 4 spaces, a mix of 2 and 4 spaces, or tabs)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label:  `code snippet update`, `consistency/formatting`, `typo/link/grammar - quick fix!`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
