### PR TITLE
astro build environments

### DIFF
--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -1209,7 +1209,8 @@ resolveId(id) {
     return 'export const foo = "bar"';
   }
 }
-  
+```
+
 ## Integration types reference
 
 ### `AstroIntegrationLogger`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In v6 Astro has three environments during the build, one more compared to the classic `ssr` and `client` Vite environments.

This PR adds a new section to the integration APIs to cover these environments. 

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->


The relevant [PR 14998](https://github.com/withastro/astro/pull/14998) was merged in main `next`