### PR TITLE
Update clever-cloud.mdx

### DIFF
--- a/src/content/docs/fr/guides/deploy/clever-cloud.mdx
+++ b/src/content/docs/fr/guides/deploy/clever-cloud.mdx
@@ -11,7 +11,7 @@ i18nReady: true
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 
-[Clever Cloud](https://clever-cloud.com) est une plateforme cloud européenne qui fournit des services automatisés et évolutifs.
+[Clever Cloud](https://clever.cloud) est une plateforme cloud européenne qui fournit des services automatisés et évolutifs.
 
 ## Configuration du projet
 
@@ -105,5 +105,5 @@ Par exemple, si vous souhaitez déployer votre branche locale `main` sans la ren
 
 
 ## Ressources officielles
-- [Documentation Clever Cloud pour déployer une application Node.js](https://www.clever-cloud.com/developers/doc/applications/javascript/nodejs/) (Anglais)
-- [Documentation Clever Cloud pour le déploiement d'Astro en tant qu'application statique](https://www.clever-cloud.com/developers/guides/astro/) (Anglais)
+- [Documentation Clever Cloud pour déployer une application Node.js](https://www.clever.cloud/developers/doc/applications/nodejs/) (Anglais)
+- [Documentation Clever Cloud pour le déploiement d'Astro en tant qu'application statique](https://www.clever.cloud/developers/guides/astro/) (Anglais)


### PR DESCRIPTION
Hello,

As part of a migration, Clever Cloud has changed its domain from clever-cloud.com to clever.cloud.

I therefore wanted to update the links in order to limit redirects and keep the news page.

Thank you.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

<!-- 🚨 IMPORTANT INFO AS WE PREPARE FOR v6 🚨 -->
<!-- We are only accepting emergency fixes for v5 docs (typos, links etc.) -->
<!-- All new feature documentation PRs must use the `v6` branch  -->
<!-- No new translations will be accepted until v6 is released -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

As part of a migration, Clever Cloud has changed its domain from clever-cloud.com to clever.cloud.

I therefore wanted to update the links in order to limit redirects and keep the news page.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
