### PR TITLE
Align experimental SVGO documentation with v4

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/svg-optimization.mdx
+++ b/src/content/docs/en/reference/experimental-flags/svg-optimization.mdx
@@ -128,7 +128,7 @@ export default defineConfig({
 })
 ```
 
-Setting `multipass` to true will run the optimization engine multiple times on each file to ensure no optimizations are missed. The `floatPrecision` parameter will be passed to all the many plugins that use it to control the number of decimal places to preserve. It can be overridden for a specific plugin by passing a value in its `params` property.
+The `multipass` option sets whether to run the optimization engine multiple times until no further optimizations are found. The `floatPrecision` option sets the number of decimal places to preserve globally, but can be overridden for a specific plugin by specifying a custom value in its `params` property.
 
 ## Common use cases
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

The SVGO documentation was written prior to v3. One breaking change and one major change has since been made to that package. Specifically, [the `active` parameter is no longer accepted](https://svgo.dev/docs/migrations/migration-from-v2-to-v3/#active-plugins) (this was replaced by an overrides parameter in v3) and `removeViewBox` is no longer included in the default preset making removing it redundant.

The SVGO documentation is also rather sparce when it comes to documenting the config object, so further clarifications were added.
