### PR TITLE
i18n(ja): add `action-called-from-server-error.mdx`

### DIFF
--- a/src/content/docs/ja/reference/errors/action-called-from-server-error.mdx
+++ b/src/content/docs/ja/reference/errors/action-called-from-server-error.mdx
@@ -1,0 +1,15 @@
+---
+title: Action unexpected called from the server.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+> **ActionCalledFromServerError**: サーバーページまたはエンドポイントから`Astro.callAction()`を使わずにActionが呼び出されています。サーバーコードからActionを呼び出す場合は、このラッパーを使用する必要があります。
+
+## 何が問題か？
+サーバーページまたはエンドポイントから`Astro.callAction()`を使わずにActionが呼び出されています。
+
+**以下も参照してください:**
+-  [`Astro.callAction()`リファレンス](/ja/reference/api-reference/#callaction)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Add documentation for ActionCalledFromServerError in Japanese.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
