### PR TITLE
Document astro dev --ignore-lock flag

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -127,6 +127,7 @@ Flags
  --host <custom-address>  Expose on a network IP address at <custom-address>
                   --open  Automatically open the app in the browser on server start
                  --force  Clear the content layer cache, forcing a full rebuild.
+           --ignore-lock  Start the dev server even if another one is already running, without checking or writing the lock file.
          --allowed-hosts  Specify a comma-separated list of allowed hosts or allow any hostname.
              --help (-h)  See all available flags.
 ```

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -228,7 +228,9 @@ Starts the dev server without checking or writing the lock file used to detect o
 astro dev --no-lock --port 4322
 ```
 
-The new server is not tracked by `astro dev stop`, `astro dev status`, or `astro dev logs`. `--no-lock` cannot be combined with `--background` (including when background mode is triggered automatically for an AI coding agent) or `--force`, since both rely on the lock file.
+The new server is not tracked by `astro dev stop`, `astro dev status`, or `astro dev logs`.
+
+When combined with `--background` (including when triggered by an AI coding agent) or `--force`, an error is throwned, as both rely on the lock file.
 
 <h3>Subcommands</h3>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -230,7 +230,7 @@ astro dev --ignore-lock --port 4322
 
 The new server is not tracked by `astro dev stop`, `astro dev status`, or `astro dev logs`.
 
-When combined with `--background` (including when triggered by an AI coding agent) or `--force`, an error is throwned, as both rely on the lock file.
+When combined with `--background` (including when triggered by an AI coding agent) or `--force`, an error is thrown, as both rely on the lock file.
 
 <h3>Subcommands</h3>
 

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -217,6 +217,18 @@ astro dev --background --force
 
 <ReadMore>See [Background mode for AI coding agents](/en/guides/build-with-ai/#background-mode) for more about automatic agent detection and the health endpoint.</ReadMore>
 
+#### `--no-lock`
+
+<p><Since v="7.1.0" /></p>
+
+Starts the dev server without checking or writing the lock file used to detect other running dev servers. This allows a new dev server to start alongside one that's already running for the same project, instead of erroring.
+
+```shell
+astro dev --no-lock --port 4322
+```
+
+The new server is not tracked by `astro dev stop`, `astro dev status`, or `astro dev logs`. `--no-lock` cannot be combined with `--background` (including when background mode is triggered automatically for an AI coding agent) or `--force`, since both rely on the lock file.
+
 <h3>Subcommands</h3>
 
 <p><Since v="7.0.0" /></p>

--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -218,14 +218,14 @@ astro dev --background --force
 
 <ReadMore>See [Background mode for AI coding agents](/en/guides/build-with-ai/#background-mode) for more about automatic agent detection and the health endpoint.</ReadMore>
 
-#### `--no-lock`
+#### `--ignore-lock`
 
 <p><Since v="7.1.0" /></p>
 
 Starts the dev server without checking or writing the lock file used to detect other running dev servers. This allows a new dev server to start alongside one that's already running for the same project, instead of erroring.
 
 ```shell
-astro dev --no-lock --port 4322
+astro dev --ignore-lock --port 4322
 ```
 
 The new server is not tracked by `astro dev stop`, `astro dev status`, or `astro dev logs`.


### PR DESCRIPTION
Documents the new `astro dev --ignore-lock` flag added in withastro/astro#17331.

- Adds a `--ignore-lock` reference section under `astro dev`
- Lists `--ignore-lock` in the `astro dev` help output