### PR TITLE
fix(v7): make v7 upgrade guide discoverable

### DIFF
--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -88,6 +88,7 @@ export const sidebar = [
 					group('guides.upgrade.major', {
 						collapsed: true,
 						items: [
+							'guides/upgrade-to/v7',
 							'guides/upgrade-to/v6',
 							'guides/upgrade-to/v5',
 							'guides/upgrade-to/v4',

--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -7,7 +7,7 @@ editUrl: false
 next: false
 banner:
   content: |
-    Astro v6 is here! <a href="/en/guides/upgrade-to/v6/">Learn how to upgrade your site</a>
+    Astro v7 is here! <a href="/en/guides/upgrade-to/v7/">Learn how to upgrade your site</a>
 hero:
   title: Astro Docs
   tagline: Guides, resources, and API references to help you build with Astro.

--- a/src/content/docs/en/upgrade-astro.mdx
+++ b/src/content/docs/en/upgrade-astro.mdx
@@ -102,6 +102,7 @@ The main Astro documentation pages are always **accurate for the latest released
 
 See the upgrade guides below for an explanation of changes, comparing the new version to the old. The upgrade guides include everything that could require you to change your own code: breaking changes, deprecations, feature removals and replacements as well as updated usage guidance. Each change to Astro includes a "What should I do?" section to help you successfully update your project code.
 
+- [Upgrade to v7](/en/guides/upgrade-to/v7/)
 - [Upgrade to v6](/en/guides/upgrade-to/v6/)
 - [Upgrade to v5](/en/guides/upgrade-to/v5/)
 - [Upgrade to v4](/en/guides/upgrade-to/v4/)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Updates the banner to link to the v7 upgrade guide instead of the v6 one.
* Adds the v7 upgrade guide in the sidebar next to the other ones.
* Lists the v7 upgrade guide in https://v7.docs.astro.build/en/upgrade-astro/#upgrade-guides

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: 7.0

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
