### PR TITLE
ci: avoid direct use of untrusted PR metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,10 +65,13 @@ jobs:
 
       - name: Save PR metadata
         if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           mkdir -p pr-metadata
-          echo "${{ github.event.pull_request.number }}" > pr-metadata/pr_number
-          BRANCH="${{ github.head_ref }}"
+          echo "$PR_NUMBER" > pr-metadata/pr_number
+          BRANCH="$HEAD_REF"
           # Sanitize branch name into a valid Wrangler preview alias.
           # Wrangler validates aliases against /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i so the
           # alias must start with a letter, contain only [a-z0-9-], and end with a letter


### PR DESCRIPTION
#### Description (required)

#### What

Pass pull request metadata through step-level environment variables before using it in the inline shell script.

#### Why

`github.head_ref` is controlled by the pull request author. Passing pull request metadata through step-level environment variables avoids embedding untrusted workflow context directly in the inline shell script while preserving the existing workflow behavior.

#### How 

- Add `PR_NUMBER` and `HEAD_REF` as step-level environment variables.
- Read those values from the shell instead of embedding GitHub context expressions directly in the `run` block.
- Keep the existing alias sanitization logic unchanged.

#### Testing 

- Ran `pnpm install`.
- Ran `pnpm run dev`.