### PR TITLE
i18n(de): update deploy guide, cleavr.mdx + heroku.mdx

### DIFF
--- a/src/content/docs/de/guides/deploy/cleavr.mdx
+++ b/src/content/docs/de/guides/deploy/cleavr.mdx
@@ -8,7 +8,6 @@ logo: cleavr
 supports: ['ssr', 'static']
 i18nReady: true
 ---
-
 import { Steps } from '@astrojs/starlight/components';
 
 Du kannst dein Astro-Projekt mit [Cleavr](https://cleavr.io/), einem Tool zur Verwaltung von Servern und Apps, auf deinem eigenen virtuellen privaten Server (VPS) veröffentlichen.

--- a/src/content/docs/de/guides/deploy/heroku.mdx
+++ b/src/content/docs/de/guides/deploy/heroku.mdx
@@ -8,20 +8,17 @@ logo: heroku
 supports: ['static']
 i18nReady: true
 ---
-
 import { Steps } from '@astrojs/starlight/components';
 
 [Heroku](https://www.heroku.com/) ist eine Platform-as-a-Service für die Erstellung, den Betrieb und die Verwaltung moderner Apps in der Cloud. Mit dieser Anleitung kannst du eine Astro-Website auf Heroku veröffentlichen.
 
-:::danger
-Die folgenden Anweisungen nutzen [das veraltete `heroku-static-buildpack`](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated).
-Schau dir stattdessen die [Heroku-Dokumentation zur Verwendung von `heroku-buildpack-nginx`](https://github.com/dokku/heroku-buildpack-nginx) an.
+:::caution
+Die folgenden Anweisungen nutzen [das veraltete `heroku-static-buildpack`](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated). Schau dir stattdessen die [Heroku-Dokumentation zur Verwendung von `heroku-buildpack-nginx`](https://github.com/dokku/heroku-buildpack-nginx) an.
 :::
 
 ## So funktioniert die Veröffentlichung
 
 <Steps>
-
 1. Installiere die Kommandozeilen&shy;schnittstelle [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
 
 2. Erstelle ein Heroku-Konto, indem du dich [anmeldest](https://signup.heroku.com/).
@@ -66,5 +63,4 @@ Schau dir stattdessen die [Heroku-Dokumentation zur Verwendung von `heroku-build
    # Browser öffnen, um die Dashboard-Version von Heroku CI anzuzeigen
    $ heroku open
    ```
-
 </Steps>


### PR DESCRIPTION
#### Description (required)

* Adds changes from #12735 to the German translation of `guides/deploy/cleavr.mdx`.
* Adds changes from #12735 to the German translation of `guides/deploy/heroku.mdx`.

#### Related issues & labels (optional)

- Suggested label: i18n