### PR TITLE
docs: narrow vercel edge middleware wording

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/vercel.mdx
+++ b/src/content/docs/en/guides/integrations-guide/vercel.mdx
@@ -442,7 +442,7 @@ export default defineConfig({
 
 ### Running Astro middleware on Vercel Edge Functions
 
-The `@astrojs/vercel` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When [`middlewareMode`](/en/reference/adapter-reference/#middlewaremode) is set to `'edge'`, an edge function will execute your middleware code for all requests, including static assets, prerendered pages, and on-demand rendered pages.
+The `@astrojs/vercel` adapter can create an [edge function](https://vercel.com/docs/functions/edge-functions) from an Astro middleware in your code base. When [`middlewareMode`](/en/reference/adapter-reference/#middlewaremode) is set to `'edge'`, an edge function will execute your middleware code for requests handled by the edge runtime, including on-demand rendered pages.
 
 For on-demand rendered pages, the `context.locals` object is serialized using JSON and sent in a header for the serverless function, which performs the rendering. As a security measure, the serverless function will refuse to serve requests with a `403 Forbidden` response unless they come from the generated edge function.
 


### PR DESCRIPTION
Addresses withastro/docs#11950.

## Summary

- narrow the Vercel edge middleware wording so it only claims requests handled by the edge runtime
- keep the note focused on on-demand rendered pages

## Testing

- docs change only
