### PR TITLE
chore: update coding in public ad wording

### DIFF
--- a/src/components/RightSidebar/LearnAstroAd.astro
+++ b/src/components/RightSidebar/LearnAstroAd.astro
@@ -23,8 +23,6 @@ const headingId = `learn-astro-course-${idCount}`;
 				</svg>
 				<span>150+ video lessons</span>
 			</span>
-			<span>•</span>
-			<span>Astro v5 ready</span>
 		</p>
 		<LinkButton href={offerUrl} class="cta" data-learn-astro-cta>Get 20% off</LinkButton>
 	</aside>


### PR DESCRIPTION
#### Description (required)

The "Astro v5 ready" makes it sound like the course isn't compatible with Astro 6+. I haven't added every detail from Astro 6–7, but the course is compatible with the newer versions