### PR TITLE
Revert change to PNPM setup in CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Setup PNPM
       uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-      with:
-        cache: true
 
     - name: Setup Node
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
#### Description (required)

This PR reverts a configuration change I made to our CI config in #13407

I added a redundant `cache` option after misunderstanding its purpose. This is harmless but also pointless, so we should remove it.