### PR TITLE
revert no-index header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,3 @@
   cache-control: max-age=31536000
   cache-control: immutable
   cache-control: public
-
-# TODO: Remove this before merging to main
-/*
-  x-robots-tag: no-index


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Reverts the headers used for the preview `v6.docs.astro.build`

Replaces #13364 

