### PR TITLE
feat(next): harden vite links in upgrade guides

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v1.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v1.mdx
@@ -46,7 +46,7 @@ Astro v1.0 introduces some changes that you should be aware of when migrating fr
 
 ### Updated: Vite 3
 
-Astro v1.0 has upgraded from Vite 2 to [Vite 3](https://vite.dev/). We've handled most of the upgrade for you inside of Astro; however, some subtle Vite behaviors may still change between versions. Refer to the official [Vite Migration Guide](https://vite.dev/guide/migration.html#general-changes) if you run into trouble.
+Astro v1.0 has upgraded from Vite 2 to [Vite 3](https://v3.vite.dev/). We've handled most of the upgrade for you inside of Astro; however, some subtle Vite behaviors may still change between versions. Refer to the official [Vite Migration Guide](https://v3.vite.dev/guide/migration.html#general-changes) if you run into trouble.
 
 ### Deprecated: `Astro.canonicalURL`
 
@@ -524,7 +524,7 @@ export default {
 };
 ```
 
-To learn more about configuring Vite, please visit their [configuration guide](https://vite.dev/config/).
+To learn more about configuring Vite, please visit their [configuration guide](https://v3.vite.dev/config/).
 
 #### Vite Plugins
 
@@ -540,7 +540,7 @@ export default {
 };
 ```
 
-To learn more about Vite plugins, please visit their [plugin guide](https://vite.dev/guide/using-plugins.html).
+To learn more about Vite plugins, please visit their [plugin guide](https://v3.vite.dev/guide/using-plugins.html).
 
 #### Vite Changes to Renderers
 
@@ -573,7 +573,7 @@ export default {
 }
 ```
 
-To learn more about Vite plugins, please visit their [plugin guide](https://vite.dev/guide/using-plugins.html).
+To learn more about Vite plugins, please visit their [plugin guide](https://v3.vite.dev/guide/using-plugins.html).
 
 :::note
 In prior releases, these were configured with `snowpackPlugin` or `snowpackPluginOptions`.
@@ -666,4 +666,4 @@ const whereShouldIPutMyImports = "on top!"
 ---
 ```
 
-[vite]: https://vite.dev
+[vite]: https://v3.vite.dev/

--- a/src/content/docs/en/guides/upgrade-to/v2.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v2.mdx
@@ -384,13 +384,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 ### Updated: Vite 4
 
-Astro v2.0 upgrades from Vite 3 to [Vite 4](https://vite.dev/), released in December 2022.
+Astro v2.0 upgrades from Vite 3 to [Vite 4](https://v4.vite.dev/), released in December 2022.
 
 #### What should I do?
 
 There should be no changes to your code necessary! We've handled most of the upgrade for you inside of Astro; however, some subtle Vite behaviors may still change between versions. 
 
-Refer to the official [Vite Migration Guide](https://vite.dev/guide/migration.html) if you run into trouble.
+Refer to the official [Vite Migration Guide](https://v4.vite.dev/guide/migration.html) if you run into trouble.
 
 ## Astro v2.0 Experimental Flags Removed
 

--- a/src/content/docs/en/guides/upgrade-to/v4.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v4.mdx
@@ -86,11 +86,11 @@ Any major upgrades to Astro's dependencies may cause breaking changes in your pr
 
 In Astro v3.0, Vite 4 was used as the development server and production bundler.
 
-Astro v4.0 upgrades from Vite 4 to Vite 5.
+Astro v4.0 upgrades from Vite 4 to [Vite 5](https://v5.vite.dev/).
 
 #### What should I do?
 
-If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://vite.dev/guide/migration) for their breaking changes and upgrade your project as needed. There are no breaking changes to Astro itself.
+If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://v5.vite.dev/guide/migration) for their breaking changes and upgrade your project as needed. There are no breaking changes to Astro itself.
 
 ### Upgraded: unified, remark, and rehype dependencies
 

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -61,11 +61,11 @@ Any major upgrades to Astro's dependencies may cause breaking changes in your pr
 
 ### Vite 6.0
 
-Astro v5.0 upgrades to Vite v6.0 as the development server and production bundler.
+Astro v5.0 upgrades to [Vite v6.0](https://v6.vite.dev/) as the development server and production bundler.
 
 #### What should I do?
 
-If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://vite.dev/guide/migration.html) for their breaking changes and upgrade your project as needed.
+If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://v6.vite.dev/guide/migration.html) for their breaking changes and upgrade your project as needed.
 
 ### `@astrojs/mdx`
 

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -91,17 +91,17 @@ Check that both your development environment and your deployment environment are
 
 <SourcePR number="14445" title="feat: update vite"/>
 
-Astro v6.0 upgrades to Vite v7.0 as the development server and production bundler.
+Astro v6.0 upgrades to [Vite v7.0](https://v7.vite.dev/) as the development server and production bundler.
 
 #### What should I do?
 
-If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://vite.dev/guide/migration) for their breaking changes and upgrade your project as needed.
+If you are using Vite-specific plugins, configuration, or APIs, check the [Vite migration guide](https://v7.vite.dev/guide/migration) for their breaking changes and upgrade your project as needed.
 
 ### Vite Environment API
 
 <SourcePR number="14306" title="feat: integrate vite environments"/>
 
-Astro v6.0 introduces significant changes to how Astro manages different runtime environments (client, server, and prerender) after an internal refactor to use [Vite's new Environments API](https://vite.dev/guide/api-environment).
+Astro v6.0 introduces significant changes to how Astro manages different runtime environments (client, server, and prerender) after an internal refactor to use [Vite's new Environments API](https://v7.vite.dev/guide/api-environment).
 
 Integration and adapter maintainers should pay special attention to changes affecting these parts of the Integration API and Adapter API (full details included below with other breaking changes to these APIs):
 
@@ -981,7 +981,7 @@ Review your links to your custom endpoints that include a file extension in the 
 
 <SourcePR number="14485" title="feat: stabilize static import meta env"/>
 
-In Astro 5.13, the `experimental.staticImportMetaEnv` flag was introduced to update the behavior when accessing `import.meta.env` directly to align with [Vite's handling of environment variables](https://vite.dev/guide/env-and-mode.html#env-variables) and ensures that `import.meta.env` values are always inlined.
+In Astro 5.13, the `experimental.staticImportMetaEnv` flag was introduced to update the behavior when accessing `import.meta.env` directly to align with [Vite's handling of environment variables](https://v7.vite.dev/guide/env-and-mode.html#env-variables) and ensures that `import.meta.env` values are always inlined.
 
 In Astro 5.x, non-public environment variables were replaced by a reference to `process.env`. Additionally, Astro could also convert the value type of your environment variables used through `import.meta.env`, which could prevent access to some values such as the strings `"true"` (which was converted to a boolean value), and `"1"` (which was converted to a number).
 
@@ -1263,7 +1263,7 @@ server.hot.send(event)
 server.environments.client.hot.send(event)
 ```
 
-<ReadMore>Learn more about the [Vite Environment API](https://vite.dev/guide/api-environment) and Astro [integration hooks](/en/reference/integrations-reference/#astrobuildsetup).</ReadMore>
+<ReadMore>Learn more about the [Vite Environment API](https://v7.vite.dev/guide/api-environment) and Astro [integration hooks](/en/reference/integrations-reference/#astrobuildsetup).</ReadMore>
 
 ### Changed: `SSRManifest` interface structure (Adapter API)
 


### PR DESCRIPTION
#### Description

This PR pin points each Vite documentation link in the major upgrade guides to their specific version for better reproducibility. The Vite documentation offers subdomains for each major Vite version, so I think it makes sense to use them in the upgrade guides. Especially Vite major migration guide links should be pin pointed so they do not all point to the current v6->v7 migration guide.