### PR TITLE
i18n(pt-br): Bring outdated pages up to date

### DIFF
--- a/src/content/docs/pt-br/astro-courses.mdx
+++ b/src/content/docs/pt-br/astro-courses.mdx
@@ -47,7 +47,7 @@ Aprenda de seus colegas astronautas com coleções selecionadas de guias, artigo
 
 <LinkCard
   title="Suporte Squid Astro"
-  href="https://get.supportsquid.ink/"
+  href="https://supportsquid.ink/"
   description="Fórum de suporte e base de conhecimento aberta sobre o Astro fora do Discord."
 />
 </CardGrid>

--- a/src/content/docs/pt-br/contribute.mdx
+++ b/src/content/docs/pt-br/contribute.mdx
@@ -23,7 +23,7 @@ Visite o [perfil do Astro no GitHub](https://github.com/withastro) para encontra
 
 - O [compilador do Astro](https://github.com/withastro/compiler), escrito em GO, distribuído como WASM.
 
-- [Ferramentas da linguagem](https://github.com/withastro/language-tools) do Astro, as ferramentas de editores necessárias para a linguagem Astro (os arquivos `.astro`).
+- [Ferramentas da linguagem](https://github.com/withastro/astro/tree/main/packages/language-tools) do Astro, as ferramentas de editores necessárias para a linguagem Astro (os arquivos `.astro`).
 
 - [Starlight](https://github.com/withastro/starlight), o framework de documentação oficial do Astro.
 

--- a/src/content/docs/pt-br/contribute.mdx
+++ b/src/content/docs/pt-br/contribute.mdx
@@ -7,6 +7,10 @@ import ContributorList from '~/components/ContributorList.astro'
 
 Nós recebemos contribuições de qualquer tamanho e contribuidores de qualquer nível de habilidade. Como um projeto open-source, nós acreditamos em dar de volta para nossos contribuidores. Somos felizes em ajudar orientando em PRs, escrita técnica, e em tornar qualquer ideia de funcionalidade em uma realidade.
 
+:::tip[Issues abertas]
+Navegue por [todas as issues abertas do Astro no GitHub marcadas com `help wanted` e `good first issue`](https://github.com/search?q=org%3Awithastro+label%3A%22good+first+issue%22%2C%22help+wanted%22%2C+state%3Aopen&type=issues) em todos os repositórios de código: código do Astro, documentação, Starlight, sites do Astro, ferramentas da linguagem, GitHub Actions, bots, o compilador... há muitos lugares para contribuir!
+:::
+
 Gostaria de se envolver ainda mais? Veja nosso [Documento de Governança](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) com descrições detalhadas dos diferentes cargos, processos de nomeação de mantenedores, processos de revisão de código, e aplicação do Código de Conduta.
 
 ## Formas de Contribuir

--- a/src/content/docs/pt-br/recipes/streaming-improve-page-performance.mdx
+++ b/src/content/docs/pt-br/recipes/streaming-improve-page-performance.mdx
@@ -80,7 +80,7 @@ Você também pode incluir Promises diretamente no template. Em vez de bloquear 
 ---
 const personPromise = fetch('https://randomuser.me/api/')
   .then(response => response.json())
-  .then(arr => arr[0].name.first);
+  .then(personData => personData.results[0].name.first);
 const factPromise = fetch('https://catfact.ninja/fact')
   .then(response => response.json())
   .then(factData => factData.fact);

--- a/src/content/docs/pt-br/tutorial/1-setup/1.mdx
+++ b/src/content/docs/pt-br/tutorial/1-setup/1.mdx
@@ -28,7 +28,7 @@ Você pode acessar a linha de comando através de um programa de terminal local 
 
 ### Node.js
 
-Para que o Astro execute no seu sistema, você também irá precisar ter o [**Node.js**](https://nodejs.org/pt-br/) instalado, versão `v18.14.1` ou superior.
+Para que o Astro execute no seu sistema, você também irá precisar ter uma versão compatível do [**Node.js**](https://nodejs.org/pt-br/) instalada. O Astro suporta versões **pares** do Node.js. A versão mínima suportada atualmente é a `v22.12.0`. Versões ímpares como a `v23` não são suportadas.
 
 Para verificar se você já tem uma versão compatível instalada, execute o seguinte comando no seu terminal:
 
@@ -36,10 +36,10 @@ Para verificar se você já tem uma versão compatível instalada, execute o seg
 node -v
 
 // Resultado de exemplo
-v18.17.1
+v22.20.0
 ```
 
-Se o comando retornar um número de versão maior que `v18.17.1` ou `v20.3.0` (excluindo qualquer `v19`), você pode continuar!
+Se o comando retornar um número de versão suportado pelo Astro, você pode continuar!
 
 Se o comando retornar uma mensagem de erro como `Command 'node' not found`, ou um número de versão menor do que o exigido, então você precisa [instalar uma versão compatível do Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 

--- a/src/content/docs/pt-br/tutorial/1-setup/5.mdx
+++ b/src/content/docs/pt-br/tutorial/1-setup/5.mdx
@@ -22,7 +22,7 @@ import Badge from "~/components/Badge.astro"
 Aqui, você irá conectar seu repositório do GitHub com a Netlify. Netlify irá usar esse projeto para fazer build e deploy do seu site ao vivo na web toda vez que você fizer commit de uma mudança no seu código. 
 
 :::tip[Nós utilizaremos...]
-Este tutorial irá utilizar **Netlify**, porém você está livre para utilizar seu serviço de hospedagem preferido para fazer deploy do seu site para a internet.
+Este tutorial irá utilizar **Netlify**, porém você está livre para utilizar seu serviço de hospedagem preferido para [fazer deploy do seu site Astro para a internet](/pt-br/guides/deploy/).
 :::
 
 ## Crie um novo site Netlify
@@ -32,7 +32,7 @@ Este tutorial irá utilizar **Netlify**, porém você está livre para utilizar 
 
     Anote o seu nome de usuário. Você irá ver seu painel de controle e quaisquer sites que criou em `https://app.netlify.com/teams/nome`
 
-2. Clique em <kbd>Add new site</kbd> > <kbd>Import an existing project</kbd>.
+2. Clique em <kbd>Add new project</kbd> > <kbd>Import an existing project</kbd>.
 
     Você será questionado a conectar com um provedor Git. Escolha o GitHub e siga os passos na tela para autenticar sua conta do GitHub. Então, escolha o repositório do GitHub do seu projeto Astro pela lista fornecida.
 
@@ -64,7 +64,7 @@ Você quer atualizar a página inicial do seu projeto existente. Quais etapas vo
       Eu abro um terminal, executo `create astro` e então visito minha URL da Netlify.
     </Option>
     <Option>
-      Eu mudo uma opção no meu aplicativo da Netlify, e então faço fork de um novo projeto Astro no StackBlitz.
+      Eu mudo uma opção no meu aplicativo da Netlify, e então começo um novo projeto Astro no astro.new.
     </Option>
     <Option isCorrect>
       Eu faço uma mudança em `index.astro`. Faço commit e push das minhas mudanças ao GitHub. Netlify vai lidar com o resto!

--- a/src/content/docs/pt-br/tutorial/2-pages/1.mdx
+++ b/src/content/docs/pt-br/tutorial/2-pages/1.mdx
@@ -106,7 +106,7 @@ Adicione uma terceira página `blog.astro` ao seu site, seguindo as mesmas [etap
 Você agora deve ter um website com três páginas que tem links de uma para a outra. Hora de adicionar algum conteúdo na página Blog.
 
 Atualize o conteúdo da página em `blog.astro` com:
-```astro astro title="src/pages/blog.astro" ins={7-8} del={6}
+```astro title="src/pages/blog.astro" ins={7-8} del={6}
 <body>
   <a href="/">Início</a>
   <a href="/about/">Sobre</a>


### PR DESCRIPTION
  #### Description (required)

  Bring several outdated pt-br pages up to date with the current English source (trivial link, code, and version fixes).
  
  - `tutorial/1-setup/1.mdx`: updated the minimum Node.js version guidance (even-numbered versions, `v22.12.0`).
  - `tutorial/1-setup/5.mdx`: linked the deploy guide, `Add new project` label, and `astro.new` wording.
  - `tutorial/2-pages/1.mdx`: fixed a duplicated `astro` code-fence language tag.
  - `recipes/streaming-improve-page-performance.mdx`: updated the random-user API example.
  - `astro-courses.mdx` and `contribute.mdx`: updated outdated external links.
  
  #### Related issues & labels (optional)
  
  - Suggested label: i18n
