### PR TITLE
fix: Tutorial docs issues

### DIFF
--- a/src/content/docs/en/tutorial/3-components/1.mdx
+++ b/src/content/docs/en/tutorial/3-components/1.mdx
@@ -34,7 +34,7 @@ To hold `.astro` files that will generate HTML but that will not become new page
 
 2. Copy your links to navigate between pages from the top of any page and paste them into your new file, `Navigation.astro`:
 
-    ```astro title="src/components/Navigation.astro" "---"
+    ```astro title="src/components/Navigation.astro"
     ---
     ---
     <a href="/">Home</a>

--- a/src/content/docs/en/tutorial/5-astro-api/3.mdx
+++ b/src/content/docs/en/tutorial/5-astro-api/3.mdx
@@ -284,7 +284,7 @@ Follow the steps below, then check your work by comparing it to the [final code 
       <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} /> 
 
       <div class="tags">
-        {tags.map((tag: string) => (
+        {frontmatter.tags.map((tag: string) => (
           <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
         ))}
       </div>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

While completing Astro Tutorial I've found a couple of issues:
1. Styling of markdown in "Make a reusable Navigation component" substep of "Components" step <img width="711" height="201" alt="image" src="https://github.com/user-attachments/assets/ee77ecdf-05c5-4feb-a4d0-ad7df5e260f1" />
2. Wrong `tags` reference in "Build a tag index page" substep of "Astro API" step <img width="583" height="434" alt="image" src="https://github.com/user-attachments/assets/abe88d43-fcc8-4273-a8b5-4d4fccaa4d71" />


#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
