### PR TITLE
i18n(pt-br): Update islands and upgrade-astro translations

### DIFF
--- a/src/content/docs/pt-br/concepts/islands.mdx
+++ b/src/content/docs/pt-br/concepts/islands.mdx
@@ -1,91 +1,134 @@
 ---
-title: Ilhas Astro
-description: >-
-  Ilhas Astro (ou Ilhas de Componente) é um padrão de arquitetura web em que
-  Astro é pioneiro. O termo “Arquitetura em ilhas” foi criado pela arquiteta
-  frontend da Etsy, Katie Sylor-Miller, em 2019 e expandido pelo criador do
-  Preact, Jason Miller.
+title: Arquitetura em Ilhas
+description: Aprenda como a arquitetura em ilhas do Astro ajuda a manter os sites rápidos.
 i18nReady: true
 ---
 
 import IslandsDiagram from '~/components/IslandsDiagram.astro';
+import ReadMore from '~/components/ReadMore.astro';
 
-Astro foi pioneiro e também popularizou uma arquitetura de frontend chamadas **Ilhas**. Arquitetura em ilhas resulta em melhor performance no frontend por lhe ajudar a evitar padrões de JavaScript monolíticos e por remover todo o JavaScript não essencial de uma página automaticamente. Desenvolvedores continuam usando seus componente e frameworks de UI favoritos com Astro e ainda recebem esses benefícios.
+O Astro ajudou a ser pioneiro e a popularizar um novo padrão de arquitetura de frontend chamado **Arquitetura em Ilhas.** A arquitetura em ilhas funciona renderizando a maior parte da sua página em HTML estático e rápido, com pequenas "ilhas" de JavaScript adicionadas quando interatividade ou personalização são necessárias na página (um carrossel de imagens, por exemplo). Isso evita os payloads de JavaScript monolíticos que reduzem a responsividade de muitos outros frameworks web de JavaScript modernos.
 
 ## Uma breve história
 
-O termo "componente em ilhas" (component island) foi cunhado inicialmente pela arquiteta de frontend da Etsy, [Katie Sylor-Miller](https://sylormiller.com/), em 2019. Essa ideia foi então ampliada e documentada [nesta postagem](https://jasonformat.com/islands-architecture/) pelo criador do Preact, Jason Miller, em 11 de Agosto de 2020.
+O termo "componente em ilhas" (component island) foi cunhado inicialmente pela arquiteta de frontend da Etsy, [Katie Sylor-Miller](https://sylormiller.com/), em 2019. Essa ideia foi então ampliada e documentada [nesta postagem](https://jasonformat.com/islands-architecture/) pelo criador do Preact, Jason Miller, em 11 de agosto de 2020.
 
 > A ideia geral de uma arquitetura em "Ilhas" é enganosamente simples: renderizar páginas HTML no servidor, e injetar espaços reservados ou slots ao redor de regiões altamente dinâmicas [...] que podem, então, ser "hidratadas" no cliente em widgets pequenos e autônomos, reutilizando o HTML inicial deles renderizado no servidor.  
 > — Jason Miller, Criador do Preact
 
-A técnica que esse padrão arquitetural se baseia também é conhecido como **hidratação parcial** ou **seletiva.**
+A técnica em que esse padrão arquitetural se baseia também é conhecida como **hidratação parcial** ou **seletiva.**
 
-Em contraste, a maioria dos frameworks web baseados em JavaScript hidratam e renderizam um website inteiro como uma grande aplicação JavaScript (também conhecidas como aplicações de página única, ou SPA). SPAs oferecem simplicidade e poder, mas sofrem de problemas de performance no carregamento da página por causa do uso pesado de JavaScript no lado do cliente.
+Em contraste, a maioria dos frameworks web baseados em JavaScript hidratam e renderizam um website inteiro como uma grande aplicação JavaScript (também conhecida como aplicação de página única, ou SPA). SPAs oferecem simplicidade e poder, mas sofrem de problemas de performance no carregamento da página por causa do uso pesado de JavaScript no lado do cliente.
 
-As SPAs tem seu lugar, incluindo [embedadas dentro de uma página Astro](/pt-br/guides/migrate-to-astro/from-create-react-app/). Entretanto, SPAs carecem da habilidade nativa de hidratar de forma selecionada e estratégica, fazendo delas escolhas excessivas para a maioria dos projetos na web hoje em dia.
+As SPAs têm seu lugar, incluindo [incorporadas dentro de uma página Astro](/pt-br/guides/migrate-to-astro/from-create-react-app/). Entretanto, SPAs carecem da habilidade nativa de hidratar de forma seletiva e estratégica, fazendo delas uma escolha excessiva para a maioria dos projetos na web hoje em dia.
 
-Astro se tornou popular como o primeiro framework web JavaScript popular com hidratação seletiva integrada, utilizando esse padrão de componentes em ilhas cunhado por Sylor-Miller.
+O Astro se tornou popular como o primeiro framework web JavaScript popular com hidratação seletiva integrada, utilizando esse mesmo padrão de componentes em ilhas cunhado inicialmente por Sylor-Miller. Desde então, expandimos e evoluímos o trabalho original de Sylor-Miller, o que ajudou a inspirar uma abordagem semelhante de componentes em ilhas para conteúdo renderizado dinamicamente no servidor.
 
 ## O que é uma ilha?
 
-**No Astro, uma "ilha" se refere a qualquer componente de UI interativo em uma página.** Pense em uma ilha como um widget interativo flutuando em um mar de HTML stático, leve e renderizado no servidor.
+No Astro, uma ilha é um componente de UI aprimorado em uma página que, fora isso, seria HTML estático.
+
+Uma [**ilha de cliente**](#ilhas-de-cliente) é um componente de UI interativo em JavaScript que é hidratado separadamente do resto da página, enquanto uma [**ilha de servidor**](#ilhas-de-servidor) é um componente de UI que renderiza seu conteúdo dinâmico no servidor separadamente do resto da página.
+
+Ambas as ilhas executam processos custosos ou mais lentos de forma independente, componente a componente, para carregamentos de página otimizados.
+
+## Componentes de ilha
+
+Componentes Astro são os blocos de construção do template da sua página. Eles são renderizados para HTML estático sem runtime no lado do cliente.
+
+Pense em uma ilha de cliente como um widget interativo flutuando em um mar de HTML estático, leve e renderizado no servidor. Ilhas de servidor podem ser adicionadas para elementos personalizados ou dinâmicos renderizados no servidor, como a foto de perfil de um visitante autenticado.
 
 <IslandsDiagram>
-    <Fragment slot="headerApp">Cabeçalho (ilha interativa)</Fragment>
-    <Fragment slot="sidebarApp">Barra lateral (HTML estático)</Fragment>
-    <Fragment slot="main">
-        Conteúdo estático como texto, imagens, etc.
-    </Fragment>
-    <Fragment slot="carouselApp">Carrossel de imagens (ilha interativa)</Fragment>
-    <Fragment slot="footer">Rodapé (HTML estático)</Fragment>
-    <Fragment slot="source">Fonte: [Arquitetura em Ilhas: Jason Miller](https://jasonformat.com/islands-architecture/)</Fragment>
+  <Fragment slot="headerApp">Cabeçalho (ilha interativa)</Fragment>
+  <Fragment slot="sidebarApp">Barra lateral (HTML estático)</Fragment>
+  <Fragment slot="main">
+    Conteúdo estático como texto, imagens, etc.
+  </Fragment>
+  <Fragment slot="carouselApp">Carrossel de imagens (ilha interativa)</Fragment>
+  <Fragment slot="footer">Rodapé (HTML estático)</Fragment>
+  <Fragment slot="source">Fonte: [Arquitetura em Ilhas: Jason Miller](https://jasonformat.com/islands-architecture/)</Fragment>
 </IslandsDiagram>
 
-Uma ilha sempre executa de forma isolada de outras ilhas na página, e múltiplas ilhas podem existir em uma página. Ilhas ainda assim podem compartilhar estado e se comunicarem umas com as outras, apesar de executarem em contextos de componentes diferentes.
+Uma ilha sempre executa de forma isolada das outras ilhas na página, e múltiplas ilhas podem existir em uma página. Ilhas de cliente ainda podem compartilhar estado e se comunicar umas com as outras, mesmo que executem em contextos de componentes diferentes.
 
-Essa flexibilidade permite que Astro suporte múltiplos frameworks de UI como [React](https://react.dev/), [Preact](https://preactjs.com/?lang=pt-br), [Svelte](https://svelte.dev/), [Vue](https://pt.vuejs.org/), e [SolidJS](https://www.solidjs.com/). Por serem independentes, você pode até misturar múltiplos frameworks em cada página.
+Essa flexibilidade permite que o Astro suporte múltiplos frameworks de UI como [React](https://react.dev/), [Preact](https://preactjs.com/?lang=pt-br), [Svelte](https://svelte.dev/), [Vue](https://pt.vuejs.org/) e [SolidJS](https://www.solidjs.com/). Por serem independentes, você pode até misturar vários frameworks em cada página.
 
 :::tip
-Apesar da maioria dos desenvolvedores se manter em um único framework de UI, Astro suporta múltiplos frameworks no mesmo projeto. Isso lhe permite:
+Apesar da maioria dos desenvolvedores se manter em um único framework de UI, o Astro suporta múltiplos frameworks no mesmo projeto. Isso permite que você:
 
-- Escolher o melhor framework para cada componente.
-- Aprender um novo framework sem precisar iniciar um novo projeto.
-- Colaborar com outros mesmo quando trabalhando em frameworks diferentes.
-- Converter de forma incremental um site existente para outro frameworks sem um período de inatividate.
+- Escolha o melhor framework para cada componente.
+- Aprenda um novo framework sem precisar iniciar um novo projeto.
+- Colabore com outras pessoas mesmo trabalhando em frameworks diferentes.
+- Converta de forma incremental um site existente para outro framework sem tempo de inatividade.
 :::
 
-## Criando uma ilha
+## Ilhas de Cliente
 
-Por padrão, Astro vai renderizar automaticamente todos os componentes de UI para apenas HTML e CSS, **removendo todo o JavaScript do lado do cliente automaticamente.**
-
+Por padrão, o Astro vai renderizar automaticamente todos os componentes de UI para apenas HTML e CSS, **removendo todo o JavaScript do lado do cliente automaticamente.**
 
 ```astro title="src/pages/index.astro"
 <MeuComponenteReact />
 ```
 
-Isso pode soar restrito, mas esse comportamento é o o que mantém websites Astro rápidos por padrão e proteje desenvolvedores de acidentalmente enviar JavaScript desnecessário ou indesejado que pode tornar seu website lento.
+Isso pode soar restritivo, mas esse comportamento é o que mantém os sites Astro rápidos por padrão e protege os desenvolvedores de enviar acidentalmente JavaScript desnecessário ou indesejado que possa deixar seu site lento.
 
-Tornar qualquer componente de UI estático em uma ilha interativa requer apenas uma diretiva `client:*`. Astro, então, vai fazer um build automaticamente e empacotar seu JavaScript do lado do cliente para uma performance otimizada.
+Tornar qualquer componente de UI estático em uma ilha interativa requer apenas uma diretiva `client:*`. O Astro, então, vai fazer o build e empacotar automaticamente seu JavaScript do lado do cliente para uma performance otimizada.
 
 ```astro title="src/pages/index.astro" ins="client:load"
 <!-- Este componente agora é interativo na página! 
-     O resto do seu website continua estático. -->
+     O resto do seu site continua estático. -->
 <MeuComponenteReact client:load />
 ```
 
-Com ilhas, JavaScript do lado do cliente só é carregado para os componentes explicitamente interativos que você demarcar utilizando diretivas `client:*`.
+Com ilhas, o JavaScript do lado do cliente só é carregado para os componentes explicitamente interativos que você demarcar utilizando diretivas `client:*`.
 
-E por causa das interações serem definidas a nível de componente, você pode lidar com diferentes prioridades de carregamento para cada componente baseado em seu uso. Por exemplo, `client:idle` informa um componente para carregar quando o navegador estiver inativo, e `client:visible` informa um componente para carregar apenas quando ele entrar na janela de visualização.
+E por causa das interações serem definidas a nível de componente, você pode lidar com diferentes prioridades de carregamento para cada componente baseado em seu uso. Por exemplo, `client:idle` informa a um componente para carregar quando o navegador estiver inativo, e `client:visible` informa a um componente para carregar apenas quando ele entrar na janela de visualização.
 
-## Quais são os benefícios das Ilhas?
+<h3>Benefícios das ilhas de cliente</h3>
 
-O mais óbvio benefício de se construir com Ilhas Astro é performance: a maior parte do seu website é convertido em HTML estático e rápido, carregando JavaScript apenas para os componentes individuais que o necessitam. JavaScript é um dos assets mais lentos que você pode carregar por byte, então cada byte conta.
+O benefício mais óbvio de se construir com Ilhas Astro é a performance: a maior parte do seu website é convertida em HTML estático e rápido, carregando JavaScript apenas para os componentes individuais que o necessitam. JavaScript é um dos assets mais lentos que você pode carregar por byte, então cada byte conta.
 
-Outro benefício é carregamento paralelo. Na ilustração de exemplo acima, a ilha de baixa prioridade "carrossel de imagens" não precisa bloquear a ilha de alta prioridade "cabeçalho". Os dois são carregados em paralelo e hidratados de forma isolada, o que significa que o cabeçalho se torna interativo imediatamente sem precisar esperar que o carrossel, mais pesado, desacelere o carregamento da página.
+Outro benefício é o carregamento paralelo. Na ilustração de exemplo acima, a ilha de baixa prioridade "carrossel de imagens" não precisa bloquear a ilha de alta prioridade "cabeçalho". As duas são carregadas em paralelo e hidratadas de forma isolada, o que significa que o cabeçalho se torna interativo imediatamente sem precisar esperar pelo carrossel, mais pesado, mais abaixo na página.
 
-Melhor ainda, você pode dizer para o Astro exatamente como e quando renderizar cada componente. Se o carrossel de imagens é realmente caro de se carregar, você pode adicionar uma [diretiva de cliente](/pt-br/reference/directives-reference/#client-directives) especial que diz ao Astro para apenas carregar o carrossel de imagens quando ele estiver visível na página. Se o usuário nunca o ver, ele nunca será carregado.
+Melhor ainda, você pode dizer ao Astro exatamente como e quando renderizar cada componente. Se aquele carrossel de imagens é realmente caro de se carregar, você pode adicionar uma [diretiva de cliente](/pt-br/reference/directives-reference/#client-directives) especial que diz ao Astro para apenas carregar o carrossel quando ele estiver visível na página. Se o usuário nunca o vir, ele nunca será carregado.
 
-No Astro, cabe a você como desenvolvedor explicitamente dizer ao Astro quais componentes na página também precisam ser executados no navegador. Astro irá apenas hidratar exatamente o que é necessário na página e deixar o resto do seu website como HTML estático.
+No Astro, cabe a você, como desenvolvedor, dizer explicitamente ao Astro quais componentes na página também precisam ser executados no navegador. O Astro irá hidratar apenas exatamente o que é necessário na página e deixar o resto do seu site como HTML estático.
 
-**Ilhas são o segredo para a história de performance rápida por padrão do Astro!**
+**Ilhas de cliente são o segredo para a história de performance rápida por padrão do Astro!**
+
+<ReadMore>Leia mais sobre [usar componentes de framework JavaScript](/pt-br/guides/framework-components/) no seu projeto.</ReadMore>
+
+## Ilhas de Servidor
+
+Ilhas de servidor são uma forma de tirar do caminho do processo de renderização principal o código custoso ou lento do lado do servidor, facilitando combinar HTML estático de alta performance com componentes dinâmicos gerados no servidor.
+
+Adicione a [diretiva `server:defer`](/pt-br/reference/directives-reference/#server-directives) a qualquer componente Astro na sua página para transformá-lo em sua própria ilha de servidor:
+
+```astro title="src/pages/index.astro" "server:defer"
+---
+import Avatar from "../components/Avatar.astro";
+---
+<Avatar server:defer />
+```
+
+Isso divide sua página em áreas menores de conteúdo renderizado no servidor que carregam em paralelo.
+
+O conteúdo principal da sua página pode ser renderizado imediatamente com conteúdo de preenchimento, como um avatar genérico, até que o conteúdo da própria ilha esteja disponível. Com ilhas de servidor, ter pequenos componentes de conteúdo personalizado não atrasa a renderização de uma página que, fora isso, seria estática.
+
+Esse padrão de renderização foi construído para ser portável. Ele não depende de nenhuma infraestrutura de servidor, então funcionará com qualquer host, de um servidor Node.js em um contêiner Docker ao provedor serverless de sua escolha.
+
+<h3>Benefícios das ilhas de servidor</h3>
+
+Um benefício das ilhas de servidor é a habilidade de renderizar em tempo real as partes mais dinâmicas da sua página. Isso permite que o invólucro externo e o conteúdo principal sejam armazenados em cache de forma mais agressiva, proporcionando uma performance mais rápida.
+
+Outro benefício é proporcionar uma ótima experiência ao visitante. Ilhas de servidor são otimizadas e carregam rapidamente, muitas vezes até antes de o navegador ter pintado a página. Mas no curto tempo que suas ilhas levam para renderizar, você pode exibir conteúdo de fallback personalizado e evitar qualquer deslocamento de layout.
+
+Um exemplo de site que se beneficia das ilhas de servidor do Astro é uma loja de e-commerce. Embora o conteúdo principal das páginas de produto mude com pouca frequência, essas páginas normalmente têm algumas partes dinâmicas:
+
+- O avatar do usuário no cabeçalho.
+- Ofertas e promoções especiais para o produto.
+- Avaliações de usuários.
+
+Usando ilhas de servidor para esses elementos, seu visitante verá imediatamente a parte mais importante da página: seu produto. Avatares genéricos, indicadores de carregamento e anúncios da loja podem ser exibidos como conteúdo de fallback até que as partes personalizadas estejam disponíveis.
+
+<ReadMore>Leia mais sobre [usar ilhas de servidor](/pt-br/guides/server-islands/) no seu projeto.</ReadMore>

--- a/src/content/docs/pt-br/upgrade-astro.mdx
+++ b/src/content/docs/pt-br/upgrade-astro.mdx
@@ -102,6 +102,8 @@ As principais páginas de documentação do Astro são sempre **específicas par
 
 Consulte os guias de atualização abaixo para obter uma explicação das alterações, comparando a nova versão com a antiga. Os guias de atualização incluem tudo o que pode exigir que você altere seu próprio código: alterações significativas, descontinuações, remoções e substituições de funcionalidades, bem como orientações de uso atualizadas. Cada alteração no Astro inclui uma seção "O que devo fazer?" para ajudá-lo a atualizar o código do seu projeto de maneira bem-sucedida.
 
+- [Atualize para v6](/pt-br/guides/upgrade-to/v6/)
+- [Atualize para v5](/pt-br/guides/upgrade-to/v5/)
 - [Atualize para v4](/pt-br/guides/upgrade-to/v4/)
 - [Atualize para v3](/pt-br/guides/upgrade-to/v3/)
 - [Atualize para v2](/pt-br/guides/upgrade-to/v2/)
@@ -111,6 +113,8 @@ Consulte os guias de atualização abaixo para obter uma explicação das altera
 
 A documentação para versões mais antigas do Astro não é mantida, mas está disponível como um arquivo estático. Use essas versões da documentação se você não puder atualizar seu projeto, mas ainda quiser consultar guias e referências:
 
+- [Arquivo v5.18.0 sem manutenção](https://v5.docs.astro.build/pt-br/)
+- [Arquivo v4.16.17 sem manutenção](https://v4.docs.astro.build/pt-br/)
 - [Arquivo v3.6.3 sem manutenção](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/pt-br/)
 - [Arquivo v2.10.15 sem manutenção](https://web.archive.org/web/20230822134745/https://docs.astro.build/en/getting-started)
 
@@ -189,7 +193,7 @@ Uma versão major também pode incluir algumas alterações e melhorias não dis
 As regras a seguir definem quando o Astro pode descontinuar, abandonar ou adicionar suporte para versões do Node.js:
 
 - As versões ímpares do Node.js podem ser depreciadas e/ou abandonadas quando a próxima versão par do Node.js for publicada. Essa alteração pode ocorrer em uma versão **minor** do Astro, após um período razoável de suporte estendido, conforme decidido pela equipe Core do Astro.
-- A atualização da versão mínima de **_Manutenção_ LTS** (dentro da mesma versão major, por exemplo, de `v18.14.*` para `v18.20.*`) do Node.js pode ocorrer em uma versão **minor** do Astro.
+- A atualização da versão mínima de **_Manutenção_ LTS** (dentro da mesma versão major, por exemplo, de `22.14.*` para `22.20.*`) do Node.js pode ocorrer em uma versão **minor** do Astro.
   - Exceção de segurança: Se uma falha de segurança no Node.js que **afeta o Astro** for divulgada e corrigida, a equipe Core poderá aumentar a versão mínima de **_Manutenção_ LTS** em uma versão **patch**.
 - O upgrade de versões minor ou major do Node.js (**não** Manutenção LTS) ocorre apenas nas versões major do Astro.
   - Exceção de segurança: Se uma falha de segurança no Node.js que **afeta o Astro** for divulgada e corrigida, a equipe Core poderá aumentar a versão mínima em uma versão **minor** do Astro.

--- a/src/content/docs/pt-br/upgrade-astro.mdx
+++ b/src/content/docs/pt-br/upgrade-astro.mdx
@@ -46,20 +46,20 @@ Para atualizar manualmente o Astro e as integrações para suas versões atuais,
 <PackageManagerTabs>
   <Fragment slot="npm">
   ```shell
-  # Exemplo: atualizar o Astro com as integrações React e Tailwind
-  npm install astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # Exemplo: atualizar o Astro com as integrações React e Partytown
+  npm install astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
   <Fragment slot="pnpm">
   ```shell
-  # Exemplo: atualizar o Astro com as integrações React e Tailwind
-  pnpm add astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # Exemplo: atualizar o Astro com as integrações React e Partytown
+  pnpm add astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
   <Fragment slot="yarn">
   ```shell
-  # Exemplo: atualizar o Astro com as integrações React e Tailwind
-  yarn add astro@latest @astrojs/react@latest @astrojs/tailwind@latest
+  # Exemplo: atualizar o Astro com as integrações React e Partytown
+  yarn add astro@latest @astrojs/react@latest @astrojs/partytown@latest
   ```
   </Fragment>
 </PackageManagerTabs>
@@ -115,7 +115,7 @@ A documentação para versões mais antigas do Astro não é mantida, mas está 
 
 - [Arquivo v5.18.0 sem manutenção](https://v5.docs.astro.build/pt-br/)
 - [Arquivo v4.16.17 sem manutenção](https://v4.docs.astro.build/pt-br/)
-- [Arquivo v3.6.3 sem manutenção](https://docs-git-v3-docs-unmaintained-astrodotbuild.vercel.app/pt-br/)
+- [Arquivo v3.6.3 sem manutenção](https://web.archive.org/web/20231203051122/https://docs.astro.build/en/getting-started/)
 - [Arquivo v2.10.15 sem manutenção](https://web.archive.org/web/20230822134745/https://docs.astro.build/en/getting-started)
 
 ## Versionamento Semântico


### PR DESCRIPTION
  #### Description (required)

  Update outdated translations of `concepts/islands.mdx` and `upgrade-astro.mdx` to match the current English source.
  
  - `concepts/islands.mdx`: restructured to the current page layout, adding the missing **Island components**, **Client islands**, and **Server islands** sections (the Server islands section did not exist in the previous translation).
  - `upgrade-astro.mdx`: added the v6 and v5 upgrade guide links and the v5.18.0 / v4.16.17 unmaintained snapshots, and updated the Node.js Maintenance LTS version example.

  #### Related issues & labels (optional)

  - Suggested label: i18n
