### PR TITLE
Fix TypeScript errors in `recipes/sharing-state.mdx`

### DIFF
--- a/src/content/docs/en/recipes/sharing-state.mdx
+++ b/src/content/docs/en/recipes/sharing-state.mdx
@@ -52,15 +52,15 @@ When building an Astro website, you may need to share state across components. A
     <button id="openDialog">Open</button>
 
     <script>
-      import { isOpen } from '../store.js';
-      
+      import { isOpen } from "../store.js";
+
       // Set the store to true when the button is clicked
       function openDialog() {
         isOpen.set(true);
       }
 
       // Add an event listener to the button
-      document.getElementById('openDialog').addEventListener('click', openDialog);
+      document.getElementById("openDialog")?.addEventListener("click", openDialog);
     </script>
     ```
 
@@ -68,16 +68,19 @@ When building an Astro website, you may need to share state across components. A
     <div id="dialog" style="display: none">Hello world!</div>
 
     <script>
-      import { isOpen } from '../store.js';
+      import { isOpen } from "../store.js";
 
-      // Listen to changes in the store, and show/hide the dialog accordingly    
-      isOpen.subscribe(open => {
-        if (open) {
-          document.getElementById('dialog').style.display = 'block';
-        } else {
-          document.getElementById('dialog').style.display = 'none';
+      const dialog = document.getElementById("dialog");
+      // Listen to changes in the store, and show/hide the dialog accordingly
+      isOpen.subscribe((open) => {
+        if (dialog) {
+          if (open) {
+            dialog.style.display = "block";
+          } else {
+            dialog.style.display = "none";
+          }
         }
-      })
+      });
     </script>
     ```
 </Steps>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

- Fixes TypeScript errors in `recipes/sharing-state.mdx`: `getElementById()` can return `null`. In the first snippet, the optional chaining operator is enough. In the second snippet, because we assign a new style, we need to wrap it with an if statement.
- Formats updated code snippets (new project, Astro extension enabled)

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089
