### PR TITLE
Update prefetch.mdx to use more technically correct language (discord username finjo)

### DIFF
--- a/src/content/docs/en/guides/prefetch.mdx
+++ b/src/content/docs/en/guides/prefetch.mdx
@@ -27,7 +27,7 @@ A prefetch script will be added to all pages of your site. You can then add the 
 <a href="/about" data-astro-prefetch>
 ```
 
-Note that prefetching only works for links within your site, and not external links.
+Note that prefetching only works for same-origin links, and not external links.
 
 ## Prefetch configuration
 


### PR DESCRIPTION
#### Description

Maybe this splitting hairs, but the existing page says that it works for links to the same site. This is not [technically correct](https://web.dev/articles/same-site-same-origin), because `same-site` URLs will work on different subdomains. If this does not work on different subdomains, it's technically `same-origin` rather than `same-site`.
