### PR TITLE
German translation, abbreviation 'z.B.': add non-breaking space [lunaria-ignore]

### DIFF
--- a/src/content/docs/de/basics/astro-components.mdx
+++ b/src/content/docs/de/basics/astro-components.mdx
@@ -50,7 +50,7 @@ import IrgendeineAstroKomponente from '../components/IrgendeineAstroKomponente.a
 import IrgendeineReactKomponente from '../components/IrgendeineReactKomponente.jsx';
 import irgendwelcheDaten from '../data/pokemon.json';
 
-// Zugriff auf übergebene Props (Komponenteneigenschaften), wie z.B. `<X title="Hallo, Welt!" />`
+// Zugriff auf übergebene Props (Komponenteneigenschaften), wie z. B. `<X title="Hallo, Welt!" />`
 const { title } = Astro.props;
 // Abrufen externer Daten, auch aus einer privaten API oder Datenbank
 const data = await fetch('EINE_GEHEIME_API_URL/users').then(r => r.json());

--- a/src/content/docs/de/basics/astro-pages.mdx
+++ b/src/content/docs/de/basics/astro-pages.mdx
@@ -152,7 +152,7 @@ Da sie sich jedoch in dem speziellen Verzeichnis `src/pages/` befinden, ist das 
 
 Partielle Seiten bieten in Kombination mit einer Rendering-Bibliothek eine Alternative zu [Astro-Inseln](/de/concepts/islands/) und [`<script>`-Tags](/de/guides/client-side-scripts/), um dynamische Inhalte in Astro zu erstellen.
 
-Seitendateien, die einen Wert für [`partial`](/de/reference/routing-reference/#partial) exportieren können (z.B. `.astro` und `.mdx`, aber nicht `.md`), können als partielle Dateien markiert werden.
+Seitendateien, die einen Wert für [`partial`](/de/reference/routing-reference/#partial) exportieren können (z. B. `.astro` und `.mdx`, aber nicht `.md`), können als partielle Dateien markiert werden.
 
 ```astro title="src/pages/partial.astro" ins={2}
 ---

--- a/src/content/docs/de/basics/layouts.mdx
+++ b/src/content/docs/de/basics/layouts.mdx
@@ -6,7 +6,7 @@ i18nReady: true
 
 import ReadMore from '~/components/ReadMore.astro'
 
-**Layouts** sind [Astro-Komponenten](/de/basics/astro-components/), die verwendet werden, um eine wiederverwendbare UI-Struktur, wie z.B. eine Seitenvorlage, bereitzustellen.
+**Layouts** sind [Astro-Komponenten](/de/basics/astro-components/), die verwendet werden, um eine wiederverwendbare UI-Struktur, wie z. B. eine Seitenvorlage, bereitzustellen.
 
 Wir verwenden den Begriff „Layout“ üblicherweise für Astro-Komponenten, die gemeinsame UI-Elemente für alle Seiten bereitstellen, wie z. B. Kopf-, Navigations- und Fußzeilen. Eine typische Astro-Layoutkomponente bietet [Astro-, Markdown- oder MDX-Seiten](/de/basics/astro-pages/) folgendes:
 - einer **Seitenhülle** (`<html>`, `<head>` und `<body>` Tags)
@@ -102,7 +102,7 @@ const { title, description, publishDate, viewCount } = Astro.props;
 
 Seitenlayouts sind besonders nützlich für einzelne Markdown-Seiten, die sonst keine Seitenformatierung haben würden. 
 
-Astro bietet eine spezielle `layout`-Frontmatter-Eigenschaft für [einzelne `.md`-Dateien, die sich innerhalb von `src/pages/` befinden und dateibasiertes Routing verwenden](/de/guides/markdown-content/#individual-markdown-pages), um anzugeben, welche `.astro`-Komponente als Seitenlayout verwendet werden soll. Diese Komponente ermöglicht es dir, `<head>`-Inhalte wie Meta-Tags (z.B. `<meta charset="utf-8">`) und Stile für die Markdown-Seite anzugeben. Standardmäßig kann die angegebene Komponente automatisch auf Daten aus der Markdown-Datei zugreifen.
+Astro bietet eine spezielle `layout`-Frontmatter-Eigenschaft für [einzelne `.md`-Dateien, die sich innerhalb von `src/pages/` befinden und dateibasiertes Routing verwenden](/de/guides/markdown-content/#individual-markdown-pages), um anzugeben, welche `.astro`-Komponente als Seitenlayout verwendet werden soll. Diese Komponente ermöglicht es dir, `<head>`-Inhalte wie Meta-Tags (z. B. `<meta charset="utf-8">`) und Stile für die Markdown-Seite anzugeben. Standardmäßig kann die angegebene Komponente automatisch auf Daten aus der Markdown-Datei zugreifen.
 
 ```markdown title="src/pages/page.md" {2} 
 ---
@@ -137,7 +137,7 @@ const { frontmatter } = Astro.props;
     <title>{frontmatter.title}</title>
   </head>
   <body>
-    <!-- Füge hier andere UI-Komponenten hinzu, wie z.B. allgemeine Kopf- und Fußzeilen. -->
+    <!-- Füge hier andere UI-Komponenten hinzu, wie z. B. allgemeine Kopf- und Fußzeilen. -->
     <h1>{frontmatter.title} by {frontmatter.author}</h1>
     <!-- 2. Das gerenderte HTML wird in den Standard-Slot übertragen. -->
     <slot />
@@ -181,8 +181,8 @@ const { frontmatter, url } = Astro.props;
 
 Ein Markdown-Layout hat über `Astro.props` Zugriff auf die folgenden Informationen:
 
-- **`file`** - Der absolute Pfad zu dieser Datei (z.B. `/home/user/projects/.../file.md`).
-- **`url`** - Die URL der Seite (z.B. `/de/guides/markdown-content`).
+- **`file`** - Der absolute Pfad zu dieser Datei (z. B. `/home/user/projects/.../file.md`).
+- **`url`** - Die URL der Seite (z. B. `/de/guides/markdown-content`).
 - **`frontmatter`** - Alle Frontmatter aus dem Markdown- oder MDX-Dokument.
   - **`frontmatter.file`** - Dasselbe wie die Top-Level-Eigenschaft „file“.
   - **`frontmatter.url`** - Dasselbe wie die Eigenschaft `url` der obersten Ebene.

--- a/src/content/docs/de/basics/project-structure.mdx
+++ b/src/content/docs/de/basics/project-structure.mdx
@@ -105,7 +105,7 @@ Es ist eine übliche Vorgehensweise, deine CSS- oder Sass-Stile im Verzeichnis `
 
 Das Verzeichnis `public/` ist für Dateien und Inhalte vorgesehen, die Astro während des Buildvorgangs nicht verarbeiten muss. Die Dateien in diesem Ordner werden unverändert in den Build-Ordner kopiert, und dann wird deine Website gebaut.
 
-Dieses Verhalten macht `public/` ideal für allgemeine Inhalte, die keine Bearbeitung benötigen, wie z.B. einige Bilder und Schriftarten oder spezielle Dateien wie `robots.txt` und `manifest.webmanifest`.
+Dieses Verhalten macht `public/` ideal für allgemeine Inhalte, die keine Bearbeitung benötigen, wie z. B. einige Bilder und Schriftarten oder spezielle Dateien wie `robots.txt` und `manifest.webmanifest`.
 
 Du kannst zwar auch CSS- und JavaScript-Dateien in `public/` speichern, beachte aber bitte, dass diese dann während des Buildvorgangs weder gebündelt noch optimiert werden.
 
@@ -115,7 +115,7 @@ Als allgemeine Regel kann man sagen, dass jeglicher CSS- oder JavaScript-Code, d
 
 ### `package.json`
 
-Diese Datei wird von JavaScript-Paketmanagern verwendet, um die erforderlichen Pakete ("Abhängigkeiten") eines Projekts zu verwalten. Sie definiert auch die Skripte, die üblicherweise dazu verwendet werden, um Astro auszuführen (z.B. `npm run dev`, `npm run build`).
+Diese Datei wird von JavaScript-Paketmanagern verwendet, um die erforderlichen Pakete ("Abhängigkeiten") eines Projekts zu verwalten. Sie definiert auch die Skripte, die üblicherweise dazu verwendet werden, um Astro auszuführen (z. B. `npm run dev`, `npm run build`).
 
 Es gibt [zwei Arten von Abhängigkeiten](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file), die du in deiner `package.json`-Datei festlegen kannst: `dependencies` und `devDependencies`. In den meisten Fällen funktionieren sie auf die gleiche Weise: Astro benötigt zum Erzeugungszeitpunkt alle Abhängigkeiten, und auch dein Paketmanager wird beide Arten installieren. Wir empfehlen dir, all deine Abhängigkeiten zunächst in `dependencies` einzutragen, und `devDependencies` nur zu verwenden, wenn dein spezieller Anwendungsfall es erfordert.
 
@@ -133,6 +133,6 @@ In der [Konfigurationsreferenz](/de/reference/configuration-reference/) findest 
 
 ### `tsconfig.json`
 
-Diese Datei wird von jeder Starter-Vorlage generiert und enthält TypeScript-Konfigurations&shy;optionen für dein Astro-Projekt. Ohne eine `tsconfig.json`-Datei werden im Editor einige Funktionalitäten (z.B. das Importieren von NPM-Paketen) noch nicht völlig unterstützt.
+Diese Datei wird von jeder Starter-Vorlage generiert und enthält TypeScript-Konfigurations&shy;optionen für dein Astro-Projekt. Ohne eine `tsconfig.json`-Datei werden im Editor einige Funktionalitäten (z. B. das Importieren von NPM-Paketen) noch nicht völlig unterstützt.
 
 Weiterführende Informationen zu den TypeScript-Einstellungen findest du in der [Anleitung zur Konfiguration von TypeScript](/de/guides/typescript/).

--- a/src/content/docs/de/develop-and-build.mdx
+++ b/src/content/docs/de/develop-and-build.mdx
@@ -14,7 +14,7 @@ Sobald du ein Astro-Projekt hast, bist du bereit, mit Astro zu bauen! 🚀
 
 Um Änderungen an deinem Projekt vorzunehmen, öffne deinen Projektordner in deinem Code-Editor. Wenn du im Entwicklungsmodus arbeitest und der Entwicklungsserver läuft, kannst du die Aktualisierungen an deiner Website sehen, während du den Code bearbeitest.
 
-Du kannst auch [Aspekte deiner Entwicklungsumgebung anpassen](#konfiguriere-deine-entwicklungsumgebung), z.B. TypeScript konfigurieren oder die offiziellen Astro-Editor-Erweiterungen installieren.
+Du kannst auch [Aspekte deiner Entwicklungsumgebung anpassen](#konfiguriere-deine-entwicklungsumgebung), z. B. TypeScript konfigurieren oder die offiziellen Astro-Editor-Erweiterungen installieren.
 
 ### Starte den Astro-Entwicklungsserver
 
@@ -74,11 +74,11 @@ Um die Version deiner Website zu überprüfen, die zur Build-Zeit erstellt wird,
 
 Astro erstellt eine einsatzbereite Version deiner Website in einem separaten Ordner (standardmäßig `dist/`) und du kannst den Fortschritt im Terminal beobachten. So wirst du auf Fehler in deinem Projekt aufmerksam gemacht, bevor du es in die Produktion überführst. Wenn TypeScript auf `strict` oder `strictest` konfiguriert ist, prüft das `build`-Skript dein Projekt auch auf Typfehler.
 
-Wenn der Build abgeschlossen ist, führst du den entsprechenden `preview`-Befehl (z.B. `npm run preview`) in deinem Terminal aus und du kannst die gebaute Version deiner Website lokal im gleichen Browser-Vorschaufenster ansehen.
+Wenn der Build abgeschlossen ist, führst du den entsprechenden `preview`-Befehl (z. B. `npm run preview`) in deinem Terminal aus und du kannst die gebaute Version deiner Website lokal im gleichen Browser-Vorschaufenster ansehen.
 
 Beachte, dass dies eine Vorschau deines Codes ist, wie er zum Zeitpunkt der letzten Ausführung des Build-Befehls vorlag. Dies soll dir eine Vorschau darauf geben, wie deine Website aussehen wird, wenn sie ins Netz gestellt wird. Spätere Änderungen, die du nach der Erstellung an deinem Code vornimmst, werden **nicht** in der Vorschau angezeigt, bis du den Build-Befehl erneut ausführst.
 
-Benutze (<kbd>Strg</kbd> + <kbd>C</kbd>), um die Vorschau zu beenden und einen anderen Terminal-Befehl auszuführen, wie z.B. den Entwicklungsserver neu zu starten, um wieder in den [Entwicklungsmodus](#arbeit-im-entwicklungsmodus) zu wechseln, der sich während der Bearbeitung aktualisiert und eine Live-Vorschau deiner Code-Änderungen zeigt.
+Benutze (<kbd>Strg</kbd> + <kbd>C</kbd>), um die Vorschau zu beenden und einen anderen Terminal-Befehl auszuführen, wie z. B. den Entwicklungsserver neu zu starten, um wieder in den [Entwicklungsmodus](#arbeit-im-entwicklungsmodus) zu wechseln, der sich während der Bearbeitung aktualisiert und eine Live-Vorschau deiner Code-Änderungen zeigt.
 
 <ReadMore>Lies mehr über [die Astro CLI](/de/reference/cli-reference/) und die Terminalbefehle, die du beim Bauen mit Astro verwenden wirst.</ReadMore>
 

--- a/src/content/docs/de/editor-setup.mdx
+++ b/src/content/docs/de/editor-setup.mdx
@@ -75,7 +75,7 @@ Eine Installationsanleitung, Editor Integration und weitere Informationen findes
 
 [Prettier](https://prettier.io/) ist ein beliebtes Code-Formatierungs-Tool für JavaScript, HTML, CSS und mehr. Wenn du die [Astro VS Code Extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) oder [die Astro language server für andere Editoren](#andere-code-editoren) verwendest, ist Code-Formatierung mit Prettier integriert.
 
-Um das Formatieren von `.astro`-Dateien außerhalb des Editors (z.B. in der Kommandozeilen&shy;schnittstelle (CLI)) zu ermöglichen, kannst du das [offizielle Prettier-Plugin für Astro](https://github.com/withastro/prettier-plugin-astro) verwenden.
+Um das Formatieren von `.astro`-Dateien außerhalb des Editors (z. B. in der Kommandozeilen&shy;schnittstelle (CLI)) zu ermöglichen, kannst du das [offizielle Prettier-Plugin für Astro](https://github.com/withastro/prettier-plugin-astro) verwenden.
 
 <Steps>
 1. Installiere `prettier` und `prettier-plugin-astro`.

--- a/src/content/docs/de/guides/cms/index.mdx
+++ b/src/content/docs/de/guides/cms/index.mdx
@@ -38,7 +38,7 @@ Da Astro sich um die _Darstellung_ deines Inhalts kümmert, solltest du ein _Hea
 
 Einige Headless CMS, wie Storyblok, bieten eine Astro-[Integration](/de/guides/integrations-guide/) an, die hilft, Inhalte speziell für eine Astro-Website abzurufen. Andere bieten ein JavaScript-SDK — eine Bibliothek, die du installierst und nutzt, um Inhalte aus der Ferne abzurufen.
 
-<ReadMore>Erkunde eine [Liste von über 100 Headless Content Management Systemen](https://jamstack.org/headless-cms/) <Badge text="Extern" />, in der du nach Typ (z.B. Git-basiert, API-gesteuert) und Lizenz (Open-Source oder Closed-Source) filtern kannst.</ReadMore>
+<ReadMore>Erkunde eine [Liste von über 100 Headless Content Management Systemen](https://jamstack.org/headless-cms/) <Badge text="Extern" />, in der du nach Typ (z. B. Git-basiert, API-gesteuert) und Lizenz (Open-Source oder Closed-Source) filtern kannst.</ReadMore>
 
 ## Kann ich Astro ohne CMS nutzen?
 

--- a/src/content/docs/de/guides/deploy/aws-via-flightcontrol.mdx
+++ b/src/content/docs/de/guides/deploy/aws-via-flightcontrol.mdx
@@ -31,7 +31,7 @@ Es werden sowohl statische als auch SSR-basierte Astro-Websites unterstützt.
 
 5. Passe die Konfiguration nach Bedarf an.
 
-6. Klicke auf „Projekt erstellen“ und führe alle erforderlichen Schritte durch (z.B. Verknüpfung deines AWS-Kontos).
+6. Klicke auf „Projekt erstellen“ und führe alle erforderlichen Schritte durch (z. B. Verknüpfung deines AWS-Kontos).
 </Steps>
 
 ### SSR-Einrichtung

--- a/src/content/docs/de/guides/deploy/gitlab.mdx
+++ b/src/content/docs/de/guides/deploy/gitlab.mdx
@@ -48,7 +48,7 @@ Du kannst eine Astro-Site auf GitLab Pages bereitstellen, indem du GitLab CI/CD 
 
     `base`
 
-    Ein Wert für `base` kann erforderlich sein, damit Astro deinen Repository-Namen (z.B. `/mein-repo`) als Stammverzeichnis deiner Website behandelt.
+    Ein Wert für `base` kann erforderlich sein, damit Astro deinen Repository-Namen (z. B. `/mein-repo`) als Stammverzeichnis deiner Website behandelt.
 
     :::note
       Setze keinen `base`-Parameter, wenn deine Seite aus dem Stammverzeichnis veröffentlicht wird.

--- a/src/content/docs/de/guides/deploy/google-cloud.mdx
+++ b/src/content/docs/de/guides/deploy/google-cloud.mdx
@@ -78,7 +78,7 @@ docker push HOSTNAME/PROJECT-ID/IMAGE:TAG
 
 **Ein anderes Tool verwenden**:
 
-Du kannst ein CI/CD-Tool verwenden, das Docker unterstützt, z.B. [GitHub Actions](https://github.com/marketplace/actions/push-to-gcr-github-action).
+Du kannst ein CI/CD-Tool verwenden, das Docker unterstützt, z. B. [GitHub Actions](https://github.com/marketplace/actions/push-to-gcr-github-action).
 
 **Erzeuge mit [Cloud Build](https://cloud.google.com/build)**:
 


### PR DESCRIPTION
This PR follows up on this [comment](https://github.com/withastro/docs/pull/12813#discussion_r2589785925) in #12813.
It adds non-breaking space to several more occurrences of the German abbreviation `z.B.`.