### PR TITLE
Fix TypeScript errors in `migrate-to` code snippets

### DIFF
--- a/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nextjs.mdx
@@ -515,16 +515,23 @@ Here's how to recreate that in `src/pages/index.astro`, replacing `getStaticProp
     ```astro title="src/pages/index.astro" "class" "</a>" "<a"
     ---
     ---
+
     <ul class="plain-list pokeList">
-        {pokemons.map((pokemon) => (
-            <li class="pokemonListItem">
-                <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
-                    <p class="pokemonId">No. {pokemon.id}</p>
-                    <img class="pokemonImage" src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`} alt={`${pokemon.name} picture`}/>
-                    <h2 class="pokemonName">{pokemon.name}</h2>
-                </a>
-            </li>
-        ))}
+      {
+        pokemons.map((pokemon: any) => (
+          <li class="pokemonListItem">
+            <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
+              <p class="pokemonId">No. {pokemon.id}</p>
+              <img
+                class="pokemonImage"
+                src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`}
+                alt={`${pokemon.name} picture`}
+              />
+              <h2 class="pokemonName">{pokemon.name}</h2>
+            </a>
+          </li>
+        ))
+      }
     </ul>
     ```
 
@@ -535,36 +542,42 @@ Here's how to recreate that in `src/pages/index.astro`, replacing `getStaticProp
     - the `getStaticProps` function is no longer needed. Data from the API is fetched directly in the code fence.
     - A `<Layout>` component is imported and wraps the page templating.
 
-    ```astro ins={2,4-16,19,31} title="src/pages/index.astro"
+    ```astro ins={2,4-16,19,37} title="src/pages/index.astro"
     ---
-    import Layout from '../layouts/layout.astro';
+    import Layout from "../layouts/layout.astro";
 
     const res = await fetch("https://pokeapi.co/api/v2/pokemon?limit=151");
     const resJson = await res.json();
-    const pokemons = resJson.results.map(pokemon => {
-        const name = pokemon.name;
-        // https://pokeapi.co/api/v2/pokemon/1/
-        const url = pokemon.url;
-        const id = url.split("/")[url.split("/").length - 2];
-        return {
-            name,
-            url,
-            id
-        }
+    const pokemons = resJson.results.map((pokemon: any) => {
+      const name = pokemon.name;
+      // https://pokeapi.co/api/v2/pokemon/1/
+      const url = pokemon.url;
+      const id = url.split("/")[url.split("/").length - 2];
+      return {
+        name,
+        url,
+        id,
+      };
     });
     ---
 
     <Layout>
       <ul class="plain-list pokeList">
-          {pokemons.map((pokemon) => (
-              <li class="pokemonListItem" key={pokemon.name}>
-                  <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
-                      <p class="pokemonId">No. {pokemon.id}</p>
-                      <img class="pokemonImage" src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`} alt={`${pokemon.name} picture`}/>
-                      <h2 class="pokemonName">{pokemon.name}</h2>
-                  </a>
-              </li>
-          ))}
+        {
+          pokemons.map((pokemon: any) => (
+            <li class="pokemonListItem">
+              <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
+                <p class="pokemonId">No. {pokemon.id}</p>
+                <img
+                  class="pokemonImage"
+                  src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`}
+                  alt={`${pokemon.name} picture`}
+                />
+                <h2 class="pokemonName">{pokemon.name}</h2>
+              </a>
+            </li>
+          ))
+        }
       </ul>
     </Layout>
     ```

--- a/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
+++ b/src/content/docs/en/guides/migrate-to-astro/from-nuxtjs.mdx
@@ -299,7 +299,7 @@ To bind an attribute or component property in an Astro component, change this sy
 
 <p aria-label={message}>...</p>
 <!-- Also support component props -->
-<Header title={"Page"}/>
+<Header title="Page"/>
 ```
 
 ### Nuxt Links to Astro
@@ -367,15 +367,16 @@ To generate multiple pages, replace the function to create routes in your `nuxt.
 ```astro title="src/pages/pokemon/[name].astro"
 ---
 export const getStaticPaths = async () => {
-  const res = await fetch("https://pokeapi.co/api/v2/pokemon?limit=151")
+  const res = await fetch("https://pokeapi.co/api/v2/pokemon?limit=151");
   const resJson = await res.json();
   const pokemons = resJson.results;
-  return pokemons.map(({ name }) => ({
-      params: { name },
-    }))
-}
+  return pokemons.map((pokemon: any) => ({
+    params: { name: pokemon.name },
+  }));
+};
 // ...
 ---
+
 <!-- Your template here -->
 ```
 
@@ -438,7 +439,7 @@ Nuxt utilizes Vue's component styling to generate a page's style.
 
  Similarly, in Astro you can drop in a `<style>` element in your page's template to provide scoped styles to the component.
 
-```astro title="src/pages/index.vue"
+```astro title="src/pages/index.astro"
 ---
 // Your server logic here
 ---
@@ -454,7 +455,7 @@ Nuxt utilizes Vue's component styling to generate a page's style.
 
 `<style>`  tags are `scoped` by default in Astro. To make a `<style>` tag global, mark it with the `is:global` attribute:
 
-```astro title="src/pages/index.vue"
+```astro title="src/pages/index.astro"
 <style is:global> 
 	p {
 		color: red;
@@ -587,7 +588,7 @@ Here's how to recreate that in `src/pages/index.astro`, replacing `asyncData()` 
 
     - `v-for` becomes `.map`.
 
-    - `:attr="val"` becomes `attr={val}`
+    - `:attr="val"` becomes `attr={val}`, except for `key` which is not an attribute of `li` in Astro
 
     - `<NuxtLink>` becomes `<a>`.
 
@@ -596,26 +597,33 @@ Here's how to recreate that in `src/pages/index.astro`, replacing `asyncData()` 
     ```astro title="src/pages/index.astro" ".map" "</a>" "<a" "key={" "}>" "href={" " {pokemon.id}" "} alt={" "src={" "}/>" ">{pokemon.name}<"
     ---
     ---
+
     <ul class="plain-list pokeList">
-        {pokemons.map((pokemon) => (
-            <li class="pokemonListItem" key={pokemon.name}>
-                <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
-                    <p class="pokemonId">No. {pokemon.id}</p>
-                    <img class="pokemonImage" src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`} alt={`${pokemon.name} picture`}/>
-                    <h2 class="pokemonName">{pokemon.name}</h2>
-                </a>
-            </li>
-        ))}
+      {
+        pokemons.map((pokemon: any) => (
+          <li class="pokemonListItem">
+            <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
+              <p class="pokemonId">No. {pokemon.id}</p>
+              <img
+                class="pokemonImage"
+                src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`}
+                alt={`${pokemon.name} picture`}
+              />
+              <h2 class="pokemonName">{pokemon.name}</h2>
+            </a>
+          </li>
+        ))
+      }
     </ul>
 
     <style>
-    .pokeList {
-      display: grid;
-      grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
-      gap: 1rem;
-    }
+      .pokeList {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1rem;
+      }
 
-    /* ... */
+      /* ... */
     </style>
     ```
 
@@ -627,47 +635,53 @@ Here's how to recreate that in `src/pages/index.astro`, replacing `asyncData()` 
     - A `<Layout>` component is imported, and wraps the page templating.
       - Our `head()` Nuxt method is passed to the `<Layout>` component, which is passed to the `<title>` element as a property.
 
-    ```astro ins={2,4-16,19,31} title="src/pages/index.astro"
+    ```astro ins={2,4-16,19,37} title="src/pages/index.astro"
     ---
-    import Layout from '../layouts/layout.astro';
+    import Layout from "../layouts/layout.astro";
 
     const res = await fetch("https://pokeapi.co/api/v2/pokemon?limit=151");
     const resJson = await res.json();
-    const pokemons = resJson.results.map(pokemon => {
-        const name = pokemon.name;
-        // https://pokeapi.co/api/v2/pokemon/1/
-        const url = pokemon.url;
-        const id = url.split("/")[url.split("/").length - 2];
-        return {
-            name,
-            url,
-            id
-        }
+    const pokemons = resJson.results.map((pokemon: any) => {
+      const name = pokemon.name;
+      // https://pokeapi.co/api/v2/pokemon/1/
+      const url = pokemon.url;
+      const id = url.split("/")[url.split("/").length - 2];
+      return {
+        name,
+        url,
+        id,
+      };
     });
     ---
 
     <Layout title="Pokedex: Generation 1">
       <ul class="plain-list pokeList">
-          {pokemons.map((pokemon) => (
-              <li class="pokemonListItem" key={pokemon.name}>
-                  <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
-                      <p class="pokemonId">No. {pokemon.id}</p>
-                      <img class="pokemonImage" src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`} alt={`${pokemon.name} picture`}/>
-                      <h2 class="pokemonName">{pokemon.name}</h2>
-                  </a>
-              </li>
-          ))}
+        {
+          pokemons.map((pokemon: any) => (
+            <li class="pokemonListItem">
+              <a class="pokemonContainer" href={`/pokemon/${pokemon.name}`}>
+                <p class="pokemonId">No. {pokemon.id}</p>
+                <img
+                  class="pokemonImage"
+                  src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`}
+                  alt={`${pokemon.name} picture`}
+                />
+                <h2 class="pokemonName">{pokemon.name}</h2>
+              </a>
+            </li>
+          ))
+        }
       </ul>
     </Layout>
 
     <style>
-    .pokeList {
-      display: grid;
-      grid-template-columns: repeat( auto-fit, minmax(250px, 1fr) );
-      gap: 1rem;
-    }
+      .pokeList {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1rem;
+      }
 
-    /* ... */
+      /* ... */
     </style>
     ```
 </Steps>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

- Fixes `from-nuxtjs`:
  - Not an error but I don't see the point to update `<Header title="Page"/>`: this works too in Astro and we don't need `{"Page"}`. If I were migrating I think I'd prefer to see I don't have to update that (we already show `{}` works too).
  - `pokemons` had no types so TS complains when we destructure `{ name }`. Either we had a type or we add `: any` without destructuring it. I think the latter might be easier for non-TypeScript users?
  - Wrong title in two places: `src/pages/index.vue` should be `src/pages/index.astro`
  - In the last snippet, TS complains about `pokemon` in the two `.map()` because it's implicitly `any`. Making it explicit fixes the red squiggles.
  - Because the last snippet has been updated, I also updated the previous one to include `: any` as this part is not meant to be updated.
  - Key is not valid on `<li>` in Astro so I removed them. And, I mentioned it in "`:attr="val"` becomes `attr={val}`" as the Vue code snippet uses `:key=""`
- Fixes `from-nextjs` (similar to the 3 last points in `from-nuxtjs`):
  - In the last snippet, TS complains about `pokemon` in the two `.map()` because it's implicitly `any`. Making it explicit fixes the red squiggles.
  - Because the last snippet has been updated, I also updated the previous one to include `: any` as this part is not meant to be updated.
  - The last snippet still had `key={pokemon.name}` (invalid) while the previous one didn't had that, so I removed it.
- Formats the corrected code snippets to have minimal visual changes when we copy/paste in a new project with the Astro extension enabled

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089

