### PR TITLE
fix: set `upgrade-to/v7.mdx` as i18n ready

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v7.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v7.mdx
@@ -3,7 +3,7 @@ title: Upgrade to Astro v7
 description: How to upgrade your project to Astro v7.0.
 sidebar:
   label: v7.0
-i18nReady: false
+i18nReady: true
 ---
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 import { Steps } from '@astrojs/starlight/components';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes an oversight from #13872 where `upgrade-to/v7.mdx` was still set to `i18nReady: false`...
