### PR TITLE
Remove Astro 6 banner

### DIFF
--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -5,9 +5,6 @@ i18nReady: true
 tableOfContents: false
 editUrl: false
 next: false
-banner:
-  content: |
-    Astro v6 is here! <a href="/en/guides/upgrade-to/v6/">Learn how to upgrade your site</a>
 hero:
   title: Astro Docs
   tagline: Guides, resources, and API references to help you build with Astro.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Removes the Astro 6 banner from the homepage. It doesn't seem we have more banners this time.

**Why:** We should leave a certain period without any banners so that users can get used to and notice the banner when Astro 7 is released.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: improve or update documentation (well... I can't think of another label for this kind of changes)

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
