### PR TITLE
Add missing flags to the `help` output in CLI reference

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -82,6 +82,7 @@ Global Flags
          --silent  Disable all logging.
         --version  Show the version number and exit.
            --help  Show this help message.
+           --json  Enables JSON logging.
 ```
 
 
@@ -114,18 +115,20 @@ The following message will display in your terminal:
 astro dev [command] [...flags]
 
 Commands
-          stop  Stop a running background dev server.
-        status  Check if a dev server is running.
-  logs [--follow]  View logs from a background dev server.
+                    stop  Stop a running background dev server.
+                  status  Check if a dev server is running.
+         logs [--follow]  View logs from a background dev server.
 
 Flags
-          --background  Start the dev server as a background process.
-               --port  Specify which port to run on. Defaults to 4321.
-               --host  Listen on all addresses, including LAN and public addresses.
---host <custom-address>  Expose on a network IP address at <custom-address>
-               --open  Automatically open the app in the browser on server start
-              --force  Clear the content layer cache, forcing a full rebuild.
-          --help (-h)  See all available flags.
+            --background  Start the dev server as a background process.
+                  --mode  Specify the mode of the project. Defaults to "development".
+                  --port  Specify which port to run on. Defaults to 4321.
+                  --host  Listen on all addresses, including LAN and public addresses.
+ --host <custom-address>  Expose on a network IP address at <custom-address>
+                  --open  Automatically open the app in the browser on server start
+                 --force  Clear the content layer cache, forcing a full rebuild.
+         --allowed-hosts  Specify a comma-separated list of allowed hosts or allow any hostname.
+             --help (-h)  See all available flags.
 ```
 
 :::note
@@ -196,6 +199,8 @@ The following hotkeys can be used in the terminal where the Astro development se
 
 <p><Since v="7.0.0" /></p>
 
+The command accepts [common flags](#common-flags) and the following additional flags.
+
 #### `--background`
 
 Starts the dev server as a detached background process and enables [JSON logging](#--json). This flag is provided automatically when an AI agent is detected. You can also use it manually:
@@ -232,7 +237,7 @@ Displays logs from a background dev server. Only works when the server was start
 
 ###### `--follow` (`-f`)
 
-Stream new log output as it's written, similar to `tail -f`. Without this flag, the current log file contents are printed and the command exits.
+Streams new log output as it's written, similar to `tail -f`. Without this flag, the current log file contents are printed and the command exits.
 
 ## `astro build`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes and formats a few things in `cli-reference.mdx`:
  - add missing flags in `help` command snippets (`--json` for the first one and `--allowed-hosts` + `mode` for the second one)
  - consistent alignment
  - consistent tense
  - consistent flags introduction

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089
