### PR TITLE
Add build.apiPrefix to configuration-reference

### DIFF
--- a/src/content/docs/en/reference/configuration-reference.mdx
+++ b/src/content/docs/en/reference/configuration-reference.mdx
@@ -1025,6 +1025,32 @@ In this case, a `fallback` property is required and will be used by default for 
 }
 ```
 
+### build.apiPrefix
+
+<p>
+
+**Type:** `string`<br />
+**Default:** `''`<br />
+<Since v="7.0.3" />
+</p>
+
+Specifies the prefix for Astro-generated links to API endpoints. These include:
+
+* actions
+* server islands
+* server endpoints (API routes)
+
+If this value is set then any Astro-generated server-side code will also need to be deployed
+to a server which is proxied by the specified host.
+
+```js
+{
+  build: {
+    apiPrefix: 'https://api.example.com'
+  }
+}
+```
+
 ### build.serverEntry
 
 <p>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- Please describe the change you are proposing, and why -->
This PR adds documentation for a new configuration option `build.apiPrefix` that is added in a PR on the main repo.

<!-- Please make changes in **one language** only -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
For Astro version: `7.0.3`. See astro PR [17121](https://github.com/withastro/astro/pull/17121).

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
Find me on discord: @thxmikezilla
<!-- https://astro.build/chat -->
