### PR TITLE
Archive v6 docs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,16 +11,9 @@ import { starlightPluginSmokeTest } from './config/plugins/smoke-test';
 import { rehypeTasklistEnhancer } from './config/plugins/rehype-tasklist-enhancer';
 import { remarkFallbackLang } from './config/plugins/remark-fallback-lang';
 
-const previewBranch = process.env.GITHUB_HEAD_REF;
-const previewSite = previewBranch
-	? `https://${previewBranch}.previews.docs.astro.build/`
-	: undefined;
-
-const site = previewSite || 'https://v6.docs.astro.build/';
-
 // https://astro.build/config
 export default defineConfig({
-	site,
+	site: 'https://docs.astro.build/',
 	integrations: [
 		devServerFileWatcher([
 			'./config/**', // Custom plugins and integrations

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
 			expressiveCode: {
 				plugins: [pluginCollapsibleSections()],
 			},
+			customCss: ['./src/styles/custom.css'],
 			components: {
 				EditLink: './src/components/starlight/EditLink.astro',
 				Hero: './src/components/starlight/Hero.astro',

--- a/scripts/lint-linkcheck.ts
+++ b/scripts/lint-linkcheck.ts
@@ -65,7 +65,7 @@ class LinkChecker {
 
 // Use our class to check for link issues
 const linkChecker = new LinkChecker({
-	baseUrl: 'https://docs.astro.build',
+	baseUrl: 'https://v6.docs.astro.build',
 	buildOutputDir: './dist',
 	pageSourceDir: './src/content/docs',
 	checks: [

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,6 +7,11 @@ import { AstroDocsI18nSchema } from './content/i18n-schema';
 import { logoKeys } from './data/logos';
 
 export const baseSchema = z.object({
+	// ADD A SITE-WIDE BANNER TO SHOW THESE ARE OLD DOCS.
+	banner: z.object({ content: z.string() }).default({
+		content:
+			'This is an unmaintained snapshot of the Astro v6 docs. <a href="https://docs.astro.build/">View the latest docs.</a>',
+	}),
 	type: z.literal('base').optional().default('base'),
 	i18nReady: z.boolean().default(false),
 	githubURL: z.url().optional(),

--- a/src/content/docs/ar/getting-started.mdx
+++ b/src/content/docs/ar/getting-started.mdx
@@ -5,9 +5,6 @@ i18nReady: true
 tableOfContents: false
 editUrl: false
 next: false
-banner:
-  content: |
-     الإصدار 6 منAstro وصل! <a href="/ar/guides/upgrade-to/v6/">تعرف على كيفية ترقية موقعك</a>
 hero:
   title: وثائق Astro
   tagline: إرشادات وموارد ومراجع API لمساعدتك في البناء باستخدام Astro.

--- a/src/content/docs/es/getting-started.mdx
+++ b/src/content/docs/es/getting-started.mdx
@@ -5,9 +5,6 @@ i18nReady: true
 tableOfContents: false
 editUrl: false
 next: false
-banner:
-  content: |
-    ¡Astro v6 está aquí! <a href="/es/guides/upgrade-to/v6/">Aprende a actualizar tu sitio</a>
 hero:
   title: Docs de Astro
   tagline: Guías, recursos y referencias de API para ayudarte a construir con Astro.

--- a/src/content/docs/es/upgrade-astro.mdx
+++ b/src/content/docs/es/upgrade-astro.mdx
@@ -2,9 +2,6 @@
 title: Actualizando Astro
 description: Conoce cómo actualizar Astro 
 i18nReady: true
-banner:
-  content: | 
-    ¡Ya está aquí Astro v5! <a href="/es/guides/upgrade-to/v5/">Aprenda a actualizar su sitio web</a>
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
 import Version from '~/components/Version.astro';

--- a/src/content/docs/hi/getting-started.mdx
+++ b/src/content/docs/hi/getting-started.mdx
@@ -5,9 +5,6 @@ i18nReady: true
 tableOfContents: false
 editUrl: false
 next: false
-banner:
-  content: |
-    Astro v6 आ गया है! <a href="/hi/guides/upgrade-to/v6/">अपनी साइट को उन्नत करना सीखें</a>
 hero:
   title: Astro दस्तावेज़
   tagline: Astro के साथ निर्माण में आपकी सहायता के लिए मार्गदर्शिकाएँ, संसाधन और API संदर्भ।

--- a/src/content/docs/zh-cn/getting-started.mdx
+++ b/src/content/docs/zh-cn/getting-started.mdx
@@ -5,9 +5,6 @@ i18nReady: true
 tableOfContents: false
 editUrl: false
 next: false
-banner:
-  content: |
-    Astro v6 已发布！<a href="/zh-cn/guides/upgrade-to/v6/">了解如何升级你的网站</a>
 hero:
   title: Astro 文档
   tagline: 指南、资源和 API 参考，帮助你使用 Astro 进行构建。

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,0 +1,4 @@
+:root {
+	--sl-color-banner-bg: var(--sl-color-orange);
+	--sl-color-banner-text: #000;
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the v6 branch used to archive the v6 docs with changes equivalent to our v5 archive: https://github.com/withastro/docs/pull/13369
* Removes outdated v5/v6 banner in translations
* Displays a warning banner on every page linking to the latest docs
* Uses `docs.astro.build` as the canonical site value to avoid this version showing up in search results
* Updates the link checker config to use `v6.docs.astro.build` as base URL

I don't know if I've forgotten anything related to the migration to Cloudflare.

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
