### PR TITLE
i18n(es): Add get-image-not-used-on-server.mdx

### DIFF
--- a/src/content/docs/es/reference/errors/get-image-not-used-on-server.mdx
+++ b/src/content/docs/es/reference/errors/get-image-not-used-on-server.mdx
@@ -1,0 +1,28 @@
+---
+title: getImage() debe usarse en el servidor.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> **GetImageNotUsedOnServer**: `getImage()` solo debe usarse en el servidor. Para usar imágenes en el cliente, renderiza el `src` de `getImage()` durante el renderizado del servidor y luego pásalo al cliente.
+
+## ¿Qué salió mal?
+La función `getImage()` solo está disponible en el servidor. Para usar imágenes en el cliente, renderiza el `src` de `getImage()` durante el renderizado del servidor para usarlo en scripts del cliente, o utiliza una etiqueta `<img>` estándar.
+
+```astro
+---
+import { getImage } from "astro:assets";
+import myImage from "../assets/my_image.png";
+
+const optimizedImage = await getImage({ src: myImage, width: 300 });
+---
+
+<script define:vars={{ imageSrc: optimizedImage.src }}>
+  // Usa imageSrc en codigo del cliente
+  document.getElementById('myImage').src = imageSrc;
+</script>
+```
+
+**Ver también:**
+-  [Imágenes](/es/guides/images/)
+-  [getImage()](/es/reference/modules/astro-assets/#getimage)


### PR DESCRIPTION
#### Description (required)

Added documentation for invalid i18n middleware configuration.