### PR TITLE
Update route caching documentation for production mode

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/route-caching.mdx
+++ b/src/content/docs/en/reference/experimental-flags/route-caching.mdx
@@ -122,7 +122,7 @@ Multiple calls to `cache.set()` within a single request are merged:
 
 Middleware, layouts, content loaders, and page code can each contribute cache directives independently.
 
-## Dev mode behavior
+### Dev mode behavior
 
 In dev mode, the cache API is available so that route code does not need conditional checks, but no actual caching occurs. `cache.enabled` is `false`, and `cache.set()` and `cache.invalidate()` are no-ops. To test your caching locally, build then preview your site.
 


### PR DESCRIPTION
The fact that caching doesn't work in development is mentioned a bit later in the doc, but as this tripped me up I thought it made sense to add an even earlier note about this. Also, the fact that it is in prod only is mentioned in "Checking if caching is enabled" - I ignored this section when I was testing earlier as i didn't need to check, I just wanted to cache, so I was confused when it didn't work.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This helps flag the fact that caching is a production mode only feature.

I'm @raymondcamden in Discord.

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
