### PR TITLE
i18n(de): fix small leftover suggestions in v6 migration guide [lunaria-ignore]

### DIFF
--- a/src/content/docs/de/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/de/guides/upgrade-to/v6.mdx
@@ -200,7 +200,7 @@ Wenn du einen Astro-Adapter für On-Demand-Rendering oder andere plattformspezif
 
 ## Legacy
 
-Die folgenden Funktionen gelten nun als veraltete Funktionen. Sie sollten zwar weiterhin normal funktionieren, werden jedoch nicht mehr empfohlen und befinden sich im Wartungsmodus. Es sind keine weiteren Verbesserungen geplant, und die Dokumentation wird nicht mehr aktualisiert. Diese Funktionen werden irgendwann als veraltet eingestuft und anschließend vollständig entfernt.
+Die folgenden Funktionen gelten nun als Legacy-Funktionen. Sie sollten zwar weiterhin normal funktionieren, werden jedoch nicht mehr empfohlen und befinden sich im Wartungsmodus. Es sind keine weiteren Verbesserungen geplant, und die Dokumentation wird nicht mehr aktualisiert. Diese Funktionen werden irgendwann als veraltet eingestuft und anschließend vollständig entfernt.
 
 ### Legacy: Rückwärtskompatibilität bei Content-Collections
 
@@ -312,7 +312,7 @@ import { defineCollection } from "astro:content"
 import { z } from "astro/zod"
 ```
 
-<ReadMore>Mehr dazu unter [Definieren von Sammlungsschemata mit Zod](/de/guides/content-collections/#defining-datatypes-with-zod).</ReadMore>
+<ReadMore>Mehr dazu unter [Definieren von Collections-Schemata mit Zod](/de/guides/content-collections/#defining-datatypes-with-zod).</ReadMore>
 
 ### Veraltet: Interne Funktionen von `astro:transitions` sind nun öffentlich zugänglich
 


### PR DESCRIPTION
#### Description

This PR fixes some German mistakes in the `upgrade-to/v6.mdx` guide.

There were 3 suggestions in #13514 which we forgot to apply, [two](https://github.com/withastro/docs/pull/13514#discussion_r3004639711) [of](https://github.com/withastro/docs/pull/13514#discussion_r3004645886) them I think are valid, [one](https://github.com/withastro/docs/pull/13514#discussion_r3004650572) is a little tricky and I did not apply, as I think the current German text is correct.

Asking @randomguy-2650 for a review please 🤝 