### PR TITLE
Document compressHTML: "jsx" config is only available since Astro 6.2.0

### DIFF
--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -339,7 +339,7 @@ Controls how Astro handles whitespace in your HTML. This affects both developmen
 
 By default, Astro removes whitespace from your HTML, including line breaks, in a lossless manner from `.astro` components. Some whitespace may be preserved as needed to maintain the visual rendering of your HTML.
 
-Setting this option to `"jsx"` instead applies the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
+Since 6.2.0, this option can also be set to `"jsx"`, Astro will apply the JSX whitespace stripping rules used by frameworks like React. Leading and trailing whitespace is only preserved when explicitly included in the source code through constructs such as `{" "}`, and is otherwise removed entirely.
 
 Setting this option to false disables HTML compression and preserves all whitespace.
 


### PR DESCRIPTION
#### Description (required)

Document on config reference page that `compressHTML: "jsx"` is only available starting Astro 6.2.0.

Without this reference, it looks like the option has always been available but users of older versions (e.g. 6.1.9) will see the following message that contradicts the documentation:
```
[config] Astro found issue(s) with your configuration:

! compressHTML: Expected type "boolean", received "string"
```

I tried to follow the writing style from [i18n.routing](https://github.com/withastro/docs/blob/bddc95657829257812652c7dcde6445edb7f4622/src/content/docs/en/reference/configuration-reference.mdx#i18nrouting) which also introduced a new option, by starting the sentence similarly.

#### Related issues & labels (optional)

- Reference: https://github.com/withastro/astro/blob/astro%406.3.6/packages/astro/CHANGELOG.md#620
- Suggested label: improve or update documentation
