### PR TITLE
fix(next): typo "v5" in v6 migration guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -973,7 +973,7 @@ Review your `<script>` and `<style>` tags to make sure they behave as desired. Y
 
 ## Breaking Changes
 
-The following changes are considered breaking changes in Astro v5.0. Breaking changes may or may not provide temporary backwards compatibility. If you were using these features, you may have to update your code as recommended in each entry.
+The following changes are considered breaking changes in Astro v6.0. Breaking changes may or may not provide temporary backwards compatibility. If you were using these features, you may have to update your code as recommended in each entry.
 
 ### Changed: endpoints with a file extension cannot be accessed with a trailing slash
 


### PR DESCRIPTION
#### Description

Under the `Breaking changes` section, the migration guide still says that these are breaking changes in "Astro v5.0", alto these are the breaking changes of Astro v6.0 in the v6 migration guide.

I noted that as well in [this comment](https://github.com/withastro/docs/pull/12921#issuecomment-3659513753).