### PR TITLE
18n(ja): update upgrade-astro to match current en

### DIFF
--- a/src/content/docs/ja/upgrade-astro.mdx
+++ b/src/content/docs/ja/upgrade-astro.mdx
@@ -2,20 +2,17 @@
 title: Astroのアップグレード
 description: Astroのアップグレード方法を学ぶ
 i18nReady: true
-banner:
-  content: |
-    Astro v5 が登場! <a href="/ja/guides/upgrade-to/v5/">サイトのアップグレード方法を学ぶ</a>
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Version from '~/components/Version.astro';
 
-
 このガイドでは、Astroや関連する依存関係のバージョンを更新する方法、バージョン間で何が変更されたかを調べる方法、そしてAstroのバージョニングシステムとそれに対応するドキュメントの更新を理解する方法について説明します。
+
 ## 変更点は何ですか？
+
 Astroの最新リリースは<Version pkgName="astro" />です。
 
 すべての変更の詳細なリストは[Astroの変更履歴](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md)で確認できます。また、各[メジャーバージョン](#メジャーレベルの変更)へのアップグレードに関する重要な説明は、[アップグレードガイド](#アップグレードガイド)に記載されています。
-
 
 ## 最新バージョンへのアップグレード
 
@@ -42,7 +39,6 @@ Astroの最新リリースは<Version pkgName="astro" />です。
   </Fragment>
 </PackageManagerTabs>
 
-
 ### 手動でのアップグレード
 
 Astroとインテグレーションを手動で現在のバージョンに更新するには、パッケージマネージャーに適したコマンドを使用してください。
@@ -50,20 +46,20 @@ Astroとインテグレーションを手動で現在のバージョンに更新
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  # 例：ReactとTailwindのインテグレーションと共にAstroをアップグレード
-  npm install astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # 例：ReactとPartytownのインテグレーションと共にAstroをアップグレード
+  npm install astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  # 例：ReactとTailwindのインテグレーションと共にAstroをアップグレード
-  pnpm add astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # 例：ReactとPartytownのインテグレーションと共にAstroをアップグレード
+  pnpm add astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
   ```shell
-  # 例：ReactとTailwindのインテグレーションと共にAstroをアップグレード
-  yarn add astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # 例：ReactとPartytownのインテグレーションと共にAstroをアップグレード
+  yarn add astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -90,7 +86,6 @@ Astroとインテグレーションを手動で現在のバージョンに更新
   </Fragment>
 </PackageManagerTabs>
 
-
 ## ドキュメントの更新
 
 このドキュメントは、[マイナーリリース](#マイナーレベルの変更)および[メジャーバージョンリリース](#メジャーレベルの変更)ごとに更新されます。新機能が追加されたり、既存の使用方法が変更されたりすると、ドキュメントは**現在のAstroの挙動**を反映するように更新されます。自分のプロジェクトを更新していない場合、最新のドキュメントと一部の挙動が一致しないことに気づくかもしれません。
@@ -107,6 +102,7 @@ Astroの主要なドキュメントページは常に**最新リリースバー�
 
 以下のアップグレードガイドでは、新旧のバージョンを比較して変更点を説明しています。アップグレードガイドには、破壊的変更や非推奨化、機能の削除や置換、および使用方法の更新ガイダンスなど、コードの変更を必要とする可能性のあるすべての内容が含まれています。Astroへの各変更には「どうすればいいですか？」というセクションが付属しており、プロジェクトコードを上手く更新するための助けとなるはずです。
 
+- [v5へのアップグレード](/ja/guides/upgrade-to/v5/)
 - [v4へのアップグレード](/ja/guides/upgrade-to/v4/)
 - [v3へのアップグレード](/ja/guides/upgrade-to/v3/)
 - [v2へのアップグレード](/ja/guides/upgrade-to/v2/)
@@ -116,7 +112,8 @@ Astroの主要なドキュメントページは常に**最新リリースバー�
 
 古いバージョンのAstroのドキュメントはメンテナンスされていませんが、静的スナップショットとして利用可能です。プロジェクトをアップグレードできないものの、ガイドやリファレンスを参照したい場合は、これらのバージョンのドキュメントを使用してください。
 
-- [メンテナンスされていないv3.6.3のスナップショット](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/)
+- [メンテナンスされていないv4.16.17のスナップショット](https://v4.docs.astro.build/en/getting-started/)
+- [メンテナンスされていないv3.6.3のスナップショット](https://web.archive.org/web/20231203051122/https://docs.astro.build/en/getting-started/)
 - [メンテナンスされていないv2.10.15のスナップショット](https://deploy-preview-4405--astro-docs-2.netlify.app/en/getting-started/)
 
 ## セマンティックバージョニング
@@ -142,7 +139,6 @@ Astroが「パッチ」バージョンを発行すると、最後の数字が増
 - 失敗したリリースの再リリース。
 
 パッチ変更には**バグ修正の多く**も含まれます。意図しないまたは望ましくない既存の挙動をユーザーが利用していた場合でも、パッチに含まれます。
-
 
 ### マイナーレベルの変更
 
@@ -189,6 +185,7 @@ Astroが「パッチ」バージョンを発行すると、最後の数字が増
 - AstroはNode.jsの[**最新の _Maintenance_ LTS**バージョン](https://nodejs.org/en/about/previous-releases#release-schedule)をサポートしています。
 - AstroはNode.jsの[**現在の _Active_ LTS**バージョン](https://nodejs.org/en/about/previous-releases#release-schedule)をサポートしています。
 - AstroはNode.jsの奇数バージョンをサポートしています。
+
 #### アップグレード
 
 次のルールは、AstroがNode.jsのバージョンのサポートを終了、削除、または追加するタイミングを定義します。


### PR DESCRIPTION
#### Description (required)

This PR's change is based on the following two commits:

- https://github.com/withastro/docs/commit/4414d59d9940c59545a353ff3542190045c684c9
- https://github.com/withastro/docs/commit/b92e0d0736e765a86c9c1d8114c0cf5da740cd7d
- https://github.com/withastro/docs/commit/3cdd846b6610dab87bef106e04ce426561579c4f
- https://github.com/withastro/docs/commit/81ae90dba4dbdffac48b8d0978ab0b59c3b47304
- https://github.com/withastro/docs/commit/e0314f117a28fb67bbd97df782d560ffd808c0a0
- https://github.com/withastro/docs/commit/45a117052d85d9a706e4095f1cb9ffb2b0bf2caa#diff-5963da07070d6cac124699479c46c876d6cc7b9e971ed4c8981a13d506d31c88
- https://github.com/withastro/docs/commit/640db10e942cf3cd5972960d7b1b7bccb8575627
- https://github.com/withastro/docs/commit/54c8fd5169b57b1e2d5a92d83351ec135abd820f

#### Related issues & labels (optional)

- Closes #
- Suggested label: i18n

#### Additional Information
I found a broken link that displaying "Site not found" while working on this update, so I opened a [Discussion](https://github.com/withastro/docs/discussions/13023) about it.
The affected area is highlighted in the attached image, and it applies to /en and several other language versions.
I'd appreciate it if you could let me know whether this is a concern.

![スクリーンショット 2026-01-08 16 15 08](https://github.com/user-attachments/assets/df8fed85-6d8a-4965-8be3-82acca22a4d1)
![スクリーンショット 2026-01-08 15 23 31](https://github.com/user-attachments/assets/4738169b-1d80-4040-86e4-a662ad3a4c6a)

I'd appreciate it if you could review this when you have time🫡