### PR TITLE
docs(mdx): note that getHeadings() excludes headings from imported files

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -147,7 +147,7 @@ The following properties are available to a `.astro` component when using an `im
 - **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.mdx`).
 - **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - Contains any data specified in the file’s YAML/TOML frontmatter.
-- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
+- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links. Headings from imported files are not included.
 - **`<Content />`** - A component that returns the full, rendered contents of the file.
 - **(any `export` value)** - MDX files can also export data with an `export` statement.
 


### PR DESCRIPTION
Closes #14042.

On the `@astrojs/mdx` page, the `getHeadings()` exported property doesn't mention that headings from imported MDX sub-files are not included in its output. This surprised the issue reporter.

Per @ArmandPhilippot's suggestion in the issue (and confirmed to be MDX-specific), this appends a single sentence to the existing description rather than adding an aside:

> ...can be used for anchor links. **Headings from imported files are not included.**

Docs-only, one line.