### PR TITLE
[next]: add migration section for removal of internal exports

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -368,6 +368,63 @@ You may also wish to consider using glob packages from NPM, such as [`fast-glob`
 
 <ReadMore>Learn more about [importing files with `import.meta.glob`](/en/guides/imports/#importmetaglob).</ReadMore>
 
+### Removed: exposed `astro:actions` internals
+
+<SourcePR number="14844" title="refactor: cleanup public actions API"/>
+
+In Astro 5.x, some internals were exported from `astro:actions` that were not meant to be exposed for public use.
+
+Astro 6.0 removes the following functions, classes and types as exports from the `astro:actions` virtual module. These can no longer be imported in your project files:
+
+- `ACTION_ERROR_CODES`
+- `ActionInputError`
+- `appendForwardSlash`
+- `astroCalledServerError`
+- `callSafely`
+- `deserializeActionResult`
+- `formDataToObject`
+- `getActionQueryString`
+- `serializeActionResult`
+- `type Actions`
+- `type ActionAccept`
+- `type AstroActionContext`
+- `type SerializedActionResult`
+
+#### What should I do?
+
+Replace all imports of `serializeActionResult()` and `deserializeActionResult()` with `getActionContext()`. These two methods are now available through `getActionContext()`:
+
+```ts title="src/middleware.ts" del={2} ins={3,6}
+import { defineMiddleware } from 'astro:middleware';
+import { serializeActionResult, deserializeActionResult } from 'astro:actions';
+import { getActionContext } from 'astro:actions';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { serializeActionResult, deserializeActionResult } = getActionContext(context);
+  // ...
+});
+```
+
+Remove any occurrences of the other removed exports:
+
+```ts del={1-13}
+import {
+  ACTION_ERROR_CODES,
+  ActionInputError,
+  appendForwardSlash,
+  astroCalledServerError,
+  callSafely,
+  formDataToObject,
+  getActionQueryString,
+  type Actions,
+  type ActionAccept,
+  type AstroActionContext,
+  type SerializedActionResult,
+} from 'astro:actions';
+```
+
+<ReadMore>Learn more about all utilities available in the [Actions API Reference](/en/reference/modules/astro-actions/).</ReadMore>
+
 ### Removed: `routes` on `astro:build:done` hook (Integration API)
 
 <SourcePR number="14446" title="feat: cleanup integration api"/>
@@ -546,63 +603,6 @@ export const server = {
 ```
 
 <ReadMore>Learn more about [rewrites](/en/guides/routing/#rewrites).</ReadMore>
-
-### Removed: exposed `astro:actions` internals
-
-<SourcePR number="14844" title="refactor: cleanup public actions API"/>
-
-In Astro 5.x, some internals were exported from `astro:actions` that were not meant to be exposed for public use.
-
-Astro 6.0 removes the following functions, classes and types as exports from the `astro:actions` virtual module. These can no longer be imported in your project files:
-
-- `ACTION_ERROR_CODES`
-- `ActionInputError`
-- `appendForwardSlash`
-- `astroCalledServerError`
-- `callSafely`
-- `deserializeActionResult`
-- `formDataToObject`
-- `getActionQueryString`
-- `serializeActionResult`
-- `type Actions`
-- `type ActionAccept`
-- `type AstroActionContext`
-- `type SerializedActionResult`
-
-#### What should I do?
-
-Replace all imports of `serializeActionResult()` and `deserializeActionResult()` with `getActionContext()`. These two methods are now available through `getActionContext()`:
-
-```ts title="src/middleware.ts" del={2} ins={3,6}
-import { defineMiddleware } from 'astro:middleware';
-import { serializeActionResult, deserializeActionResult } from 'astro:actions';
-import { getActionContext } from 'astro:actions';
-
-export const onRequest = defineMiddleware(async (context, next) => {
-  const { serializeActionResult, deserializeActionResult } = getActionContext(context);
-  // ...
-});
-```
-
-Remove any occurrences of the other removed exports:
-
-```ts del={1-13}
-import {
-  ACTION_ERROR_CODES,
-  ActionInputError,
-  appendForwardSlash,
-  astroCalledServerError,
-  callSafely,
-  formDataToObject,
-  getActionQueryString,
-  type Actions,
-  type ActionAccept,
-  type AstroActionContext,
-  type SerializedActionResult,
-} from 'astro:actions';
-```
-
-<ReadMore>Learn more about all utilities available in the [Actions API Reference](/en/reference/modules/astro-actions/).</ReadMore>
 
 ### Experimental Flags
 


### PR DESCRIPTION
#### Description (required)

This PR adds a section to the v6 migration guide regarding [ refactor: cleanup public actions API #14844 ](https://github.com/withastro/astro/pull/14844).

I listed all removed utilities (classes, functions and types) for clarity. I'm not sure if this is a good approach, as when people search for these terms in the future, they'll be able to find them here, alto they are not documented anywhere (because they got removed).

I did not come up with a better example to demonstrate a removal and I was so cheeky to include myself in there. Feel free to suggest a more appropriate example 🙌 

#### Related issues & labels (optional)

- Code PR: https://github.com/withastro/astro/pull/14844

#### For Astro version: `6.x`. See astro PR [#14844](https://github.com/withastro/astro/pull/14844).

Pinging @florian-lefebvre for review (no rush!).
