### PR TITLE
Encode requests to npm.antfu.dev

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -187,7 +187,7 @@ export const collections = {
 				'astro',
 			];
 			// See https://github.com/antfu/fast-npm-meta
-			const url = `https://npm.antfu.dev/${packages.join('+')}`;
+			const url = `https://npm.antfu.dev/${encodeURIComponent(packages.join('+'))}`;
 			const data = await fetch(url).then((res) => res.json());
 			return data.map((pkg: any) => ({ id: pkg.name, version: pkg.version }));
 		},


### PR DESCRIPTION

#### Description (required)

This PR is a workaround for https://github.com/antfu/fast-npm-meta/issues/33

https://github.com/antfu/fast-npm-meta/issues/32 caused our requests for package data from https://npm.antfu.dev to fail. Until the issue is fixed, we can encode our requested packages to work around the change in behaviour.