### PR TITLE
i18n(ja): add `unknown-clierror.mdx‎`

### DIFF
--- a/src/content/docs/ja/reference/errors/unknown-clierror.mdx
+++ b/src/content/docs/ja/reference/errors/unknown-clierror.mdx
@@ -1,0 +1,12 @@
+---
+title: Unknown CLI Error.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+import DontEditWarning from '~/components/DontEditWarning.astro'
+
+## 何が問題か？
+AstroのCLIコマンドの起動中に、不明なエラーが発生しました。エラーメッセージに詳細な情報が含まれているはずです。
+
+このエラーを再現できる場合は、[issueを作成](https://astro.build/issues/)していただけると助かります。


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Add documentation for Unknown CLI Error in Japanese.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
