### PR TITLE
Fix preview deploys for PRs targeting version branches

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -84,7 +84,9 @@ jobs:
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: versions upload --preview-alias "${{ steps.metadata.outputs.preview_alias }}"
+          # Always upload to the main "docs" Worker so previews use the
+          # *.previews.docs.astro.build domain, even for PRs targeting version branches.
+          command: versions upload --name docs --preview-alias "${{ steps.metadata.outputs.preview_alias }}"
 
       - name: Comment deployment complete
         if: success()


### PR DESCRIPTION
Preview deploys for PRs targeting version branches (e.g. `v7`) were broken. The deploy succeeded but the preview URL returned 'not found'.

**Root cause:** The `versions upload --preview-alias` command was using the Worker name from `wrangler.jsonc` in the build output. For PRs targeting `v7`, this uploaded the preview to the `docs-v7` Worker, but the preview URL (`*.previews.docs.astro.build`) is only configured on the main `docs` Worker.

**Fix:** Pass `--name docs` to always upload preview aliases to the main Worker, regardless of which branch the PR targets.

Fixes the broken preview on #14065.