### PR TITLE
Fix TypeScript errors in `endpoints.mdx` code snippets

### DIFF
--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -231,10 +231,11 @@ export const POST = (async ({ request }) => {
 
 The endpoint context exports a `redirect()` utility similar to `Astro.redirect`:
 
-```js title="src/pages/links/[id].js" {14}
+```js title="src/pages/links/[id].js" {15}
+import type { APIRoute } from "astro";
 import { getLinkUrl } from "../db";
 
-export async function GET({ params, redirect }) {
+export const GET = (async ({ params, redirect }) => {
   const { id } = params;
   const link = await getLinkUrl(id);
 
@@ -246,5 +247,5 @@ export async function GET({ params, redirect }) {
   }
 
   return redirect(link, 307);
-}
+}) satisfies APIRoute;
 ```

--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -59,7 +59,7 @@ import type { APIRoute } from "astro";
 const usernames = ["Sarah", "Chris", "Yan", "Elian"];
 
 export const GET = (({ params, request }) => {
-  const id = params.id;
+  const id = Number(params.id);
   
   return new Response(
     JSON.stringify({

--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -162,6 +162,8 @@ In addition to the `GET` function, you can export a function with the name of an
 You can also export an `ALL` function to match any method that doesn't have a corresponding exported function. If there is a request with no matching method, it will redirect to your site's [404 page](/en/basics/astro-pages/#custom-404-error-page).
 
 ```ts title="src/pages/methods.json.ts"
+import type { APIRoute } from "astro";
+
 export const GET = (({ params, request }) => {
   return new Response(
     JSON.stringify({
@@ -204,6 +206,8 @@ If you define a `GET` function but no `HEAD` function, Astro will automatically 
 In SSR mode, the `request` property returns a fully usable [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object that refers to the current request. This allows you to accept data and check headers:
 
 ```ts title="src/pages/test-post.json.ts"
+import type { APIRoute } from "astro";
+
 export const POST = (async ({ request }) => {
   if (request.headers.get("Content-Type") === "application/json") {
     const body = await request.json();

--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -113,9 +113,10 @@ Be sure to [enable an on-demand rendering mode](/en/guides/on-demand-rendering/)
 Server endpoints can access `params` without exporting `getStaticPaths`, and they can return a `Response` object, allowing you to set status codes and headers:
 
 ```js title="src/pages/[id].json.js"
+import type { APIRoute } from "astro";
 import { getProduct } from "../db";
 
-export async function GET({ params }) {
+export const GET = (async ({ params }) => {
   const id = params.id;
   const product = await getProduct(id);
 
@@ -132,7 +133,7 @@ export async function GET({ params }) {
       "Content-Type": "application/json",
     },
   });
-}
+}) satisfies APIRoute;
 ```
 
 This will respond to any request that matches the dynamic route. For example, if we navigate to `/helmet.json`, `params.id` will be set to `helmet`. If `helmet` exists in the mock product database, the endpoint will use a `Response` object to respond with JSON and return a successful [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/API/Response/status). If not, it will use a `Response` object to respond with a `404`.

--- a/src/content/docs/en/guides/endpoints.mdx
+++ b/src/content/docs/en/guides/endpoints.mdx
@@ -141,16 +141,18 @@ This will respond to any request that matches the dynamic route. For example, if
 In SSR mode, certain providers require the `Content-Type` header to return an image. In this case, use a `Response` object to specify a `headers` property. For example, to produce a binary `.png` image:
 
 ```ts title="src/pages/astro-logo.png.ts"
-export async function GET({ params, request }) {
+import type { APIRoute } from "astro";
+
+export const GET = (async ({ params, request }) => {
   const response = await fetch(
     "https://docs.astro.build/assets/full-logo-light.png",
   );
-  const buffer = Buffer.from(await response.arrayBuffer());
-  
+  const buffer = Buffer.from(await response.arrayBuffer()); // requires `@types/node` in your dependencies for type safety
+
   return new Response(buffer, {
     headers: { "Content-Type": "image/png" },
   });
-}
+}) satisfies APIRoute;
 ```
 
 ### HTTP methods


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes the code snippet.

Fixes code snippets in `guides/endpoints.mdx`:
  * `params.id` is `string | undefined` and `undefined` "cannot be used as an index type". If we narrow the type to `string` (using `APIRoute` type parameters), TypeScript complains because a string can't be used for index access... `Number()` might not be the best (`NaN`) but it's the easier fix to make it TS friendly.
  * without `satisfies APIRoute`, TypeScript complains about the destructured properties.
  * TypeScript complains about `Buffer` and, unlike `process.env`, there is no clues in the editor to fix this, adding a comment might be helpful
  * missing import

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
