### PR TITLE
Document preserveBuildServerDir adapter feature

### DIFF
--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -854,6 +854,39 @@ export default function createIntegration() {
 }
 ```
 
+### `preserveBuildServerDir`
+
+<p>
+
+**Type:** `boolean`<br />
+**Default:** `false`<br />
+<Since v="6.4.0" />
+</p>
+
+When `true`, static builds will preserve the `client/server` directory structure for server output instead of outputting directly to `outDir`. This ensures static builds use `build.server` for server files, maintaining consistency with server builds.
+
+This is useful for adapters that require a consistent `dist/client/` and `dist/server/` layout regardless of the build output type, such as when a static site may still contain server islands or image endpoints that need a server entry.
+
+```js title="my-adapter.mjs" ins={10-12}
+export default function createIntegration() {
+  return {
+    name: '@example/my-adapter',
+    hooks: {
+      'astro:config:done': ({ setAdapter }) => {
+        setAdapter({
+          name: '@example/my-adapter',
+          entrypointResolution: 'auto',
+          serverEntrypoint: '@example/my-adapter/server.js',
+          adapterFeatures: {
+            preserveBuildServerDir: true,
+          },
+        });
+      },
+    },
+  };
+}
+```
+
 ## Adapter types reference
 
 The following types can be imported from the `astro` module:


### PR DESCRIPTION

#### Description (required)

Documents the new `preserveBuildServerDir` adapter feature.

#### Related issues & labels (optional)

https://github.com/withastro/astro/pull/16468

#### For Astro version: `6.4`. See astro PR [#16468](https://github.com/withastro/astro/pull/16468).
