### PR TITLE
docs: add multi-environment Cloudflare deployment guide

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -664,22 +664,23 @@ To deploy to a specific Cloudflare environment, prefix your command with the `CL
 
 #### Multi-environment deployments with `platformProxy`
 
-When deploying to multiple Cloudflare environments (e.g., production and preview), you need to configure three things that must match:
+When deploying to multiple Cloudflare environments, three things must match:
 
-1. **`CLOUDFLARE_ENV` environment variable** — set during build
-2. **`[env.<name>]` section in wrangler.toml** — environment-specific bindings
-3. **`platformProxy.environment`** in adapter config — tells the Vite plugin which environment to use during dev/build
-
-##### Correct: all three match
-
-**`CLOUDFLARE_ENV=production`** — everything uses `production`:
+1. **`CLOUDFLARE_ENV`** — environment variable set during build
+2. **`[env.<name>]`** — section in wrangler.toml with environment-specific bindings
+3. **`platformProxy.environment`** — adapter option that tells the Vite plugin which environment to use
 
 ```js title="astro.config.mjs"
-adapter: cloudflare({
-  platformProxy: {
-    environment: process.env.CLOUDFLARE_ENV, // "production"
-  },
-}),
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare({
+    platformProxy: {
+      environment: process.env.CLOUDFLARE_ENV,
+    },
+  }),
+});
 ```
 
 ```jsonc title="wrangler.jsonc"
@@ -688,13 +689,6 @@ adapter: cloudflare({
   "kv_namespaces": [
     { "binding": "SESSION", "id": "prod-kv-abc123" }
   ],
-
-  "env.production": {
-    "name": "my-app-production",
-    "kv_namespaces": [
-      { "binding": "SESSION", "id": "prod-kv-abc123" }
-    ]
-  },
 
   "env.development": {
     "name": "my-app-dev",
@@ -706,115 +700,16 @@ adapter: cloudflare({
 ```
 
 ```sh
-CLOUDFLARE_ENV=production astro build && wrangler deploy --env production
-# ✓ platformProxy reads "production"
-# ✓ wrangler.toml has "env.production" section
-# ✓ wrangler deploys to "production" environment
-```
+# Production (uses top-level bindings)
+CLOUDFLARE_ENV=production astro build && wrangler deploy
 
----
-
-**`CLOUDFLARE_ENV=development`** — same config, different env:
-
-```sh
+# Development (uses env.development bindings)
 CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
-# ✓ platformProxy reads "development"
-# ✓ wrangler.toml has "env.development" section
-# ✓ wrangler deploys to "development" environment
-```
-
----
-
-##### Incorrect: `CLOUDFLARE_ENV` doesn't match any `[env.*]` section
-
-```jsonc title="wrangler.jsonc"
-{
-  "env.production": { ... },
-  "env.development": { ... }
-  // No "env.staging" section
-}
-```
-
-```sh
-CLOUDFLARE_ENV=staging astro build && wrangler deploy --env staging
-# ✗ platformProxy reads "staging" — no matching section in wrangler.toml
-# ✗ Vite plugin uses top-level (production) bindings instead
-# ✗ Build succeeds but uses wrong KV/D1 bindings
-```
-
----
-
-##### Incorrect: `platformProxy` missing — Vite plugin ignores `CLOUDFLARE_ENV`
-
-```js title="astro.config.mjs"
-adapter: cloudflare({
-  // platformProxy not set
-}),
-```
-
-```sh
-CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
-# ✗ platformProxy not configured — Vite plugin doesn't read CLOUDFLARE_ENV
-# ✗ astro dev uses top-level (production) bindings
-# ✗ Build may work but dev server has wrong bindings
-```
-
----
-
-##### Incorrect: `wrangler deploy --env` doesn't match build env
-
-```js title="astro.config.mjs"
-adapter: cloudflare({
-  platformProxy: {
-    environment: process.env.CLOUDFLARE_ENV, // "development"
-  },
-}),
-```
-
-```sh
-CLOUDFLARE_ENV=development astro build && wrangler deploy --env production
-# ✗ Build used "development" bindings (KV id: dev-kv-xyz789)
-# ✗ Deploy targets "production" environment (expects prod-kv-abc123)
-# ✗ Worker runs with dev bindings in production
-```
-
----
-
-##### Correct: hardcoded for single-environment projects
-
-If you only have one environment, hardcoding is fine:
-
-```js title="astro.config.mjs"
-adapter: cloudflare({
-  platformProxy: {
-    environment: 'production', // hardcoded
-  },
-}),
-```
-
-```sh
-astro build && wrangler deploy
-# ✓ Always uses production bindings
-# ✓ No CLOUDFLARE_ENV needed
 ```
 
 :::caution[Environment names must match]
-The value of `CLOUDFLARE_ENV` must exactly match the `[env.<name>]` section name in your wrangler config. If they don't match, the Vite plugin won't find the correct bindings during the build, and your Worker may fail to access KV namespaces, D1 databases, or other resources.
+The value of `CLOUDFLARE_ENV` must exactly match the `[env.<name>]` section name in your wrangler config. If they don't match, the Vite plugin won't find the correct bindings, and your Worker may fail to access KV namespaces, D1 databases, or other resources.
 :::
-
-#### Further reading
-
-<details>
-<summary>Issues and PRs that contributed to this solution</summary>
-
-- [PR #11445](https://github.com/withastro/docs/pull/11445) — Added `platformProxy.environment` option docs
-- [PR #13578](https://github.com/withastro/docs/pull/13578) — Added `CLOUDFLARE_ENV` variable docs
-- [#15917](https://github.com/withastro/astro/issues/15917) — Users documented the three-way matching workaround
-- [#16031](https://github.com/withastro/astro/issues/16031) — Same issue, suggested `cloudflareEnv` adapter option
-- [#14540](https://github.com/withastro/astro/issues/14540) — Independent discovery of the same workaround
-- [#13897](https://github.com/withastro/docs/issues/13897) — Misleading env vars documentation
-
-</details>
 
 <ReadMore>Learn how to update your [Cloudflare environments](https://developers.cloudflare.com/workers/vite-plugin/reference/cloudflare-environments/) in the [Migrate from wrangler dev guide](https://developers.cloudflare.com/workers/vite-plugin/reference/migrating-from-wrangler-dev/#cloudflare-environments).</ReadMore>
 

--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -670,57 +670,151 @@ When deploying to multiple Cloudflare environments (e.g., production and preview
 2. **`[env.<name>]` section in wrangler.toml** — environment-specific bindings
 3. **`platformProxy.environment`** in adapter config — tells the Vite plugin which environment to use during dev/build
 
-Here's a complete example for a project with `production` and `development` environments:
+##### Correct: all three match
+
+**`CLOUDFLARE_ENV=production`** — everything uses `production`:
 
 ```js title="astro.config.mjs"
-import { defineConfig } from 'astro/config';
-import cloudflare from '@astrojs/cloudflare';
-
-export default defineConfig({
-  adapter: cloudflare({
-    platformProxy: {
-      // Use CLOUDFLARE_ENV to select the right [env.<name>] section from wrangler.toml
-      environment: process.env.CLOUDFLARE_ENV,
-    },
-  }),
-});
+adapter: cloudflare({
+  platformProxy: {
+    environment: process.env.CLOUDFLARE_ENV, // "production"
+  },
+}),
 ```
 
 ```jsonc title="wrangler.jsonc"
 {
-  "name": "my-astro-app",
-  "compatibility_date": "2024-12-18",
-  "compatibility_flags": ["nodejs_compat"],
-  "main": "@astrojs/cloudflare/entrypoints/server",
-  "assets": { "directory": "./dist", "binding": "ASSETS" },
-
-  // Default production bindings
+  "name": "my-app",
   "kv_namespaces": [
-    { "binding": "SESSION", "id": "production-kv-id" }
+    { "binding": "SESSION", "id": "prod-kv-abc123" }
   ],
 
-  // Development-specific bindings
-  [env.development]
-  "name": "my-astro-app-dev",
-  "kv_namespaces": [
-    { "binding": "SESSION", "id": "development-kv-id" }
-  ]
+  "env.production": {
+    "name": "my-app-production",
+    "kv_namespaces": [
+      { "binding": "SESSION", "id": "prod-kv-abc123" }
+    ]
+  },
+
+  "env.development": {
+    "name": "my-app-dev",
+    "kv_namespaces": [
+      { "binding": "SESSION", "id": "dev-kv-xyz789" }
+    ]
+  }
 }
 ```
 
-Then build and deploy for each environment:
+```sh
+CLOUDFLARE_ENV=production astro build && wrangler deploy --env production
+# ✓ platformProxy reads "production"
+# ✓ wrangler.toml has "env.production" section
+# ✓ wrangler deploys to "production" environment
+```
+
+---
+
+**`CLOUDFLARE_ENV=development`** — same config, different env:
 
 ```sh
-# Production
-CLOUDFLARE_ENV=production astro build && wrangler deploy
-
-# Development/preview
 CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
+# ✓ platformProxy reads "development"
+# ✓ wrangler.toml has "env.development" section
+# ✓ wrangler deploys to "development" environment
+```
+
+---
+
+##### Incorrect: `CLOUDFLARE_ENV` doesn't match any `[env.*]` section
+
+```jsonc title="wrangler.jsonc"
+{
+  "env.production": { ... },
+  "env.development": { ... }
+  // No "env.staging" section
+}
+```
+
+```sh
+CLOUDFLARE_ENV=staging astro build && wrangler deploy --env staging
+# ✗ platformProxy reads "staging" — no matching section in wrangler.toml
+# ✗ Vite plugin uses top-level (production) bindings instead
+# ✗ Build succeeds but uses wrong KV/D1 bindings
+```
+
+---
+
+##### Incorrect: `platformProxy` missing — Vite plugin ignores `CLOUDFLARE_ENV`
+
+```js title="astro.config.mjs"
+adapter: cloudflare({
+  // platformProxy not set
+}),
+```
+
+```sh
+CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
+# ✗ platformProxy not configured — Vite plugin doesn't read CLOUDFLARE_ENV
+# ✗ astro dev uses top-level (production) bindings
+# ✗ Build may work but dev server has wrong bindings
+```
+
+---
+
+##### Incorrect: `wrangler deploy --env` doesn't match build env
+
+```js title="astro.config.mjs"
+adapter: cloudflare({
+  platformProxy: {
+    environment: process.env.CLOUDFLARE_ENV, // "development"
+  },
+}),
+```
+
+```sh
+CLOUDFLARE_ENV=development astro build && wrangler deploy --env production
+# ✗ Build used "development" bindings (KV id: dev-kv-xyz789)
+# ✗ Deploy targets "production" environment (expects prod-kv-abc123)
+# ✗ Worker runs with dev bindings in production
+```
+
+---
+
+##### Correct: hardcoded for single-environment projects
+
+If you only have one environment, hardcoding is fine:
+
+```js title="astro.config.mjs"
+adapter: cloudflare({
+  platformProxy: {
+    environment: 'production', // hardcoded
+  },
+}),
+```
+
+```sh
+astro build && wrangler deploy
+# ✓ Always uses production bindings
+# ✓ No CLOUDFLARE_ENV needed
 ```
 
 :::caution[Environment names must match]
 The value of `CLOUDFLARE_ENV` must exactly match the `[env.<name>]` section name in your wrangler config. If they don't match, the Vite plugin won't find the correct bindings during the build, and your Worker may fail to access KV namespaces, D1 databases, or other resources.
 :::
+
+#### Further reading
+
+<details>
+<summary>Issues and PRs that contributed to this solution</summary>
+
+- [PR #11445](https://github.com/withastro/docs/pull/11445) — Added `platformProxy.environment` option docs
+- [PR #13578](https://github.com/withastro/docs/pull/13578) — Added `CLOUDFLARE_ENV` variable docs
+- [#15917](https://github.com/withastro/astro/issues/15917) — Users documented the three-way matching workaround
+- [#16031](https://github.com/withastro/astro/issues/16031) — Same issue, suggested `cloudflareEnv` adapter option
+- [#14540](https://github.com/withastro/astro/issues/14540) — Independent discovery of the same workaround
+- [#13897](https://github.com/withastro/docs/issues/13897) — Misleading env vars documentation
+
+</details>
 
 <ReadMore>Learn how to update your [Cloudflare environments](https://developers.cloudflare.com/workers/vite-plugin/reference/cloudflare-environments/) in the [Migrate from wrangler dev guide](https://developers.cloudflare.com/workers/vite-plugin/reference/migrating-from-wrangler-dev/#cloudflare-environments).</ReadMore>
 

--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -662,6 +662,66 @@ Since Astro 6.0, the integration relies on the Cloudflare Vite plugin and this b
 
 To deploy to a specific Cloudflare environment, prefix your command with the `CLOUDFLARE_ENV` variable. For example, the command `CLOUDFLARE_ENV=some-env astro build && wrangler deploy` will build your Astro project and deploy it with Wrangler using the `some-env` environment.
 
+#### Multi-environment deployments with `platformProxy`
+
+When deploying to multiple Cloudflare environments (e.g., production and preview), you need to configure three things that must match:
+
+1. **`CLOUDFLARE_ENV` environment variable** — set during build
+2. **`[env.<name>]` section in wrangler.toml** — environment-specific bindings
+3. **`platformProxy.environment`** in adapter config — tells the Vite plugin which environment to use during dev/build
+
+Here's a complete example for a project with `production` and `development` environments:
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare({
+    platformProxy: {
+      // Use CLOUDFLARE_ENV to select the right [env.<name>] section from wrangler.toml
+      environment: process.env.CLOUDFLARE_ENV,
+    },
+  }),
+});
+```
+
+```jsonc title="wrangler.jsonc"
+{
+  "name": "my-astro-app",
+  "compatibility_date": "2024-12-18",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "@astrojs/cloudflare/entrypoints/server",
+  "assets": { "directory": "./dist", "binding": "ASSETS" },
+
+  // Default production bindings
+  "kv_namespaces": [
+    { "binding": "SESSION", "id": "production-kv-id" }
+  ],
+
+  // Development-specific bindings
+  [env.development]
+  "name": "my-astro-app-dev",
+  "kv_namespaces": [
+    { "binding": "SESSION", "id": "development-kv-id" }
+  ]
+}
+```
+
+Then build and deploy for each environment:
+
+```sh
+# Production
+CLOUDFLARE_ENV=production astro build && wrangler deploy
+
+# Development/preview
+CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
+```
+
+:::caution[Environment names must match]
+The value of `CLOUDFLARE_ENV` must exactly match the `[env.<name>]` section name in your wrangler config. If they don't match, the Vite plugin won't find the correct bindings during the build, and your Worker may fail to access KV namespaces, D1 databases, or other resources.
+:::
+
 <ReadMore>Learn how to update your [Cloudflare environments](https://developers.cloudflare.com/workers/vite-plugin/reference/cloudflare-environments/) in the [Migrate from wrangler dev guide](https://developers.cloudflare.com/workers/vite-plugin/reference/migrating-from-wrangler-dev/#cloudflare-environments).</ReadMore>
 
 [astro-integration]: /en/guides/integrations/


### PR DESCRIPTION
## Summary

Adds documentation for the three-way matching requirement when deploying to multiple Cloudflare environments with `@astrojs/cloudflare`.

## Environment

Tested with:
- Astro 6.x
- `@astrojs/cloudflare` v13.x
- Cloudflare Workers with `nodejs_compat` compatibility flag
- Wrangler latest

## What's Missing from Current Docs

The current docs mention `CLOUDFLARE_ENV` but don't explain:
1. The `platformProxy: { environment: process.env.CLOUDFLARE_ENV }` adapter config
2. The matching `[env.<name>]` section in wrangler.toml
3. Why environment names must match exactly

## Changes

Added "Multi-environment deployments with `platformProxy`" section with:
- Three-way matching explanation
- Complete code example for astro.config.mjs and wrangler.toml
- Build commands for production and development
- Caution note about matching environment names

---

## Extended Examples (for reference)

### Correct: all three match

**`CLOUDFLARE_ENV=production`** — everything uses `production`:

```js
adapter: cloudflare({
  platformProxy: {
    environment: process.env.CLOUDFLARE_ENV, // "production"
  },
}),
```

```jsonc
{
  "env.production": {
    "name": "my-app-production",
    "kv_namespaces": [
      { "binding": "SESSION", "id": "prod-kv-abc123" }
    ]
  },
  "env.development": {
    "name": "my-app-dev",
    "kv_namespaces": [
      { "binding": "SESSION", "id": "dev-kv-xyz789" }
    ]
  }
}
```

```sh
CLOUDFLARE_ENV=production astro build && wrangler deploy --env production
# ✓ platformProxy reads "production"
# ✓ wrangler.toml has "env.production" section
# ✓ wrangler deploys to "production" environment
```

**`CLOUDFLARE_ENV=development`** — same config, different env:

```sh
CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
# ✓ platformProxy reads "development"
# ✓ wrangler.toml has "env.development" section
# ✓ wrangler deploys to "development" environment
```

### Incorrect: `CLOUDFLARE_ENV` doesn't match any `[env.*]` section

```jsonc
{
  "env.production": { ... },
  "env.development": { ... }
  // No "env.staging" section
}
```

```sh
CLOUDFLARE_ENV=staging astro build && wrangler deploy --env staging
# ✗ platformProxy reads "staging" — no matching section in wrangler.toml
# ✗ Vite plugin uses top-level (production) bindings instead
# ✗ Build succeeds but uses wrong KV/D1 bindings
```

### Incorrect: `platformProxy` missing — Vite plugin ignores `CLOUDFLARE_ENV`

```js
adapter: cloudflare({
  // platformProxy not set
}),
```

```sh
CLOUDFLARE_ENV=development astro build && wrangler deploy --env development
# ✗ platformProxy not configured — Vite plugin doesn't read CLOUDFLARE_ENV
# ✗ astro dev uses top-level (production) bindings
# ✗ Build may work but dev server has wrong bindings
```

### Incorrect: `wrangler deploy --env` doesn't match build env

```js
adapter: cloudflare({
  platformProxy: {
    environment: process.env.CLOUDFLARE_ENV, // "development"
  },
}),
```

```sh
CLOUDFLARE_ENV=development astro build && wrangler deploy --env production
# ✗ Build used "development" bindings (KV id: dev-kv-xyz789)
# ✗ Deploy targets "production" environment (expects prod-kv-abc123)
# ✗ Worker runs with dev bindings in production
```

### Correct: hardcoded for single-environment projects

```js
adapter: cloudflare({
  platformProxy: {
    environment: 'production', // hardcoded
  },
}),
```

```sh
astro build && wrangler deploy
# ✓ Always uses production bindings
# ✓ No CLOUDFLARE_ENV needed
```

---

## Sources

- [PR #11445](https://github.com/withastro/docs/pull/11445) — Added `platformProxy.environment` option docs
- [PR #13578](https://github.com/withastro/docs/pull/13578) — Added `CLOUDFLARE_ENV` variable docs
- [#15917](https://github.com/withastro/astro/issues/15917) — Users documented the three-way matching workaround
- [#16031](https://github.com/withastro/astro/issues/16031) — Same issue, suggested `cloudflareEnv` adapter option
- [#14540](https://github.com/withastro/astro/issues/14540) — Independent discovery of the same workaround
- [#13897](https://github.com/withastro/docs/issues/13897) — Misleading env vars documentation
- [#16040](https://github.com/withastro/astro/issues/16040) — Same issue, pointed to workaround

## Related Issues

Closes #15917, #16031, #16040, #14540, #13897
