### PR TITLE
ci: update nightly reference sync for v7 transition

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,12 +21,7 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen
             PR_TITLE: 'ci: update configuration reference docs'
-          # Custom options for running with Astro v7 beta code
-          - SOURCE_BRANCH: next
-            TARGET_BRANCH: v7
-            LABEL: 7.0,ci
-            PR_BRANCH: ci/docgen-beta
-            PR_TITLE: '[BETA] ci: update reference docs'
+
     steps:
       - name: Check out code using Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -68,12 +63,7 @@ jobs:
             LABEL: ci
             PR_BRANCH: ci/docgen-errors
             PR_TITLE: 'ci: update error reference docs'
-          # Custom options for running with Astro v7 beta code
-          - SOURCE_BRANCH: next
-            TARGET_BRANCH: v7
-            LABEL: 7.0,ci
-            PR_BRANCH: ci/docgen-errors-beta
-            PR_TITLE: '[BETA] ci: update error reference docs'
+
     steps:
       - name: Check out code using Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,12 +15,18 @@ jobs:
     strategy:
       matrix:
         include:
-          # Options for updating the v7 docs branch from Astro's main (v7 is now on main)
+          # TODO: switch this back to main source branch for normal operations after v7 merge!
+          - SOURCE_BRANCH: 6-legacy
+            TARGET_BRANCH: main
+            LABEL: ci
+            PR_BRANCH: ci/docgen
+            PR_TITLE: 'ci: update configuration reference docs'
+          # Custom options for running with Astro v7 code
           - SOURCE_BRANCH: main
             TARGET_BRANCH: v7
             LABEL: 7.0,ci
-            PR_BRANCH: ci/docgen-v7
-            PR_TITLE: 'ci: update v7 configuration reference docs'
+            PR_BRANCH: ci/docgen-beta
+            PR_TITLE: '[BETA] ci: update reference docs'
 
     steps:
       - name: Check out code using Git
@@ -57,12 +63,18 @@ jobs:
     strategy:
       matrix:
         include:
-          # Options for updating the v7 docs branch from Astro's main (v7 is now on main)
+          # TODO: switch this back to main source branch for normal operations after v7 merge!
+          - SOURCE_BRANCH: 6-legacy
+            TARGET_BRANCH: main
+            LABEL: ci
+            PR_BRANCH: ci/docgen-errors
+            PR_TITLE: 'ci: update error reference docs'
+          # Custom options for running with Astro v7 code
           - SOURCE_BRANCH: main
             TARGET_BRANCH: v7
             LABEL: 7.0,ci
-            PR_BRANCH: ci/docgen-errors-v7
-            PR_TITLE: 'ci: update v7 error reference docs'
+            PR_BRANCH: ci/docgen-errors-beta
+            PR_TITLE: '[BETA] ci: update error reference docs'
 
     steps:
       - name: Check out code using Git

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         include:
-          # Default options for running with latest Astro code
+          # Options for updating the v7 docs branch from Astro's main (v7 is now on main)
           - SOURCE_BRANCH: main
-            TARGET_BRANCH: main
-            LABEL: ci
-            PR_BRANCH: ci/docgen
-            PR_TITLE: 'ci: update configuration reference docs'
+            TARGET_BRANCH: v7
+            LABEL: 7.0,ci
+            PR_BRANCH: ci/docgen-v7
+            PR_TITLE: 'ci: update v7 configuration reference docs'
 
     steps:
       - name: Check out code using Git
@@ -57,12 +57,12 @@ jobs:
     strategy:
       matrix:
         include:
-          # Default options for running with latest Astro code
+          # Options for updating the v7 docs branch from Astro's main (v7 is now on main)
           - SOURCE_BRANCH: main
-            TARGET_BRANCH: main
-            LABEL: ci
-            PR_BRANCH: ci/docgen-errors
-            PR_TITLE: 'ci: update error reference docs'
+            TARGET_BRANCH: v7
+            LABEL: 7.0,ci
+            PR_BRANCH: ci/docgen-errors-v7
+            PR_TITLE: 'ci: update v7 error reference docs'
 
     steps:
       - name: Check out code using Git


### PR DESCRIPTION
Updates the nightly reference doc workflow now that Astro v7 source has moved from `next` to `main` in `withastro/astro`.

This follows the same transition pattern used for v6 in #13176 and #13373:

- docs `main` pulls generated references from Astro `6-legacy`, so current v6 docs do not receive v7 API reference changes but can still receive last-minute v6 fixes
- docs `v7` pulls generated references from Astro `main`, where v7 now lives

After the docs `v7` branch is merged later, we can do the usual follow-up cleanup: switch docs `main` back to Astro `main` and comment out the version-branch entry.