### PR TITLE
docs for drop cloudflare pages pr

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -224,44 +224,6 @@ export default defineConfig({
 	}),
 });
 ```
-### `routes.extend`
-
-On Cloudflare Workers, this option is not applicable. Refer to [Routing on Cloudflare Workers](#routing-on-cloudflare-workers) for more information.
-
-On Cloudflare Pages, this option allows you to add or exclude custom patterns (e.g. `/fonts/*`) to the generated `_routes.json` file that determines which routes are generated on-demand. This can be useful if you need to add route patterns which cannot be automatically generated, or exclude prerendered routes.
-
-More information about the custom route patterns can be found in [Cloudflare's routing docs](https://developers.cloudflare.com/pages/functions/routing/#functions-invocation-routes). Any routes specified are not automatically deduplicated and will be appended to the existing routes as is.
-
-#### `routes.extend.include`
-
-<p>
-**Type:** `{ pattern: string }[]`<br />
-**Default:** `undefined`
-</p>
-
-Configures additional routes to be generated on demand by the Cloudflare adapter in the `routes.extend.include` array.
-
-#### `routes.extend.exclude`
-
-<p>
-**Type:** `{ pattern: string }[]`<br />
-**Default:** `undefined`
-</p>
-
-Configures routes to be excluded from on-demand rendering in the `routes.extend.exclude` array. These routes will be prerendered and served statically instead, and will not invoke the server function. Additionally you can use this option to serve any static asset (e.g. images, fonts, css, js, html, txt, json, etc.) files directly without routing the request through the server function.
-
-```js title="astro.config.mjs"
-export default defineConfig({
-  adapter: cloudflare({
-    routes: {
-      extend: {
-        include: [{ pattern: '/static' }], // Route a prerended page to the server function for on-demand rendering
-        exclude: [{ pattern: '/pagefind/*' }], // Use Starlight's pagefind search, which is generated statically at build time
-      }
-    },
-  }),
-});
-```
 
 ### `sessionKVBindingName`
 <p>
@@ -479,38 +441,12 @@ declare namespace App {
 
 You can attach [custom headers](https://developers.cloudflare.com/pages/platform/headers/) to your responses by adding a `_headers` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
 
-This is available on Cloudflare Workers and Pages.
-
 ### Assets
 Assets built by Astro are all named with a hash and therefore can be given long cache headers. By default, Astro on Cloudflare will add such a header for these files.
 
 ### Redirects
 
 You can declare [custom redirects](https://developers.cloudflare.com/pages/platform/redirects/) to redirect requests to a different URL. To do so, add a `_redirects` file in your Astro project's `public/` folder. This file will be copied to your build output directory.
-
-This is available on Cloudflare Workers and Pages.
-
-### Routes
-#### Routing on Cloudflare Workers
-
-Routing for static assets is based on the file structure in the build directory (e.g. `./dist`). If no match is found, this will fall back to the Worker for on-demand rendering. Read more about [static asset routing with Cloudflare Workers](https://developers.cloudflare.com/workers/static-assets/routing/).
-
-Unlike [Cloudflare Pages](#routing-on-cloudflare-pages), with Workers, you do not need a `_routes.json` file. 
-
-Currently, the Cloudflare adapter always generates this file. To work around this, create a `.assetsignore` file in your `public/` folder, and add the following lines to it:
-  ```txt title="public/.assetsignore"
-  _worker.js
-  _routes.json
-  ```
-
-#### Routing on Cloudflare Pages
-
-For Cloudflare Pages, [routing](https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes) uses a `_routes.json` file to determine which requests are routed to the server function and which are served as static assets. By default, a `_routes.json` file will be automatically generated for your project based on its files and configuration.
-
-You can [specify additional routing patterns to follow](#routesextend) in your adapter config, or create your own custom `_routes.json` file to fully override the automatic generation.
-
-
-Creating a custom `public/_routes.json` will override the automatic generation. See [Cloudflare's documentation on creating a custom `_routes.json`](https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file) for more details.
 
 ## Sessions
 


### PR DESCRIPTION
This PR removes references to Cloudflare Pages because we will drop support for it, it also removes the routes sections as this is not needed anymore, since out of the box everything will be configured for the user.

cc @ascorbic not sure how much you have WIP for this page and if we might get conflicted