### PR TITLE
Fix TypeScript errors in `guides/routing.mdx` code snippets

### DIFF
--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -505,8 +505,11 @@ The following example displays current information for the page along with links
 ```astro /(?<=const.*)(page)/ /page\\.[a-zA-Z]+(?:\\.(?:prev|next|first|last))?/
 ---
 // src/pages/astronauts/[page].astro
+import type { GetStaticPaths } from "astro";
+
 // Paginate same list of `{ astronaut }` objects as the previous example
-export function getStaticPaths({ paginate }) { /* ... */ }
+export const getStaticPaths = (({ paginate }) => { /* ... */}) satisfies GetStaticPaths;
+
 const { page } = Astro.props;
 ---
 <h1>Page {page.currentPage}</h1>

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -431,23 +431,26 @@ Paginated route names should use the same `[bracket]` syntax as a standard dynam
 
 You can use the `paginate()` function to generate these pages for an array of values like so:
 
-```astro /{ (paginate) }/ /paginate\\(.*\\);/ /(?<=const.*)(page)/ /page\\.[a-zA-Z]+/
+```astro title="src/pages/astronauts/[page].astro" /{ (paginate) }/ /paginate\\(.*\\);/ /(?<=const.*)(page)/ /page\\.[a-zA-Z]+/
 ---
-// src/pages/astronauts/[page].astro
-export function getStaticPaths({ paginate }) {
+import type { GetStaticPaths } from "astro";
+
+export const getStaticPaths = (({ paginate }) => {
   const astronautPages = [
     { astronaut: "Neil Armstrong" },
     { astronaut: "Buzz Aldrin" },
     { astronaut: "Sally Ride" },
     { astronaut: "John Glenn" },
   ];
-  
+
   // Generate pages from our array of astronauts, with 2 to a page
   return paginate(astronautPages, { pageSize: 2 });
-}
+}) satisfies GetStaticPaths;
+
 // All paginated data is passed on the "page" prop
 const { page } = Astro.props;
 ---
+
 <!-- Display the current page number. `Astro.params.page` can also be used! -->
 <h1>Page {page.currentPage}</h1>
 <ul>

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -539,26 +539,32 @@ Nested pagination works by returning an array of `paginate()` results from `getS
 
 In the following example, we will implement nested pagination to build the URLs listed above:
 
-```astro /(?:[(]|=== )(tag)/ "params: { tag }," /const [{ ]*(page|params)/
+```astro title="src/pages/[tag]/[page].astro" /(?:[(]|=== )(tag)/ "params: { tag }," /const [{ ]*(page|params)/
 ---
-// src/pages/[tag]/[page].astro
-export function getStaticPaths({ paginate }) {
+import type { GetStaticPaths } from "astro";
+
+export const getStaticPaths = (({ paginate }) => {
   const allTags = ["red", "blue", "green"];
-  const allPosts = Object.values(import.meta.glob("../pages/post/*.md", { eager: true }));
+  const allPosts = Object.values(
+    import.meta.glob("../pages/post/*.md", { eager: true }),
+  );
   // For every tag, return a `paginate()` result.
   // Make sure that you pass `{ params: { tag }}` to `paginate()`
   // so that Astro knows which tag grouping the result is for.
   return allTags.flatMap((tag) => {
-    const filteredPosts = allPosts.filter((post) => post.frontmatter.tag === tag);
+    const filteredPosts = allPosts.filter(
+      (post: any) => post.frontmatter.tag === tag,
+    );
     return paginate(filteredPosts, {
       params: { tag },
-      pageSize: 10
+      pageSize: 10,
     });
   });
-}
+}) satisfies GetStaticPaths;
 
 const { page } = Astro.props;
 const params = Astro.params;
+---
 ```
 
 ## Excluding pages


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes the code snippet.

Fixes code snippets in `guides/routing.mdx`:
- TypeScript complains about `page` without `satisfies GetStaticPaths`
- because `function getStaticPaths` has been updated to `const getStaticPaths` above, the following code snippet should use the same syntax
- missing closing fence
- TS complains about `post.frontmatter.tag`, we need `post: any`
- a few formatting changes

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
