### PR TITLE
Clarify Cloudflare env API boundaries

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -265,10 +265,10 @@ const myKVNamespace = env.MY_KV;
 ---
 ```
 
-They are also compatible with the [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables):
+You can also use Astro's [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables) in the same project for variables defined in your Astro `env.schema`. These APIs are separate: values defined only in `wrangler.jsonc`, `.dev.vars`, or the Cloudflare dashboard are not automatically available as `astro:env/server` imports.
 
 ```js
-import { MY_VARIABLE } from 'astro:env/server';
+import { API_SECRET } from 'astro:env/server';
 ```
 
 See the [list of all supported bindings](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings) in the Cloudflare documentation.


### PR DESCRIPTION
#### Description (required)

Clarifies the Cloudflare environment variables section so readers can distinguish between Cloudflare runtime bindings and Astro's type-safe `astro:env` API.

The updated text says the two APIs can be used in the same project, but values defined only in `wrangler.jsonc`, `.dev.vars`, or the Cloudflare dashboard are not automatically available as `astro:env/server` imports.

#### Related issues & labels (optional)

- Closes #13897
- Suggested label: improve or update documentation

#### Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check src/content/docs/en/guides/integrations-guide/cloudflare.mdx`
- `git diff --check`
- `pnpm exec eslint src/content/docs/en/guides/integrations-guide/cloudflare.mdx` (0 errors; file is ignored by repo config)
- `pnpm run check`
