### PR TITLE
Fix syntax bug of cssVariable example in fonts.mdx

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/fonts.mdx
+++ b/src/content/docs/en/reference/experimental-flags/fonts.mdx
@@ -230,7 +230,7 @@ export default defineConfig({
     fonts: [
       {
         name: "Roboto",
-        cssVariable: "--font-roboto"
+        cssVariable: "--font-roboto",
         provider: fontProviders.google(),
         // Default included:
         // weights: [400] ,


### PR DESCRIPTION
#### Description (required)

Missing `,` - breaks when copying and pasting.