### PR TITLE
i18n(fr): update `legacy-flags.mdx`

### DIFF
--- a/src/content/docs/fr/reference/legacy-flags.mdx
+++ b/src/content/docs/fr/reference/legacy-flags.mdx
@@ -18,7 +18,7 @@ Ces options vous permettent d'accepter certains comportements dépréciés ou ob
 <Since v="6.0.0" />
 </p>
 
-L'option `legacy.collectionsBackwardsCompat` assure une rétrocompatibilité temporaire pour les projets incapables de migrer vers l'API Content Layer introduite dans la version 5.0.
+L'option `legacy.collectionsBackwardsCompat` assure une rétrocompatibilité temporaire pour les projets incapables de migrer vers l'API de la couche de contenu introduite dans la version 5.0.
 
 ```js
 // astro.config.mjs
@@ -36,4 +36,4 @@ Cette option préserve certaines fonctionnalités héritées des collections de 
 - Préserve les entrée d'API existantes : `entry.slug` et `entry.render()`
 - Utilise des identifiants d'entrée basés sur le chemin au lieu d'identifiants basés sur le slug.
 
-Il s'agit d'un outil d'aide à la migration temporaire. Migrez les collections vers l'API Content Layer, puis désactivez cette option.
+Il s'agit d'un outil d'aide à la migration temporaire. Migrez les collections vers l'API de la couche de contenu, puis désactivez cette option.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `legacy-flags.mdx` for consistency. Our [i18n guide](https://github.com/withastro/docs/blob/main/i18n-guides/fran%C3%A7ais.md#concepts-et-api-dastro) says to use "couche de contenu" for "Content Layer", and all other translated files use this (e.g. [Content Loader Reference](https://docs.astro.build/fr/reference/content-loader-reference/) or [Content Collections](https://docs.astro.build/fr/guides/content-collections/)).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
