### PR TITLE
i18n(fr): update `markdoc.mdx`

### DIFF
--- a/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
@@ -419,6 +419,7 @@ Pour remplacer le nœud d'image par défaut, vous pouvez configurer un composant
 
     ```astro title="src/components/MarkdocImage.astro"
     ---
+    import type { ImageMetadata } from "astro";
     import { Image } from "astro:assets";
     interface Props {
       src: ImageMetadata;
@@ -431,8 +432,9 @@ Pour remplacer le nœud d'image par défaut, vous pouvez configurer un composant
 
 2. Le composant `<Image />` requiert `width` et `height` pour les images à distance qui ne peuvent pas être fournies à l'aide de la syntaxe `![]()`. Pour éviter les erreurs lors de l'utilisation d'images distantes, mettez à jour votre composant pour afficher une balise HTML standard `<img>` lorsqu'une URL distante `src` est trouvée :
 
-    ```astro title="src/components/MarkdocImage.astro" ins="| string" del={9} ins={10-12}
+    ```astro title="src/components/MarkdocImage.astro" ins="| string" del={10} ins={11-13}
     ---
+    import type { ImageMetadata } from "astro";
     import { Image } from "astro:assets";
     interface Props {
       src: ImageMetadata | string;
@@ -484,7 +486,7 @@ Les étapes suivantes permettent de créer une balise image Markdoc personnalis�
 
     ```astro title="src/components/MarkdocFigure.astro"
     ---
-    // src/components/MarkdocFigure.astro
+    import type { ImageMetadata } from "astro";
     import { Image } from "astro:assets";
 
     interface Props {


### PR DESCRIPTION
#### Description (required)

Adds changes from #12893 to the French translation of `guides/integrations-guide/markdoc.mdx`‎.

Related issues & labels (optional)
Suggested label: i18n