### PR TITLE
docs(cms): use TinaCMS (one word) on the Tina CMS guide page

### DIFF
--- a/src/content/docs/en/guides/cms/tina-cms.mdx
+++ b/src/content/docs/en/guides/cms/tina-cms.mdx
@@ -1,8 +1,8 @@
 ---
-title: Tina CMS & Astro
+title: TinaCMS & Astro
 description: Add content to your Astro project using Tina as a CMS
 sidebar:
-  label: Tina CMS
+  label: TinaCMS
 type: cms
 stub: false
 logo: tina-cms
@@ -13,7 +13,7 @@ import Grid from '~/components/FluidGrid.astro';
 import Card from '~/components/ShowcaseCard.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-[Tina CMS](https://tina.io/) is a Git-backed headless content management system.
+[TinaCMS](https://tina.io/) is a Git-backed headless content management system.
 
 ## Integrating with Astro
 


### PR DESCRIPTION
## Summary

The product's official name is **TinaCMS** (one word — see [tina.io](https://tina.io/)). On the Tina CMS guide, the page title, sidebar label, and the intro link still render it as "Tina CMS" with a space, while the rest of the page (lines 87, 151, 156) already uses "TinaCMS". This PR makes those three references consistent with the brand and with the rest of the page.

### Changes

In `src/content/docs/en/guides/cms/tina-cms.mdx`:

- Frontmatter `title`: `Tina CMS & Astro` → `TinaCMS & Astro`
- Frontmatter `sidebar.label`: `Tina CMS` → `TinaCMS`
- Intro paragraph link text: `[Tina CMS]` → `[TinaCMS]`

Other "Tina" references on the page (`Tina Cloud`, `Tina Data Layer`, `Tina Docs`, and the prose "using Tina as a CMS") are separate product names / generic prose and are intentionally left alone.

## Test plan

- [ ] `pnpm dev` and visit `/en/guides/cms/tina-cms/` — verify page title and sidebar entry render as "TinaCMS"
- [ ] Confirm no broken links (the `tina.io` link is unchanged)