### PR TITLE
Remove unnecessary double dashes in npm commands

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -96,7 +96,7 @@ This allows you to run the dev server or build your site connecting to different
     npm run astro dev --mode staging
 
     # Build a site that connects to a "production" API with additional debug information
-    npm run astro build -- --devOutput
+    npm run astro build --devOutput
 
     # Build a site that connects to a "testing" API
     npm run astro build --mode testing


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

`astro dev -- --mode dev` does not work, `astro dev --mode dev` does work. Not sure if this was changed recently and docs weren't updated, but this had me stuck for a while.

Not sure about --devOutput but since it's documented as a CLI command to astro I assume that the double dashes should be removed for that as well.

#### Related issues & labels (optional)

- Suggested label: Improve or update documentation <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

No need for first time contributor, I am @MarcusOtter on work account 🕵️ 