### PR TITLE
Lunaria: fix configuration

### DIFF
--- a/lunaria.config.ts
+++ b/lunaria.config.ts
@@ -123,7 +123,7 @@ export default defineConfig({
 	],
 	tracking: {
 		localizableProperty: 'i18nReady',
-		ignoredKeywords: [
+		ignoreKeywords: [
 			'lunaria-ignore',
 			'typo',
 			'en-only',


### PR DESCRIPTION
In the Lunaria config file, you will find option `ignoredKeywords`. According to lunaria [documentation](https://lunaria.dev/reference/configuration/#ignorekeywords), the correct spelling is `ignoreKeywords`, however.
This PR fixes that issue.