### PR TITLE
Add MCP instructions for Google Antigravity

### DIFF
--- a/src/content/docs/en/guides/build-with-ai.mdx
+++ b/src/content/docs/en/guides/build-with-ai.mdx
@@ -225,9 +225,9 @@ You can configure MCP servers at the global level in the `~/.gemini/settings.jso
 
 <Steps>
 
-1. Open `~/gemini/antigravity/mcp_config.json` by following the [Connecting Custom MCP Servers guide](https://antigravity.google/docs/mcp#connecting-custom-mcp-servers).
+1. Open `~/.gemini/antigravity/mcp_config.json` by following the [Connecting Custom MCP Servers guide](https://antigravity.google/docs/mcp#connecting-custom-mcp-servers).
 2. Add the following configuration to `mcp_config.json`:
-   ```json title=".gemini/antigravity/mcp_config.json" {3-5}
+   ```json title="mcp_config.json" {3-5}
    {
      "mcpServers": {
        "astro-docs": {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Instructions for adding the Astro Docs MCP server to Google Antigravity.

While the other instructions use `Astro docs` as the MCP server name, Antigravity doesn't allow spaces in the key of an MCP server entry, so I used `astro-docs` instead.

I've also posted a guide with screenshots [here](https://jhuleatt.com/posts/astro-mcp-antigravity).