### PR TITLE
i18n(fr): add other small changes from 6.4 to guides & references

### DIFF
--- a/src/content/docs/fr/guides/migrate-to-astro/index.mdx
+++ b/src/content/docs/fr/guides/migrate-to-astro/index.mdx
@@ -27,7 +27,7 @@ En fonction de votre projet existant, vous pourrez peut-être réutiliser :
 
 - vos [feuilles de style ou bibliothèques CSS](/fr/guides/styling/), y compris Tailwind.
 
-- vos [fichiers Markdown/MDX](/fr/guides/markdown-content/), configuré en utilisant vos [modules d'extension remark et rehype](/fr/guides/markdown-content/#modules-dextension-markdown) existants.
+- vos [fichiers Markdown/MDX](/fr/guides/markdown-content/), avec un [processeur Markdown configurable](/fr/guides/markdown-content/#modules-dextension-markdown) qui prend en charge les modules d'extension.
 
 - votre [contenu depuis un CMS](/fr/guides/cms/) à travers une intégration ou une API.
 

--- a/src/content/docs/fr/reference/content-loader-reference.mdx
+++ b/src/content/docs/fr/reference/content-loader-reference.mdx
@@ -1305,7 +1305,7 @@ Spécifie la liste des titres présents dans ce fichier. Chaque titre est décri
 **Type :** `Record<string, any>`
 </p>
 
-Décrit le frontmatter brut, analysé à partir du fichier. Cela peut inclure [des données injectées par programmation à partir de modules d'extension Remark](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter).
+Décrit le frontmatter brut, analysé à partir du fichier. Cela peut inclure [des données injectées par programmation à partir de modules d'extension pour Markdown](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter).
 
 ## API des chargeurs en direct
 

--- a/src/content/docs/fr/reference/modules/astro-content.mdx
+++ b/src/content/docs/fr/reference/modules/astro-content.mdx
@@ -328,7 +328,7 @@ Une fonction permettant de compiler une entrée donnée pour le rendu. Elle renv
 
 - `<Content />` - Un composant utilisé pour restituer le contenu du document dans un fichier Astro.
 - `headings` - Une liste générée de titres, [reflétant l'utilitaire `getHeadings()` d'Astro](/fr/guides/markdown-content/#propriétés-disponibles) sur les importations Markdown et MDX.
-- `remarkPluginFrontmatter ` - L'objet frontmatter modifié après que tous les [modules d'extension Remark ou Rehype ont été appliqués](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter). Définit sur le type `any`.
+- `remarkPluginFrontmatter ` - L'objet frontmatter modifié après que tous les [modules d'extension pour Markdown ont été appliqués](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter). Définit sur le type `any`.
 
 ```astro title="src/pages/blog/article-1.astro"
 ---

--- a/src/content/docs/fr/reference/programmatic-reference.mdx
+++ b/src/content/docs/fr/reference/programmatic-reference.mdx
@@ -190,7 +190,7 @@ Les utilitaires suivants peuvent être [importés depuis `astro/config`](/fr/ref
 
 Accepte un objet de configuration Astro et un objet partiel contenant un ensemble quelconque d'options de configuration Astro valides, et renvoie une configuration Astro valide combinant les deux valeurs de telle sorte que :
 
-- Les tableaux sont concaténés (y compris les intégrations et les modules d'extension Remark).
+- Les tableaux sont concaténés (y compris les intégrations).
 - Les objets sont fusionnés de manière récursive.
 - Les options de Vite sont fusionnées à l'aide de [la fonction `mergeConfig()` de Vite](https://vite.dev/guide/api-javascript#mergeconfig) avec l'option `isRoot` par défaut.
 - Les options qui peuvent être fournies sous forme de fonctions sont encapsulées dans de nouvelles fonctions qui fusionnent de manière récursive les valeurs de retour des deux configurations avec ces mêmes règles.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds the remaining small changes from #13945 to the French translations of `migrate-to-astro/index.mdx`, `content-loader-reference.mdx`, `modules/astro-content.mdx`, and `programmatic-reference.mdx`.

In `programmatic-reference.mdx`, I only updated the l193 not the whole file. 😅 But, it seems the file was using CRLF instead of LF as the other files... and so the change is wanted.
I see the same diff in #13461 (well, the opposite actually). It seems this was introduced by https://github.com/withastro/docs/pull/13461/changes/7cec69ee9773deb4e7d0d88336358c12002bc112 I don't know what happened (a misclick or wrong shortcut before committing!?)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
