### PR TITLE
fix: use the `unified()` processor in remark/rehype recipes

### DIFF
--- a/src/content/docs/en/recipes/external-links.mdx
+++ b/src/content/docs/en/recipes/external-links.mdx
@@ -16,7 +16,7 @@ Using a rehype plugin, you can identify and modify links in your Markdown files 
 ## Recipe
 
 <Steps>
-1. Install the `rehype-external-links` plugin.
+1. Install the [`rehype-external-links`](https://www.npmjs.com/package/rehype-external-links) plugin.
 
     <PackageManagerTabs>
         <Fragment slot="npm">
@@ -36,25 +36,48 @@ Using a rehype plugin, you can identify and modify links in your Markdown files 
         </Fragment>
       </PackageManagerTabs>
 
-2. Import the plugin into your `astro.config.mjs` file.
+2. Install [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
+
+    <PackageManagerTabs>
+        <Fragment slot="npm">
+        ```shell
+        npm install @astrojs/markdown-remark
+        ```
+        </Fragment>
+        <Fragment slot="pnpm">
+        ```shell
+        pnpm add @astrojs/markdown-remark
+        ```
+        </Fragment>
+        <Fragment slot="yarn">
+        ```shell
+        yarn add @astrojs/markdown-remark
+        ```
+        </Fragment>
+      </PackageManagerTabs>
+
+3. Import the plugin into your `astro.config.mjs` file.
 
 	Pass `rehypeExternalLinks` to the `rehypePlugins` array, along with an options object that includes a content property. Set this property's `type` to `text` if you want to add plain text to the end of the link. To add HTML to the end of the link instead, set the property `type` to	`raw`.
 
-    ```ts
-    // ...
+    ```js title="astro.config.mjs"
+    import { unified } from '@astrojs/markdown-remark';
+    import { defineConfig } from 'astro/config';
     import rehypeExternalLinks from 'rehype-external-links';
 
     export default defineConfig({
       // ...
       markdown: {
-        rehypePlugins: [
-          [
-            rehypeExternalLinks,
-            {
-              content: { type: 'text', value: ' 🔗' }
-            }
-          ],
-        ]
+        processor: unified({
+          rehypePlugins: [
+            [
+              rehypeExternalLinks,
+              {
+                content: { type: 'text', value: ' 🔗' }
+              }
+            ],
+          ]
+        }),
       },
     });
     ```
@@ -63,7 +86,3 @@ Using a rehype plugin, you can identify and modify links in your Markdown files 
       The value of the `content` property is [not represented in the accessibility tree](https://developer.mozilla.org/en-US/docs/Web/CSS/content#accessibility_concerns). As such, it's best to make clear that the link is external in the surrounding content, rather than relying on the icon alone.
     :::
 </Steps>
-
-
-## Resources
-- [rehype-external-links](https://www.npmjs.com/package/rehype-external-links)

--- a/src/content/docs/en/recipes/external-links.mdx
+++ b/src/content/docs/en/recipes/external-links.mdx
@@ -16,49 +16,29 @@ Using a rehype plugin, you can identify and modify links in your Markdown files 
 ## Recipe
 
 <Steps>
-1. Install the [`rehype-external-links`](https://www.npmjs.com/package/rehype-external-links) plugin.
+1. Install both the [`rehype-external-links`](https://www.npmjs.com/package/rehype-external-links) plugin and [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark).
 
     <PackageManagerTabs>
         <Fragment slot="npm">
         ```shell
-        npm install rehype-external-links
+        npm install rehype-external-links @astrojs/markdown-remark
         ```
         </Fragment>
         <Fragment slot="pnpm">
         ```shell
-        pnpm add rehype-external-links
+        pnpm add rehype-external-links @astrojs/markdown-remark
         ```
         </Fragment>
         <Fragment slot="yarn">
         ```shell
-        yarn add rehype-external-links
+        yarn add rehype-external-links @astrojs/markdown-remark
         ```
         </Fragment>
       </PackageManagerTabs>
 
-2. Install [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
+2. Configure the plugin in your `astro.config.mjs` file.
 
-    <PackageManagerTabs>
-        <Fragment slot="npm">
-        ```shell
-        npm install @astrojs/markdown-remark
-        ```
-        </Fragment>
-        <Fragment slot="pnpm">
-        ```shell
-        pnpm add @astrojs/markdown-remark
-        ```
-        </Fragment>
-        <Fragment slot="yarn">
-        ```shell
-        yarn add @astrojs/markdown-remark
-        ```
-        </Fragment>
-      </PackageManagerTabs>
-
-3. Import the plugin into your `astro.config.mjs` file.
-
-	Pass `rehypeExternalLinks` to the `rehypePlugins` array, along with an options object that includes a content property. Set this property's `type` to `text` if you want to add plain text to the end of the link. To add HTML to the end of the link instead, set the property `type` to	`raw`.
+    Import `unified()` and define it as the Markdown processor to [support remark plugins](/en/guides/markdown-content/#using-remark-and-rehype-plugins). Then, pass to `rehypePlugins` an array containing your imported `rehypeExternalLinks` plugin and an options object with a `content` property. Set this property's `type` to `text` if you want to add plain text to the end of the link. To add HTML to the end of the link instead, set the property `type` to	`raw`.
 
     ```js title="astro.config.mjs"
     import { unified } from '@astrojs/markdown-remark';

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -16,9 +16,7 @@ This recipe calculates time based on your repository’s Git history and may not
 ## Recipe
 
 <Steps>
-1. Install Helper Packages
-
-   Install [`Day.js`](https://www.npmjs.com/package/dayjs) to modify and format times, and [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
+1. Install [`Day.js`](https://www.npmjs.com/package/dayjs) to modify and format times, and [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
 
    <PackageManagerTabs>
      <Fragment slot="npm">

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -18,42 +18,22 @@ This recipe calculates time based on your repository’s Git history and may not
 <Steps>
 1. Install Helper Packages
 
-   Install [`Day.js`](https://www.npmjs.com/package/dayjs) to modify and format times:
+   Install [`Day.js`](https://www.npmjs.com/package/dayjs) to modify and format times, and [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
 
    <PackageManagerTabs>
      <Fragment slot="npm">
        ```shell
-       npm install dayjs
+       npm install dayjs @astrojs/markdown-remark
        ```
      </Fragment>
      <Fragment slot="pnpm">
        ```shell
-       pnpm add dayjs
+       pnpm add dayjs @astrojs/markdown-remark
        ```
      </Fragment>
      <Fragment slot="yarn">
        ```shell
-       yarn add dayjs
-       ```
-     </Fragment>
-   </PackageManagerTabs>
-
-   Install [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
-
-   <PackageManagerTabs>
-     <Fragment slot="npm">
-       ```shell
-       npm install @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="pnpm">
-       ```shell
-       pnpm add @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="yarn">
-       ```shell
-       yarn add @astrojs/markdown-remark
+       yarn add dayjs @astrojs/markdown-remark
        ```
      </Fragment>
    </PackageManagerTabs>

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -14,47 +14,28 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
 <Steps>
 1. Install Helper Packages
 
-    Install these two helper packages:
+    Install these three packages:
     - [`reading-time`](https://www.npmjs.com/package/reading-time) to calculate minutes read
     - [`mdast-util-to-string`](https://www.npmjs.com/package/mdast-util-to-string) to extract all text from your markdown
+    - [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
 
     <PackageManagerTabs>
       <Fragment slot="npm">
       ```shell
-    npm install reading-time mdast-util-to-string
+    npm install reading-time mdast-util-to-string @astrojs/markdown-remark
       ```
       </Fragment>
       <Fragment slot="pnpm">
       ```shell
-    pnpm add reading-time mdast-util-to-string
+    pnpm add reading-time mdast-util-to-string @astrojs/markdown-remark
       ```
       </Fragment>
       <Fragment slot="yarn">
       ```shell
-    yarn add reading-time mdast-util-to-string
+    yarn add reading-time mdast-util-to-string @astrojs/markdown-remark
       ```
       </Fragment>
     </PackageManagerTabs>
-
-   Install [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
-
-   <PackageManagerTabs>
-     <Fragment slot="npm">
-       ```shell
-       npm install @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="pnpm">
-       ```shell
-       pnpm add @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="yarn">
-       ```shell
-       yarn add @astrojs/markdown-remark
-       ```
-     </Fragment>
-   </PackageManagerTabs>
 
 2. Create a remark plugin.
 

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -36,6 +36,26 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
       </Fragment>
     </PackageManagerTabs>
 
+   Install [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):
+
+   <PackageManagerTabs>
+     <Fragment slot="npm">
+       ```shell
+       npm install @astrojs/markdown-remark
+       ```
+     </Fragment>
+     <Fragment slot="pnpm">
+       ```shell
+       pnpm add @astrojs/markdown-remark
+       ```
+     </Fragment>
+     <Fragment slot="yarn">
+       ```shell
+       yarn add @astrojs/markdown-remark
+       ```
+     </Fragment>
+   </PackageManagerTabs>
+
 2. Create a remark plugin.
 
     This plugin uses the `mdast-util-to-string` package to get the Markdown file's text. This text is then passed to the `reading-time` package to calculate the reading time in minutes. 
@@ -57,13 +77,16 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
 
 3. Add the plugin to your config:
 
-    ```js title="astro.config.mjs" "import { remarkReadingTime } from './remark-reading-time.mjs';" "remarkPlugins: [remarkReadingTime],"
+    ```js title="astro.config.mjs" {1,3,7-9}
+    import { unified } from '@astrojs/markdown-remark';
     import { defineConfig } from 'astro/config';
     import { remarkReadingTime } from './remark-reading-time.mjs';
 
     export default defineConfig({
       markdown: {
-        remarkPlugins: [remarkReadingTime],
+        processor: unified({
+          remarkPlugins: [remarkReadingTime],
+        }),
       },
     });
     ```

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -12,9 +12,7 @@ Create a [remark plugin](https://github.com/remarkjs/remark) which adds a readin
 ## Recipe
 
 <Steps>
-1. Install Helper Packages
-
-    Install these three packages:
+1. Install the following packages:
     - [`reading-time`](https://www.npmjs.com/package/reading-time) to calculate minutes read
     - [`mdast-util-to-string`](https://www.npmjs.com/package/mdast-util-to-string) to extract all text from your markdown
     - [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) to use [the `unified()` processor](/en/guides/markdown-content/#using-remark-and-rehype-plugins):


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The [`remarkPlugins`](https://docs.astro.build/en/reference/configuration-reference/#markdownremarkplugins) and [`rehypePlugins`](https://docs.astro.build/en/reference/configuration-reference/#markdownrehypeplugins) top-level properties are now deprecated in favor of the [`processor`](https://docs.astro.build/en/reference/configuration-reference/#markdownprocessor) config. This follows #14029 to update the last two recipes using remark/rehype plugins.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: improve or update docs

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
