### PR TITLE
Upgrade wrangler-action to v4.0.0

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,7 +81,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Deploy preview
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: versions upload --preview-alias "${{ steps.metadata.outputs.preview_alias }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           github.ref == 'refs/heads/v5' ||
           github.ref == 'refs/heads/v6' ||
           github.ref == 'refs/heads/v7'
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy


### PR DESCRIPTION
The `cloudflare/wrangler-action` was pinned to v3.15.0, which defaults to wrangler 3.x. Wrangler 3 doesn't support `wrangler.jsonc` or the `--preview-alias` flag used in preview deploys.

This upgrades to the v4.0.0 action which defaults to wrangler 4.

**This should be merged ASAP** -- preview deploys are broken on all PRs until this lands.