### PR TITLE
i18n(zh-tw): translate reference/errors/invalid-rewrite404.mdx

### DIFF
--- a/src/content/docs/zh-tw/reference/errors/invalid-rewrite404.mdx
+++ b/src/content/docs/zh-tw/reference/errors/invalid-rewrite404.mdx
@@ -1,0 +1,16 @@
+---
+title: You attempted to rewrite a 404 inside a static page, and this isn't allowed.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+:::caution[已廢棄]
+此錯誤來自舊版本的 Astro，已不再使用。如果你無法將專案升級到新版本，可以檢視 [未維護的舊文件快照](/zh-tw/upgrade-astro/#舊版本文件不再維護) 以獲取幫助。
+:::
+
+> **InvalidRewrite404**：只有在隨需頁面 (On-demand pages) 中才允許重寫 404。
+
+## 發生了什麼錯誤？
+使用者嘗試在靜態頁面中重寫 404 頁面。
+
+


### PR DESCRIPTION
新增有關無效重寫404的繁中翻譯

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->
Proposing Change: Added the Traditional Chinese (zh-tw) translation for the InvalidRewrite404 error reference page.

Why:Currently, this error message is missing its Traditional Chinese version. Providing this translation helps developers in the Taiwan community better understand deployment constraints regarding static vs. on-demand pages.
<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
