### PR TITLE
Fix HTML output example in upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -1084,7 +1084,7 @@ If you have manual links to headings, you may need to update the anchor link val
 will now generate the following HTML with a trailing hyphen in the heading `id`:
 
 ```html ins="-"
-<h2 id="picture-"><code>&lt;Picture /&gt;</h2>
+<h2 id="picture-"><code>&lt;Picture /&gt;</code></h2>
 ```
 
 and must now be linked to as:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

Update HTML output example for heading id in v6 upgrade guide, added missing closing tag: `</code>`.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
