### PR TITLE
Fix TypeScript errors in "Server rendering" code snippets

### DIFF
--- a/src/content/docs/en/guides/actions.mdx
+++ b/src/content/docs/en/guides/actions.mdx
@@ -733,20 +733,20 @@ Use the [`getActionContext()` function](/en/reference/modules/astro-actions/#get
 The following example rejects all action requests that do not have a valid session token. If the check fails, a "Forbidden" response is returned. Note: this method ensures that actions are only accessible when a session is present, but is _not_ a substitute for secure authorization.
 
 ```ts title="src/middleware.ts"
-import { defineMiddleware } from 'astro:middleware';
-import { getActionContext } from 'astro:actions';
+import { defineMiddleware } from "astro:middleware";
+import { getActionContext } from "astro:actions";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { action } = getActionContext(context);
   // Check if the action was called from a client-side function
-  if (action?.calledFrom === 'rpc') {
+  if (action?.calledFrom === "rpc") {
     // If so, check for a user session token
-    if (!context.cookies.has('user-session')) {
-      return new Response('Forbidden', { status: 403 });
+    if (!context.cookies.has("user-session")) {
+      return new Response("Forbidden", { status: 403 });
     }
   }
-  
-  context.cookies.set('user-session', /* session token */);
+
+  context.cookies.set("user-session", "session-token-value");
   return next();
 });
 ```

--- a/src/content/docs/en/guides/on-demand-rendering.mdx
+++ b/src/content/docs/en/guides/on-demand-rendering.mdx
@@ -73,7 +73,7 @@ This content will be server-rendered on demand!
 Just add an adapter integration for a server runtime!
 All other pages are statically-generated at build time!
 -->
-<html>
+</html>
 ```
 
 The following example shows opting out of prerendering in order to display a random number each time the endpoint is hit:
@@ -106,7 +106,7 @@ export const prerender = true
 `output: 'server'` is configured, but this page is static!
 The rest of my site is rendered on demand!
 -->
-<html>
+</html>
 ```
 
 Add `export const prerender = true` to any page or route to prerender a static page or endpoint:

--- a/src/content/docs/en/guides/server-islands.mdx
+++ b/src/content/docs/en/guides/server-islands.mdx
@@ -98,9 +98,14 @@ To access information from the page's URL, you can check the [Referer](https://d
 
 ```astro
 ---
-const referer = Astro.request.headers.get('Referer');
+const referer = Astro.request.headers.get("Referer");
+
+if (!referer) {
+  throw new Error("Referer header is missing");
+}
+
 const url = new URL(referer);
-const productId = url.searchParams.get('product');
+const productId = url.searchParams.get("product");
 ---
 ```
 

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -140,9 +140,11 @@ const cart = await Astro.session?.get('cart');
 In API endpoints, the session object is available on the `context` object. For example, to add an item to a shopping cart:
 
 ```ts title="src/pages/api/addToCart.ts" "context.session"
+import type { APIContext } from "astro";
+
 export async function POST(context: APIContext) {
   const cart = await context.session?.get('cart') || [];
-	const data = await context.request.json<{ item: string }>();
+  const data = await context.request.json();
   if(!data?.item) {
     return new Response('Item is required', { status: 400 });
   }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: prevent red squiggles in our code snippets to improve UX.

Fixes code snippets in "Server rendering" pages:
* `sessions.mdx`:
  * missing import
  * type parameter on `context.request.json` doesn't seem valid
* `actions.mdx`:
  * the second argument on `context.cookies.set()` is required, using a comment there is a bit unclear (maybe it's a me thing)
* `server-islands.mdx`:
  * `Astro.request.headers.get` can return `null`
* `on-demand-rendering.mdx`:
  * fix closing tags
  
For the formatting see #14089 for the reasoning.
  

To help review and explain my changes I made a commit per code snippet (with a few exceptions where the changes were the same), with a short explanation of why in the commit message.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
