### PR TITLE
Change nav links display from none to block

### DIFF
--- a/src/content/docs/en/tutorial/3-components/3.mdx
+++ b/src/content/docs/en/tutorial/3-components/3.mdx
@@ -140,7 +140,7 @@ Since your site will be viewed on different devices, it's time to create a page 
 
     .nav-links {
       width: 100%;
-      display: none;
+      display: block;
       margin: 0;
     }
 


### PR DESCRIPTION
Needed to make sure links still display in small screen sizes

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Noticed that the current CSS in the docs instead just makes the entire links menu disappear on small screen sizes. (verified in both firefox and chrome to make sure there wasn't a strange css interaction being leveraged) technically would behave the same if the display property were removed from both .nav-blocks sections in the snippet as block is the default, but it's fine to simply leave it explicit for both screen sizes.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes: small so did not establish an issue to discuss but can if needed.<!-- Add an issue number if this PR will close it. -->
- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
