### PR TITLE
feat: add `jsx` as valid option for `compressHTML`

### DIFF
--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -331,20 +331,23 @@ The value can be either an absolute file system path or a path relative to the p
 
 <p>
 
-**Type:** `boolean`<br />
+**Type:** `boolean | "jsx"`<br />
 **Default:** `true`
 </p>
 
-This is an option to minify your HTML output and reduce the size of your HTML files.
+Controls how Astro handles whitespace in your HTML. This affects both the development mode and the final build output.
 
-By default, Astro removes whitespace from your HTML, including line breaks, from `.astro` components in a lossless manner.
-Some whitespace may be kept as needed to preserve the visual rendering of your HTML. This occurs both in development mode and in the final build.
+By default, Astro removes unnecessary whitespace, including line breaks, from `.astro` components in a lossless way. Some whitespace may be kept to preserve the visual rendering of the HTML.
 
-To disable HTML compression, set `compressHTML` to false.
+To opt into a more aggressive compression mode, set `compressHTML` to `"jsx"`. With JSX, whitespace is only preserved if explicitly included in the source code. This means the final HTML code removes all whitespace, including line breaks and indentation.
+
+To disable HTML compression and preserve all whitespace, set `compressHTML` to `false`.
 
 ```js
 {
   compressHTML: false
+  // or:
+  // compressHTML: 'jsx'
 }
 ```
 
@@ -2505,4 +2508,3 @@ Font [variation settings](https://developer.mozilla.org/en-US/docs/Web/CSS/@font
 ```js
 variationSettings: "'xhgt' 0.7"
 ```
-

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -331,23 +331,20 @@ The value can be either an absolute file system path or a path relative to the p
 
 <p>
 
-**Type:** `boolean | "jsx"`<br />
+**Type:** `boolean`<br />
 **Default:** `true`
 </p>
 
-Controls how Astro handles whitespace in your HTML. This affects both the development mode and the final build output.
+This is an option to minify your HTML output and reduce the size of your HTML files.
 
-By default, Astro removes unnecessary whitespace, including line breaks, from `.astro` components in a lossless way. Some whitespace may be kept to preserve the visual rendering of the HTML.
+By default, Astro removes whitespace from your HTML, including line breaks, from `.astro` components in a lossless manner.
+Some whitespace may be kept as needed to preserve the visual rendering of your HTML. This occurs both in development mode and in the final build.
 
-To opt into a more aggressive compression mode, set `compressHTML` to `"jsx"`. With JSX, whitespace is only preserved if explicitly included in the source code. This means the final HTML code removes all whitespace, including line breaks and indentation.
-
-To disable HTML compression and preserve all whitespace, set `compressHTML` to `false`.
+To disable HTML compression, set `compressHTML` to false.
 
 ```js
 {
   compressHTML: false
-  // or:
-  // compressHTML: 'jsx'
 }
 ```
 
@@ -2508,3 +2505,4 @@ Font [variation settings](https://developer.mozilla.org/en-US/docs/Web/CSS/@font
 ```js
 variationSettings: "'xhgt' 0.7"
 ```
+

--- a/src/content/docs/en/reference/integrations-reference.mdx
+++ b/src/content/docs/en/reference/integrations-reference.mdx
@@ -2102,7 +2102,7 @@ Specifies the [configured output file format](/en/reference/configuration-refere
 
 <p>
 
-**Type:** `boolean`<br />
+**Type:** `boolean | "jsx"`<br />
 <Since v="2.7.2" />
 </p>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates `SSRManifest.compressHTML` type to include `"jsx"` as valid option. Docs PR for https://github.com/withastro/astro/pull/15725

#### Related issues & labels (optional)

- Related: https://github.com/withastro/astro/pull/15725
- Suggested label: update or improve documentation, merge-on-release, minor release

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
