### PR TITLE
i18n(de): Tutorial cleanup

### DIFF
--- a/src/content/docs/de/getting-started.mdx
+++ b/src/content/docs/de/getting-started.mdx
@@ -7,7 +7,7 @@ editUrl: false
 next: false
 banner:
   content: |
-    Astro v6 ist da! <a href="/de/guides/upgrade-to/v6/">Erfahre, wie Du deine Website aktualisieren kannst</a>
+    Astro v6 ist da! <a href="/de/guides/upgrade-to/v6/">Erfahre, wie du deine Website aktualisieren kannst</a>
 hero:
   title: Astro Dokumentation
   tagline: Guides, Ressourcen und API-Referenzen, um mit Astro zu arbeiten.

--- a/src/content/docs/de/tutorial/0-introduction/index.mdx
+++ b/src/content/docs/de/tutorial/0-introduction/index.mdx
@@ -27,7 +27,7 @@ Dabei wirst du:
 - Interaktivität zu deiner Website hinzufügen
 - Deine Website im Web veröffentlichen
 
-Willst du jetzt schon sehen, was du erstellen wirst? Du kannst das fertige Projekt auf [GitHub](https://github.com/withastro/blog-tutorial-demo) oder eine funktionierende Version in einer Online-Coding-Umgebung wie [IDX](https://idx.google.com/import?url=https:%2F%2Fgithub.com%2Fwithastro%2Fblog-tutorial-demo%2F) oder [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro) ansehen.
+Willst du jetzt schon sehen, was du erstellen wirst? Du kannst das fertige Projekt auf [GitHub](https://github.com/withastro/blog-tutorial-demo) oder eine funktionierende Version in einer Online-Coding-Umgebung wie [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro) ansehen.
 
 :::note
 Wenn du lieber mit einer vorgefertigten Astro-Seite starten möchtest, kannst du https://astro.new besuchen und eine Starter-Vorlage auswählen, die du online bearbeiten kannst.

--- a/src/content/docs/de/tutorial/0-introduction/index.mdx
+++ b/src/content/docs/de/tutorial/0-introduction/index.mdx
@@ -3,7 +3,7 @@ type: tutorial
 unitTitle: 'Willkommen, Welt!'
 title: Erstelle deinen ersten Astro-Blog
 sidebar:
-  label: 'Tutorial: Erstelle einen Blog'
+  label: 'Einführung'
 description: >-
   Lerne die Grundlagen von Astro mit einem projektbasierten Tutorial – inklusive allem Hintergrundwissen, das du zum Start brauchst!
 i18nReady: true
@@ -20,7 +20,7 @@ import Lede from '~/components/tutorial/Lede.astro';
 
 Dabei wirst du:
 
-- Deine Entwicklungsumgebung einrichten 
+- Deine Entwicklungsumgebung einrichten
 - Seiten und Blogbeiträge für deine Website erstellen
 - Mit Astro-Komponenten bauen
 - Lokale Dateien abfragen und verwenden

--- a/src/content/docs/de/tutorial/1-setup/index.mdx
+++ b/src/content/docs/de/tutorial/1-setup/index.mdx
@@ -2,6 +2,8 @@
 type: tutorial
 unitTitle: Erstelle und veröffentliche deine erste Astro-Website
 title: 'Wissenscheck: Lektion 1 – Einrichtung'
+sidebar:
+  label: 'Lektion 1 - Einrichtung'
 description: >-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Richte deine Entwicklungsumgebung ein und erstelle und veröffentliche deine erste Astro-Website

--- a/src/content/docs/de/tutorial/1-setup/index.mdx
+++ b/src/content/docs/de/tutorial/1-setup/index.mdx
@@ -23,50 +23,8 @@ In dieser Lektion lernst du, wie du deine Entwicklungsumgebung einrichtest und d
 
 :::tip[Mache das Tutorial in einem Online-Code-Editor]
 
-Möchtest du dieses Tutorial lieber in einem Online-Code-Editor absolvieren? Befolge die folgenden Anweisungen, um mit Google IDX zu starten.
+Möchtest du dieses Tutorial lieber in einem Online-Code-Editor absolvieren? Befolge die folgenden Anweisungen, um mit StackBlitz zu starten.
 
-<details>
-<summary>Mit Google IDX: Befolge diese Schritte und gehe dann direkt zu Lektion 2!</summary>
-
-**IDX einrichten**
-
-<Steps>
-1. Folge dem externen Link, um [die „Empty Project“-Vorlage in einem neuen Workspace auf IDX zu öffnen](https://astro.new/minimal?on=idx).
-
-2. Folge der Aufforderung, dich in dein Google-Konto einzuloggen, falls du noch nicht angemeldet bist.
-
-3. Gib deinem Projekt einen Namen, wenn du es anders als „Empty Project“ nennen möchtest. Klicke **Create**.
-
-4. Warte, bis der Workspace erstellt wurde. Das kann 30–60 Sekunden dauern. Wenn alles klappt, siehst du dein Astro-Projekt in einem Online-Code-Editor geladen.
-
-5. Warte, bis IDX zwei Skripte ausführt: eines zur Installation von Astro und eines zum Starten des Entwicklungsservers. Es kann kurzzeitig die Meldung erscheinen, dass dein Workspace „Astro nicht finden konnte“. Diese Meldung kann ignoriert oder geschlossen werden, falls sie sich nicht von selbst schließt.
-</Steps>
-
-**Änderung vornehmen**
-
-Wenn alles funktioniert hat, solltest du den Code der Datei `src/pages/index.astro` geöffnet sehen, in geteilter Ansicht mit einer Live-Vorschau der Website. Folge der Anleitung unter [„Schreibe deine erste Zeile Astro“](/de/tutorial/1-setup/3/), um diese Datei zu ändern.
-
-**GitHub-Repository erstellen**
-
-<Steps>
-1. Öffne den Navigationspunkt „Source Control“ in der vertikalen Menüleiste oder mit <kbd>Strg + Umschalttaste + G</kbd>. 
-
-2. Wähle die Option, das Projekt auf GitHub zu veröffentlichen. Dadurch wird ein neues Repository in deinem GitHub-Konto erstellt.
-3. Folge den Anweisungen, um dich bei deinem GitHub-Konto anzumelden.
-4. Nach der Anmeldung kannst du in IDX den Namen deines neuen Repositories wählen und festlegen, ob es privat oder öffentlich sein soll. Für dieses Tutorial kannst du beides wählen.
-5. IDX führt einen ersten Commit aus und veröffentlicht das Projekt in deinem neuen GitHub-Repository.
-6. Wenn du zukünftig Änderungen hast, die zurück an GitHub übertragen werden sollen, zeigt das Symbol für „Source Control“ eine Zahl an – die Anzahl der Dateien, die sich seit dem letzten Commit geändert haben. Öffne diesen Tab, führe die beiden Schritte „Commit“ und „Publish“ aus, gib eine Commit-Nachricht ein und aktualisiere dein Repository.
-</Steps>
-
-**Website veröffentlichen**
-
-Wenn du deine Seite auf Netlify veröffentlichen möchtest, um eine live veröffentlichte Version deiner Website zu haben, fahre in Lektion 1 mit [„Deine Website im Web veröffentlichen“](/de/tutorial/1-setup/5/) fort.
-
-Andernfalls kannst du diese Lektion überspringen und mit [Lektion 2](/de/tutorial/2-pages/) weitermachen, um mit Astro zu bauen!
-
-</details>
-
-{/* StackBlitz instructions 
 <details>
 <summary>Mit StackBlitz: Befolge diese Schritte und gehe dann direkt zu Lektion 2!</summary>
 
@@ -101,7 +59,6 @@ Wenn du zu Netlify deployen möchtest, um eine live veröffentlichte Version dei
 Andernfalls überspringe diese Lektion und beginne mit [Lektion 2](/de/tutorial/2-pages/), um mit Astro zu bauen!
 
 </details>
-*/}
 :::
 
 ## Wohin geht die Reise?

--- a/src/content/docs/de/tutorial/2-pages/index.mdx
+++ b/src/content/docs/de/tutorial/2-pages/index.mdx
@@ -2,6 +2,8 @@
 type: tutorial
 unitTitle: 'Seiten auf deiner Website hinzufügen, gestalten und verlinken'
 title: 'Wissenscheck: Lektion 2 – Seiten'
+sidebar:
+  label: 'Lektion 2 - Seiten'
 description: |-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Erstelle, gestalte und verlinke Seiten und Beiträge auf deiner Website

--- a/src/content/docs/de/tutorial/3-components/index.mdx
+++ b/src/content/docs/de/tutorial/3-components/index.mdx
@@ -2,6 +2,8 @@
 type: tutorial
 unitTitle: Erstelle und gestalte mit Astro-Komponenten
 title: 'Wissenscheck: Lektion 3 – Komponenten'
+sidebar:
+  label: 'Lektion 3 - Komponenten'
 description: |-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Erstelle Astro-Komponenten, um Code für gemeinsame Elemente auf deiner Website wiederzuverwenden

--- a/src/content/docs/de/tutorial/4-layouts/index.mdx
+++ b/src/content/docs/de/tutorial/4-layouts/index.mdx
@@ -3,7 +3,7 @@ type: tutorial
 unitTitle: Zeit und Energie sparen mit wiederverwendbaren Seiten-Layouts
 title: 'Wissenscheck: Lektion 4 – Layouts'
 sidebar:
-  label: 'Lektion $ - Layouts'
+  label: 'Lektion 4 - Layouts'
 description: >-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Verwende Astro-Layouts, um gemeinsame Elemente und Styles über deine Seiten und Blog-Beiträge hinweg zu teilen

--- a/src/content/docs/de/tutorial/4-layouts/index.mdx
+++ b/src/content/docs/de/tutorial/4-layouts/index.mdx
@@ -2,6 +2,8 @@
 type: tutorial
 unitTitle: Zeit und Energie sparen mit wiederverwendbaren Seiten-Layouts
 title: 'Wissenscheck: Lektion 4 – Layouts'
+sidebar:
+  label: 'Lektion $ - Layouts'
 description: >-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Verwende Astro-Layouts, um gemeinsame Elemente und Styles über deine Seiten und Blog-Beiträge hinweg zu teilen

--- a/src/content/docs/de/tutorial/5-astro-api/index.mdx
+++ b/src/content/docs/de/tutorial/5-astro-api/index.mdx
@@ -2,6 +2,8 @@
 type: tutorial
 unitTitle: Verbessere deinen Blog
 title: 'Wissenscheck: Lektion 5 – Astro API'
+sidebar:
+  label: 'Lektion 5 - Astro API'
 description: >-
   Tutorial: Erstelle deinen ersten Astro-Blog –
   Abrufen und Verwenden von Daten aus Projektdateien, um Seiten-Inhalte und Routen

--- a/src/content/docs/de/tutorial/6-islands/1.mdx
+++ b/src/content/docs/de/tutorial/6-islands/1.mdx
@@ -16,7 +16,7 @@ import PreCheck from '~/components/tutorial/PreCheck.astro';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Verwende eine Preact-Komponente, um deine Besucher:innen mit einer zufällig ausgewählten Willkommensnachricht zu begrüßen!
+Verwende eine Preact-Komponente, um deine Besucher mit einer zufällig ausgewählten Willkommensnachricht zu begrüßen!
 
 <PreCheck>
   - Preact zu deinem Astro-Projekt hinzuzufügen

--- a/src/content/docs/de/tutorial/6-islands/4.mdx
+++ b/src/content/docs/de/tutorial/6-islands/4.mdx
@@ -119,7 +119,7 @@ Aktualisiere Astro und alle Integrationen auf die neuesten Versionen, indem du i
     ```ts title="src/content.config.ts"
     // Importiere den Loader 'glob'
     import { glob } from "astro/loaders";
-    // Importiere Utilitys von `astro:content`
+    // Importiere Utilities von `astro:content`
     import { defineCollection } from "astro:content";
     // Importiere Zod
     import { z } from "astro/zod";
@@ -138,7 +138,7 @@ Aktualisiere Astro und alle Integrationen auf die neuesten Versionen, indem du i
           tags: z.array(z.string())
         })
     });
-    // Exportiere ein einzelnes Objekt `collections` um Deine Collection(s) zu registrieren 
+    // Exportiere ein einzelnes Objekt `collections`, um deine Collection(s) zu registrieren 
     export const collections = { blog };
     ```
 
@@ -214,7 +214,7 @@ Im Blog-Tutorial war `pubDate` ursprünglich ein String. Laut Schema ist es jetz
 <BaseLayout pageTitle={frontmatter.title}>
     <p>{frontmatter.pubDate.toLocaleDateString()}</p>
     <p><em>{frontmatter.description}</em></p>
-    <p>Autor/Autorin: {frontmatter.author}</p>
+    <p>Autor/-in: {frontmatter.author}</p>
     <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
 <!-- ... -->
 ```

--- a/src/content/docs/de/tutorial/6-islands/index.mdx
+++ b/src/content/docs/de/tutorial/6-islands/index.mdx
@@ -1,7 +1,9 @@
 ---
 type: tutorial
 unitTitle: Stich in See zu den Astro-Islands
-title: 'Lege los: Lektion 6 – Astro-Islands'
+title: 'Wissenscheck: Lektion 6 – Astro-Islands'
+sidebar:
+  label: 'Lektion 6 - Astro-Islands'
 description: |-
   Tutorial: Erstelle deinen ersten Astro-Blog —
   Verwende Astro-Islands, um Komponenten von Frontend-Frameworks zu deiner Astro-Website hinzuzufügen.


### PR DESCRIPTION
#### Description

This PR cleans up some of the _issues_ from the old PR #12502 that were missed after merge. This also updates the sidebar labels in accordance with the new sidebar organisation (5 to 4 tabs) in #13571. 

#### Related issues & labels

- Suggested label: `i18n`, `tutorial`, `consistency/formatting` (if applicable)
