### PR TITLE
docs: clarify 500 page error handling

### DIFF
--- a/src/content/docs/en/basics/astro-pages.mdx
+++ b/src/content/docs/en/basics/astro-pages.mdx
@@ -115,7 +115,7 @@ During development, if you have a `500.astro`, the error thrown at runtime is lo
 
 <p><Since v="4.11.0" /></p>
 
-`src/pages/500.astro` is a special page that is automatically passed an `error` prop for any error thrown during rendering. This allows you to use the details of an error (e.g. from a page, from middleware, etc.) to display information to your visitor.
+`src/pages/500.astro` is a special page that is automatically passed an `error` prop for errors thrown before the response body starts streaming. This allows you to use the details of an error (for example from a page or middleware) to display information to your visitor. Errors thrown later while rendering a streamed response cannot be turned into a `500.astro` page.
 
 The `error` prop's data type can be anything, which may affect how you type or use the value in your code:
 


### PR DESCRIPTION
Addresses withastro/docs#12172.

## Summary

- clarify that `500.astro` receives the `error` prop only for errors thrown before the response body starts streaming
- note that later streaming-time errors cannot be converted into a `500.astro` page

## Testing

- docs change only
