### PR TITLE
fonts: clarify adobe id loading

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -152,7 +152,9 @@ body {
 
 ## Available remote font providers
 
-Astro re-exports most [unifont](https://github.com/unjs/unifont/) providers. The following have built-in support:
+Astro re-exports most [unifont](https://github.com/unjs/unifont/) providers. You can also [make a custom Astro font provider](#build-your-own-font-provider) for any unifont provider.
+
+The following providers have built-in support:
 
 - [Adobe](https://fonts.adobe.com/)
 - [Bunny](https://fonts.bunny.net/)
@@ -170,11 +172,7 @@ To use a built-in remote provider, configure `provider` with the appropriate val
 provider: fontProviders.adobe({ id: 'your-id' })
 ```
 
-Pass the Adobe font provider an ID loaded as an [environment variable in your Astro config file](/en/guides/environment-variables/#in-the-astro-config-file)
-
-<ReadMore>Learn more about using environment variables [in the Astro config file](/en/guides/environment-variables/#in-the-astro-config-file).</ReadMore>
-
----
+Pass the Adobe font provider an ID loaded as an [environment variable in your Astro config file](/en/guides/environment-variables/#in-the-astro-config-file).
 
 </TabItem>
 
@@ -218,13 +216,9 @@ provider: fontProviders.google({
 })
 ```
 
----
-
 </TabItem>
 
 </Tabs>
-
-You can also [make a custom Astro font provider](#build-your-own-font-provider) for any unifont provider.
 
 ## Usage examples
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Our example of the adobe provider was wrong: `process.env` is not necessarily loaded by default. This PR updates this section to make it clearer and link to the relevant docs.

I also added some `hr` tags under font providers with text to make it standout more with the sentence below about custom font providers.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
