### PR TITLE
i18n(pt-br): fix broken link

### DIFF
--- a/src/content/docs/pt-br/recipes/reading-time.mdx
+++ b/src/content/docs/pt-br/recipes/reading-time.mdx
@@ -102,7 +102,7 @@ Crie um [plugin remark](https://github.com/remarkjs/remark) que adiciona uma pro
     </html>
     ```
 
-    Se você está usando um [layout Markdown](/pt-br/basics/layouts/#markdown-layouts), use a propriedade de frontmatter `minutesRead` de `Astro.props` no template do seu layout.
+    Se você está usando um [layout Markdown](/pt-br/basics/layouts/#layouts-markdown), use a propriedade de frontmatter `minutesRead` de `Astro.props` no template do seu layout.
 
     ```astro title="src/layouts/BlogLayout.astro" "const { minutesRead } = Astro.props.frontmatter;" "<p>{minutesRead}</p>"
     ---


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes a broken link in a pt-br translation, introduced by #14088. ([ci is failing on main](https://github.com/withastro/docs/commits/main/)) This is weird because "Check links" is green on that PR...

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
