### PR TITLE
i18n(fr): update `experimental-flags/advanced-routing.mdx`

### DIFF
--- a/src/content/docs/fr/reference/experimental-flags/advanced-routing.mdx
+++ b/src/content/docs/fr/reference/experimental-flags/advanced-routing.mdx
@@ -477,3 +477,53 @@ export default app;
 ```
 
 Le module `astro/hono` exporte les mêmes noms de gestionnaires que `astro/fetch` (`astro`, `pages`, `middleware`, `actions`, `sessions`, `redirects`, `cache`, `i18n`, `trailingSlash`), mais chacun renvoie une fonction middleware Hono. Cela vous permet de mélanger les gestionnaires d'Astro avec n'importe quel middleware Hono de l'écosystème.
+
+## Adaptateur Cloudflare
+
+L'adaptateur [`@astrojs/cloudflare`](/fr/guides/integrations-guide/cloudflare/) fournit des gestionnaires complémentaires qui appliquent une configuration spécifique à Cloudflare à votre pipeline de routage avancé. Ces gestionnaires configurent l'injection de liaison KV pour les sessions, la diffusion de ressources statiques via la liaison `ASSETS`, `Astro.locals.cfContext`, l'adresse du client à partir de l'en-tête `cf-connecting-ip`, `waitUntil` et la récupération des pages d'erreur pré-rendues.
+
+Vous pouvez utiliser les API `astro/fetch` et `astro/hono` depuis `src/app.ts` sur Cloudflare sans ces gestionnaires. Le point d'entrée par défaut de l'adaptateur prend en charge la configuration spécifique à Cloudflare pour vous. Ces gestionnaires complémentaires sont utiles lorsque vous avez déjà un [point d'entrée de worker personnalisé](https://developers.cloudflare.com/workers/wrangler/configuration/#inheritable-keys) (`src/worker.ts`), par exemple, pour exporter un objet durable (Durable Object), et que vous souhaitez utiliser les API de routage avancé directement depuis ce fichier.
+
+Lorsque vous utilisez ces gestionnaires dans votre point d'entrée de worker, ils remplacent la fonctionnalité du gestionnaire par défaut de l'adaptateur, vous ne devez donc pas utiliser les deux en même temps. Placez le gestionnaire Cloudflare avant les autres gestionnaires d'Astro afin que les liaisons et les locaux soient disponibles pour le reste du pipeline.
+
+### `@astrojs/cloudflare/fetch`
+
+<p><Since v="13.6.0" pkg="@astrojs/cloudflare" /></p>
+
+Pour une utilisation avec `astro/fetch`. La fonction `cf()` reçoit un objet `FetchState`, l'`env` de Cloudflare et le contexte d'exécution (`ExecutionContext`). Elle renvoie une réponse (`Response`) pour les accès aux ressources statiques, ou `undefined` lorsque la requête doit se poursuivre avec le rendu d'Astro :
+
+```ts title="src/worker.ts"
+import { astro, FetchState } from 'astro/fetch';
+import { cf } from '@astrojs/cloudflare/fetch';
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const state = new FetchState(request);
+    const asset = await cf(state, env, ctx);
+    if (asset) return asset;
+    return astro(state);
+  },
+};
+```
+
+### `@astrojs/cloudflare/hono`
+
+<p><Since v="13.6.0" pkg="@astrojs/cloudflare" /></p>
+
+Pour une utilisation avec `astro/hono`. La fonction `cf()` renvoie un middleware Hono qui lit automatiquement `env` et `executionCtx` depuis le contexte d'Hono :
+
+```ts title="src/worker.ts"
+import { Hono } from 'hono';
+import { actions, middleware, pages, i18n } from 'astro/hono';
+import { cf } from '@astrojs/cloudflare/hono';
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.use(cf());
+app.use(actions());
+app.use(middleware());
+app.use(pages());
+app.use(i18n());
+
+export default app;
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #13912 to the French translation of `experimental-flags/advanced-routing.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
