### PR TITLE
docs: fix missing space in CONTRIBUTING.md (en-only)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Some of our English-language pages are generated from outside sources and mainta
 The page's **Edit this page** button should redirect you to the file that should be changed. Alternatively, you can get the correct URL from the file's `githubURL` frontmatter property.
 
 > **Note**
-> All of the generated pages will have a dev-only warning at the top and the `githubURL`frontmatter property.
+> All of the generated pages will have a dev-only warning at the top and the `githubURL` frontmatter property.
 
 When you make a PR with docs changes in another repo, please ping **@withastro/maintainers-docs** so we are aware of the changes made and can properly review your contribution.
 


### PR DESCRIPTION
## Summary
- Fixes a missing space in `CONTRIBUTING.md`: `` `githubURL`frontmatter `` → `` `githubURL` frontmatter ``

This is a tiny, unsolicited documentation fix per the "Examples of Helpful GitHub PRs" section of this same file, which welcomes PRs addressing typos and other minor problems.

en-only