### PR TITLE
ci: use version tags for `withastro/automation`

### DIFF
--- a/.github/workflows/discord-congrats.yml
+++ b/.github/workflows/discord-congrats.yml
@@ -10,7 +10,7 @@ jobs:
   congrats:
     name: congratsbot
     if: ${{ github.repository_owner == 'withastro' && github.event.commits[0].message != '[ci] format' }}
-    uses: withastro/automation/.github/workflows/congratsbot.yml@290b37409535e2a496482b5bf0e4f5f2e4803f84 # main
+    uses: withastro/automation/.github/workflows/congratsbot.yml@290b37409535e2a496482b5bf0e4f5f2e4803f84 # v1.0.0
     with:
       EMOJIS: '🎉,🎊,🧑‍🚀,🥳,🙌,🚀,<:notworsethanwhatwehadbefore:1020455379353751573>,<:houston_chef:1082696404780200067>,<:houston_uwu:1100481288143650977>'
     secrets:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR updates usage of the `withastro/automation` reusable workflow to use version tags instead of the `main` branch and make it works properly with the [`minimumReleaseAge` config](https://github.com/withastro/docs/blob/main/.github/renovate.json5#L12).

More context available in this [Discord thread](https://discord.com/channels/830184174198718474/1507425718374633544) if needed.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: ci

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
