### PR TITLE
docs: add first-time contributor quick start section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,32 @@ Larger contributions to the docs are encouraged after participating in Issues an
 
 <!-- ## Who Are We? -->
 
+## First-Time Contributor Quick Start
+
+If this is your first time contributing to Astro Docs, we recommend starting with one of the small, high-impact tasks below. These contributions are quick to review and help you get familiar with our workflow.
+
+### Recommended first contributions
+
+- Fix typos, grammar issues, or broken links on existing documentation pages
+- Clarify confusing sentences or explanations
+- Improve code comments or short examples for readability
+- Open an issue for documentation that feels outdated, unclear, or incorrect
+
+### Where to look
+
+- Browse files in `src/content/docs/en/`
+- Look for Issues labeled `good first issue` or `help wanted`
+- Use the “Edit this page” button on docs.astro.build to make small changes directly
+
+### Tips for success
+
+- Keep your first PR small and focused
+- Avoid reformatting entire files
+- Use clear commit messages (e.g. `docs: clarify explanation of partial hydration`)
+- If unsure, open an Issue or Discussion before making large changes
+
+Starting small is the best way to learn the Astro Docs contribution process and build confidence for larger contributions.
+
 ## Making a New Issue
 
 If you're unsure which type of contribution best represents your concern, please [make a new issue](https://github.com/withastro/docs/issues/new)!


### PR DESCRIPTION
What does this PR change?
This PR adds a new “First-Time Contributor Quick Start” section to CONTRIBUTING.md.
The section provides clear guidance for new contributors on how to make a small, high-impact first contribution to Astro Docs.

Why is this change needed?
While the contributing guide is very comprehensive, new contributors may feel overwhelmed and unsure where to begin.
This section offers a simple, actionable starting point, helping contributors get involved more confidently and improving the overall onboarding experience.

What kind of change is this?
(x)Documentation improvement.
(x)No functional or behavioral changes.
(x)No impact on existing contribution workflows.

Additional notes
->The section is intentionally concise and focused on small, safe first contributions.
->It does not alter any existing guidance, only adds clarity for first-time contributors.
