### PR TITLE
Fix config for static workers section of cloudflare deploy guide

### DIFF
--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -77,8 +77,7 @@ To get started, you will need:
           "name": "my-astro-app",
           "compatibility_date": "YYYY-MM-DD", // Update to the day you deploy
           "assets": {
-            "binding": "ASSETS",
-            "directory": "./dist",
+            "directory": "./dist"
           }
         }
         ```


### PR DESCRIPTION
Current config creates this error:

```sh
✘ [ERROR] Cannot use assets with a binding in an assets-only Worker.

  Please remove the asset binding from your configuration file, or provide
  a Worker script in your configuration file (`main`).
```
