### PR TITLE
Enhance session set method documentation

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -924,7 +924,7 @@ Returns the value of the given key in the session. If the key does not exist, it
 
 </p>
 
-Sets the value of the given key in the session. The value can be any serializable type. This method is synchronous and the value is immediately available for retrieval, but it is not saved to the backend until the end of the request. The `ttl` option is a time specified in seconds determining how long the value can be retrieved. 
+Sets the value of the given key in the session. The value can be any serializable type. This method is synchronous and the value is immediately available for retrieval, but it is not saved to the backend until the end of the request. The `ttl` option sets the value's expiration time, in seconds.
 
 <Tabs>
   <TabItem label="Astro.session">


### PR DESCRIPTION
Added explanation of 'ttl' option for session value. Specifically it makes it clear the value is seconds, not miliseconds.


#### Description (required)

As said above, ttl wasn't described here. It's kinda obvious it it is "time to live", but not that the value is in seconds.

