### PR TITLE
fix(logger): make AstroLoggerDestination not generic

### DIFF
--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -41,11 +41,7 @@ export default defineConfig({
 The following example implements a minimal logger returning an [`AstroLoggerDestination` object](#astrologgerdestination) with the required `write()` function:
 
 ```ts title="@org/custom-logger/index.ts"
-import type { 
-  AstroLoggerLevel, 
-  AstroLoggerDestination, 
-  AstroLoggerMessage 
-} from "astro";
+import type { AstroLoggerLevel, AstroLoggerDestination } from "astro";
 import { matchesLevel } from "astro/logger"; 
 
 type LoggerOptions = {
@@ -55,7 +51,7 @@ type LoggerOptions = {
 function orgLogger(options: LoggerOptions = {}): AstroLoggerDestination {
   const { level = 'info' } = options;
   return {
-    write(message: AstroLoggerMessage) {
+    write(message) {
       // Use this utility to understand if the message should be printed 
       if (matchesLevel(message.level, level)) {
         // log message somewhere and take the level into consideration


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->
Updates the reference to remove an unecessary type

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/astro/pull/17390
<!-- If this PR needs to be merged for a specific Astro release, add the version below. -->
- For Astro version `7.1.0`

