### PR TITLE
i18n(ko-KR): update `cannot-determine-weight-and-style-from-font-file.mdx`

### DIFF
--- a/src/content/docs/ko/reference/errors/cannot-determine-weight-and-style-from-font-file.mdx
+++ b/src/content/docs/ko/reference/errors/cannot-determine-weight-and-style-from-font-file.mdx
@@ -4,7 +4,7 @@ i18nReady: true
 githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 ---
 
-> An error occured while determining the weight and style from the local font file.
+> An error occurred while determining the weight and style from the local font file.
 
 ## 무엇이 잘못되었나요?
 글꼴 파일에서 굵기와 스타일을 결정할 수 없습니다. 패밀리 구성을 업데이트하여 `weight`와 `style`을 수동으로 설정하세요.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

- #12658

A bug in the i18n tracker caused some old changes to be registered.

However, I didn't notice it and reviewed the files anyway, only to find that there actually were real typos lol

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
