### PR TITLE
i18n(en): correct 'TypeScript' capitalization in three docs pages

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/sitemap.mdx
+++ b/src/content/docs/en/guides/integrations-guide/sitemap.mdx
@@ -603,7 +603,7 @@ import {
 <Since pkg="@astrojs/sitemap" v="1.3.2" />
 </p>
 
-A [Typescript enumeration](https://www.typescriptlang.org/docs/handbook/enums.html) where each key is the uppercase version of a valid value defined in the [specification of `<changefreq>`](https://www.sitemaps.org/protocol.html#changefreqdef).
+A [TypeScript enumeration](https://www.typescriptlang.org/docs/handbook/enums.html) where each key is the uppercase version of a valid value defined in the [specification of `<changefreq>`](https://www.sitemaps.org/protocol.html#changefreqdef).
 
 The following example uses `serialize()` to update the [`changefreq`](#sitemapitemchangefreq) of the blog index:
 

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -209,7 +209,7 @@ declare namespace App {
 }
 ```
 
-A `.d.ts` file is an [ambient module](https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules) declaration. While its syntax is similar to ES modules, these files do not allow top-level imports/exports. If Typescript encounters one, the file will be considered a [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) and this will break your global types.
+A `.d.ts` file is an [ambient module](https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules) declaration. While its syntax is similar to ES modules, these files do not allow top-level imports/exports. If TypeScript encounters one, the file will be considered a [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) and this will break your global types.
 
 ## Component Props
 

--- a/src/content/docs/en/guides/upgrade-to/v5.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v5.mdx
@@ -1229,7 +1229,7 @@ export default {
 
 <ReadMore>Read more about [developing a dev toolbar app for Astro using the Dev Toolbar API](/en/reference/dev-toolbar-app-reference/).</ReadMore>
 
-### Removed: configuring Typescript during `create-astro`
+### Removed: configuring TypeScript during `create-astro`
 
 <SourcePR number="12083" title="create-astro updates"/>
 


### PR DESCRIPTION
Three places in the English docs spelled the language "Typescript" while every surrounding paragraph (and the official brand) uses "TypeScript":

- `guides/integrations-guide/sitemap.mdx` — link text for the enum docs
- `guides/typescript.mdx` — the `.d.ts` ambient module paragraph
- `guides/upgrade-to/v5.mdx` — the "configuring TypeScript during `create-astro`" heading

No content changes, just the capitalization.