### PR TITLE
fix: tiny nits in `content-loader-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/content-loader-reference.mdx
+++ b/src/content/docs/en/reference/content-loader-reference.mdx
@@ -56,7 +56,6 @@ const notes = defineCollection({
     base: './src/data/notes',
     retainBody: false
   }),
-  schema: /* ... */
 });
 const authors = defineCollection({
   /* Retrieve all JSON files in your authors directory while retaining
@@ -694,7 +693,7 @@ Optionally, you can return a third property defining a schema to validate your c
 
 <p>
 
-**Type**: `string`
+**Type:** `string`
 <Since v="5.0.0" />
 </p>
 
@@ -704,7 +703,7 @@ A unique name for the loader, used in logs and [for conditional loading](/en/ref
 
 <p>
 
-**Type**: <code>(context: <a href="#loadercontext">LoaderContext</a>) => Promise&lt;void&gt;</code>
+**Type:** <code>(context: <a href="#loadercontext">LoaderContext</a>) => Promise&lt;void&gt;</code>
 <Since v="5.0.0" />
 </p>
 
@@ -714,7 +713,7 @@ An async function that is called at build time to load data and update the store
 
 <p>
 
-**Type**: `ZodSchema`
+**Type:** `ZodSchema`
 <Since v="5.0.0" />
 </p>
 
@@ -728,7 +727,7 @@ If present, it will be overridden by any Zod `schema` defined for the collection
 
 <p>
 
-**Type**: `() => Promise<{ schema: ZodSchema; types: string }>`
+**Type:** `() => Promise<{ schema: ZodSchema; types: string }>`
 <Since v="6.0.0" />
 </p>
 
@@ -788,7 +787,7 @@ This object is passed to the [`load()`](#loaderload) method of the loader, and c
 
 <p>
 
-**Type**: `string`
+**Type:** `string`
 <Since v="5.0.0" />
 </p>
 
@@ -798,7 +797,7 @@ The unique name of the collection. This is the key in the `collections` object i
 
 <p>
 
-**Type**: [`DataStore`](#datastore)
+**Type:** [`DataStore`](#datastore)
 <Since v="5.0.0" />
 </p>
 
@@ -808,7 +807,7 @@ A database to store the actual data. Use this to update the store with new entri
 
 <p>
 
-**Type**: `MetaStore`
+**Type:** `MetaStore`
 <Since v="5.0.0" />
 </p>
 
@@ -824,7 +823,7 @@ meta.set("lastModified", new Date().toISOString());
 
 <p>
 
-**Type**: [`AstroIntegrationLogger`](/en/reference/integrations-reference/#astrointegrationlogger)
+**Type:** [`AstroIntegrationLogger`](/en/reference/integrations-reference/#astrointegrationlogger)
 <Since v="5.0.0" />
 </p>
 
@@ -852,7 +851,7 @@ return {
 
 <p>
 
-**Type**: `AstroConfig`
+**Type:** `AstroConfig`
 <Since v="5.0.0" />
 </p>
 
@@ -880,7 +879,7 @@ return {
 
 <p>
 
-**Type**: `(props: ParseDataOptions<TData>) => Promise<TData>`
+**Type:** `(props: ParseDataOptions<TData>) => Promise<TData>`
 <Since v="5.0.0" />
 </p>
 
@@ -919,7 +918,7 @@ export function feedLoader({ url }) {
 
 <p>
 
-**Type**: `(content: string, options?: { fileURL?: URL }) => Promise<RenderedContent>`
+**Type:** `(content: string, options?: { fileURL?: URL }) => Promise<RenderedContent>`
 <Since v="5.9.0" />
 </p>
 
@@ -958,7 +957,7 @@ export function myLoader(settings) {
 
 <p>
 
-**Type**: `URL`
+**Type:** `URL`
 <Since v="6.0.0" />
 </p>
 
@@ -983,7 +982,7 @@ for (const file of files) {
 
 <p>
 
-**Type**: `(data: Record<string, unknown> | string) => string`
+**Type:** `(data: Record<string, unknown> | string) => string`
 <Since v="5.0.0" />
 </p>
 
@@ -1026,7 +1025,7 @@ export function feedLoader({ url }) {
 
 <p>
 
-**Type**: `FSWatcher`
+**Type:** `FSWatcher`
 <Since v="5.0.0" />
 </p>
 
@@ -1054,7 +1053,7 @@ return {
 
 <p>
 
-**Type**: `Record<string, unknown>`
+**Type:** `Record<string, unknown>`
 <Since v="5.0.0" />
 </p>
 
@@ -1086,7 +1085,7 @@ The data store is a loader's interface to the content collection data. It is a k
 
 <p>
 
-**Type**: <code>(key: string) => <a href="#dataentry">DataEntry</a> | undefined</code>
+**Type:** <code>(key: string) => <a href="#dataentry">DataEntry</a> | undefined</code>
 <Since v="5.0.0" />
 </p>
 
@@ -1102,7 +1101,7 @@ The returned object is a [`DataEntry`](#dataentry) object.
 
 <p>
 
-**Type**: <code>(entry: <a href="#dataentry">DataEntry</a>) => boolean</code>
+**Type:** <code>(entry: <a href="#dataentry">DataEntry</a>) => boolean</code>
 <Since v="5.0.0" />
 </p>
 
@@ -1131,7 +1130,7 @@ Used after data has been [validated and parsed](#loadercontextparsedata) to add 
 
 <p>
 
-**Type**: <code>() => Array\<[id: string, <a href="#dataentry">DataEntry</a>]\></code>
+**Type:** <code>() => Array\<[id: string, <a href="#dataentry">DataEntry</a>]\></code>
 <Since v="5.0.0" />
 </p>
 
@@ -1141,7 +1140,7 @@ Get all entries in the collection as an array of key-value pairs.
 
 <p>
 
-**Type**: `() => Array<string>`
+**Type:** `() => Array<string>`
 <Since v="5.0.0" />
 </p>
 
@@ -1151,7 +1150,7 @@ Get all the keys of the entries in the collection.
 
 <p>
 
-**Type**: <code>() => Array\<<a href="#dataentry">DataEntry</a>\></code>
+**Type:** <code>() => Array\<<a href="#dataentry">DataEntry</a>\></code>
 <Since v="5.0.0" />
 </p>
 
@@ -1161,7 +1160,7 @@ Get all entries in the collection as an array.
 
 <p>
 
-**Type**: `(key: string) => void`
+**Type:** `(key: string) => void`
 <Since v="5.0.0" />
 </p>
 
@@ -1171,7 +1170,7 @@ Delete an entry from the store by its ID.
 
 <p>
 
-**Type**: `() => void`
+**Type:** `() => void`
 <Since v="5.0.0" />
 </p>
 
@@ -1181,7 +1180,7 @@ Clear all entries from the collection.
 
 <p>
 
-**Type**: `(key: string) => boolean`
+**Type:** `(key: string) => boolean`
 <Since v="5.0.0" />
 </p>
 
@@ -1195,7 +1194,7 @@ This is the type of the object that is stored in the data store. It has the foll
 
 <p>
 
-**Type**: `string`
+**Type:** `string`
 <Since v="5.0.0" />
 </p>
 
@@ -1205,7 +1204,7 @@ An identifier for the entry, which must be unique within the collection. This is
 
 <p>
 
-**Type**: `Record<string, unknown>`
+**Type:** `Record<string, unknown>`
 <Since v="5.0.0" />
 </p>
 
@@ -1217,7 +1216,7 @@ It is the loader's responsibility to use [`parseData()`](#loadercontextparsedata
 
 <p>
 
-**Type**: `string | undefined`
+**Type:** `string | undefined`
 <Since v="5.0.0" />
 </p>
 
@@ -1229,7 +1228,7 @@ If not set, then any fields in the schema that use [the `image()` helper](/en/gu
 
 <p>
 
-**Type**: `string | undefined`
+**Type:** `string | undefined`
 <Since v="5.0.0" />
 </p>
 
@@ -1239,7 +1238,7 @@ The raw body of the entry, if applicable. If the entry includes [rendered conten
 
 <p>
 
-**Type**: `string | undefined`
+**Type:** `string | undefined`
 <Since v="5.0.0" />
 </p>
 
@@ -1253,7 +1252,7 @@ The format of the digest is up to the loader, but it must be a string that chang
 
 <p>
 
-**Type**: `RenderedContent | undefined`
+**Type:** `RenderedContent | undefined`
 <Since v="5.0.0" />
 </p>
 
@@ -1267,7 +1266,7 @@ If the entry has Markdown content then you can use the [`renderMarkdown()`](#loa
 
 <p>
 
-**Type**: `string`
+**Type:** `string`
 </p>
 
 Contains the rendered HTML string. This is used by [`render()`](/en/reference/modules/astro-content/#render) to return a component that renders this HTML.
@@ -1276,7 +1275,7 @@ Contains the rendered HTML string. This is used by [`render()`](/en/reference/mo
 
 <p>
 
-**Type**: `object | undefined`
+**Type:** `object | undefined`
 </p>
 
 Describes the metadata present in this file. This includes the `imagePaths`, the `headings`, the `frontmatter`, and any other metadata present in the file. When the file has not been rendered as HTML, this value will be `undefined`.
@@ -1285,7 +1284,7 @@ Describes the metadata present in this file. This includes the `imagePaths`, the
 
 <p>
 
-**Type**: `string[]`
+**Type:** `string[]`
 </p>
 
 Specifies the list of images paths present in this entry. Each path is relative to the [entry `filePath`](#dataentryfilepath).
@@ -1294,7 +1293,7 @@ Specifies the list of images paths present in this entry. Each path is relative 
 
 <p>
 
-**Type**: `MarkdownHeading[]`
+**Type:** `MarkdownHeading[]`
 </p>
 
 Specifies the list of headings present in this file. Each heading is described by a `depth` determined by the heading level (`h1 -> h6`), a `slug` generated with [`github-slugger`](https://github.com/Flet/github-slugger), and its `text` content.
@@ -1303,7 +1302,7 @@ Specifies the list of headings present in this file. Each heading is described b
 
 <p>
 
-**Type**: `Record<string, any>`
+**Type:** `Record<string, any>`
 </p>
 
 Describes the raw frontmatter, parsed from the file. This may include [programmatically injected data from remark plugins](/en/guides/markdown-content/#modifying-frontmatter-programmatically).
@@ -1419,7 +1418,7 @@ This is the type object that is returned by the [`loadEntry()`](#liveloaderloade
 
 <p>
 
-**Type**: `string`
+**Type:** `string`
 <Since v="6.0.0" />
 </p>
 
@@ -1429,7 +1428,7 @@ An identifier for the entry, which must be unique within the collection. This is
 
 <p>
 
-**Type**: `Record<string, unknown>`
+**Type:** `Record<string, unknown>`
 <Since v="6.0.0" />
 </p>
 
@@ -1441,7 +1440,7 @@ It is the loader's responsibility to validate and parse the data before returnin
 
 <p>
 
-**Type**: `{ html: string }`
+**Type:** `{ html: string }`
 <Since v="6.0.0" />
 </p>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In #12322 we removed almost all `schema: /* ... */` in `content-loader-reference.mdx` because this is invalid code and this is not necessary (see https://github.com/withastro/docs/pull/12322/changes#diff-a4b088418618b66fd166198b8232044082d22a8ca665c1d3ac2c4ec5f55f69ef). There was one left.

In addition, while translating, the inconsistency between `**Type:**` and `**Type**:` bothered me... so, since this file needs an update in all languages, I figured we could bring some consistency. 😀 

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label:  `code snippet update`, `consistency/formatting `

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
