### PR TITLE
docs(react): add react compiler enablement instructions

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -280,6 +280,29 @@ export default defineConfig({
 });
 ```
 
+### Enable React Compiler
+
+Astro comes with an option to enable [React Compiler](https://react.dev/learn/react-compiler).
+
+React Compiler allows for automatic optimization of React components by handling memoization for you, eliminating the need for the manual use of `useMemo`, `useCallback` and `React.memo`.
+
+To enable React Compiler in your project, install `babel-plugin-react-compiler` using your preferred package manager and configure `@astrojs/react` with `reactCompilerEnabled: true`:
+
+```js title="astro.config.mjs" ins={8}
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  // ...
+  integrations: [
+    react({
+        reactCompilerEnabled: true,
+    })
+  ]
+});
+```
+
+
 [astro-integration]: /en/guides/integrations-guide/
 
 [astro-ui-frameworks]: /en/guides/framework-components/#using-framework-components


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I have been working on adding a config option for Astro's React integration which would enable React Compiler (withastro/astro#14955). This will be a draft for now, just to show a preview. I will add the config options after we get through the types.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #N/A<!-- Add an issue number if this PR will close it. -->
- Suggested label: add new content, minor release<!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `5.x` (don't know when we'll be done with this, leaving it as `x` for now! Also N/A, as it's related to the React integration?). See astro PR [#14955](https://github.com/withastro/astro/pull/14955). 

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
