### PR TITLE
Fix TypeScript errors in "Build your UI" code snippets

### DIFF
--- a/src/content/docs/en/guides/client-side-scripts.mdx
+++ b/src/content/docs/en/guides/client-side-scripts.mdx
@@ -139,24 +139,26 @@ In this example, we define a new `<astro-heart>` HTML element that tracks how ma
 </astro-heart>
 
 <script>
-  // Define the behaviour for our new type of HTML element.
+  // Define the behavior for our new type of HTML element.
   class AstroHeart extends HTMLElement {
     connectedCallback() {
       let count = 0;
 
-      const heartButton = this.querySelector('button');
-      const countSpan = this.querySelector('span');
+      const heartButton = this.querySelector("button");
+      const countSpan = this.querySelector("span");
 
       // Each time the button is clicked, update the count.
-			heartButton.addEventListener('click', () => {
-        count++;
-        countSpan.textContent = count.toString();
-      });
-		}
+      if (heartButton && countSpan) {
+        heartButton.addEventListener("click", () => {
+          count++;
+          countSpan.textContent = count.toString();
+        });
+      }
+    }
   }
 
   // Tell the browser to use our AstroHeart class for <astro-heart> elements.
-  customElements.define('astro-heart', AstroHeart);
+  customElements.define("astro-heart", AstroHeart);
 </script>
 ```
 

--- a/src/content/docs/en/guides/client-side-scripts.mdx
+++ b/src/content/docs/en/guides/client-side-scripts.mdx
@@ -195,10 +195,10 @@ const { message = 'Welcome, world!' } = Astro.props;
       // Read the message from the data attribute.
       const message = this.dataset.message;
       const button = this.querySelector('button');
-      button.addEventListener('click', () => {
+      button?.addEventListener('click', () => {
         alert(message);
       });
-		}
+    }
   }
 
   customElements.define('astro-greet', AstroGreet);

--- a/src/content/docs/en/guides/fonts.mdx
+++ b/src/content/docs/en/guides/fonts.mdx
@@ -319,7 +319,7 @@ export const GET: APIRoute = async (context) => {
     },
   );
 
-  const pngBuffer = await sharp(Buffer.from(svg))
+  const pngBuffer = await sharp(Buffer.from(svg)) // requires `@types/node` in your dependencies for type safety
     .resize(600, 400)
     .png()
     .toBuffer();


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of #14089. TL;DR: prevent red squiggles in our code snippets to improve UX.

Fixes code snippets in "Build your UI":
* `client-side-scripts.mdx`:
  * `querySelector` may return `null`
  * fix spelling for consistency
  * formatting, this is what I get in a new project (see #14089 for the reasoning)
* `fonts.mdx`:
  * TS complains about `Buffer` and, unlike `process.env`, there is not clues in the editor, so a comment might be helpful

To help review and explain my changes I made a commit per code snippet (with a few exceptions where the changes were the same), with a short explanation of why in the commit message.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
