### PR TITLE
i18n(de): update island tutorial, 3.mdx

### DIFF
--- a/src/content/docs/de/tutorial/6-islands/3.mdx
+++ b/src/content/docs/de/tutorial/6-islands/3.mdx
@@ -44,7 +44,7 @@ const textCase = "uppercase";
 
 Wir hoffen, du hast beim Lernen der Astro-Grundlagen ein bisschen Spaß gehabt!
 
-Du findest den Code für das Projekt aus diesem Tutorial auf [GitHub](https://github.com/withastro/blog-tutorial-demo/tree/complete), oder du kannst eine funktionierende Version in einer Online-Entwicklungsumgebung wie [IDX](https://idx.google.com/import?url=https:%2F%2Fgithub.com%2Fwithastro%2Fblog-tutorial-demo%2F) oder [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src/pages/index.astro) öffnen.
+Du findest den Code für das Projekt aus diesem Tutorial auf [GitHub](https://github.com/withastro/blog-tutorial-demo/tree/complete), oder du kannst eine funktionierende Version in einer Online-Entwicklungsumgebung wie [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src/pages/index.astro) öffnen.
 
 Schau in unserer Dokumentation vorbei, um Anleitungen und Referenzen zu finden, oder besuche unseren Discord, um Fragen zu stellen, Hilfe zu bekommen oder einfach ein wenig zu plaudern!
 


### PR DESCRIPTION
#### Description (required)

* Adds changes from #13548 to the German translation of `tutorial/6-islands/3.mdx`.

#### Related issues & labels (optional)

- Suggested label: i18n