### PR TITLE
fix: update `nightly.yml` to pull v7 config and errors changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,12 +21,12 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen
             PR_TITLE: 'ci: update configuration reference docs'
-          # Custom options for running with Astro v6 beta code
-          # - SOURCE_BRANCH: main
-          #  TARGET_BRANCH: v6
-          #  LABEL: 6.0,ci
-          #  PR_BRANCH: ci/docgen-beta
-          #  PR_TITLE: '[BETA] ci: update reference docs'
+          # Custom options for running with Astro v7 beta code
+          - SOURCE_BRANCH: next
+            TARGET_BRANCH: v7
+            LABEL: 7.0,ci
+            PR_BRANCH: ci/docgen-beta
+            PR_TITLE: '[BETA] ci: update reference docs'
     steps:
       - name: Check out code using Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -68,12 +68,12 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen-errors
             PR_TITLE: 'ci: update error reference docs'
-          # Custom options for running with Astro v6 beta code
-          # - SOURCE_BRANCH: main
-          #  TARGET_BRANCH: v6
-          #  LABEL: 6.0,ci
-          #  PR_BRANCH: ci/docgen-errors-beta
-          #  PR_TITLE: '[BETA] ci: update error reference docs'
+          # Custom options for running with Astro v7 beta code
+          - SOURCE_BRANCH: next
+            TARGET_BRANCH: v7
+            LABEL: 7.0,ci
+            PR_BRANCH: ci/docgen-errors-beta
+            PR_TITLE: '[BETA] ci: update error reference docs'
     steps:
       - name: Check out code using Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds the same changes made in #13876 but this time on `main`!

I had to manually trigger the workflow from the v7 branch to get #14048 ... If everything was working as expected, I think this should have been created yesterday (https://github.com/withastro/astro/pull/17019 was merged 2 days ago).

It would appear that my previous PR should have targeted `main` and not `v7`. I'll remember that for next time... 😅 

#### Related issues & labels (optional)

- Suggested label: action

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
