### PR TITLE
Deprecate `@astrojs/db`

### DIFF
--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -11,7 +11,7 @@ import Since from '~/components/Since.astro';
 import { Steps } from '@astrojs/starlight/components';
 
 :::caution[Deprecated]
-The `@astrojs/db` integration has been deprecated in Astro v6.4.4 and is no longer maintained.
+The `@astrojs/db` integration has been deprecated in Astro v6.5 and is no longer maintained.
 
 If you were using this integration in your project, we recommend that you use a database client (e.g., Drizzle, Kysely) directly in your Astro project.
 :::

--- a/src/content/docs/en/guides/astro-db.mdx
+++ b/src/content/docs/en/guides/astro-db.mdx
@@ -10,6 +10,12 @@ import ReadMore from '~/components/ReadMore.astro';
 import Since from '~/components/Since.astro';
 import { Steps } from '@astrojs/starlight/components';
 
+:::caution[Deprecated]
+The `@astrojs/db` integration has been deprecated in Astro v6.4.4 and is no longer maintained.
+
+If you were using this integration in your project, we recommend that you use a database client (e.g., Drizzle, Kysely) directly in your Astro project.
+:::
+
 Astro DB is a fully-managed SQL database designed for the Astro ecosystem. Develop locally in Astro and deploy to any libSQL-compatible database.
 
 Astro DB is a complete solution to configuring, developing, and querying your data. A local database is created in `.astro/content.db` whenever you run `astro dev` to manage your data without the need for Docker or a network connection.

--- a/src/content/docs/en/guides/integrations-guide/db.mdx
+++ b/src/content/docs/en/guides/integrations-guide/db.mdx
@@ -14,7 +14,7 @@ import ReadMore from '~/components/ReadMore.astro';
 import Since from '~/components/Since.astro';
 
 :::caution[Deprecated]
-The Astro DB integration has been deprecated in Astro v6.4.4 and is no longer maintained.
+The Astro DB integration has been deprecated in Astro v6.5 and is no longer maintained.
 
 If you were using this integration in your project, we recommend that you use a database client (e.g., Drizzle, Kysely) directly in your Astro project.
 :::

--- a/src/content/docs/en/guides/integrations-guide/db.mdx
+++ b/src/content/docs/en/guides/integrations-guide/db.mdx
@@ -13,6 +13,12 @@ import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import ReadMore from '~/components/ReadMore.astro';
 import Since from '~/components/Since.astro';
 
+:::caution[Deprecated]
+The Astro DB integration has been deprecated in Astro v6.4.4 and is no longer maintained.
+
+If you were using this integration in your project, we recommend that you use a database client (e.g., Drizzle, Kysely) directly in your Astro project.
+:::
+
 Astro DB is a fully-managed SQL database designed for the Astro ecosystem: develop locally in Astro and deploy to any [libSQL-compatible database](/en/guides/astro-db/).
 
 With Astro DB you have a powerful, local, type-safe tool to query and model content as a relational database.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds a callout in `integrations-guide/db.mdx` and `guides/astro-db.mdx` to warn about `@astrojs/db` deprecation.

We might need to update the Astro version if this isn't shipped with https://github.com/withastro/astro/pull/16972.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: update or improve documentation

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
#### For Astro version: `6.4.5`. See astro PR [#16964](https://github.com/withastro/astro/pull/16964).

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
