### PR TITLE
fonts: updated default subset

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -82,7 +82,7 @@ body {
     });
     ```
 
-    More configuration options, such as defining [fallback font families](#fallbacks) and which [`weights`](#weights) and [`styles`](#styles) to download, are available and some will depend on your chosen provider.
+    More configuration options, such as defining [fallback font families](#fallbacks) and which [`weights`](#weights), [`styles`](#styles) and [`subsets`](#subsets) to download, are available and some will depend on your chosen provider.
     
     See the full [configuration reference](#font-configuration-reference) to learn more.
 
@@ -233,7 +233,7 @@ export default defineConfig({
         // Default included:
         // weights: [400] ,
         // styles: ["normal", "italics"],
-        // subsets: ["cyrillic-ext", "cyrillic", "greek-ext", "greek", "vietnamese", "latin-ext", "latin"],
+        // subsets: ["latin"],
         // fallbacks: ["sans-serif"], 
       },
       {
@@ -245,14 +245,14 @@ export default defineConfig({
         // Specify styles that are actually used
         styles: ["normal"],
         // Download only font files for characters used on the page
-        subsets: ["cyrillic"],
+        subsets: ["latin", "cyrillic"],
       },
       {
         name: "JetBrains Mono",
         cssVariable: "--font-jetbrains-mono",
         provider: fontProviders.fontsource(),
         // Download only font files for characters used on the page
-        subsets: ["latin"],
+        subsets: ["latin", "latin-ext"],
         // Use a fallback font family matching the intended appearance
         fallbacks: ["monospace"],
       },
@@ -550,7 +550,7 @@ styles: ["normal", "oblique"]
 <p>
 
 **Type:** `string[]`<br />
-**Default:** `["cyrillic-ext", "cyrillic", "greek-ext", "greek", "vietnamese", "latin-ext", "latin"]`
+**Default:** `["latin"]`
 </p>
 
 Defines a list of [font subsets](https://knaap.dev/posts/font-subsetting/) to preload.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The default subset is updated. I don't think we need to add a `Since` for this

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.?`. See astro PR [14796](https://github.com/withastro/astro/pull/14796).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
