### PR TITLE
fix: typo asyncronous -> asynchronous

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -256,7 +256,7 @@ You can provide your entries as an array of objects with an `id` property, or in
 
 #### Parsing other data formats
 
-Support for parsing single JSON, YAML, and TOML files into collection entries with the `file()` loader is built-in (unless you have a [nested JSON document](#nested-json-documents)). To load your collection from unsupported file types, such as `.csv`, you will need to create a [parser function](/en/reference/content-loader-reference/#parser). This function can be made async if required (e.g. to fetch files from the web, or if your parser is asyncronous).
+Support for parsing single JSON, YAML, and TOML files into collection entries with the `file()` loader is built-in (unless you have a [nested JSON document](#nested-json-documents)). To load your collection from unsupported file types, such as `.csv`, you will need to create a [parser function](/en/reference/content-loader-reference/#parser). This function can be made async if required (e.g. to fetch files from the web, or if your parser is asynchronous).
 
 The following example shows importing a third-party CSV parser then passing a custom `parser` function to the `file()` loader:
 


### PR DESCRIPTION
## Summary

- Fix typo `asyncronous` → `asynchronous` in `src/content/docs/en/guides/content-collections.mdx:259`