### PR TITLE
fix: replace v7 link in the upgrade guide aside

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v7.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v7.mdx
@@ -15,7 +15,7 @@ Copy this prompt to upgrade your project:
 
 ```
 Upgrade my Astro project to v7. Follow the migration guide at
-https://v7.docs.astro.build/en/guides/upgrade-to/v7/
+https://docs.astro.build/en/guides/upgrade-to/v7/
 ```
 :::
 

--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -1250,7 +1250,7 @@ export default defineConfig({
 });
 ```
 
-Learn more about customizing the request pipeline in the [advanced routing guide](https://v7.docs.astro.build/en/guides/routing/#advanced-routing).
+Learn more about customizing the request pipeline in the [advanced routing guide](https://docs.astro.build/en/guides/routing/#advanced-routing).
 
 ## Logger Options
 
@@ -1263,7 +1263,7 @@ Learn more about customizing the request pipeline in the [advanced routing guide
 
 Configures how Astro logs messages during development and production.
 
-By default, Astro uses a built-in logger that outputs human-friendly logs to the console. You can customize this behavior by providing [your own logger handler](https://v7.docs.astro.build/en/reference/logger-reference/#custom-loggers) or by using one of the [built-in log handlers](https://v7.docs.astro.build/en/reference/logger-reference/#built-in-loggers):
+By default, Astro uses a built-in logger that outputs human-friendly logs to the console. You can customize this behavior by providing [your own logger handler](https://docs.astro.build/en/reference/logger-reference/#custom-loggers) or by using one of the [built-in log handlers](https://docs.astro.build/en/reference/logger-reference/#built-in-loggers):
 
 ```js
 // astro.config.mjs
@@ -1274,7 +1274,7 @@ export default defineConfig({
 });
 ```
 
-See [the logger API reference](https://v7.docs.astro.build/en/reference/logger-reference/) for more information.
+See [the logger API reference](https://docs.astro.build/en/reference/logger-reference/) for more information.
 
 ### logger.entrypoint
 
@@ -2766,4 +2766,3 @@ import { memoryCache } from 'astro/config';
   },
 }
 ```
-


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

I forgot we had this now:
<img width="744" height="201" alt="image" src="https://github.com/user-attachments/assets/f33aa0ce-a271-4a01-a461-d8f89f682061" />

This removes `v7.` from that link. I also updated the links in the configuration reference (CI would have done the same when pulling changes made in https://github.com/withastro/astro/pull/17143).

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: quick fix

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
