### PR TITLE
csp: improve docs

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/csp.mdx
+++ b/src/content/docs/en/reference/experimental-flags/csp.mdx
@@ -146,7 +146,7 @@ These properties are added to all pages and **completely override Astro's defaul
 <Since v="5.9.0" />
 </p>
 
-A list of valid sources for the `script-src` and `style-src` directives.
+A list of valid sources for the `script-src` and `style-src` directives, including [values for subclasses](#adding-values-for-subclasses).
 
 The `script-src` and `style-src` directives are handled by Astro by default, and use the `'self'` resource. This means that scripts and styles can only be downloaded by the current host (usually the current website).
 
@@ -187,6 +187,8 @@ After the build, the `<meta>` element will instead apply your sources to the `st
   >
 </head>
 ```
+
+### Adding values for subclasses
 
 You can also use this field to add valid values that belong to [`script-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src-attr), [`script-src-elem`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src-elem), [`style-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src-attr) and [`style-src-elem`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src-elem), such as `unsafe-hashes` and `unsafe-inline`.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Some users have asked how, with CSP, can support `script-src-*` and `style-src-*`.

Well, the thing is, we already do! However, this information was "hidden", in the sense that we don't explicitly state that `resources` can be used to add the values supported by those directives.

This was due to my lack of knowledge.

This PR expands the docs of `resources`. 

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->
- Related support thread: https://discord.com/channels/830184174198718474/1443253672036536445

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
