### PR TITLE
Fix TypeScript errors in `view-transitions.mdx` code snippets

### DIFF
--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -44,9 +44,13 @@ Import and add the `<ClientRouter />` component to your common `<head>` or share
 
 The example below shows adding Astro's default page navigation animations site-wide, including the default fallback control option for non-supporting browsers, by importing and adding this component to a `<CommonHead />` Astro component:
 
-```astro title="src/components/CommonHead.astro" ins={2,12}
+```astro title="src/components/CommonHead.astro" ins={2,16}
 ---
 import { ClientRouter } from "astro:transitions";
+
+type Props = { title: string; description: string };
+
+const { title, description } = Astro.props;
 ---
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -724,7 +724,7 @@ The following example demonstrates how to use these functions to recreate Astro'
   document.addEventListener("astro:before-swap", (event) => {
     event.swap = () => mySwap(event.newDocument);
   });
-<script>
+</script>
 ```
 
 Custom swap implementations can start with this template and add or replace individual steps with custom logic as needed.

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -740,10 +740,12 @@ This is the latest point in the lifecycle where it is still safe to, for example
 The `astro:after-swap` event occurs immediately after the browser history has been updated and the scroll position has been set. 
 Therefore, one use of targeting this event is to override the default scroll restore for history navigation. The following example resets the horizontal and vertical scroll position to the top left corner of the page for each navigation.
 
-```js
-document.addEventListener("astro:after-swap", () =>
-  window.scrollTo({ left: 0, top: 0, behavior: "instant" }),
-);
+```astro
+<script>
+  document.addEventListener("astro:after-swap", () =>
+    window.scrollTo({ left: 0, top: 0, behavior: "instant" }),
+  );
+</script>
 ```
 
 ### `astro:page-load`

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -332,11 +332,16 @@ The following example shows an Astro component that navigates a visitor to anoth
 <script>
   import { navigate } from "astro:transitions/client";
 
+  const select = document.querySelector("select");
   // Navigate to the selected option automatically.
-  document.querySelector("select").onchange = (event) => {
-    let href = event.target.value;
-    navigate(href);
-  };
+  if (select) {
+    select.onchange = (event) => {
+      if (event.target instanceof HTMLSelectElement) {
+        let href = event.target.value;
+        navigate(href);
+      }
+    };
+  }
 </script>
 <select>
   <option value="/play">Play</option>

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -758,6 +758,8 @@ You can use this event to run code on every page navigation, for example to set 
 
 ```astro
 <script>
+  import { setupStuff } from "../utils.ts";
+
   document.addEventListener("astro:page-load", () => {
     // This runs on first page load and after every navigation.
     setupStuff(); // e.g. add event listeners

--- a/src/content/docs/en/guides/view-transitions.mdx
+++ b/src/content/docs/en/guides/view-transitions.mdx
@@ -462,7 +462,7 @@ One way to implement this safely is to ensure only a set of known paths can be r
   const redirect = params.get('redirect');
   const allowedPaths = ['/home', '/about', '/contact'];
 
-  if (allowedPaths.includes(redirect)) {
+  if (redirect && allowedPaths.includes(redirect)) {
     navigate(redirect);
   }
 </script>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)


Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes the code snippet.

Fixes code snippets in `guides/view-transitions.mdx`:
  * add missing `Astro.props`
  * `querySelector` can return `null`
  * `event.target.value` is not available without narrowing the type
  * `redirect` can be null when using `params.get`
  * unclosed `<script />` tag
  * consistency: other snippets are wrapped in script tags
  * `setupStuff()` comes from nowhere, a fake import can be helpful

I haven't updated a few code snippets in `view-transitions.mdx` as I'm not really familiar with the API but:
* https://docs.astro.build/en/guides/view-transitions/#fallback-control a transition on `<title>` seems weird to me
* https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap the second code snippet uses `diff()` in an `is:inline` script... not sure this is clear to everyone where `diff()` comes from.

#### Related issues & labels (optional)

- Suggested label: code snippet update

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `6.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="6.x.x" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->
