### PR TITLE
i18n(fr): update `sessions.mdx`, `server-islands.mdx` & `on-demand-rendering.mdx`

### DIFF
--- a/src/content/docs/fr/guides/on-demand-rendering.mdx
+++ b/src/content/docs/fr/guides/on-demand-rendering.mdx
@@ -73,7 +73,7 @@ Ce contenu sera rendu sur le serveur à la demande !
 Ajoutez simplement une intégration d’adaptateur pour un environnement d’exécution de serveur !
 Toutes les autres pages sont générées statiquement au moment de la compilation !
 -->
-<html>
+</html>
 ```
 
 L'exemple suivant montre comment désactiver le prérendu afin d'afficher un nombre aléatoire à chaque fois que le point de terminaison est atteint :
@@ -106,7 +106,7 @@ export const prerender = true
 `output: 'server'` est configuré, mais cette page est statique !
 Le reste de mon site est rendu à la demande !
 -->
-<html>
+</html>
 ```
 
 Ajoutez `export const prerender = true` à n'importe quelle page ou route pour effectuer le prérendu d'une page statique ou d'un point de terminaison :

--- a/src/content/docs/fr/guides/server-islands.mdx
+++ b/src/content/docs/fr/guides/server-islands.mdx
@@ -98,9 +98,14 @@ Pour accéder aux informations de l'URL de la page, vous pouvez vérifier l'en-t
 
 ```astro
 ---
-const referer = Astro.request.headers.get('Referer');
+const referer = Astro.request.headers.get("Referer");
+
+if (!referer) {
+  throw new Error("L'en-tête Referer est manquant");
+}
+
 const url = new URL(referer);
-const productId = url.searchParams.get('product');
+const productId = url.searchParams.get("produit");
 ---
 ```
 

--- a/src/content/docs/fr/guides/sessions.mdx
+++ b/src/content/docs/fr/guides/sessions.mdx
@@ -140,9 +140,11 @@ const cart = await Astro.session?.get('cart');
 Dans les points de terminaison d'API, l'objet session est disponible dans l'objet `context`. Par exemple, pour ajouter un article à un panier :
 
 ```ts title="src/pages/api/addToCart.ts" "context.session"
+import type { APIContext } from "astro";
+
 export async function POST(context: APIContext) {
   const cart = await context.session?.get('cart') || [];
-	const data = await context.request.json<{ item: string }>();
+  const data = await context.request.json();
   if(!data?.item) {
     return new Response('Un article est obligatoire', { status: 400 });
   }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds changes from #14092 to the French translations of `guides/sessions.mdx`, `guides/server-islands.mdx`, and `guides/on-demand-rendering.mdx`.

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: i18n

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
