### PR TITLE
i18n(pt-br): bring tutorial unit index pages up-to-date

### DIFF
--- a/src/content/docs/pt-br/tutorial/0-introduction/index.mdx
+++ b/src/content/docs/pt-br/tutorial/0-introduction/index.mdx
@@ -2,10 +2,15 @@
 type: tutorial
 unitTitle: 'Bem-vindo, mundo!'
 title: Construa seu primeiro blog Astro
+sidebar:
+  label: 'Introdução'
 description: >-
   Aprenda os fundamentos do Astro com um tutorial baseado em projeto. Com todo o conhecimento
   prévio necessário para começar!
 i18nReady: true
+head:
+  - tag: title
+    content: Tutorial de blog | Docs
 ---
 
 import Checklist from '~/components/Checklist.astro';
@@ -23,7 +28,7 @@ Durante o caminho, você irá:
 - Adicionar interatividade ao seu site 
 - Fazer deploy do seu site para a web
 
-Quer uma pré-visualização do que você irá construir? Você pode ver o projeto final no [GitHub](https://github.com/withastro/blog-tutorial-demo) ou [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro).
+Quer uma pré-visualização do que você irá construir? Você pode ver o projeto final no [GitHub](https://github.com/withastro/blog-tutorial-demo) ou abrir uma versão funcional em um ambiente de programação online como o [StackBlitz](https://stackblitz.com/github/withastro/blog-tutorial-demo/tree/complete?file=src%2Fpages%2Findex.astro).
 
 :::note
 Se ao invés disso você prefere começar a explorar o Astro a partir de um site pré-construído, você pode visitar https://astro.new e escolher um template inicial para abrir e editá-lo em um editor online.

--- a/src/content/docs/pt-br/tutorial/1-setup/index.mdx
+++ b/src/content/docs/pt-br/tutorial/1-setup/index.mdx
@@ -2,12 +2,17 @@
 type: tutorial
 unitTitle: Crie e faça deploy do seu primeiro site Astro
 title: 'Check in: Unidade 1 - Configuração'
+sidebar:
+  label: 'Unidade 1 - Configuração'
 description: >-
   Tutorial: Construa seu primeiro blog Astro —
 
   Prepare seu ambiente de desenvolvimento, crie e faça deploy
   do seu primeiro site Astro
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 1 - Configuração | Docs'
 ---
 import Checklist from '~/components/Checklist.astro';
 import Box from '~/components/tutorial/Box.astro';
@@ -17,16 +22,16 @@ Agora que você sabe o que estará construindo, é hora de configurar todas as f
 
 Essa unidade te mostra como configurar seu ambiente de desenvolvimento e como fazer deploy para a Netlify. Pule para a [Unidade 2](/pt-br/tutorial/2-pages/) se você já está confortável com seu ambiente e fluxo de trabalho.
 
-:::tip[Utilizando StackBlitz]
+:::tip[Faça o tutorial em um editor de código online]
 
-Quer completar este tutorial em um editor de código online ao invés disso?
+Quer completar este tutorial em um editor de código online ao invés disso? Siga as instruções abaixo para começar no StackBlitz.
 <details>
-<summary>Siga estas instruções, então vá diretamente para a Unidade 2!</summary>
+<summary>Utilizando StackBlitz: Siga estas instruções, então vá diretamente para a Unidade 2!</summary>
 
 **Configure o StackBlitz**
 
 <Steps>
-1. Visite [astro.new](https://astro.new) e clique no botão para abrir o template "Empty Project" no StackBlitz. 
+1. Siga o link externo para [abrir o template "Empty Project" no StackBlitz](https://astro.new/minimal?on=stackblitz). 
 
 2. Clique em "Sign in" no lado superior direito para entrar com suas credenciais do GitHub.
 
@@ -49,7 +54,7 @@ No painel de arquivos, você deve ver `src/pages/index.astro`. Clique para abrí
 
 **Faça Deploy do seu Site**
 
-Se você quiser fazer deploy para a Netlify, pule para [Faça deploy do seu site para a web](/pt-br/tutorial/1-setup/5/).
+Se você quiser fazer deploy para a Netlify e ter uma versão publicada ao vivo do seu site enquanto trabalha, siga em frente na Unidade 1 para [Faça deploy do seu site para a web](/pt-br/tutorial/1-setup/5/).
 Caso contrário, pule para a [Unidade 2](/pt-br/tutorial/2-pages/) para começar a construir com o Astro!
 
 </details>

--- a/src/content/docs/pt-br/tutorial/2-pages/index.mdx
+++ b/src/content/docs/pt-br/tutorial/2-pages/index.mdx
@@ -2,10 +2,15 @@
 type: tutorial
 unitTitle: 'Adicione, estilize e faça links para páginas no seu site'
 title: 'Check in: Unidade 2 - Páginas'
+sidebar:
+  label: 'Unidade 2 - Páginas'
 description: |-
   Tutorial: Construa seu primeiro blog Astro —
   Crie, estilize e faça links para postagens em páginas no seu site
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 2 - Páginas | Docs'
 ---
 import Checklist from '~/components/Checklist.astro';
 

--- a/src/content/docs/pt-br/tutorial/3-components/index.mdx
+++ b/src/content/docs/pt-br/tutorial/3-components/index.mdx
@@ -2,10 +2,15 @@
 type: tutorial
 unitTitle: Construa e projete com componentes de UI Astro
 title: 'Check in: Unidade 3 - Componentes'
+sidebar:
+  label: 'Unidade 3 - Componentes'
 description: |-
   Tutorial: Construa seu primeiro blog Astro —
   Construa componentes Astro para reutilizar código entre elementos comuns através do seu website
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 3 - Componentes | Docs'
 ---
 
 import Box from '~/components/tutorial/Box.astro';
@@ -24,7 +29,7 @@ Você irá construir:
 - Um componente de Navegação que apresenta um menu de links para suas páginas 
 - Um componente de Rodapé para incluir no fim de cada página
 - Um componente de Rede Social, usado no rodapé, para links de páginas de perfil
-- Um componente interativo Hamburger para mostrar a Navegação em dispositivos móveis
+- Um componente interativo de Menu para mostrar a Navegação em dispositivos móveis
 
 Durante o caminho, você utilizará CSS e JavaScript para construir um design responsivo que reage a tamanhos de tela e a interação do usuário.
 

--- a/src/content/docs/pt-br/tutorial/4-layouts/index.mdx
+++ b/src/content/docs/pt-br/tutorial/4-layouts/index.mdx
@@ -2,11 +2,16 @@
 type: tutorial
 unitTitle: Salve tempo e energia com layouts de página reutilizáveis
 title: 'Check in: Unidade 4 - Layouts'
+sidebar:
+  label: 'Unidade 4 - Layouts'
 description: >-
   Tutorial: Construa seu primeiro blog Astro —
   Utilize layouts Astro para compartilhar elementos e estilos comuns entre suas páginas
   e postagens
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 4 - Layouts | Docs'
 ---
 
 import Box from '~/components/tutorial/Box.astro';

--- a/src/content/docs/pt-br/tutorial/5-astro-api/index.mdx
+++ b/src/content/docs/pt-br/tutorial/5-astro-api/index.mdx
@@ -2,11 +2,16 @@
 type: tutorial
 unitTitle: Incremente seu blog
 title: 'Check in: Unidade 5 - API do Astro'
+sidebar:
+  label: 'Unidade 5 - API do Astro'
 description: >-
   Tutorial: Construa seu primeiro blog Astro —
   Buscando e utilizando dados de arquivos do projeto para gerar 
   o conteúdo de páginas e rotas dinamicamente
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 5 - API do Astro | Docs'
 ---
 
 import Box from '~/components/tutorial/Box.astro';
@@ -21,7 +26,7 @@ Agora que você tem algumas postagens do blog, é hora de usar a API do Astro pa
 Nesta unidade, você irá incrementar o seu blog com uma página de índice, uma página de tags e um feed RSS. 
 
 Durante o caminho, você irá aprender como utilizar:
-- `Astro.glob()` para acessar dados de arquivos no seu projeto
+- `import.meta.glob()` para acessar dados de arquivos no seu projeto
 - `getStaticPaths()` para criar múltiplas páginas (rotas) de uma vez
 - O pacote Astro RSS para criar um feed RSS
 

--- a/src/content/docs/pt-br/tutorial/6-islands/index.mdx
+++ b/src/content/docs/pt-br/tutorial/6-islands/index.mdx
@@ -2,10 +2,15 @@
 type: tutorial
 unitTitle: Ice as velas para as Ilhas Astro
 title: 'Check in: Unidade 6 - Ilhas Astro'
+sidebar:
+  label: 'Unidade 6 - Ilhas Astro'
 description: |-
   Tutorial: Construa seu primeiro blog Astro —
   Utilize ilhas Astro para trazer componentes de frameworks frontend para seu site Astro
 i18nReady: true
+head:
+  - tag: title
+    content: 'Tutorial de blog: Unidade 6 - Ilhas Astro | Docs'
 ---
 
 import Box from '~/components/tutorial/Box.astro';
@@ -29,7 +34,7 @@ Você irá:
 
 ## Checklist
 
-<Checklist key="interactivity">
+<Checklist>
 - [ ] Eu estou pronto para adicionar interatividade ao meu site, e começar a viver essa vida em uma ilha!
 </Checklist>
 </Box>


### PR DESCRIPTION
Brings the 7 pt-br tutorial unit index pages (units 0–6) up-to-date with the English source.

  ## Changes

  - Add `sidebar.label` and `head.title` frontmatter to all 7 unit index pages.
  - Sync minor content drift with English:
    - Units 0 & 1: StackBlitz wording / tip block
    - Unit 3: "Hamburger" → "Menu"
    - Unit 5: `Astro.glob()` → `import.meta.glob()`
    - Unit 6: `<Checklist>` without `key`