### PR TITLE
Github action correct default node version

### DIFF
--- a/src/content/docs/en/guides/deploy/github.mdx
+++ b/src/content/docs/en/guides/deploy/github.mdx
@@ -48,7 +48,7 @@ Follow the instructions below to use the GitHub Action to deploy your Astro site
             uses: withastro/action@v6
             # with:
               # path: . # The root location of your Astro project inside the repository. (optional)
-              # node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
+              # node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 24. (optional)
               # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
               # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
             # env:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
Update the default node version for the github action in the documentation. 

This brings it in line with https://github.com/withastro/action