### PR TITLE
Fix font styles from 'italics' to 'italic'

### DIFF
--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -261,7 +261,7 @@ export default defineConfig({
       provider: fontProviders.google(),
       // Default included:
       // weights: [400] ,
-      // styles: ["normal", "italics"],
+      // styles: ["normal", "italic"],
       // subsets: ["latin"],
       // fallbacks: ["sans-serif"], 
       // formats: ["woff2"],


### PR DESCRIPTION
Now:
```
styles: ["normal", "italics"],
```

Should be:
```
styles: ["normal", "italic"],
```
