### PR TITLE
fix(logger): update highlighted lines & add docs for the `--json` flag

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -198,7 +198,7 @@ The following hotkeys can be used in the terminal where the Astro development se
 
 #### `--background`
 
-Starts the dev server as a detached background process. This flag is provided automatically when an AI agent is detected. You can also use it manually:
+Starts the dev server as a detached background process and enables [JSON logging](#--json). This flag is provided automatically when an AI agent is detected. You can also use it manually:
 
 ```shell
 astro dev --background
@@ -525,6 +525,12 @@ Enables silent logging, which will run the server without any console output.
 ### `--open`
 
 Automatically opens the app in the browser on server start. Can be passed a full URL string (e.g. `--open http://example.com`) or a pathname (e.g. `--open /about`) to specify the URL to open.
+
+### `--json`
+
+<p><Since v="7.0.0" /></p>
+
+Enables [JSON logging](/en/reference/logger-reference/#loghandlersjson), which is useful for machine-readable output.
 
 ## Global flags
 

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -80,7 +80,7 @@ There are three levels, from the highest to the lowest score:
 
 The following example configures the JSON logger to print only messages that have the `warn` level or higher:
 
-```js title="astro.config.mjs" {5} ins='level: "warn"'
+```js title="astro.config.mjs" {4} ins='level: "warn"'
 import { defineConfig, logHandlers } from 'astro/config';
 
 export default defineConfig({
@@ -103,6 +103,7 @@ Astro offers built-in loggers that applications can use.
 ### `logHandlers.json()`
 
 A logger that outputs messages in a JSON format. A log would look like this:
+
 ```json
 { "message": "<the message>", "label": "router", "level": "info", "time": "<UNIX timestamp>"  }
 ```
@@ -120,7 +121,7 @@ The `json` logger accepts the following options:
 - `pretty`: when `true`, the JSON log is printed on multiple lines. Defaults to `false`.
 - `level`: the [level](#log-level) of logs that should be printed.
 
-```js title="astro.config.mjs" {5} ins="json"
+```js title="astro.config.mjs" {4} ins="json"
 import { defineConfig, logHandlers } from 'astro/config';
 
 export default defineConfig({
@@ -174,7 +175,7 @@ The `node` logger accepts the following options:
 
 - `level`: the [level](#log-level) of logs that should be printed.
 
-```js title="astro.config.mjs" {5} ins="node"
+```js title="astro.config.mjs" {4} ins="node"
 import { defineConfig, logHandlers } from 'astro/config';
 
 export default defineConfig({

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -149,7 +149,7 @@ The `console` logger accepts the following options:
 
 - `level`: the [level](#log-level) of logs that should be printed.
 
-```js title="astro.config.mjs" {5} ins="console"
+```js title="astro.config.mjs" {4} ins="console"
 import { defineConfig, logHandlers } from 'astro/config';
 
 export default defineConfig({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

* Fixes the highlighted lines in the Logger reference (#14027 was done too hastily... 😅 ), see https://v7.docs.astro.build/en/reference/logger-reference/#log-level for example
* Adds docs for the new `--json` flag. This has been lost when unflagging the [experimental logger](https://docs.astro.build/en/reference/experimental-flags/logger/).
* Updates the `--background` flag description. According to the blog post ([#2458](https://github.com/withastro/astro.build/pull/2458)), this enables JSON logging automatically.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: 7.0

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
