### PR TITLE
fix: clarify streaming errors

### DIFF
--- a/src/content/docs/en/basics/astro-pages.mdx
+++ b/src/content/docs/en/basics/astro-pages.mdx
@@ -115,7 +115,7 @@ During development, if you have a `500.astro`, the error thrown at runtime is lo
 
 <p><Since v="4.11.0" /></p>
 
-`src/pages/500.astro` is a special page that is automatically passed an `error` prop for any error thrown during rendering. This allows you to use the details of an error (e.g. from a page, from middleware, etc.) to display information to your visitor.
+`src/pages/500.astro` is a special page that is automatically passed an `error` prop for error thrown during rendering. This allows you to use the details of an error (e.g. from a page, from middleware, etc.) to display information to your visitor.
 
 The `error` prop's data type can be anything, which may affect how you type or use the value in your code:
 
@@ -131,6 +131,37 @@ const { error } = Astro.props;
 ```
 
 To avoid leaking sensitive information when displaying content from the `error` prop, consider evaluating the error first, and returning appropriate content based on the error thrown. For example, you should avoid displaying the error's stack as it contains information about how your code is structured on the server.
+
+:::caution
+Astro streams content to the browser as it is rendered. If an error occurs in a component template after the initial response headers have been sent, the server cannot trigger the 500 error page.
+:::
+
+To ensure that errors are captured by the 500 page, try to perform data fetching and validation in the frontmatter. Errors thrown here happen before rendering begins, allowing the server to display the error page.
+
+If you must catch errors that occur during rendering (e.g. inside a component's template), you can use middleware to buffer the response. This forces the entire page to render in memory before sending anything to the browser.
+
+```ts title="src/middleware.ts"
+import { defineMiddleware } from "astro:middleware";
+
+export const onRequest = defineMiddleware(async (_, next) => {
+  const response = await next();
+
+  // Important: must filter out non-HTML requests here!
+
+  try {
+    const html = await response.text();
+    return new Response(html, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (error) {
+    throw error;
+  }
+});
+```
+:::note
+Buffering the response in middleware disables streaming for that page, which may delay the Time to First Byte (TTFB). Use this only if capturing rendering errors is critical for your application. 
+:::
 
 ## Page Partials
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
This PR clarifies the limitations of `src/pages/500.astro` regarding streaming rendering errors and provides a workaround using middleware.

<img width="763" height="358" alt="スクリーンショット 2025-12-13 10 14 46" src="https://github.com/user-attachments/assets/819b64b0-660d-4a7a-9cba-240160710863" />
<img width="759" height="665" alt="スクリーンショット 2025-12-13 10 14 58" src="https://github.com/user-attachments/assets/7994d91f-6fd8-4a02-9fe5-a00639be4b4b" />



<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #12172 
- Suggested label: `implove or update documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
