### PR TITLE
chore: remove redundant twitter metadata tags

### DIFF
--- a/src/content/docs/en/guides/media/cloudinary.mdx
+++ b/src/content/docs/en/guides/media/cloudinary.mdx
@@ -155,9 +155,7 @@ const ogImageUrl = getCldOgImageUrl({ src: '<Public ID>' });
 <meta property="og:image:secure_url" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="twitter:title" content="<Twitter Title>" />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content={ogImageUrl} />
 ```
 
 

--- a/src/content/docs/es/guides/media/cloudinary.mdx
+++ b/src/content/docs/es/guides/media/cloudinary.mdx
@@ -155,9 +155,7 @@ const ogImageUrl = getCldOgImageUrl({ src: '<ID Público>' });
 <meta property="og:image:secure_url" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="twitter:title" content="<Título de Twitter>" />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content={ogImageUrl} />
 ```
 
 

--- a/src/content/docs/fr/guides/media/cloudinary.mdx
+++ b/src/content/docs/fr/guides/media/cloudinary.mdx
@@ -155,9 +155,7 @@ const ogImageUrl = getCldOgImageUrl({ src: '<ID public>' });
 <meta property="og:image:secure_url" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="twitter:title" content="<Titre Twitter>" />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content={ogImageUrl} />
 ```
 
 

--- a/src/content/docs/ko/guides/media/cloudinary.mdx
+++ b/src/content/docs/ko/guides/media/cloudinary.mdx
@@ -155,9 +155,7 @@ const ogImageUrl = getCldOgImageUrl({ src: '<Public ID>' });
 <meta property="og:image:secure_url" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="twitter:title" content="<Twitter Title>" />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content={ogImageUrl} />
 ```
 
 

--- a/src/content/docs/zh-cn/guides/media/cloudinary.mdx
+++ b/src/content/docs/zh-cn/guides/media/cloudinary.mdx
@@ -155,9 +155,7 @@ const ogImageUrl = getCldOgImageUrl({ src: '<Public ID>' });
 <meta property="og:image:secure_url" content={ogImageUrl} />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="twitter:title" content="<Twitter Title>" />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content={ogImageUrl} />
 ```
 
 在 Cloudinary 文档中查找 [Cloudinary 社交媒体卡模板](https://astro.cloudinary.dev/templates/social-media-cards)。

--- a/src/routeData.ts
+++ b/src/routeData.ts
@@ -41,7 +41,6 @@ function updateHead(context: APIContext) {
 	const is404 = context.url.pathname.endsWith('/404/');
 
 	head.push({ tag: 'meta', attrs: { property: 'og:image', content: canonicalImageSrc.href } });
-	head.push({ tag: 'meta', attrs: { name: 'twitter:image', content: canonicalImageSrc.href } });
 	head.push({ tag: 'meta', attrs: { name: 'twitter:site', content: 'astrodotbuild' } });
 
 	// Algolia docsearch language facet


### PR DESCRIPTION
## Description

This PR removes redundant Twitter (X) metadata generation in SEO-related components and clarifies the relationship between Open Graph and Twitter card tags.

Historically, several Twitter-specific meta tags were explicitly generated (`twitter:title`, `twitter:description`, `twitter:image`, `twitter:url`) even though equivalent Open Graph properties already provide the same data. Since Twitter cards can fall back to Open Graph metadata, these tags are unnecessary duplication in this setup.

Key changes:

* `twitter:title` is fully derived from `og:title`
* `twitter:image` is fully derived from `og:image`
* Removed redundant generation of:

  * `twitter:title`
  * `twitter:image`
* Retained essential metadata:

  * `twitter:card`
  * `twitter:site`

## Resources

Twitter Cards documentation is no longer reliably available on the official site, but archived references confirm that Open Graph properties can be used as fallbacks:

* [https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup](https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup)
* [https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started](https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started)

Notably, if `og:type`, `og:title`, and `og:description` are present but `twitter:card` is absent, a summary card may still be rendered.

Typical metadata structure:

```html
<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:site" content="@site" />
<meta name="twitter:creator" content="@creator" />
<meta property="og:url" content="" />
<meta property="og:title" content="" />
<meta property="og:description" content="" />
<meta property="og:image" content="" />
```
