### PR TITLE
i18n(fr): add `errors/remote-image-not-allowed.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -45,6 +45,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**InvalidImageService**](/fr/reference/errors/invalid-image-service/)<br/>Erreur lors du chargement du service d'image.
 - [**MissingImageDimension**](/fr/reference/errors/missing-image-dimension/)<br/>Dimensions de l'image manquantes
 - [**FailedToFetchRemoteImageDimensions**](/fr/reference/errors/failed-to-fetch-remote-image-dimensions/)<br/>Échec de la récupération des dimensions de l'image distante
+- [**RemoteImageNotAllowed**](/fr/reference/errors/remote-image-not-allowed/)<br/>L'image distante n'est pas autorisée
 - [**UnsupportedImageFormat**](/fr/reference/errors/unsupported-image-format/)<br/>Format d'image non pris en charge
 - [**UnsupportedImageConversion**](/fr/reference/errors/unsupported-image-conversion/)<br/>Conversion d'image non prise en charge.
 - [**PrerenderDynamicEndpointPathCollide**](/fr/reference/errors/prerender-dynamic-endpoint-path-collide/)<br/>Le point de terminaison dynamique généré entre en collision avec une autre route.

--- a/src/content/docs/fr/reference/errors/remote-image-not-allowed.mdx
+++ b/src/content/docs/fr/reference/errors/remote-image-not-allowed.mdx
@@ -1,0 +1,10 @@
+---
+title: L'image distante n'est pas autorisée
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> Remote image `IMAGE_URL` is not allowed by your image configuration.
+
+## Qu'est-ce qui a mal tourné ?
+L'URL de l'image distante ne correspond pas aux paramètres `image.domains` ou `image.remotePatterns` que vous avez configurés.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

<!-- 🚨 IMPORTANT INFO AS WE PREPARE FOR v6 🚨 -->
<!-- We are only accepting emergency fixes for v5 docs (typos, links etc.) -->
<!-- All new feature documentation PRs must use the `v6` branch  -->
<!-- No new translations will be accepted until v6 is released -->

#### Description (required)

Adds changes from #13283 to the French translation:
* update `error-reference.mdx`
* translate `errors/remote-image-not-allowed.mdx`

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
