### PR TITLE
Update to pnpm 11 and move config to YAML file

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,15 +69,5 @@
     "remark-smartypants": "^3.0.2",
     "sharp": "^0.34.5"
   },
-  "packageManager": "pnpm@10.33.0",
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@types/react",
-        "react",
-        "react-dom",
-        "vite"
-      ]
-    }
-  }
+  "packageManager": "pnpm@11.1.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+peerDependencyRules:
+  # Suppress warnings about these peer dependencies which we don’t need.
+  ignoreMissing:
+    - '@types/react'
+    - 'react'
+    - 'react-dom'
+    - 'vite'
+
+# Wait 3 days before permitting newly published packages to be installed. This helps protect against
+# compromised packages that with any luck will be detected and removed within 3 days.
+minimumReleaseAge: 4320
+
+# We don’t need to run these build scripts, so explicitly disallow them as a minor security measure.
+allowBuilds:
+  esbuild: false
+  sharp: false


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Updates package manager to pnpm 11
- Moves pnpm config to a dedicated YAML file to permit comments on our config
- Adds a rule to require a minimum release age of 3 days (matching `astro` monorepo)
- Adds a rule to explicitly block the build scripts of native deps `esbuild` and `sharp`. The build scripts are not strictly speaking needed (unless running on a very rare system/architecture) and have been implicitly disabled until now. Doing this explicitly is preferred in pnpm 11 to avoid warnings/errors.