### PR TITLE
chore: remove gitpod/ona mention, update idx -> firebase studio

### DIFF
--- a/src/content/docs/en/editor-setup.mdx
+++ b/src/content/docs/en/editor-setup.mdx
@@ -53,8 +53,9 @@ Our amazing community maintains several extensions for other popular editors, in
 
 In addition to local editors, Astro also runs well on in-browser hosted editors, including:
 
-- [StackBlitz](https://stackblitz.com/), [CodeSandbox](https://codesandbox.io/) and [Firebase Studio](https://firebase.studio/) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
+- [StackBlitz](https://stackblitz.com/) and [CodeSandbox](https://codesandbox.io/) - online editors that run in your browser, with built-in syntax highlighting support for `.astro` files. No installation or configuration required!
 - [GitHub.dev](https://github.dev/) - allows you to install the Astro VS Code extension as a [web extension](https://code.visualstudio.com/api/extension-guides/web-extensions), which gives you access to only some of the full extension features. Currently, only syntax highlighting is supported.
+- [Firebase Studio](https://firebase.studio/) - a full dev environment in the cloud that can install the official Astro VS Code Extension from Open VSX.
 
 ## Other tools
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I have been slowly deleting mentions of Gitpod from the Astro codebase (as Gitpod is now Ona, an AI-powered paid vibe coding tool) - here are some examples: #12642 [#3495](https://github.com/withastro/starlight/pull/3495) - and just noticed that editor-setup.mdx still mentions it. I also updated the mention of IDX, which is now Firebase Studio - I moved it next to other editors, such as Stackblitz, as they all seem very similar to each other, so a separate mention of Firebase Studio did not seem like it was needed anymore. Open to feedback though!

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #N/A<!-- Add an issue number if this PR will close it. -->
- Suggested label: improve or update documentation <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `5.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
