### PR TITLE
fix: add missing `fallbackType` option in i18n `middleware()`

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -212,9 +212,9 @@ export const onRequest = defineMiddleware(async (ctx, next) => {
 
 #### middleware function
 
-The [`middleware`](/en/reference/modules/astro-i18n/#middleware) function manually creates Astro's i18n middleware. This allows you to extend Astro's i18n routing instead of completely replacing it. 
+The [`middleware()`](/en/reference/modules/astro-i18n/#middleware) function manually creates Astro's i18n middleware. This allows you to extend Astro's i18n routing instead of completely replacing it. 
 
-You can run `middleware` with [routing options](#routing) in combination with your own middleware, using the [`sequence`](/en/reference/modules/astro-middleware/#sequence) utility to determine the order:
+You can run `middleware()` with [routing options](#routing) in combination with your own middleware, using the [`sequence()`](/en/reference/modules/astro-middleware/#sequence) utility to determine the order:
 
 ```js title="src/middleware.js"
 import { defineMiddleware, sequence } from "astro:middleware";

--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -212,35 +212,35 @@ export const onRequest = defineMiddleware(async (ctx, next) => {
 
 #### middleware function
 
-The [`middleware`](#middleware-function) function manually creates Astro's i18n middleware. This allows you to extend Astro's i18n routing instead of completely replacing it. 
+The [`middleware`](/en/reference/modules/astro-i18n/#middleware) function manually creates Astro's i18n middleware. This allows you to extend Astro's i18n routing instead of completely replacing it. 
 
 You can run `middleware` with [routing options](#routing) in combination with your own middleware, using the [`sequence`](/en/reference/modules/astro-middleware/#sequence) utility to determine the order:
 
 ```js title="src/middleware.js"
-import {defineMiddleware, sequence} from "astro:middleware";
+import { defineMiddleware, sequence } from "astro:middleware";
 import { middleware } from "astro:i18n"; // Astro's own i18n routing config
 
 export const userMiddleware = defineMiddleware(async (ctx, next) => {
   // this response might come from Astro's i18n middleware, and it might return a 404
   const response = await next();
   // the /about page is an exception and we want to render it
-  if (ctx.url.startsWith("/about")) {
+  if (ctx.url.pathname.startsWith("/about")) {
     return new Response("About page", {
-      status: 200
+      status: 200,
     });
   } else {
     return response;
   }
 });
 
-
 export const onRequest = sequence(
   userMiddleware,
   middleware({
     redirectToDefaultLocale: false,
-    prefixDefaultLocale: true
-  })
-)
+    prefixDefaultLocale: true,
+    fallbackType: "redirect",
+  }),
+);
 ```
 
 ## `domains`

--- a/src/content/docs/en/reference/modules/astro-i18n.mdx
+++ b/src/content/docs/en/reference/modules/astro-i18n.mdx
@@ -285,7 +285,7 @@ export const onRequest = defineMiddleware((context, next) => {
 
 <p>
 
-**Type:** `(options: { prefixDefaultLocale: boolean, redirectToDefaultLocale: boolean }) => MiddlewareHandler`<br />
+**Type:** `(options: { fallbackType: "redirect" | "rewrite", prefixDefaultLocale: boolean, redirectToDefaultLocale: boolean }) => MiddlewareHandler`<br />
 <Since v="4.6.0" />
 </p>
 
@@ -310,10 +310,14 @@ const customLogic = defineMiddleware(async (context, next) => {
   return response;
 });
 
-export const onRequest = sequence(customLogic, middleware({
-	prefixDefaultLocale: true,
-	redirectToDefaultLocale: false
-}))
+export const onRequest = sequence(
+  customLogic,
+  middleware({
+    prefixDefaultLocale: true,
+    redirectToDefaultLocale: false,
+    fallbackType: "redirect",
+  }),
+);
 ```
 
 ### `requestHasLocale()`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The `middleware()` helper imported from `astro:i18n` [requires `fallbackType`](https://github.com/withastro/astro/blob/c0f33eda8adf6f8f2588688f6205b76a96a42466/packages/astro/src/virtual-modules/i18n.ts#L346-L357). Before Florian's fix in https://github.com/withastro/astro/pull/14890, the type used the `i18n.routing` nested properties directly. So, it seems this was introduced at the same time as the [`i18n.routing.fallbackType`](https://docs.astro.build/en/reference/configuration-reference/#i18nroutingfallbacktype) config option and we forgot to update the docs.

In addition to the missing `fallbackType` option, this:
* Fixes a code snippet in the i18n guide (`ctx.url` is a `URL`; `startsWith()` can't work)
* Formats two code snippets
* Fixes a self-referencing link

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: improve or update docs

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
