### PR TITLE
fix: set `experimental-flags/advanced-routing` as translation-ready

### DIFF
--- a/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
+++ b/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
@@ -2,7 +2,7 @@
 title: Experimental advanced routing
 sidebar:
   label: Advanced routing
-i18nReady: false
+i18nReady: true
 ---
 
 import Since from '~/components/Since.astro'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Swaps the value for `i18nReady` in `experimental-flags/advanced-routing.mdx`. I don't see any reason to use `i18nReady: false` there and if we want more people to try it, we should probably translate this page.

**EDIT:** I updated the title as `i18nReady` is a keyword to ignore Lunaria status change. This should trigger a status change now despite what astrobot says.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: quick fix

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
