### PR TITLE
Update Renovate config to wait for 3 days before applying updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
 	],
 	rangeStrategy: 'bump',
 	ignorePaths: ['**/node_modules/**', '.nvmrc'],
+	minimumReleaseAge: '3 days',
 	packageRules: [
 		{
 			groupName: 'github-actions',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Small configuration update to bring Renovate in line with the changes in #13877 — delays updates from Renovate until 3 days have passed since release.