### PR TITLE
remove no-longer-necessary beta argument in v6 upgrade guide

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -24,19 +24,19 @@ Update your project's version of Astro to the latest version using your package 
   <Fragment slot="npm">
   ```shell
   # Upgrade Astro and official integrations together
-  npx @astrojs/upgrade beta
+  npx @astrojs/upgrade
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
   # Upgrade Astro and official integrations together
-  pnpm dlx @astrojs/upgrade beta
+  pnpm dlx @astrojs/upgrade
   ```
   </Fragment>
   <Fragment slot="yarn">
   ```shell
   # Upgrade Astro and official integrations together
-  yarn dlx @astrojs/upgrade beta
+  yarn dlx @astrojs/upgrade
   ```
   </Fragment>
 </PackageManagerTabs>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

An unnecessary `beta` argument was specified on the v6 migration page, this PR removes it.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
