### PR TITLE
Add docs for `PreviewServerParams.open` used by adapters

### DIFF
--- a/src/content/docs/en/reference/adapter-reference.mdx
+++ b/src/content/docs/en/reference/adapter-reference.mdx
@@ -1181,6 +1181,16 @@ Describes the [configured HTTP response headers](/en/reference/configuration-ref
 
 Describes the [configured allowed hosts](/en/reference/configuration-reference/#serverallowedhosts) that the preview server should respond to.
 
+#### `PreviewServerParams.open`
+
+<p>
+
+**Type:** `string | boolean`<br />
+<Since v="7.0.8" />
+</p>
+
+Specifies the [configured open option](/en/reference/configuration-reference/#serveropen) for the preview server.
+
 #### `PreviewServerParams.root`
 
 <p>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Adds docs for a new `PreviewServerParams` property.

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/astro/pull/17363
- For Astro version `7.0.8`
