### PR TITLE
i18n(de): Replace straight quote with smart quote in sidebar navigation

### DIFF
--- a/src/content/nav/de.ts
+++ b/src/content/nav/de.ts
@@ -1,7 +1,7 @@
 import { navDictionary } from '../../util/navDictionary';
 
 export default navDictionary({
-	start: "Los geht's",
+	start: "Los geht’s",
 	'start.welcome': 'Willkommen, Welt!',
 	'start.newProject': 'Ein neues Projekt starten',
 	'start.config': 'Konfiguration',


### PR DESCRIPTION
#### Description

This PR replaces the straight quote in “Los geht's” with the smart quote (“Los geht’s”). SmartyPants does not apply here, so it would make sense to basically do “manual SmartyPants formatting” in this file.

#### Related labels

- Suggested label: i18n