### PR TITLE
fix(ci): do not run format and deploys on forks

### DIFF
--- a/.github/workflows/deploy-lunaria.yml
+++ b/.github/workflows/deploy-lunaria.yml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   deploy:
+    if: ${{ github.repository_owner == 'withastro' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   deploy-preview:
     if: >-
+      github.repository_owner == 'withastro' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   deploy:
+    if: ${{ github.repository_owner == 'withastro' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   format:
+    if: ${{ github.repository_owner == 'withastro' }}
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
#### Description

I recently noticed that 3 GitHub actions in my fork of Astro docs are failing when I update my `main` branch with the changes from this `main` branch here. The reason is that the format and deploy workflows, which are triggered on push to `main` do not include any checks to prevent running them, but they expect environment variables/secrets to run successfully.

I therefore propose to add a check so these workflows only run in this repo's `main` branch.

We could also add this check to basically all workflows as far as I am aware, since external PRs will still run under the `withastro` org, so the check doesn't block any workflows from running here.