### PR TITLE
Fix TS errors in `reference/astro-syntax.mdx`

### DIFF
--- a/src/content/docs/en/reference/astro-syntax.mdx
+++ b/src/content/docs/en/reference/astro-syntax.mdx
@@ -35,6 +35,7 @@ Local variables can be used in curly braces to pass attribute values to both HTM
 
 ```astro title="src/components/DynamicAttributes.astro" "{name}" "${name}"
 ---
+import MyComponent from "./MyComponent.astro";
 const name = "Astro";
 ---
 <h1 class={name}>Attribute expressions are supported</h1>
@@ -66,7 +67,7 @@ Instead, use a client-side script to add the event handler, like you would in va
   function handleClick () {
     console.log("button clicked!");
   }
-  document.getElementById("button").addEventListener("click", handleClick);
+  document.getElementById("button")?.addEventListener("click", handleClick);
 </script>
 ```
 :::
@@ -243,7 +244,7 @@ A callback function passed as `<Shout />`’s child will receive the all-caps `m
 import Shout from "../components/Shout.astro";
 ---
 <Shout message="slots!">
-  {(message) => <div>{message}</div>}
+  {(message: string) => <div>{message}</div>}
 </Shout>
 
 <!-- renders as <div>SLOTS!</div> -->
@@ -254,7 +255,7 @@ Callback functions can be passed to named slots inside a wrapping HTML element t
 ```astro
 <Shout message="slots!">
   <fragment slot="message">
-    {(message) => <div>{message}</div>}
+    {(message: string) => <div>{message}</div>}
   </fragment>
 </Shout>
 ```
@@ -265,23 +266,24 @@ Use a standard HTML element for the wrapping tag or any lowercase tag (e.g. `<fr
 
 `Astro.self` allows Astro components to be recursively called. This behavior lets you render an Astro component from within itself by using `<Astro.self>` in the component template. This can help iterate over large data stores and nested data structures.
 
-```astro
+```astro title="src/components/NestedList.astro" {14}
 ---
-// NestedList.astro
+type Props = {
+  items: (string | string[])[];
+};
 const { items } = Astro.props;
 ---
+
 <ul class="nested-list">
-  {items.map((item) => (
-    <li>
-      <!-- If there is a nested data-structure we render `<Astro.self>` -->
-      <!-- and can pass props through with the recursive call -->
-      {Array.isArray(item) ? (
-        <Astro.self items={item} />
-      ) : (
-        item
-      )}
-    </li>
-  ))}
+  {
+    items.map((item) => (
+      <li>
+        {/* If there is a nested data-structure we render `<Astro.self>` */}
+        {/* and can pass props through with the recursive call */}
+        {Array.isArray(item) ? <Astro.self items={item} /> : item}
+      </li>
+    ))
+  }
 </ul>
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes code snippets in `reference/astro-syntax.mdx`:
  - missing import
  - `getElementById` can return `null`
  - `Shout`: TypeScript complains about `message` (implicitly any)
  - `NestedList`: there is a bug preventing formatting when using HTML comments inside `.map()` (https://github.com/withastro/prettier-plugin-astro/issues/449), and anyway switching to JSX comments might make more sense (not in the final output).
  - `NestedList`: TypeScript complains about `item` (implicitly any), I think adding `type Props` makes more sense than `any` here

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14089
