### PR TITLE
fix: update code block titles in "Manual setup" section of `build-with-ai.mdx`

### DIFF
--- a/src/content/docs/en/guides/build-with-ai.mdx
+++ b/src/content/docs/en/guides/build-with-ai.mdx
@@ -49,7 +49,7 @@ Many tools support a common JSON configuration format for MCP servers. If there 
 
 <Tabs>
   <TabItem label="Streamable HTTP">
-    ```json title="mcp.json" {3-6}
+    ```json title="MCP Configuration" {3-6}
     {
       "mcpServers": {
         "Astro docs": {
@@ -61,7 +61,7 @@ Many tools support a common JSON configuration format for MCP servers. If there 
     ```
   </TabItem>
   <TabItem label="Local Proxy">
-    ```json title="mcp.json" {3-7}
+    ```json title="MCP Configuration" {3-7}
     {
       "mcpServers": {
         "Astro docs": {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

Changed the code block labels in the "Manual setup" section from `mcp.json` to `MCP Configuration`.

#### Related issues & labels (optional)

- Closes #13777 
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
