### PR TITLE
Add details about pinning Vite for Astro 6 upgrade.

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -432,22 +432,20 @@ export default defineConfig({
 
 Astro 6 brings significant improvements to the Cloudflare development experience and requires `@astrojs/cloudflare` v13 or later. Now, `astro dev` uses Cloudflare's Vite plugin and `workerd` runtime to closely mirror production behavior.
 
-:::tip[You may hit a conflict when trying to upgrade]
-There's a chance that using standard components within your Astro site on Cloudflare, you are pulling in both Vite **7.x** and Vite **8.x**.
-This may cause a conflict considering Astro doesn't _yet_ support Vite 8.
+:::note[Conflicting Vite versions]
+Astro is not yet compatible with Vite 8. If you encounter issues in your project not addressed in the following sections during the upgrade, it may be due to different dependencies that pull both Vite 7 and Vite 8.
 
-A workaround is to pin all 3rd party imports of Vite to a supported version in your application's `package.json`:
+You can work around this issue by defining an `overrides` field in your `package.json` file:
 
 ```json
 {
-  "name": "my-awesome-astro-app",
+  "name": "my-astro-app",
   ...
   "overrides": {
-    "vite": "^7.3.1" // <- this pins Vite to a single version supported by Astro
+    "vite": "^7.3.1" // Pins Vite to a version supported by Astro
   }
 }
 ```
-***Be sure to test before rolling out to the production!***
 :::
 
 <ReadMore>See [the Astro 6 upgrade guide](/en/guides/upgrade-to/v6/) for full instructions on upgrading Astro itself.</ReadMore>


### PR DESCRIPTION
Add details in the Cloudflare-specific upgrade details about pinning Vite to a 7.x version.

Related: https://github.com/withastro/astro/issues/16029

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

When upgrading to Astro 6 on Cloudflare, there are some transitive dependencies that result in Vite 7.x and 8.x getting pulled in. Well, Vite 8.x isn't supported by Astro and this causes things to break. Pinning the version of Vite is a suitable workaround that should be documented to help people migrate and adopt Astro faster.
