### PR TITLE
docs: use the Bun runtime

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -84,6 +84,25 @@ bun run build
 
 When the build is finished, run the appropriate preview command (e.g. `bun run preview`) in your terminal and you can view the built version of your site locally in the same browser preview window.
 
+### Runtime
+
+By default, Bun will run the Astro dev server with Node.js.
+To force the Bun runtime, pass the `--bun` flag, for example:
+
+```bash
+bun --bun run dev
+```
+
+This also applies to other `bun run` commands, such as `bun run build` and `bun run preview`.
+
+As an alternative, you can configure this once in the `bunfig.toml` file in your project root:
+
+```toml
+[run]
+# equivalent to `bun --bun` for all `bun run` commands
+bun = true
+```
+
 ## Testing
 
 Bun ships with a fast, built-in, Jest-compatible test runner through the [`bun test` command](https://bun.sh/docs/cli/test). You can also use any other [testing tools for Astro](/en/guides/testing/).


### PR DESCRIPTION
By default, `bun run` starts the Astro dev server on the Node.js runtime.
This change adds instructions for using the Bun runtime instead.

Reasons:

1. Users running Astro with Bun may prefer to use the Bun runtime.
2. The CI and production environments may only include Bun, not Node.js; configuring Bun runtime keeps development, CI, and production consistent.
3. Bun’s official Astro guide also documents using the Bun runtime:
   https://bun.com/docs/guides/ecosystem/astro