### PR TITLE
[docs]: Clarify astro:env/server variable evaluation and secret handling

### DIFF
--- a/src/content/docs/en/guides/environment-variables.mdx
+++ b/src/content/docs/en/guides/environment-variables.mdx
@@ -279,7 +279,9 @@ There are three kinds of environment variables, determined by the combination of
    import { API_SECRET } from "astro:env/server";
    ```
 
-   By default, secrets are only validated at runtime. You can enable validating private variables on start by [configuring `validateSecrets: true`](/en/reference/configuration-reference/#envvalidatesecrets).
+   By default, all secrets are validated whenever anything is imported from the `astro:env/server` module. This means, secrets may be validated even when they are not imported. You may need to [pass dummy environment variables](#setting-environment-variables) to satisfy this validation during the build.
+
+   You can also enable validating secrets on start by [configuring `validateSecrets: true`](/en/reference/configuration-reference/#envvalidatesecrets).
 
 :::note
 **Secret client variables** are not supported because there is no safe way to send this data to the client. Therefore, it is not possible to configure both `context: "client"` and `access: "secret"` in your schema.
@@ -319,33 +321,6 @@ envField.enum({
 ```
 
 <ReadMore>For a complete list of validation fields, see the [`envField` API reference](/en/reference/configuration-reference/#envschema).</ReadMore>
-
-### Secrets during the build
-
-**Secret server variables** are validated even during `astro build` because `astro:env/server` is evaluated on import.
-
-If your build process does not have access to these secrets, the build will fail. You can pass dummy values to the build command to satisfy the validation:
-
-<PackageManagerTabs>
- <Fragment slot="npm">
-    ```shell
-    # Example: passing a dummy value to build
-    MY_SECRET_KEY="dummy" npm run build
-    ```
- </Fragment>
- <Fragment slot="pnpm">
-    ```shell
-    # Example: passing a dummy value to build
-    MY_SECRET_KEY="dummy" pnpm build
-    ```
- </Fragment>
-  <Fragment slot="yarn">
-    ```shell
-    # Example: passing a dummy value to build
-    MY_SECRET_KEY="dummy" yarn build
-    ```
- </Fragment>
-</PackageManagerTabs>
 
 ### Retrieving secrets dynamically
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Added documentation regarding `secret server variable` validation during the build process.
Since `astro:env/server` is evaluated on import, builds can fail if secrets are missing. This PR adds a section explaining this behavior and how to fix it using dummy values.

<img width="926" height="558" alt="スクリーンショット 2025-12-03 23 31 59" src="https://github.com/user-attachments/assets/5ef9ee8a-1f10-4874-8c9d-7db7a916fd0d" />

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #12581
- Suggested label: `improve or update documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
