### PR TITLE
docs(astro-assets): clarify getImage() options don't match all Image props

### DIFF
--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -645,7 +645,7 @@ If you need the resulting image URL client-side, you can [pass the `src` from a 
 
 The `getImage()` function is intended for generating images destined to be used somewhere else than directly in HTML, for example in an [API Route](/en/guides/endpoints/#server-endpoints-api-routes). It also allows you to create your own custom `<Image />` component.
 
-This takes an options object with the [same properties as the Image component](#image-) (except `alt`) and returns a [`GetImageResult` object](#getimageresult).
+This takes an options object with a subset of the [Image component properties](#image-) (excluding `alt`, `priority`, and `layout`) and returns a [`GetImageResult` object](#getimageresult).
 
 The following example generates an AVIF `background-image` for a `<div />`:
 
@@ -828,7 +828,7 @@ See [`getConfiguredImageService()`](#getconfiguredimageservice) from `astro:asse
 **Type:** <code>(options: <a href="#unresolvedimagetransform">UnresolvedImageTransform</a>, imageConfig: <a href="/en/reference/configuration-reference/#image-options">AstroConfig['image']</a>) => Promise\<<a href="#getimageresult">GetImageResult</a>\></code>
 </p>
 
-A function similar to [`getImage()`](#getimage) from `astro:assets` with two required arguments: an `options` object with [the same properties as the Image component](#image-) and a second object for the [image configuration](/en/reference/configuration-reference/#image-options).
+A function similar to [`getImage()`](#getimage) from `astro:assets` with two required arguments: an `options` object with a subset of the [Image component properties](#image-) (excluding `alt`, `priority`, and `layout`), and a second object for the [image configuration](/en/reference/configuration-reference/#image-options).
 
 ### `isLocalService()`
 


### PR DESCRIPTION
## Summary

The reference docs state that \`getImage()\` takes an options object with \"the same properties as the Image component (except \`alt\`)\". That isn't accurate: \`getImage()\` accepts \`UnresolvedImageTransform\`, which does not include \`priority\` or \`layout\` either — those are \`<Image />\`-only props.

The same wording was duplicated in the \`LocalImageService\` / \`ExternalImageService\` \`getImage()\` entry, so both are updated.

## Issue

Fixes #13301

## Changes

- \`src/content/docs/en/reference/modules/astro-assets.mdx\`: reword the two \`getImage()\` descriptions to say \"a subset of the Image component properties (excluding \`alt\`, \`priority\`, and \`layout\`)\".

## Testing

- Docs-only change; no code or configuration touched.