### PR TITLE
fix(v6): replaces `RendererContent` code snippet with docs

### DIFF
--- a/src/content/docs/en/reference/content-loader-reference.mdx
+++ b/src/content/docs/en/reference/content-loader-reference.mdx
@@ -121,7 +121,7 @@ When `retainBody` is `false`, [`entry.body`](/en/reference/modules/astro-content
 
 Setting this property to `false` significantly reduces the deployed size of the data store and helps avoid hitting size limits for sites with very large collections.
 
-For Markdown files, the rendered body will still be available in the [`entry.rendered.html` property](/en/reference/content-loader-reference/#rendered), and the [`entry.filePath` property](/en/reference/content-loader-reference/#filepath) will still point to the original file. 
+For Markdown files, the rendered body will still be available in the [`entry.rendered.html` property](#renderedhtml), and the [`entry.filePath` property](#filepath) will still point to the original file. 
 
 For MDX collections, this will dramatically reduce the size of the collection, as there will no longer be any body retained in the store.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

<!-- 🚨 IMPORTANT INFO AS WE PREPARE FOR v6 🚨 -->
<!-- We are only accepting emergency fixes for v5 docs (typos, links etc.) -->
<!-- All new feature documentation PRs must use the `v6` branch  -->
<!-- No new translations will be accepted until v6 is released -->

#### Description (required)

Replaces the code block describing `RendererContent` with proper docs.

#### Related issues & labels (optional)

- Suggested label: improve or update documentation, v6

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
