### PR TITLE
Fix TypeScript errors in `recipes/i18n.mdx`

### DIFF
--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -85,23 +85,21 @@ If you prefer the default language to not be visible in the URL unlike other lan
 
 2. Create a `src/content.config.ts` file and export a collection for each type of content.
 
-    ```ts
-    //src/content.config.ts
-    import { defineCollection } from 'astro:content';
-    import { z } from 'astro/zod';
+    ```ts title="src/content.config.ts"
+    import { defineCollection } from "astro:content";
+    import { z } from "astro/zod";
 
     const blogCollection = defineCollection({
       schema: z.object({
         title: z.string(),
         author: z.string(),
-        date: z.date()
-      })
+        date: z.date(),
+      }),
     });
 
     export const collections = {
-      'blog': blogCollection
+      blog: blogCollection,
     };
-
     ```
     
     <ReadMore>Read more about [Content Collections](/en/guides/content-collections/).</ReadMore>
@@ -112,17 +110,16 @@ If you prefer the default language to not be visible in the URL unlike other lan
       <Fragment slot="static">
         In static rendering mode, use `getStaticPaths` to map each content entry to a page:
 
-        ```astro
-        //src/pages/[lang]/blog/[...slug].astro
+        ```astro title="src/pages/[lang]/blog/[...slug].astro"
         ---
-        import { getCollection, render } from 'astro:content';
-        
-        export async function getStaticPaths() {
-          const pages = await getCollection('blog');
+        import { getCollection, render } from "astro:content";
 
-          const paths = pages.map(page => {
-            const [lang, ...slug] = page.id.split('/');
-            return { params: { lang, slug: slug.join('/') || undefined }, props: page };
+        export async function getStaticPaths() {
+          const pages = await getCollection("blog");
+
+          const paths = pages.map((page) => {
+            const [lang, ...slug] = page.id.split("/");
+            return { params: { lang, slug: slug.join("/") || undefined }, props: page };
           });
 
           return paths;
@@ -133,33 +130,34 @@ If you prefer the default language to not be visible in the URL unlike other lan
         const formattedDate = page.data.date.toLocaleString(lang);
         const { Content } = await render(page);
         ---
+
         <h1>{page.data.title}</h1>
         <p>by {page.data.author} • {formattedDate}</p>
-        <Content/>
+        <Content />
         ```
       </Fragment>
 
       <Fragment slot="ssr">
         In [SSR mode](/en/guides/on-demand-rendering/), fetch the requested entry directly:
 
-        ```astro
-        //src/pages/[lang]/blog/[...slug].astro
+        ```astro title="src/pages/[lang]/blog/[...slug].astro"
         ---
-        import { getEntry, render } from 'astro:content';
+        import { getEntry, render } from "astro:content";
 
         const { lang, slug } = Astro.params;
-        const page = await getEntry('blog', `${lang}/${slug}`);
+        const page = await getEntry("blog", `${lang}/${slug}`);
 
         if (!page) {
-          return Astro.redirect('/404');
+          return Astro.redirect("/404");
         }
 
         const formattedDate = page.data.date.toLocaleString(lang);
         const { Content, headings } = await render(page);
         ---
+
         <h1>{page.data.title}</h1>
         <p>by {page.data.author} • {formattedDate}</p>
-        <Content/>
+        <Content />
         ```
       </Fragment>
     </StaticSsrTabs>
@@ -179,24 +177,23 @@ Create dictionaries of terms to translate the labels for UI elements around your
 <Steps>
 1. Create a `src/i18n/ui.ts` file to store your translation strings:
 
-    ```ts
-    // src/i18n/ui.ts
+    ```ts title="src/i18n/ui.ts"
     export const languages = {
-      en: 'English',
-      fr: 'Français',
+      en: "English",
+      fr: "Français",
     };
 
-    export const defaultLang = 'en';
-    
+    export const defaultLang = "en";
+
     export const ui = {
       en: {
-        'nav.home': 'Home',
-        'nav.about': 'About',
-        'nav.twitter': 'Twitter',
+        "nav.home": "Home",
+        "nav.about": "About",
+        "nav.twitter": "Twitter",
       },
       fr: {
-        'nav.home': 'Accueil',
-        'nav.about': 'À propos',
+        "nav.home": "Accueil",
+        "nav.about": "À propos",
       },
     } as const;
     ```
@@ -226,66 +223,65 @@ Create dictionaries of terms to translate the labels for UI elements around your
     
 3. Import the helpers where needed and use them to choose the UI string that corresponds to the current language. For example, a nav component might look like:
 
-    ```astro 
+    ```astro title="src/components/Nav.astro"
     ---
-    // src/components/Nav.astro
-    import { getLangFromUrl, useTranslations } from '../i18n/utils';
-    
+    import { getLangFromUrl, useTranslations } from "../i18n/utils";
+
     const lang = getLangFromUrl(Astro.url);
     const t = useTranslations(lang);
     ---
+
     <ul>
-        <li>
-            <a href={`/${lang}/home/`}>
-              {t('nav.home')}
-            </a>
-        </li>
-        <li>
-            <a href={`/${lang}/about/`}>
-              {t('nav.about')}
-            </a>
-        </li>
-        <li>
-            <a href="https://twitter.com/astrodotbuild">
-              {t('nav.twitter')}
-            </a>
-        </li>
+      <li>
+        <a href={`/${lang}/home/`}>
+          {t("nav.home")}
+        </a>
+      </li>
+      <li>
+        <a href={`/${lang}/about/`}>
+          {t("nav.about")}
+        </a>
+      </li>
+      <li>
+        <a href="https://twitter.com/astrodotbuild">
+          {t("nav.twitter")}
+        </a>
+      </li>
     </ul>
     ```
 
 4. Each page must have a `lang` attribute on the `<html>` element that matches the language on the page. In this example, a [reusable layout](/en/basics/layouts/) extracts the language from the current route:
 
-    ```astro
+    ```astro title="src/layouts/Base.astro"
     ---
-    // src/layouts/Base.astro
-    
-    import { getLangFromUrl } from '../i18n/utils';
-    
+    import { getLangFromUrl } from "../i18n/utils";
+
     const lang = getLangFromUrl(Astro.url);
     ---
+
     <html lang={lang}>
-        <head>
-            <meta charset="utf-8" />
-            <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-            <meta name="viewport" content="width=device-width" />
-            <title>Astro</title>
-        </head>
-        <body>
-            <slot />
-        </body>
+      <head>
+        <meta charset="utf-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta name="viewport" content="width=device-width" />
+        <title>Astro</title>
+      </head>
+      <body>
+        <slot />
+      </body>
     </html>
     ```
 
     You can then use this base layout to ensure that pages use the correct `lang` attribute automatically.
     
-    ```astro
+    ```astro title="src/pages/en/about.astro"
     ---
-    // src/pages/en/about.astro
-    import Base from '../../layouts/Base.astro';
+    import Base from "../../layouts/Base.astro";
     ---
+
     <Base>
-        <h1>About me</h1>
-        ...
+      <h1>About me</h1>
+      ...
     </Base>
     ```
 </Steps>
@@ -297,43 +293,45 @@ Create links to the different languages you support so users can choose the lang
 <Steps>
 1. Create a component to show a link for each language:
 
-    ```astro
+    ```astro title="src/components/LanguagePicker.astro"
     ---
-    // src/components/LanguagePicker.astro
-    import { languages } from '../i18n/ui';
+    import { languages } from "../i18n/ui";
     ---
+
     <ul>
-      {Object.entries(languages).map(([lang, label]) => (
-        <li>
-          <a href={`/${lang}/`}>{label}</a>
-        </li>
-      ))}
+      {
+        Object.entries(languages).map(([lang, label]) => (
+          <li>
+            <a href={`/${lang}/`}>{label}</a>
+          </li>
+        ))
+      }
     </ul>
     ```
 
 2. Add `<LanguagePicker />` to your site so it is shown on every page. The example below adds it to the site footer in a base layout:
 
-    ```astro ins={3,17-19}
+    ```astro ins={2,17-19} title="src/layouts/Base.astro"
     ---
-    // src/layouts/Base.astro
-    import LanguagePicker from '../components/LanguagePicker.astro';
-    import { getLangFromUrl } from '../i18n/utils';
-    
+    import LanguagePicker from "../components/LanguagePicker.astro";
+    import { getLangFromUrl } from "../i18n/utils";
+
     const lang = getLangFromUrl(Astro.url);
     ---
+
     <html lang={lang}>
-        <head>
-            <meta charset="utf-8" />
-            <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-            <meta name="viewport" content="width=device-width" />
-            <title>Astro</title>
-        </head>
-        <body>
-            <slot />
-            <footer>
-              <LanguagePicker />
-            </footer>
-        </body>
+      <head>
+        <meta charset="utf-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta name="viewport" content="width=device-width" />
+        <title>Astro</title>
+      </head>
+      <body>
+        <slot />
+        <footer>
+          <LanguagePicker />
+        </footer>
+      </body>
     </html>
     ```
 </Steps>
@@ -355,71 +353,75 @@ Create links to the different languages you support so users can choose the lang
 
 2. Add another line to the `src/i18n/ui.ts` file to toggle the feature:
 
-    ```ts
-    // src/i18n/ui.ts
+    ```ts title="src/i18n/ui.ts"
     export const showDefaultLang = false;
     ```
 
 3. Add a helper function to `src/i18n/utils.ts`, to translate paths based on the current language:
 
-   ```js
-   // src/i18n/utils.ts
-   import { ui, defaultLang, showDefaultLang } from './ui';
+    ```ts title="src/i18n/utils.ts"
+    import { ui, defaultLang, showDefaultLang } from "./ui";
 
-   export function useTranslatedPath(lang: keyof typeof ui) {
-     return function translatePath(path: string, l: string = lang) {
-       return !showDefaultLang && l === defaultLang ? path : `/${l}${path}`
-     }
-   }
-   ```
+    export function useTranslatedPath(lang: keyof typeof ui) {
+      return function translatePath(path: string, l: string = lang) {
+        return !showDefaultLang && l === defaultLang ? path : `/${l}${path}`;
+      };
+    }
+    ```
 
 4. Import the helper where needed. For example, a `nav` component might look like:
 
-    ```astro 
+    ```astro title="src/components/Nav.astro"
     ---
-    // src/components/Nav.astro
-    import { getLangFromUrl, useTranslations, useTranslatedPath } from '../i18n/utils';
-    
+    import {
+      getLangFromUrl,
+      useTranslations,
+      useTranslatedPath,
+    } from "../i18n/utils";
+
     const lang = getLangFromUrl(Astro.url);
     const t = useTranslations(lang);
     const translatePath = useTranslatedPath(lang);
     ---
+
     <ul>
-        <li>
-            <a href={translatePath('/home/')}>
-              {t('nav.home')}
-            </a>
-        </li>
-        <li>
-            <a href={translatePath('/about/')}>
-              {t('nav.about')}
-            </a>
-        </li>
-        <li>
-            <a href="https://twitter.com/astrodotbuild">
-              {t('nav.twitter')}
-            </a>
-        </li>
+      <li>
+        <a href={translatePath("/home/")}>
+          {t("nav.home")}
+        </a>
+      </li>
+      <li>
+        <a href={translatePath("/about/")}>
+          {t("nav.about")}
+        </a>
+      </li>
+      <li>
+        <a href="https://twitter.com/astrodotbuild">
+          {t("nav.twitter")}
+        </a>
+      </li>
     </ul>
     ```
 
 5. The helper function can also be used to translate paths for a specific language. For example, when users switch between languages:
 
-    ```astro
+    ```astro title="src/components/LanguagePicker.astro"
     ---
-    // src/components/LanguagePicker.astro
-    import { languages } from '../i18n/ui';
-    import { getLangFromUrl, useTranslatedPath } from '../i18n/utils';
-    
+    import { languages } from "../i18n/ui";
+    import { getLangFromUrl, useTranslatedPath } from "../i18n/utils";
+
     const lang = getLangFromUrl(Astro.url);
     const translatePath = useTranslatedPath(lang);
     ---
+
     <ul>
-      {Object.entries(languages).map(([lang, label]) => (
-        <li>
-          <a href={translatePath('/', lang)}>{label}</a>
-        </li>
-      ))}
+      {
+        Object.entries(languages).map(([lang, label]) => (
+          <li>
+            <a href={translatePath("/", lang)}>{label}</a>
+          </li>
+        ))
+      }
     </ul>
     ```
 </Steps>
@@ -431,22 +433,21 @@ Translate the routes of your pages for each language.
 <Steps>
 1. Add route mappings to `src/i18n/ui.ts`:
 
-    ```ts
-    // src/i18n/ui.ts
+    ```ts title="src/i18n/ui.ts"
     export const routes = {
       de: {
-        'services': 'leistungen',
+        services: "leistungen",
       },
       fr: {
-        'services': 'prestations-de-service',
+        services: "prestations-de-service",
       },
-    }
+    };
     ```
 
 2. Update the `useTranslatedPath` helper function in `src/i18n/utils.ts` to add router translation logic.
 
     ```ts title="src/i18n/utils.ts"
-    import { ui, defaultLang, showDefaultLang, routes } from './ui';
+    import { ui, defaultLang, showDefaultLang, routes } from "./ui";
 
     export function useTranslatedPath(lang: keyof typeof ui) {
       return function translatePath(path: string, l: string = lang) {
@@ -468,59 +469,63 @@ Translate the routes of your pages for each language.
 
 3. Create a helper function to get the route, if it exists based on the current URL, in `src/i18n/utils.ts`:
 
-    ```js
-    // src/i18n/utils.ts
-    import { ui, defaultLang, showDefaultLang, routes } from './ui';
-    
+    ```ts title="src/i18n/utils.ts"
+    import { ui, defaultLang, showDefaultLang, routes } from "./ui";
+
     export function getRouteFromUrl(url: URL): string | undefined {
       const pathname = new URL(url).pathname;
-      const parts = pathname?.split('/');
+      const parts = pathname?.split("/");
       const path = parts.pop() || parts.pop();
-    
+
       if (path === undefined) {
         return undefined;
       }
-      
+
       const currentLang = getLangFromUrl(url);
-    
-    if (defaultLang === currentLang) {
-      const route = Object.values(routes)[0] as Record<string, string>;
-      return route[path];
-    }
-      
-      const getKeyByValue = (obj: Record<string, string>, value: string): string | undefined  => {
-          return Object.keys(obj).find((key) => obj[key] === value);
+
+      if (defaultLang === currentLang) {
+        const route = Object.values(routes)[0] as Record<string, string>;
+        return route[path];
       }
-    
+
+      const getKeyByValue = (
+        obj: Record<string, string>,
+        value: string,
+      ): string | undefined => {
+        return Object.keys(obj).find((key) => obj[key] === value);
+      };
+
       const reversedKey = getKeyByValue(routes[currentLang], path);
-    
+
       if (reversedKey !== undefined) {
         return reversedKey;
       }
-    
+
       return undefined;
     }
     ```
 
 4. The helper function can be used to get a translated route. For example, when no translated route is defined, the user will be redirected to the home page:
 
-    ```astro
+    ```astro title="src/components/LanguagePicker.astro"
     ---
-    // src/components/LanguagePicker.astro
-    import { languages } from '../i18n/ui';
-    import { getRouteFromUrl, useTranslatedPath } from '../i18n/utils';
+    import { languages } from "../i18n/ui";
+    import { getRouteFromUrl, useTranslatedPath } from "../i18n/utils";
 
     const route = getRouteFromUrl(Astro.url);
     ---
+
     <ul>
-      {Object.entries(languages).map(([lang, label]) => {
-        const translatePath = useTranslatedPath(lang);
-        return (
-          <li>
-            <a href={translatePath(`/${route ? route : ''}`)}>{label}</a>
-          </li>
-        )
-      })}
+      {
+        Object.entries(languages).map(([lang, label]) => {
+          const translatePath = useTranslatedPath(lang);
+          return (
+            <li>
+              <a href={translatePath(`/${route ? route : ""}`)}>{label}</a>
+            </li>
+          );
+        })
+      }
     </ul>
     ```
 </Steps>

--- a/src/content/docs/en/recipes/i18n.mdx
+++ b/src/content/docs/en/recipes/i18n.mdx
@@ -203,20 +203,20 @@ Create dictionaries of terms to translate the labels for UI elements around your
     
 2. Create two helper functions: one to detect the page language based on the current URL, and one to get translations strings for different parts of the UI in `src/i18n/utils.ts`:
 
-    ```js
-    // src/i18n/utils.ts
-    import { ui, defaultLang } from './ui';
-    
+    ```ts title="src/i18n/utils.ts"
+    import { ui, defaultLang } from "./ui";
+
     export function getLangFromUrl(url: URL) {
-      const [, lang] = url.pathname.split('/');
+      const [, lang] = url.pathname.split("/");
       if (lang in ui) return lang as keyof typeof ui;
       return defaultLang;
     }
-    
+
     export function useTranslations(lang: keyof typeof ui) {
-      return function t(key: keyof typeof ui[typeof defaultLang]) {
-        return ui[lang][key] || ui[defaultLang][key];
-      }
+      const localizedUI: Record<string, string> = ui[lang];
+      return function t(key: keyof (typeof ui)[typeof defaultLang]) {
+        return key in localizedUI ? localizedUI[key] : ui[defaultLang][key];
+      };
     }
     ```
 
@@ -445,18 +445,24 @@ Translate the routes of your pages for each language.
 
 2. Update the `useTranslatedPath` helper function in `src/i18n/utils.ts` to add router translation logic.
 
-    ```js
-    // src/i18n/utils.ts
+    ```ts title="src/i18n/utils.ts"
     import { ui, defaultLang, showDefaultLang, routes } from './ui';
 
     export function useTranslatedPath(lang: keyof typeof ui) {
       return function translatePath(path: string, l: string = lang) {
-        const pathName = path.replaceAll('/', '')
-        const hasTranslation = defaultLang !== l && routes[l] !== undefined && routes[l][pathName] !== undefined
-        const translatedPath = hasTranslation ? '/' + routes[l][pathName] : path
-    
-        return !showDefaultLang && l === defaultLang ? translatedPath : `/${l}${translatedPath}`
-      }
+        const pathName = path.replaceAll("/", "");
+        const routeMap: Record<string, string> | undefined =
+          l !== defaultLang && l in routes
+            ? routes[l as keyof typeof routes]
+            : undefined;
+        const translatedPath = routeMap?.[pathName]
+          ? "/" + routeMap[pathName]
+          : path;
+
+        return !showDefaultLang && l === defaultLang
+          ? translatedPath
+          : `/${l}${translatedPath}`;
+      };
     }
     ```
 
@@ -477,10 +483,10 @@ Translate the routes of your pages for each language.
       
       const currentLang = getLangFromUrl(url);
     
-      if (defaultLang === currentLang) {
-        const route = Object.values(routes)[0];
-        return route[path] !== undefined ? route[path] : undefined;
-      }
+    if (defaultLang === currentLang) {
+      const route = Object.values(routes)[0] as Record<string, string>;
+      return route[path];
+    }
       
       const getKeyByValue = (obj: Record<string, string>, value: string): string | undefined  => {
           return Object.keys(obj).find((key) => obj[key] === value);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

- Fixes a few TypeScript errors in `recipes/i18n.mdx`:
  - In `useTranslations()`, TypeScript complains because `ui.fr` doesn't have a `nav.about key`. Using an intermediary object typed with `Record<string, string>` fixes this.
  - When `useTranslatedPath()` uses `keyof typeof ui` for its parameter, we get an error in `LanguagePicker.astro` because `lang` is typed as `string`. Using `string` to type the parameter fixes this. We loose autocompletion but I think it's fine, and we already use `lang: string` for `translatePath()`.
  - Introduces `routeMap` and a cast (`keyof typeof routes`) in `useTranslatedPath()` because TypeScript complains about `routes[l]` (can't be used to index type).
  - Introduces a cast in `getRouteFromUrl()` because TypeScript complains about `route[path]` (can't be used to index type). Also replaces the return statement as the conditional logic was useless (ie. if undefined returns undefined...).
- Formats each code snippet (new project, Astro extension enabled) to prevent visual changes, and for consistency between fixed and not fixed code snippets.

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089
