### PR TITLE
fix: removed parentheses following a instances of Astro.site in v6.mdx

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -248,7 +248,7 @@ Astro 6.0 deprecates this object for `getStaticPaths()` to avoid confusion and i
 
 #### What should I do?
 
-Update your `getStaticPaths()` function if you were attempting to access any `Astro` properties inside its scope. Remove `Astro.generator` entirely, and replace all occurrences of `Astro.site()` with `import.meta.env.SITE`:
+Update your `getStaticPaths()` function if you were attempting to access any `Astro` properties inside its scope. Remove `Astro.generator` entirely, and replace all occurrences of `Astro.site` with `import.meta.env.SITE`:
 
 ```astro title="src/pages/blog/[slug].astro" del={5,6} ins={7}
 ---


### PR DESCRIPTION
#### Description

- Removed parentheses following some instances of `Astro.site` in `v6.mdx`

This PR is because the typo could be a little misleading for readers I think.
Astro.site is looks like just a property not a method, therefore I think that it might better to remove.

I'd really appreciate it if you could check this when you get a chance🫡