### PR TITLE
docs: clarify Cloudflare env API wording

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -265,7 +265,7 @@ const myKVNamespace = env.MY_KV;
 ---
 ```
 
-They are also compatible with the [`astro:env` API](/en/guides/environment-variables/#type-safe-environment-variables):
+The `cloudflare:workers` and [`astro:env`](/en/guides/environment-variables/#type-safe-environment-variables) APIs are separate. If you prefer Astro's type-safe API for environment variables, you can access supported values with `astro:env`:
 
 ```js
 import { MY_VARIABLE } from 'astro:env/server';


### PR DESCRIPTION
Addresses withastro/docs#13897.

## Summary

- clarify that `cloudflare:workers` and `astro:env` are separate APIs
- keep the existing `astro:env` example, but make the wording less misleading

## Testing

- docs change only
