### PR TITLE
Deploy Lunaria translation dashboard to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy-lunaria.yml
+++ b/.github/workflows/deploy-lunaria.yml
@@ -1,0 +1,36 @@
+name: Deploy Lunaria
+
+on:
+  push:
+    branches: [main]
+
+# Cancel older runs so we always deploy the latest translation status.
+concurrency:
+  group: lunaria-deploy
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Install Tools & Dependencies
+        uses: ./.github/actions/install
+
+      - name: Build Lunaria
+        run: pnpm lunaria:build
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy --config wrangler.lunaria.jsonc

--- a/wrangler.lunaria.jsonc
+++ b/wrangler.lunaria.jsonc
@@ -1,0 +1,9 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "docs-lunaria",
+	"compatibility_date": "2026-06-12",
+	"assets": {
+		"directory": "./dist/lunaria",
+		"html_handling": "auto-trailing-slash"
+	}
+}


### PR DESCRIPTION
Fixes the Lunaria translation dashboard (`i18n.docs.astro.build`) which stopped updating after the Netlify to Cloudflare migration.

## What broke

The Lunaria dashboard was previously deployed as a separate Netlify site connected to the same repo. It used a `NETLIFY_BUILD_SCRIPT` env var to run `pnpm lunaria:build` instead of the regular Astro build. When the migration removed `netlify.toml` and the `netlify:build` script from `package.json`, the Lunaria Netlify site could no longer build.

## What this PR does

- Adds a dedicated GitHub Actions workflow (`deploy-lunaria.yml`) that runs `pnpm lunaria:build` on push to `main` and deploys to Cloudflare Workers
- Adds a separate wrangler config (`wrangler.lunaria.jsonc`) for the `docs-lunaria` Worker
- Uses `fetch-depth: 0` since Lunaria needs full git history to track translation commit dates
