### PR TITLE
docs: update transition:persist known limitations for canvas

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -113,7 +113,7 @@ In the example below, the component's internal state of the count will not be re
 ```
 
 :::note[Known limitations]
-Not all state can be preserved in this way. The restart of CSS animations and the reload of iframes cannot be avoided during view transitions even when using `transition:persist`.
+Not all state can be preserved in this way. The restart of CSS animations and the reload of iframes cannot be avoided during view transitions even when using `transition:persist`. Canvas elements, including WebGL/WebGL2 context and drawn content, are preserved.
 :::
 
 You can also [manually identify corresponding elements](#naming-a-transition) if the island/element is in a different component between the two pages.


### PR DESCRIPTION
## Summary
- Updates the `transition:persist` known limitations note to clarify that canvas elements (including WebGL/WebGL2 context) are preserved during view transitions
- Companion to [withastro/astro#15728](https://github.com/withastro/astro/pull/15728)

## Related
- Fix PR: https://github.com/withastro/astro/pull/15728
- Issue: https://github.com/withastro/astro/issues/15727