### PR TITLE
i18n(fr): fix heading levels in `integrations-reference.mdx`

### DIFF
--- a/src/content/docs/fr/reference/integrations-reference.mdx
+++ b/src/content/docs/fr/reference/integrations-reference.mdx
@@ -2545,7 +2545,7 @@ Une union des codes d'état de redirection pris en charge.
 
 Les types suivants sont dépréciés et seront supprimés dans une future version majeure :
 
-### `IntegrationRouteData`
+#### `IntegrationRouteData`
 
 :::caution
 Ce type est déprécié depuis la v5.0. Utilisez plutôt [`IntegrationResolvedRoute`](#integrationresolvedroute).
@@ -2562,7 +2562,7 @@ type IntegrationRouteData = Omit<
 };
 ```
 
-#### `redirectRoute`
+##### `redirectRoute`
 
 <p>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

<!-- 🚨 IMPORTANT INFO AS WE PREPARE FOR v6 🚨 -->
<!-- We are only accepting emergency fixes for v5 docs (typos, links etc.) -->
<!-- All new feature documentation PRs must use the `v6` branch  -->
<!-- No new translations will be accepted until v6 is released -->

#### Description (required)

Updates the French translation of `integrations-reference.mdx` to fix two incorrect heading levels (should be nested under the deprecated imports).

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
