### PR TITLE
Add notes about `glob()`'s normalization of `id`s in upgrade guides

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -121,7 +121,7 @@ See the instructions below for updating an existing content collection (`type: '
 
 1. **Move the content config file**. This file no longer lives within the `src/content/` folder. This file should now exist at `src/content.config.ts`.
 
-2. **Edit the collection definition**. Your updated collection requires a `loader` which indicates both a folder for the location of your collection (`base`) and a `pattern` defining the collection entry filenames and extensions to match. (You may need to update the example below accordingly. You can use [globster.xyz](https://globster.xyz/) to check your glob pattern.) The option to select a collection `type` is no longer available.
+2. **Edit the collection definition**. Your updated collection requires a `loader` which indicates both a folder for the location of your collection (`base`) and a `pattern` defining the collection entry filenames and extensions to match. (You may need to update the example below accordingly. You can use [globster.xyz](https://globster.xyz/) to check your glob pattern.) The option to select a collection `type` is no longer available. Different from content collctions, the `glob()` loader normalizes `id`s to a kebab-cased slug by default, so hard-coded `id`s that contain capital letters (like `getEntry("UpperCase")`) in your code may break. You can pass a custom [`generateID()` helper function](/en/reference/content-loader-reference/#generateid) to override this behavior.
 
     ```ts ins={3,8} del={7}
     // src/content.config.ts

--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -612,6 +612,8 @@ const blog = defineCollection({
   }),
 });
 ```
+
+Different from content collections, the `glob()` loader normalizes `id`s to kebab-cased slugs by default, so hard-coded `id`s including capital letters (like `getEntry("UpperCase")`) in your code may break. You can pass a custom [`generateID()` helper function](/en/reference/content-loader-reference/#generateid) to override this behavior.
 </details>
 
 <details>


### PR DESCRIPTION
#### Description

This PR updates the documentation to clarify that collection entry IDs are automatically lowercased when migrating legacy content collections to `glob()`. In legacy content collections, file names with uppercase characters could be used directly as IDs, while `glob()` normalizes them to kebab-case. This change is currently not clearly documented in the migration guide, which may lead to confusion for users.

```js
getEntry('data', 'testTest') // ❌
getEntry('data', 'testtest') // ✅
```

#### Related issues & labels

- This has been reported in https://github.com/withastro/astro/issues/13265#issuecomment-2666292571:

> Would still be useful to have that in the migration guide or content collections docs, as it's not expected.
