### PR TITLE
clarify Astro's public API in semantic versioning docs

### DIFF
--- a/src/content/docs/en/upgrade-astro.mdx
+++ b/src/content/docs/en/upgrade-astro.mdx
@@ -118,7 +118,7 @@ Documentation for older versions of Astro is not maintained, but is available as
 
 ## Semantic versioning
 
-Astro attempts to adhere as much as possible to [semantic versioning](https://semver.org/), which is a set of rules developers use to determine how to assign a version number to a release. Semantic version follows a predictable pattern to inform users of the kind of changes they can expect from one version to the next.
+Astro attempts to adhere as much as possible to [semantic versioning](https://semver.org/), which is a set of rules developers use to determine how to assign a version number to a release. Semantic version follows a predictable pattern to inform users of the kind of changes they can expect from one version to the next. Astro's public API is defined by the features documented on the [official Astro documentation](https://docs.astro.build).
 
 Semantic versioning enforces a pattern of `X.Y.Z` for software version numbers. These values represent **major (X)**, **minor (Y)**, and **patch (Z)** updates.
 


### PR DESCRIPTION
Adds a sentence to the semantic versioning section clarifying that Astro's public API is defined by the features documented on the official Astro documentation.


>  For this system to work, you first need to declare a public API.

https://semver.org