### PR TITLE
[next]: make runtime csp optional

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1054,7 +1054,7 @@ Loads a session by ID. In normal use, a session is loaded automatically from the
 
 <p>
 
-**Type**: `AstroSharedContextCsp`
+**Type**: `object | undefined`
 <Since v="6.0.0" />
 </p>
 
@@ -1077,8 +1077,8 @@ Adds a single directive to the current page. You can call this method multiple t
 
 ```astro title="src/pages/index.astro"
 ---
-Astro.csp.insertDirective("default-src 'self'");
-Astro.csp.insertDirective("img-src 'self' https://images.cdn.example.com");
+Astro.csp?.insertDirective("default-src 'self'");
+Astro.csp?.insertDirective("img-src 'self' https://images.cdn.example.com");
 ---
 ```
 
@@ -1108,7 +1108,7 @@ Inserts a new resource to be used for the `style-src` directive.
 
 ```astro title="src/pages/index.astro"
 ---
-Astro.csp.insertStyleResource("https://styles.cdn.example.com");
+Astro.csp?.insertStyleResource("https://styles.cdn.example.com");
 ---
 ```
 
@@ -1136,7 +1136,7 @@ Adds a new hash to the `style-src` directive.
 
 ```astro  title="src/pages/index.astro"
 ---
-Astro.csp.insertStyleHash("sha512-styleHash");
+Astro.csp?.insertStyleHash("sha512-styleHash");
 ---
 ```
 
@@ -1164,7 +1164,7 @@ Inserts a new valid source to be used for the `script-src` directive.
 
 ```astro title="src/pages/index.astro"
 ---
-Astro.csp.insertScriptResource("https://scripts.cdn.example.com");
+Astro.csp?.insertScriptResource("https://scripts.cdn.example.com");
 ---
 ```
 
@@ -1192,7 +1192,7 @@ Adds a new hash to the `script-src` directive.
 
 ```astro title="src/pages/index.astro"
 ---
-Astro.csp.insertScriptHash("sha512-scriptHash");
+Astro.csp?.insertScriptHash("sha512-scriptHash");
 ---
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
I didn't include an entry in the upgrade guide because this is a breaking change affecting a feature stabilized during the alpha
<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `6.0`. See astro PR [#15266](https://github.com/withastro/astro/pull/15266).

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
