### PR TITLE
Add `astro dev --background` to CLI reference

### DIFF
--- a/src/content/docs/en/guides/build-with-ai.mdx
+++ b/src/content/docs/en/guides/build-with-ai.mdx
@@ -9,6 +9,8 @@ i18nReady: true
 description: Resources and tips for building Astro sites with AI assistance
 ---
 
+import Since from '~/components/Since.astro';
+import ReadMore from '~/components/ReadMore.astro';
 import { Steps, LinkButton, Card, Tabs, TabItem } from '@astrojs/starlight/components';
 
 AI-powered editors and agentic coding tools generally have good knowledge of Astro's core APIs and concepts. However, some may use older APIs and may not be aware of newer features or recent changes to the framework.
@@ -355,6 +357,28 @@ If you are still having problems, open an issue in the [Astro Docs MCP Server re
 The same technology that powers Astro's MCP server is also available as a chatbot in the [Astro Discord](https://astro.build/chat) for self-serve support. Visit the `#support-ai` channel to ask questions about Astro or your project code in natural language. Your conversation is automatically threaded, and you can ask an unlimited number of follow-up questions.
 
 **Conversations with the chatbot are public, and are subject to the same server rules for language and behavior as the rest of our channels**, but they are not actively visited by our volunteer support members. For assistance from the community, please create a thread in our regular `#support` channel.
+
+## Background mode
+
+<p><Since v="7.0.0" /></p>
+
+When an AI coding agent is detected, `astro dev` automatically starts the dev server as a detached background process. This prevents the dev server from blocking the agent's terminal and allows it to continue working while the server runs.
+
+A lock file (`.astro/dev.json`) is written when the dev server starts, recording the server's URL, port, and PID. This prevents duplicate servers from being started for the same project.
+
+If you are not using an AI coding agent, `astro dev` starts in the foreground process and logs to the terminal.
+
+To opt out of automatic background mode, set the `ASTRO_DEV_BACKGROUND` environment variable before running `astro dev`:
+
+```shell
+ASTRO_DEV_BACKGROUND=0 astro dev
+```
+
+<ReadMore>See the [CLI reference](/en/reference/cli-reference/#astro-dev) for the full list of `astro dev` flags and subcommands.</ReadMore>
+
+### Health endpoint
+
+The dev server exposes a `/_astro/status` endpoint that returns `{"ok": true}` as JSON. This allows agents and other tools to check programmatically whether the dev server is ready to accept requests. This endpoint is only available in the dev server and does not exist in production builds.
 
 ## Tips for AI-Powered Astro Development
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -212,7 +212,7 @@ astro dev --background --force
 
 <ReadMore>See [Background mode for AI coding agents](/en/guides/build-with-ai/#background-mode) for more about automatic agent detection and the health endpoint.</ReadMore>
 
-<h3>Subcommands</h3>
+### Subcommands
 
 <p><Since v="7.0.0" /></p>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -192,7 +192,7 @@ The following hotkeys can be used in the terminal where the Astro development se
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 
-### Flags
+<h3>Flags</h3>
 
 <p><Since v="7.0.0" /></p>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -190,7 +190,7 @@ The following hotkeys can be used in the terminal where the Astro development se
 
 <p><Since v="7.0.0" /></p>
 
-When an AI coding agent is detected (via the [`am-i-vibing`](https://github.com/ascorbic/am-i-vibing) library), `astro dev` automatically starts the dev server as a detached background process. This prevents the dev server from blocking the agent's terminal and allows it to continue working while the server runs.
+When an AI coding agent is detected, `astro dev` automatically starts the dev server as a detached background process. This prevents the dev server from blocking the agent's terminal and allows it to continue working while the server runs.
 
 A lock file (`.astro/dev.json`) is written when the dev server starts, recording the server's URL, port, and PID. This prevents duplicate servers from being started for the same project.
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -212,7 +212,7 @@ astro dev --background --force
 
 <ReadMore>See [Background mode for AI coding agents](/en/guides/build-with-ai/#background-mode) for more about automatic agent detection and the health endpoint.</ReadMore>
 
-### Subcommands
+<h3>Subcommands</h3>
 
 <p><Since v="7.0.0" /></p>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -202,19 +202,21 @@ To opt out of automatic background mode, set the `ASTRO_DEV_BACKGROUND` environm
 ASTRO_DEV_BACKGROUND=0 astro dev
 ```
 
-### `astro dev background`
+### `--background`
 
 <p><Since v="7.0.0" /></p>
 
-Starts the dev server as a detached background process. This is the command that runs automatically when an AI agent is detected, but it can also be used manually.
+Starts the dev server as a detached background process. This is the flag that is used automatically when an AI agent is detected, but it can also be used manually.
+
+```shell
+astro dev --background
+```
 
 If a server is already running for the project, the command prints the existing server's info and exits without starting a new one. Use the `--force` flag to stop the existing server and start a new one.
 
-<h4>Flags</h4>
-
-##### `--force`
-
-Stop an existing background dev server before starting a new one.
+```shell
+astro dev --background --force
+```
 
 ### `astro dev stop`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -192,7 +192,7 @@ The following hotkeys can be used in the terminal where the Astro development se
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 
-<h3>Flags</h3>
+### Flags
 
 <p><Since v="7.0.0" /></p>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -186,6 +186,66 @@ The following hotkeys can be used in the terminal where the Astro development se
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 
+### Background mode for AI coding agents
+
+<p><Since v="7.0.0" /></p>
+
+When an AI coding agent is detected (via the [`am-i-vibing`](https://github.com/ascorbic/am-i-vibing) library), `astro dev` automatically starts the dev server as a detached background process. This prevents the dev server from blocking the agent's terminal and allows it to continue working while the server runs.
+
+A lock file (`.astro/dev.json`) is written when the dev server starts, recording the server's URL, port, and PID. This prevents duplicate servers from being started for the same project.
+
+If you are not using an AI coding agent, `astro dev` behaves exactly as before.
+
+To opt out of automatic background mode, set the `ASTRO_DEV_BACKGROUND` environment variable before running `astro dev`:
+
+```shell
+ASTRO_DEV_BACKGROUND=0 astro dev
+```
+
+### `astro dev background`
+
+<p><Since v="7.0.0" /></p>
+
+Starts the dev server as a detached background process. This is the command that runs automatically when an AI agent is detected, but it can also be used manually.
+
+If a server is already running for the project, the command prints the existing server's info and exits without starting a new one. Use the `--force` flag to stop the existing server and start a new one.
+
+<h4>Flags</h4>
+
+##### `--force`
+
+Stop an existing background dev server before starting a new one.
+
+### `astro dev stop`
+
+<p><Since v="7.0.0" /></p>
+
+Stops a running background dev server. Sends `SIGTERM` and waits up to 5 seconds for the server to exit gracefully. If the process is still running after that, it escalates to `SIGKILL`.
+
+### `astro dev status`
+
+<p><Since v="7.0.0" /></p>
+
+Checks whether a background dev server is running and displays its URL, PID, and uptime.
+
+### `astro dev logs`
+
+<p><Since v="7.0.0" /></p>
+
+Displays logs from a background dev server. Only works when the server was started with `astro dev background`, since foreground servers write logs directly to the terminal.
+
+<h4>Flags</h4>
+
+##### `--follow` (`-f`)
+
+Stream new log output as it's written, similar to `tail -f`. Without this flag, the current log file contents are printed and the command exits.
+
+### Health endpoint
+
+<p><Since v="7.0.0" /></p>
+
+The dev server exposes a `/_astro/status` endpoint that returns `{"ok": true}` as JSON. This is useful for AI agents and other tools that need to check programmatically whether the dev server is ready to accept requests.
+
 ## `astro build`
 
 Builds your site for deployment. By default, this will generate static files and place them in a `dist/` directory. If any routes are [rendered on demand](/en/guides/on-demand-rendering/), this will generate the necessary server files to serve your site.

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -111,15 +111,21 @@ You can add the `--help` flag after any command to get a list of all the flags f
 The following message will display in your terminal:
 
 ```bash
-astro dev [...flags]
+astro dev [command] [...flags]
+
+Commands
+          stop  Stop a running background dev server.
+        status  Check if a dev server is running.
+  logs [--follow]  View logs from a background dev server.
 
 Flags
-                 --port  Specify which port to run on. Defaults to 4321.
-                 --host  Listen on all addresses, including LAN and public addresses.
+          --background  Start the dev server as a background process.
+               --port  Specify which port to run on. Defaults to 4321.
+               --host  Listen on all addresses, including LAN and public addresses.
 --host <custom-address>  Expose on a network IP address at <custom-address>
-                 --open  Automatically open the app in the browser on server start
-                --force  Clear the content layer cache, forcing a full rebuild.
-            --help (-h)  See all available flags.
+               --open  Automatically open the app in the browser on server start
+              --force  Clear the content layer cache, forcing a full rebuild.
+          --help (-h)  See all available flags.
 ```
 
 :::note
@@ -186,27 +192,13 @@ The following hotkeys can be used in the terminal where the Astro development se
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 
-### Background mode for AI coding agents
+<h3>Flags</h3>
 
 <p><Since v="7.0.0" /></p>
 
-When an AI coding agent is detected, `astro dev` automatically starts the dev server as a detached background process. This prevents the dev server from blocking the agent's terminal and allows it to continue working while the server runs.
+#### `--background`
 
-A lock file (`.astro/dev.json`) is written when the dev server starts, recording the server's URL, port, and PID. This prevents duplicate servers from being started for the same project.
-
-If you are not using an AI coding agent, `astro dev` starts in the foreground process and logs to the terminal.
-
-To opt out of automatic background mode, set the `ASTRO_DEV_BACKGROUND` environment variable before running `astro dev`:
-
-```shell
-ASTRO_DEV_BACKGROUND=0 astro dev
-```
-
-### `--background`
-
-<p><Since v="7.0.0" /></p>
-
-Starts the dev server as a detached background process. This is the flag that is used automatically when an AI agent is detected, but it can also be used manually.
+Starts the dev server as a detached background process. This flag is provided automatically when an AI agent is detected. You can also use it manually:
 
 ```shell
 astro dev --background
@@ -218,35 +210,29 @@ If a server is already running for the project, the command prints the existing 
 astro dev --background --force
 ```
 
-### `astro dev stop`
+<ReadMore>See [Background mode for AI coding agents](/en/guides/build-with-ai/#background-mode) for more about automatic agent detection and the health endpoint.</ReadMore>
+
+<h3>Subcommands</h3>
 
 <p><Since v="7.0.0" /></p>
+
+#### `astro dev stop`
 
 Stops a running background dev server. Sends `SIGTERM` and waits up to 5 seconds for the server to exit gracefully. If the process is still running after that, it escalates to `SIGKILL`.
 
-### `astro dev status`
-
-<p><Since v="7.0.0" /></p>
+#### `astro dev status`
 
 Checks whether a background dev server is running and displays its URL, PID, and uptime.
 
-### `astro dev logs`
+#### `astro dev logs`
 
-<p><Since v="7.0.0" /></p>
+Displays logs from a background dev server. Only works when the server was started with `astro dev --background`, since foreground servers write logs directly to the terminal.
 
-Displays logs from a background dev server. Only works when the server was started with `astro dev background`, since foreground servers write logs directly to the terminal.
+<h5>Flags</h5>
 
-<h4>Flags</h4>
-
-##### `--follow` (`-f`)
+###### `--follow` (`-f`)
 
 Stream new log output as it's written, similar to `tail -f`. Without this flag, the current log file contents are printed and the command exits.
-
-### Health endpoint
-
-<p><Since v="7.0.0" /></p>
-
-The dev server exposes a `/_astro/status` endpoint that returns `{"ok": true}` as JSON. This is useful for AI agents and other tools that need to check programmatically whether the dev server is ready to accept requests.
 
 ## `astro build`
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -228,7 +228,7 @@ Checks whether a background dev server is running and displays its URL, PID, and
 
 Displays logs from a background dev server. Only works when the server was started with `astro dev --background`, since foreground servers write logs directly to the terminal.
 
-<h5>Flags</h5>
+##### Flags
 
 ###### `--follow` (`-f`)
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -194,7 +194,7 @@ When an AI coding agent is detected, `astro dev` automatically starts the dev se
 
 A lock file (`.astro/dev.json`) is written when the dev server starts, recording the server's URL, port, and PID. This prevents duplicate servers from being started for the same project.
 
-If you are not using an AI coding agent, `astro dev` behaves exactly as before.
+If you are not using an AI coding agent, `astro dev` starts in the foreground process and logs to the terminal.
 
 To opt out of automatic background mode, set the `ASTRO_DEV_BACKGROUND` environment variable before running `astro dev`:
 


### PR DESCRIPTION
#### Description (required)

Adds documentation for the new `astro dev --background` flag and `astro dev stop`, `astro dev status`, and `astro dev logs` subcommands for managing background dev servers. Also documents the `/_astro/status` health endpoint and automatic agent detection behavior.

#### Related issues & labels (optional)

- Implementation PR: https://github.com/withastro/astro/pull/16610
- RFC: https://github.com/withastro/roadmap/pull/1362

This is for Astro 7.