### PR TITLE
Extend advanced routing docs with new features added by the RFC

### DIFF
--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -111,6 +111,41 @@ See your hosting platform's documentation for more information. You cannot use A
 **See Also:**
 - build.format
 
+### fetchFile
+
+<p>
+
+**Type:** `string | null`<br />
+**Default:** `'app'`<br />
+<Since v="6.4.0" />
+</p>
+
+Customize the file used as the [advanced routing](/en/reference/experimental-flags/advanced-routing/) entrypoint inside your `srcDir`. Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
+
+Set to a different string to use a different filename:
+
+```js
+export default defineConfig({
+  fetchFile: 'fetch.ts',
+  experimental: {
+    advancedRouting: true,
+  },
+});
+```
+
+With this configuration, Astro will look for `src/fetch.ts` instead of `src/app.ts`.
+
+Set to `null` to disable the advanced routing entrypoint entirely. This is useful if you already have a `src/app.ts` file used for other purposes:
+
+```js
+export default defineConfig({
+  fetchFile: null,
+  experimental: {
+    advancedRouting: true,
+  },
+});
+```
+
 ### redirects
 
 <p>

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -111,40 +111,6 @@ See your hosting platform's documentation for more information. You cannot use A
 **See Also:**
 - build.format
 
-### fetchFile
-
-<p>
-
-**Type:** `string | null`<br />
-**Default:** `'app'`
-</p>
-
-Customize the file used as the [advanced routing](/en/reference/experimental-flags/advanced-routing/) entrypoint inside your `srcDir`. Defaults to `'app'`, meaning Astro looks for `src/app.ts`.
-
-Set to a different string to use a different filename:
-
-```js
-export default defineConfig({
-  fetchFile: 'fetch.ts',
-  experimental: {
-    advancedRouting: true,
-  },
-});
-```
-
-With this configuration, Astro will look for `src/fetch.ts` instead of `src/app.ts`.
-
-Set to `null` to disable the advanced routing entrypoint entirely. This is useful if you already have a `src/app.ts` file used for other purposes:
-
-```js
-export default defineConfig({
-  fetchFile: null,
-  experimental: {
-    advancedRouting: true,
-  },
-});
-```
-
 ### redirects
 
 <p>

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -116,8 +116,7 @@ See your hosting platform's documentation for more information. You cannot use A
 <p>
 
 **Type:** `string | null`<br />
-**Default:** `'app'`<br />
-<Since v="6.4.0" />
+**Default:** `'app'`
 </p>
 
 Customize the file used as the [advanced routing](/en/reference/experimental-flags/advanced-routing/) entrypoint inside your `srcDir`. Defaults to `'app'`, meaning Astro looks for `src/app.ts`.

--- a/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
+++ b/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
@@ -46,9 +46,33 @@ export default {
 } satisfies Fetchable;
 ```
 
-:::tip
-To rename the entrypoint file or disable the feature entirely, use the [`fetchFile`](/en/reference/configuration-reference/#fetchfile) config option.
-:::
+### Customizing the entrypoint file
+
+By default, Astro looks for `src/app.ts` as the advanced routing entrypoint. Pass an object to `advancedRouting` with a `fetchFile` option to use a different file:
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  experimental: {
+    advancedRouting: {
+      fetchFile: 'fetch.ts',
+    },
+  },
+});
+```
+
+With this configuration, Astro will look for `src/fetch.ts` instead of `src/app.ts`.
+
+Set `fetchFile` to `null` to disable the entrypoint entirely. This is useful if you already have a `src/app.ts` file used for other purposes:
+
+```js title="astro.config.mjs"
+export default defineConfig({
+  experimental: {
+    advancedRouting: {
+      fetchFile: null,
+    },
+  },
+});
+```
 
 ### Using `astro()`
 
@@ -147,6 +171,20 @@ export default {
   },
 };
 ```
+
+## Typing custom providers with `App.Providers`
+
+When you register custom context providers with [`state.provide()`](#stateprovide), you can declare their types using the `App.Providers` interface so that `Astro` and `ctx` are fully typed in your components and middleware:
+
+```ts title="src/env.d.ts"
+declare namespace App {
+  interface Providers {
+    oauth: import('./lib/oauth').OAuthSession;
+  }
+}
+```
+
+After declaring a provider, `ctx.oauth` (and `Astro.oauth` in `.astro` files) will be typed automatically.
 
 ## `astro/fetch` handler reference
 
@@ -295,20 +333,6 @@ try {
   await state.finalizeAll();
 }
 ```
-
-### Typing custom providers with `App.Providers`
-
-When you register custom context providers with [`state.provide()`](#stateprovide), you can declare their types using the `App.Providers` interface so that `Astro` and `ctx` are fully typed in your components and middleware:
-
-```ts title="src/env.d.ts"
-declare namespace App {
-  interface Providers {
-    oauth: import('./lib/oauth').OAuthSession;
-  }
-}
-```
-
-After declaring a provider, `ctx.oauth` (and `Astro.oauth` in `.astro` files) will be typed automatically.
 
 ### `astro()`
 

--- a/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
+++ b/src/content/docs/en/reference/experimental-flags/advanced-routing.mdx
@@ -34,6 +34,22 @@ When `advancedRouting` is enabled, create a `src/app.ts` (or `.js`, `.mjs`, `.mt
 
 If no `src/app.ts` file exists (or `advancedRouting` is not enabled), Astro uses its built-in pipeline, which runs all features automatically.
 
+You can optionally import the `Fetchable` type from `astro` to type-check your entrypoint:
+
+```ts title="src/app.ts"
+import type { Fetchable } from 'astro';
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    // ...
+  },
+} satisfies Fetchable;
+```
+
+:::tip
+To rename the entrypoint file or disable the feature entirely, use the [`fetchFile`](/en/reference/configuration-reference/#fetchfile) config option.
+:::
+
 ### Using `astro()`
 
 The easiest way to get started is with the [`astro()` handler](#astro), which runs Astro's full built-in pipeline (sessions, cache, redirects, trailing-slash, actions, middleware, pages, and i18n) in the default order. This lets you add custom logic before or after Astro without changing how the internal pipeline works:
@@ -202,6 +218,21 @@ Route parameters derived from the matched route and pathname (e.g. `{ slug: 'my-
 
 The HTTP status code for the response. You can set this before rendering to control the response status (e.g. `state.status = 404`).
 
+##### `state.response`
+
+<p>
+
+**Type:** `Response | undefined`<br />
+**Default:** `undefined`
+</p>
+
+The `Response` produced by handlers after rendering completes. This is set automatically by [`pages()`](#pages) and [`middleware()`](#middleware), allowing you to inspect or use the response later in the pipeline:
+
+```ts
+const response = await middleware(state, (s) => pages(s));
+// state.response is now the same object as response
+```
+
 #### Methods
 
 ##### `state.rewrite()`
@@ -264,6 +295,20 @@ try {
   await state.finalizeAll();
 }
 ```
+
+### Typing custom providers with `App.Providers`
+
+When you register custom context providers with [`state.provide()`](#stateprovide), you can declare their types using the `App.Providers` interface so that `Astro` and `ctx` are fully typed in your components and middleware:
+
+```ts title="src/env.d.ts"
+declare namespace App {
+  interface Providers {
+    oauth: import('./lib/oauth').OAuthSession;
+  }
+}
+```
+
+After declaring a provider, `ctx.oauth` (and `Astro.oauth` in `.astro` files) will be typed automatically.
 
 ### `astro()`
 


### PR DESCRIPTION
#### Description (required)

Adds new docs for:

- `fetchFile` option
- extending Provider types
- the Fetchable. type.

#### Related issues & labels (optional)

Associated with https://github.com/withastro/astro/pull/16723

