### PR TITLE
fix: logger version

### DIFF
--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -1234,7 +1234,7 @@ content="
 <p>
 
   **Type**: `object | undefined`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 An object that allows you to add additional logs during the rendering of a page. This is particularly useful with [on-demand routes](/en/guides/on-demand-rendering/) and when connecting log aggregation services (e.g. Kibana, Grafana, Loki).
@@ -1242,7 +1242,7 @@ An object that allows you to add additional logs during the rendering of a page.
 <p>
 
   **Type**: `(msg: string) => void`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 Emits a message with `error` level.
@@ -1257,7 +1257,7 @@ Astro.logger.error("Can't find the checkout ID.");
 <p>
 
   **Type**: `(msg: string) => void`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 Emits a message with `warn` level.
 
@@ -1271,7 +1271,7 @@ Astro.logger.warn("Can't find the checkout ID.");
 <p>
 
   **Type**: `(msg: string) => void`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
   
 Emits a message with `info` level.

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -7,7 +7,7 @@ i18nReady: true
 import Since from '~/components/Since.astro';
 
 <p>
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 
@@ -116,7 +116,7 @@ A logger that outputs messages in a JSON format. A log would look like this:
 <p>
   **Type:** `{ pretty: boolean; level: AstroLoggerLevel; }`<br />
   **Default:** `{ pretty: false, level: 'info' }`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 The `json` logger accepts the following options:
@@ -147,7 +147,7 @@ A logger that prints messages using the `console` as its destination. Based on t
 <p>
   **Type:** `{ level: AstroLoggerLevel }`<br />
   **Default:** `{ level: 'info' }`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 The `console` logger accepts the following options:
@@ -175,7 +175,7 @@ This is Astro's default logger.
 <p>
   **Type:** `{ level: AstroLoggerLevel }`<br />
   **Default:** `{ level: 'info' }`
-  <Since v="6.4.0" />
+  <Since v="7.0.0" />
 </p>
 
 The `node` logger accepts the following options:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes the version of `Since` for the logger 

Previous PR https://github.com/withastro/docs/pull/13907

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
