### PR TITLE
i18n(fr): small fixes (broken markdown links, quotes...)

### DIFF
--- a/src/content/docs/fr/guides/astro-db.mdx
+++ b/src/content/docs/fr/guides/astro-db.mdx
@@ -424,7 +424,7 @@ export const server = {
 
 <ReadMore>
 
-Consultez la [référence de l'API `insert()` de Drizzle] (https://orm.drizzle.team/docs/insert) pour une vue d'ensemble complète.
+Consultez la [référence de l'API `insert()` de Drizzle](https://orm.drizzle.team/docs/insert) pour une vue d'ensemble complète.
 
 </ReadMore>
 

--- a/src/content/docs/fr/guides/build-with-ai.mdx
+++ b/src/content/docs/fr/guides/build-with-ai.mdx
@@ -42,7 +42,7 @@ Le processus de configuration varie en fonction de votre outil de développement
 De nombreux outils prennent en charge un format de configuration JSON commun pour les serveurs MCP. Si votre outil ne dispose pas d'instructions spécifiques, vous pouvez peut-être ajouter le serveur MCP d'Astro Docs en incluant la configuration suivante dans les paramètres MCP de votre outil :
 
 <Tabs>
-  <TabItem label="Streamable HTTP">
+  <TabItem label="HTTP diffusable">
     ```json title="Configuration MCP" {3-6}
     {
       "mcpServers": {
@@ -54,7 +54,7 @@ De nombreux outils prennent en charge un format de configuration JSON commun pou
     }
     ```
   </TabItem>
-  <TabItem label="Local Proxy">
+  <TabItem label="Proxy local">
     ```json title="Configuration MCP" {3-7}
     {
       "mcpServers": {

--- a/src/content/docs/fr/guides/imports.mdx
+++ b/src/content/docs/fr/guides/imports.mdx
@@ -64,7 +64,7 @@ import { getUser } from './user.ts';
 import type { UserType } from './user.ts';
 ```
 
-Astro comprend une prise en charge intégrée pour [TypeScript] (https://www.typescriptlang.org/). Vous pouvez importer des fichiers `.ts` et `.tsx` directement dans votre projet Astro, et même écrire du code TypeScript directement dans votre [script de composant Astro](/fr/basics/astro-components/#le-script-du-composant) et dans n'importe quelle [balise de scripts](/fr/guides/client-side-scripts/).
+Astro comprend une prise en charge intégrée pour [TypeScript](https://www.typescriptlang.org/). Vous pouvez importer des fichiers `.ts` et `.tsx` directement dans votre projet Astro, et même écrire du code TypeScript directement dans votre [script de composant Astro](/fr/basics/astro-components/#le-script-du-composant) et dans n'importe quelle [balise de scripts](/fr/guides/client-side-scripts/).
 
 **Astro n'effectue aucune vérification de type lui-même.** La vérification de type doit être prise en charge en dehors d'Astro, soit par votre IDE, soit par un script séparé. Pour vérifier le type des fichiers Astro, la commande [`astro check`](/fr/reference/cli-reference/#astro-check) est fournie.
 

--- a/src/content/docs/fr/guides/integrations-guide/preact.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/preact.mdx
@@ -154,7 +154,7 @@ export default defineConfig({
 });
 ```
 
-Avec l'option `compat` activée, l'intégration Preact effectuera le rendu des composants React ainsi que des composants Preact dans votre projet et vous permettra également d'importer des composants React à l'intérieur des composants Preact. Pour en savoir plus, consultez ["Switching to Preact (from React)"](https://preactjs.com/guide/v10/switching-to-preact) sur le site web de Preact.
+Avec l'option `compat` activée, l'intégration Preact effectuera le rendu des composants React ainsi que des composants Preact dans votre projet et vous permettra également d'importer des composants React à l'intérieur des composants Preact. Pour en savoir plus, consultez [« Switching to Preact (from React) »](https://preactjs.com/guide/v10/switching-to-preact) sur le site web de Preact.
 
 Lorsque vous importez des bibliothèques de composants React, afin de remplacer les dépendances `react` et `react-dom` par `preact/compat`, vous pouvez utiliser [`overrides`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) pour le faire.
 

--- a/src/content/docs/fr/guides/styling.mdx
+++ b/src/content/docs/fr/guides/styling.mdx
@@ -28,7 +28,7 @@ La mise en forme d'un composant Astro est aussi simple que l'ajout d'une balise 
 
 Les règles CSS définies dans la balise `<style>` d'Astro disposent automatiquement d'une **portée limitée par défaut** (« scoped » en anglais). Les styles à portée limitée sont compilés en arrière-plan pour s'appliquer uniquement au code HTML écrit à l'intérieur de ce même composant. Le CSS que vous écrivez à l'intérieur d'un composant Astro est automatiquement encapsulé à l'intérieur de ce composant.
 
-Ce CSS:
+Ce CSS :
 ```astro title="src/pages/index.astro"
 <style>
   h1 {

--- a/src/content/docs/fr/guides/testing.mdx
+++ b/src/content/docs/fr/guides/testing.mdx
@@ -373,8 +373,8 @@ Vous pouvez installer NightwatchJS dans votre projet Astro en utilisant le gesti
 		});
 		```
 
-    :::tip[Configurer `baseUrl]
-    Vous pouvez définir [`"baseURL": "http://localhost:4321"`](https://nightwatchjs.org/guide/reference/settings.html#setting-the-baseurl-property) dans le fichier de configuration `nightwatch.conf.js` pour utiliser `browser.navigateTo("/")` au lieu de `browser.navigateTo("http://localhost:4321/")` pour une URL plus pratique..
+    :::tip[Configurer `baseUrl`]
+    Vous pouvez définir [`"baseURL": "http://localhost:4321"`](https://nightwatchjs.org/guide/reference/settings.html#setting-the-baseurl-property) dans le fichier de configuration `nightwatch.conf.js` pour utiliser `browser.navigateTo("/")` au lieu de `browser.navigateTo("http://localhost:4321/")` pour une URL plus pratique.
     :::
 </Steps>
 

--- a/src/content/docs/fr/guides/typescript.mdx
+++ b/src/content/docs/fr/guides/typescript.mdx
@@ -20,7 +20,7 @@ Les projets de démarrage d'Astro incluent un fichier `tsconfig.json` dans votre
 
 ### Modèles TSConfig
 
-Trois modèles extensibles `tsconfig.json` sont inclus dans Astro : `base`, `strict`, et `strictest`. Le modèle `base` active la prise en charge des fonctionnalités modernes de JavaScript et est également utilisé comme base pour les autres modèles. Nous recommandons d'utiliser `strict` ou `strictest` si vous prévoyez d'écrire du TypeScript dans votre projet. Vous pouvez voir et comparer les trois configurations de modèles dans [astro/tsconfigs/] (https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
+Trois modèles extensibles `tsconfig.json` sont inclus dans Astro : `base`, `strict`, et `strictest`. Le modèle `base` active la prise en charge des fonctionnalités modernes de JavaScript et est également utilisé comme base pour les autres modèles. Nous recommandons d'utiliser `strict` ou `strictest` si vous prévoyez d'écrire du TypeScript dans votre projet. Vous pouvez voir et comparer les trois configurations de modèles dans [astro/tsconfigs/](https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/).
 
 Pour hériter d'un des modèles, utilisez [le paramètre `extends`](https://www.typescriptlang.org/tsconfig#extends) :
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates multiple French translations to:
* Fix 3 broken Markdown links (extra space)
* Replace double quotes with French quotes
* Translate tabs label in Build with AI (I used "HTTP diffusable" instead of "HTTP diffusable en continu" because of small viewports, I think it's okay for a tab label)
* Add a missing space before colon
* Add a missing backtick

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
