### PR TITLE
Clarify Cloudflare env API boundaries

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -265,10 +265,10 @@ const myKVNamespace = env.MY_KV;
 ---
 ```
 
-They are also compatible with the [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables):
+You can also use Astro's [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables) in the same project for variables defined in your Astro `env.schema`. These APIs are separate: values defined only in `wrangler.jsonc`, `.dev.vars`, or the Cloudflare dashboard are not automatically available as `astro:env/server` imports.
 
 ```js
-import { MY_VARIABLE } from 'astro:env/server';
+import { API_SECRET } from 'astro:env/server';
 ```
 
 See the [list of all supported bindings](https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings) in the Cloudflare documentation.


### PR DESCRIPTION
#### Description (required)

This clarifies the Cloudflare integration guide wording around Cloudflare bindings and Astro’s `astro:env` API.

The previous sentence said Cloudflare bindings were also compatible with `astro:env`, which could imply values defined only in `wrangler.jsonc`, `.dev.vars`, or the Cloudflare dashboard are automatically importable from `astro:env/server`. The updated copy keeps the useful connection but makes the boundary explicit: `astro:env` can be used in the same project for variables declared in Astro’s `env.schema`, while Cloudflare-provided bindings remain separate.

Validation:

- `git diff --check origin/main...HEAD`
- `pnpm exec prettier --check src/content/docs/en/guides/integrations-guide/cloudflare.mdx`
- `pnpm run check`

#### Related issues & labels (optional)

- Suggested label: documentation