### PR TITLE
docs(tutorial): fix typo

### DIFF
--- a/src/content/docs/en/tutorial/6-islands/4.mdx
+++ b/src/content/docs/en/tutorial/6-islands/4.mdx
@@ -204,7 +204,7 @@ Upgrade to the latest version of Astro, and upgrade all integrations to their la
 ## Replace `import.meta.glob()` with `getCollection()`
 
 <Steps>
-5. Anywhere you have a list of blog posts, like the tutorial's Blog page (`src/pages/blog.astro/`), you will need to replace `import.meta.glob()` with [`getCollection()`](/en/reference/modules/astro-content/#getcollection) as the way to fetch content and metadata from your Markdown files.
+5. Anywhere you have a list of blog posts, like the tutorial's Blog page (`src/pages/blog.astro`), you will need to replace `import.meta.glob()` with [`getCollection()`](/en/reference/modules/astro-content/#getcollection) as the way to fetch content and metadata from your Markdown files.
 
     ```astro title="src/pages/blog.astro" "post.data" "getCollection(\"blog\")" "/posts/${post.id}/" del={7} ins={2,8}
     ---


### PR DESCRIPTION
#### Description

The file, as visible from the fenced code block below, is `blog.astro`, not (a directory called) `blog.astro/`.

#### Related issues & labels (optional)

- Suggested label: `tutorial`