### PR TITLE
fix: make code snippets TS-friendly in `troubleshooting.mdx`

### DIFF
--- a/src/content/docs/en/guides/troubleshooting.mdx
+++ b/src/content/docs/en/guides/troubleshooting.mdx
@@ -40,8 +40,8 @@ This component provides a way to inspect values on the client-side, without any 
 
 ```astro {2,7}
 ---
-import { Debug } from 'astro:components';
-const sum = (a, b) => a + b;
+import { Debug } from "astro:components";
+const sum = (a: any, b: any) => a + b;
 ---
 
 <!-- Example: Outputs {answer: 6} to the browser -->
@@ -50,15 +50,16 @@ const sum = (a, b) => a + b;
 
 The Debug component supports a variety of syntax options for even more flexible and concise debugging:
 
-```astro {2,7-9}
+```astro {2,8-10}
 ---
-import { Debug } from 'astro:components';
-const sum = (a, b) => a + b;
+import { Debug } from "astro:components";
+const sum = (a: any, b: any) => a + b;
 const answer = sum(2, 4);
 ---
+
 <!-- Example: All three examples are equivalent. -->
 <Debug answer={sum(2, 4)} />
-<Debug {...{answer: sum(2, 4)}} />
+<Debug {...{ answer: sum(2, 4) }} />
 <Debug {answer} />
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes to code snippets in `troubleshooting.mdx`. Without `any`, Typescript complains.

#### References

<!-- Optional section. Delete any points that don’t apply. -->


<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089
