### PR TITLE
Document prerenderEnvironment in Cloudflare upgrade

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -479,6 +479,16 @@ This change helps you catch issues during development that would have previously
 
 This change is transparent for most projects. If your project had special configuration for `astro dev` or was relying on Node.js-specific behavior in development, adjust your code or configuration accordingly.
 
+### New: `prerenderEnvironment` option
+
+In Astro 6, prerendered pages now run in Cloudflare's `workerd` runtime by default during development and build. Previously, these pages always ran in Node.js.
+
+If your prerendered pages depend on Node.js APIs (for example `node:fs`) or NPM packages that are not compatible with `workerd`, set `prerenderEnvironment: 'node'` in your Cloudflare adapter config to restore the previous behavior for prerendering.
+
+On-demand rendered pages are not affected by this option and continue to run in `workerd`.
+
+<ReadMore>See [`prerenderEnvironment`](#prerenderenvironment) for configuration details.</ReadMore>
+
 ### Some dependencies might need to be pre-compiled
 
 The new workerd environment does not support CommonJS syntax, including Node.js specific syntax such as `require` and `module.exports`. This means that some of your project dependencies may throw errors in the development server or during the build.


### PR DESCRIPTION


#### Description (required)

Updates the Cloudflare upgrade guide to mention `prerenderEnvironment`

