### PR TITLE
fix: replace `model` with `module` in `upgrade-to/v6.mdx`

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -268,7 +268,7 @@ export async function getStaticPaths() {
 
 <SourcePR number="14461" title="feat: deprecate import.meta.env.ASSETS_PREFIX"/>
 
-In Astro 5.x, it was possible to access `build.assetsPrefix` in your Astro config via the built-in environment variable `import.meta.env.ASSETS_PREFIX`. However, Astro v5.7.0 introduced the `astro:config` virtual model to expose a non-exhaustive, serializable, type-safe version of the Astro configuration which included access to `build.assetsPrefix` directly. This became the preferred way to access the prefix for Astro-generated asset links when set, although the environment variable still existed.
+In Astro 5.x, it was possible to access `build.assetsPrefix` in your Astro config via the built-in environment variable `import.meta.env.ASSETS_PREFIX`. However, Astro v5.7.0 introduced the `astro:config` virtual module to expose a non-exhaustive, serializable, type-safe version of the Astro configuration which included access to `build.assetsPrefix` directly. This became the preferred way to access the prefix for Astro-generated asset links when set, although the environment variable still existed.
 
 Astro 6.0 deprecates this variable in favor of `build.assetsPrefix` from the `astro:config/server` module.
 
@@ -284,7 +284,7 @@ someLogic(import.meta.env.ASSETS_PREFIX)
 someLogic(build.assetsPrefix)
 ```
 
-<ReadMore>Read more about the [`astro:config` virtual modules](/en/reference/modules/astro-config/).</ReadMore>
+<ReadMore>Read more about the [`astro:config` virtual module](/en/reference/modules/astro-config/).</ReadMore>
 
 ### Deprecated: `astro:schema` and `z` from `astro:content`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I spotted two typos (so far) in the `upgrade-to/v6.mdx` guide: `virtual model` > `virtual module` and plural/singular.

I think the first one can affect some translations so I haven't used typo in the PR title.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
