### PR TITLE
docs: clarify response headers in on-demand rendering

### DIFF
--- a/src/content/docs/en/guides/on-demand-rendering.mdx
+++ b/src/content/docs/en/guides/on-demand-rendering.mdx
@@ -141,7 +141,9 @@ With HTML streaming, a document is broken up into chunks, sent over the network 
 <RecipeLinks slugs={["en/recipes/streaming-improve-page-performance"]}/>
 
 :::caution
-Features that modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) are only available at the **page level**. (You can't use them inside of components, including layout components.) By the time Astro runs your component code, it has already sent the Response headers and they cannot be modified.
+For the most predictable behavior, set [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) in your page code.
+
+Statically prerendered routes do not have a per-request response to modify. During on-demand rendering, layouts and components can still update `Astro.response.headers` before the response is sent, so they are not limited to the page level.
 
 :::
 


### PR DESCRIPTION
#### Description (required)

Closes #11843

Clarifies the HTML streaming warning in the on-demand rendering guide so it no longer says response-header changes are only available at the page level.

The updated wording keeps page-level changes as the recommendation, but distinguishes statically prerendered routes from on-demand rendering, where layouts and components can still update `Astro.response.headers` before the response is sent.

Verification:
- reproduced the issue report locally with the linked repro project
- confirmed `Astro.response.headers` set in a layout and component are present in the response for an on-demand route

#### Related issues & labels (optional)

- Closes #11843
- Suggested label: improve or update documentation
