### PR TITLE
Add body content example to Markdown JSX expressions

### DIFF
--- a/src/content/docs/en/guides/markdown-content.mdx
+++ b/src/content/docs/en/guides/markdown-content.mdx
@@ -57,6 +57,8 @@ const posts = Object.values(import.meta.glob('./posts/*.md', { eager: true }));
 <p>{greatPost.frontmatter.title}</p>
 <p>Written by: {greatPost.frontmatter.author}</p>
 
+{greatPost.compiledContent()}
+
 <p>Post Archive:</p>
 <ul>
   {posts.map(post => <li><a href={post.url}>{post.frontmatter.title}</a></li>)}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates the code example in the "Dynamic JSX-like expressions" section to include `{greatPost.compiledContent()}`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #12970
- Suggested label: `code snippet update`, `good first issue`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
