### PR TITLE
i18n(fr): remove Firebase Studio mentions

### DIFF
--- a/src/content/docs/fr/editor-setup.mdx
+++ b/src/content/docs/fr/editor-setup.mdx
@@ -55,7 +55,6 @@ En plus des éditeurs locaux, Astro fonctionne également bien dans les éditeur
 
 - [StackBlitz](https://stackblitz.com/) et [CodeSandbox](https://codesandbox.io/) - des éditeurs en ligne qui s'exécutent dans votre navigateur, avec prise en charge intégrée de la coloration syntaxique pour les fichiers `.astro`. Aucune installation ou configuration n'est nécessaire !
 - [GitHub.dev](https://github.dev/) - vous permet d'installer l'extension Astro pour VS Code en tant qu'[extension web](https://code.visualstudio.com/api/extension-guides/web-extensions), ce qui ne vous donne accès qu'à certaines des fonctionnalités complètes de l'extension. Actuellement, seule la coloration syntaxique est prise en charge.
-- [Firebase Studio](https://firebase.studio/) - un environnement de développement complet dans le cloud qui peut installer l'extension officielle Astro pour VS Code depuis Open VSX.
 
 ## Autres outils
 

--- a/src/content/docs/fr/guides/cms/builderio.mdx
+++ b/src/content/docs/fr/guides/cms/builderio.mdx
@@ -174,7 +174,7 @@ Les choses peuvent parfois mal tourner lors de la mise en place de la prévisual
 * Assurez-vous que le site est en ligne - par exemple, votre serveur de développement est en cours d'exécution.
 * Assurez-vous que les URL correspondent exactement - celle de votre projet Astro et celle définie dans l'application Builder.
 * Assurez-vous qu'il s'agit de l'URL complète, y compris le protocole, par exemple `https://`.
-* Si vous travaillez dans un environnement virtuel comme [Firebase Studio](https://studio.firebase.google.com/) ou [StackBlitz](https://stackblitz.com/), vous devrez peut-être copier et coller l'URL à nouveau lorsque vous redémarrez votre espace de travail, car cela génère généralement une nouvelle URL pour votre projet.
+* Si vous travaillez dans un environnement virtuel comme [StackBlitz](https://stackblitz.com/), vous devrez peut-être copier et coller l'URL à nouveau lorsque vous redémarrez votre espace de travail, car cela génère généralement une nouvelle URL pour votre projet.
 
 Pour plus d'informations, consultez [le guide de dépannage de Builder](https://www.builder.io/c/docs/guides/preview-url-working).
 :::

--- a/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-docusaurus.mdx
@@ -68,7 +68,7 @@ Vous pouvez passer un argument `--template` à la commande `create astro` pour d
 
 L'intégration MDX d'Astro est incluse par défaut, ce qui vous permet de [transférer vos fichiers de contenu existants vers Starlight](https://starlight.astro.build/fr/getting-started/#ajouter-du-contenu) immédiatement.
 
-Vous pouvez trouver le modèle de démarrage pour les sites de documentation d'Astro, et d'autres modèles officiels, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Vous pouvez trouver le modèle de démarrage pour les sites de documentation d'Astro, et d'autres modèles officiels, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-eleventy.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-eleventy.mdx
@@ -62,7 +62,7 @@ Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration option
 
 Votre projet Eleventy vous a permis d'utiliser une variété de langages de création de modèles pour créer votre site. Dans un projet Astro, la création de modèles pour vos pages sera principalement réalisée à l'aide de composants Astro, qui peuvent être utilisés comme éléments d'interface utilisateur, de mises en page et même de pages complètes. Vous pouvez explorer [la syntaxe des composants Astro](/fr/basics/astro-components/) pour découvrir comment créer des modèles dans Astro en utilisant des composants.
 
-Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gatsby.mdx
@@ -80,7 +80,7 @@ Vous pouvez utiliser un argument `--template` avec la commande `create astro` po
 Ensuite, copiez les fichiers existants de votre projet Gatsby vers votre nouveau projet Astro dans un dossier séparé en dehors de `src`.
 
 :::tip
-Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans Firebase Studio, StackBlitz ou CodeSandbox.
+Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans StackBlitz ou CodeSandbox.
 :::
 
 ### Installer des intégrations (facultatif)

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gitbook.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gitbook.mdx
@@ -26,7 +26,7 @@ GitBook et Astro partagent certaines similitudes qui vous aideront à migrer vot
 
 Lorsque vous migrez votre documentation de GitBook vers Astro, vous remarquerez quelques différences importantes :
 
-- Un site GitBook est édité à l'aide d'un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine, ou choisir un éditeur/environnement de développement dans le cloud comme Firebase Studio, StackBlitz ou CodeSandbox.
+- Un site GitBook est édité à l'aide d'un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine, ou choisir un éditeur/environnement de développement dans le cloud comme StackBlitz ou CodeSandbox.
 
 - GitBook stocke votre contenu dans une base de données. Dans Astro, vous aurez des fichiers individuels (typiquement Markdown ou MDX) dans votre [répertoire de projet](/fr/basics/project-structure/) pour le contenu de chaque page. Vous pouvez également choisir d'utiliser un [CMS pour votre contenu](/fr/guides/cms/) et utiliser Astro pour récupérer et présenter les données.
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-gridsome.mdx
@@ -66,7 +66,7 @@ La structure de projet de Gridsome étant similaire à celle d'Astro, vous pourr
 
 Étant donné qu'Astro interroge et importe vos fichiers locaux différemment de Gridsome, vous souhaiterez peut-être lire comment charger des fichiers en utilisant [`import.meta.glob()`](/fr/guides/imports/#importmetaglob) pour comprendre comment travailler avec vos fichiers locaux.
 
-Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez d'autres modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez d'autres modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-hugo.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-hugo.mdx
@@ -64,7 +64,7 @@ Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration option
 
 Pour continuer à utiliser du contenu dynamique tel que des variables, des expressions ou des composants d'interface utilisateur dans votre contenu Markdown, ajoutez l'intégration MDX facultative d'Astro et convertissez vos fichiers Markdown existants en [pages MDX](/fr/guides/markdown-content/). MDX prend en charge les frontmatters YAML et TOML, vous pouvez donc conserver vos propriétés de frontmatter existantes. Mais vous devez remplacer toute syntaxe de shortcode par [la syntaxe propre à MDX](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax), qui autorise les expressions JSX et/ou les importations de composants.
 
-Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, consultez les modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, consultez les modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-jekyll.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-jekyll.mdx
@@ -64,7 +64,7 @@ Une grande partie du contenu de vos pages HTML existantes peut être convertie e
 
 Astro ne possède pas de propriété `permalink` acceptant des valeurs par défaut. Vous devrez peut-être vous renseigner sur [le routage des pages d'Astro](/fr/guides/routing/) si vous souhaitez conserver votre structure d'URL existante. Vous pouvez également envisager de [définir des redirections chez un hébergeur comme Netlify](https://docs.netlify.com/routing/redirects/).
 
-Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez les modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, tels qu'un site de portfolio ou de documentation, consultez les modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nextjs.mdx
@@ -78,7 +78,7 @@ Vous pouvez utiliser un argument `--template` avec la commande `create astro` po
 Ensuite, copiez les fichiers existants de votre projet Next vers votre nouveau projet Astro dans un dossier séparé en dehors de `src`.
 
 :::tip
-Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans Firebase Studio, StackBlitz ou CodeSandbox.
+Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans StackBlitz ou CodeSandbox.
 :::
 
 ### Installer des intégrations (facultatif)

--- a/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -79,7 +79,7 @@ Vous pouvez utiliser un argument `--template` avec la commande `create astro` po
 Ensuite, copiez les fichiers existants de votre projet Nuxt vers votre nouveau projet Astro dans un dossier séparé en dehors de `src`.
 
 :::tip
-Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans Firebase Studio, StackBlitz ou CodeSandbox.
+Consultez https://astro.new pour la liste complète des modèles de démarrage officiels et des liens pour ouvrir un nouveau projet dans StackBlitz ou CodeSandbox.
 :::
 
 ### Installer des intégrations (facultatif)

--- a/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-pelican.mdx
@@ -61,7 +61,7 @@ Pelican a peut-être géré une grande partie de la mise en page et des métadon
 
 Comme Pelican, Astro dispose de nombreux modules d'extension qui étendent ses fonctionnalités. Explorez la [liste officielle des intégrations](/fr/guides/integrations-guide/) pour ajouter des fonctionnalités telles que la prise en charge de MDX et trouvez des centaines d'autres intégrations gérées par la communauté dans le [répertoire des intégrations Astro](https://astro.build/integrations/). Vous pouvez même utiliser l'[API des intégrations d'Astro](/fr/reference/integrations-reference/) pour créer votre propre intégration personnalisée afin d'étendre les fonctionnalités de votre projet.
 
-Pour convertir d'autres types de sites, comme un portfolio ou un blog, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, comme un portfolio ou un blog, consultez d'autres modèles de départ officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-sveltekit.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-sveltekit.mdx
@@ -67,7 +67,7 @@ Apportez vos fichiers Markdown existants (ou MDX, avec notre intégration option
 
 Bien que les composants de routage et de mise en page basés sur les fichiers soient similaires dans Astro, vous souhaiterez peut-être en savoir plus sur [la structure de projet d'Astro](/fr/basics/project-structure/) pour savoir où les fichiers doivent être placés.
 
-Pour convertir d'autres types de sites, tels qu'un portfolio ou un site de documentation, consultez les modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, tels qu'un portfolio ou un site de documentation, consultez les modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-vuepress.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-vuepress.mdx
@@ -61,7 +61,7 @@ Apportez vos fichiers de contenu Markdown existants à [créer des pages Markdow
 
 VuePress, ou tout autre thème que vous avez installé, a probablement géré une grande partie de la mise en page et des métadonnées de votre site pour vous. Vous souhaiterez peut-être en savoir plus sur [la création de mises en page Astro en tant qu'enveloppes de page Markdown](/fr/basics/layouts/#mises-en-page-markdown) pour découvrir comment gérer vous-même la création de modèles dans Astro, y compris la balise `<head>` de votre page.
 
-Vous pouvez trouver la documentation de démarrage d'Astro, ainsi que d'autres modèles, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Vous pouvez trouver la documentation de démarrage d'Astro, ainsi que d'autres modèles, sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/guides/migrate-to-astro/from-wordpress.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/from-wordpress.mdx
@@ -30,7 +30,7 @@ WordPress et Astro partagent certaines similitudes qui vous aideront à migrer v
 
 Lorsque vous recréez votre site WordPress avec Astro, vous remarquerez quelques différences importantes :
 
-- Un site WordPress est édité en utilisant un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine ou choisir un éditeur/environnement de développement en ligne comme Firebase Studio, StackBlitz ou CodeSandbox.
+- Un site WordPress est édité en utilisant un tableau de bord en ligne. Dans Astro, vous utiliserez un [éditeur de code](/fr/editor-setup/) et un environnement de développement pour maintenir votre site. Vous pouvez développer localement sur votre machine ou choisir un éditeur/environnement de développement en ligne comme StackBlitz ou CodeSandbox.
 
 - WordPress dispose d’un vaste marché de modules d'extension et de thèmes. Dans Astro, vous trouverez quelques thèmes et [intégrations](https://astro.build/integrations/) disponibles, mais vous devrez peut-être désormais créer vous-même bon nombre de vos fonctionnalités existantes au lieu de rechercher des solutions tierces. Vous pouvez également choisir de commencer avec un [thème Astro](https://astro.build/themes) possédant des fonctionnalités intégrées !
 
@@ -66,7 +66,7 @@ Vous souhaiterez peut-être suivre le [tutoriel Construire un blog](/fr/tutorial
 
 Si vous souhaitez déplacer tous vos articles existants vers Astro, vous pourriez trouver cet [outil utile pour exporter du contenu Markdown depuis WordPress](https://github.com/lonekorean/wordpress-export-to-markdown). Vous devrez peut-être apporter quelques ajustements au résultat si vous devez [convertir un site WordPress volumineux ou compliqué vers Markdown](https://swizec.com/blog/how-to-export-a-large-wordpress-site-to-markdown/).
 
-Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, découvrez plus de modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne Firebase Studio, StackBlitz et CodeSandbox.
+Pour convertir d'autres types de sites, comme un portfolio ou un site de documentation, découvrez plus de modèles de démarrage officiels sur [astro.new](https://astro.new). Vous trouverez un lien vers le dépôt GitHub de chaque projet, ainsi que des liens en un clic pour ouvrir un projet fonctionnel dans les environnements de développement en ligne StackBlitz et CodeSandbox.
 
 ## Ressources communautaires
 

--- a/src/content/docs/fr/tutorial/0-introduction/index.mdx
+++ b/src/content/docs/fr/tutorial/0-introduction/index.mdx
@@ -26,7 +26,7 @@ Tout au long du processus, vous allez :
 - Ajouter de l'interactivité à votre site
 - Déployer votre site sur le web
 
-Vous voulez avoir un aperçu de ce que vous allez créer ? Vous pouvez consulter le projet final sur [GitHub](https://github.com/withastro/blog-tutorial-demo) ou ouvrir une version fonctionnelle dans un environnement de développement en ligne tel que [Firebase Studio](https://studio.firebase.google.com/import?url=https:%2F%2Fgithub.com%2Fwithastro%2Fblog-tutorial-demo%2F) ou [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro).
+Vous voulez avoir un aperçu de ce que vous allez créer ? Vous pouvez consulter le projet final sur [GitHub](https://github.com/withastro/blog-tutorial-demo) ou ouvrir une version fonctionnelle dans un environnement de développement en ligne tel que [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro).
 
 :::note
 Si vous préférez commencer à explorer Astro avec un site Astro pré-construit, vous pouvez visiter https://astro.new et choisir un modèle de départ à ouvrir et à éditer dans un éditeur en ligne.

--- a/src/content/docs/fr/tutorial/1-setup/index.mdx
+++ b/src/content/docs/fr/tutorial/1-setup/index.mdx
@@ -22,50 +22,8 @@ Cette unité vous montre comment configurer votre environnement de développemen
 
 :::tip[Suivre le tutoriel dans un éditeur de code en ligne]
 
-Vous préférez suivre ce tutoriel dans un éditeur de code en ligne ? Suivez les instructions ci-dessous pour commencer à utiliser Firebase Studio.
+Vous préférez suivre ce tutoriel dans un éditeur de code en ligne ? Suivez les instructions ci-dessous pour commencer à utiliser StackBlitz.
 
-<details>
-<summary>Utilisation de Firebase Studio : suivez ces instructions, puis passez directement à l’unité 2 !</summary>
-
-**Configurer Firebase Studio**
-
-<Steps>
-1. Suivez le lien externe pour [ouvrir le modèle « Empty project » dans un nouvel espace de travail sur Firebase Studio](https://astro.new/minimal?on=firebase-studio).
-
-2. Suivez l’invite pour vous connecter à votre compte Google si vous n’êtes pas déjà connecté.
-
-3. Saisissez un nom pour votre projet si vous souhaitez remplacer le nom par défaut « Empty project ». Cliquez sur **Créer**.
-
-4. Attendez que l'espace de travail soit créé. Cela peut prendre 30 à 60 secondes. Si tout se passe bien, vous verrez le projet Astro chargé dans un éditeur de code en ligne.
-
-5. Attendez que Firebase Studio exécute deux scripts : un pour installer Astro et un autre pour démarrer le serveur de développement. Notez que vous pouvez voir brièvement un message indiquant que votre espace de travail « n'a pas pu trouver Astro » si votre espace de travail se charge avant la fin de l'installation d'Astro. Ce message peut être ignoré et annulé s'il ne s'efface pas de lui-même.
-</Steps>
-
-**Faire un changement**
-
-Si tout se passe bien, vous devriez voir le code du fichier `src/pages/index.astro` ouvert en écran partagé avec un aperçu en direct du site web. Suivez les instructions dans [« Écrire votre première ligne d'Astro »](/fr/tutorial/1-setup/3/) pour apporter une modification à ce fichier.
-
-**Créer un dépôt GitHub**
-
-<Steps>
-1. Accédez à l'élément de navigation « Contrôle de source » dans la barre de menu verticale ou ouvrez avec <kbd>CTRL + SHIFT + G</kbd>. 
-
-2. Sélectionnez l'option Publier sur GitHub. Cela créera un nouveau dépôt dans votre compte GitHub.
-3. Suivez les instructions pour vous connecter à votre compte GitHub.
-4. Une fois connecté, revenez à l'onglet Firebase Studio et vous aurez le choix de nommer votre nouveau dépôt et de choisir si vous souhaitez créer un dépôt privé ou public. Vous pouvez choisir n'importe quel nom et n'importe quel type de dépôt pour ce tutoriel.
-5. Firebase Studio effectuera un commit initial et publiera dans votre nouveau dépôt GitHub.
-6. À l'avenir, chaque fois que vous aurez des modifications à valider sur GitHub, l'icône de navigation du contrôle de source affichera un numéro. Il s'agit du nombre de fichiers qui ont été modifiés depuis votre dernière validation. En accédant à cet onglet et en effectuant deux étapes (validation et publication), vous pourrez saisir un message de validation et mettre à jour votre dépôt.
-</Steps>
-
-**Déployer votre site**
-
-Si vous souhaitez déployer sur Netlify et disposer d'une version en ligne de votre site pendant que vous travaillez, passez à l'unité 1 pour [Déployer votre site sur le web](/fr/tutorial/1-setup/5/).
-
-Sinon, passez à l'[unité 2](/fr/tutorial/2-pages/) pour commencer à créer avec Astro !
-
-</details>
-
-{/* StackBlitz instructions 
 <details>
 <summary>Utilisation de StackBlitz : Suivez ces instructions, puis passez directement à l'unité 2 !</summary>
 
@@ -74,7 +32,7 @@ Sinon, passez à l'[unité 2](/fr/tutorial/2-pages/) pour commencer à créer av
 <Steps>
 1. Suivez le lien externe pour [ouvrir le modèle « Empty project » sur StackBlitz](https://astro.new/minimal?on=stackblitz).
 
-2. Cliquez sur "Sign in" en haut à droite pour vous connecter en utilisant vos identifiants GitHub.
+2. Cliquez sur « Sign in » en haut à droite pour vous connecter en utilisant vos identifiants GitHub.
 
 3. En haut à gauche de la fenêtre de l'éditeur StackBlitz, cliquez sur « fork » le modèle (enregistrer dans le tableau de bord de votre compte).
 
@@ -100,7 +58,6 @@ Si vous souhaitez déployer sur Netlify et disposer d'une version en ligne de vo
 Sinon, passez à l'[unité 2](/fr/tutorial/2-pages/) pour commencer à créer avec Astro !
 
 </details>
-*/}
 :::
 
 ## Vers quoi vous dirigez-vous ?

--- a/src/content/docs/fr/tutorial/6-islands/3.mdx
+++ b/src/content/docs/fr/tutorial/6-islands/3.mdx
@@ -45,8 +45,7 @@ const textCase = "uppercase";
 
 Nous espérons que vous avez un peu appris les bases d'Astro et que vous avez pris du plaisir tout au long du tutoriel !
 
-Vous pouvez trouver le code à ce stade du tutoriel sur [GitHub](https://github.com/withastro/blog-tutorial-demo/tree/complete) ou ouvrir une version fonctionnelle dans un environnement de code en ligne comme [Firebase Studio](https://studio.firebase.google.com/import?url=https:%2F%2Fgithub.com%2Fwithastro%2Fblog-tutorial-demo%2F) ou
-[StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src/pages/index.astro).
+Vous pouvez trouver le code à ce stade du tutoriel sur [GitHub](https://github.com/withastro/blog-tutorial-demo/tree/complete) ou ouvrir une version fonctionnelle dans un environnement de code en ligne comme [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src/pages/index.astro).
 
 Consultez notre documentation pour des guides et des références, et rejoignez notre Discord pour poser des questions, obtenir de l'aide ou simplement discuter !
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #13548 to the French translations to remove Firebase Studio mentions (+ French quotes use).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
