### PR TITLE
Describe interaction of getHeadings with MDX imports

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/mdx.mdx
+++ b/src/content/docs/en/guides/integrations-guide/mdx.mdx
@@ -147,7 +147,7 @@ The following properties are available to a `.astro` component when using an `im
 - **`file`** - The absolute file path (e.g. `/home/user/projects/.../file.mdx`).
 - **`url`** - The URL of the page (e.g. `/en/guides/markdown-content`).
 - **`frontmatter`** - Contains any data specified in the file’s YAML/TOML frontmatter.
-- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links.
+- **`getHeadings()`** - An async function that returns an array of all headings (`<h1>` to `<h6>`) in the file with the type: `{ depth: number; slug: string; text: string }[]`. Each heading’s `slug` corresponds to the generated ID for a given heading and can be used for anchor links. Headings from imported files are not included.
 - **`<Content />`** - A component that returns the full, rendered contents of the file.
 - **(any `export` value)** - MDX files can also export data with an `export` statement.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

The MDX docs used to explicitly mention the behavior of `getHeadings` regarding files imported in MDX. This PR adds a one-sentence description of this behavior.

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #14042 
- Suggested label: `improve or update documentation`

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
