### PR TITLE
Use new wrangler preview command for preview deployments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -85,9 +85,9 @@ jobs:
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          # Always upload to the main "docs" Worker so previews use the
+          # Always create the preview on the main "docs" Worker so previews use the
           # *.previews.docs.astro.build domain, even for PRs targeting version branches.
-          command: versions upload --name docs --preview-alias "${{ steps.metadata.outputs.preview_alias }}"
+          command: preview --worker-name docs --name "${{ steps.metadata.outputs.preview_alias }}"
 
       - name: Comment deployment complete
         if: success()

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,4 +9,5 @@
 		"not_found_handling": "none",
 	},
 	"preview_urls": true,
+	"workers_dev": false,
 }


### PR DESCRIPTION
Switches preview deploys from `wrangler versions upload --preview-alias` to the new Previews command `wrangler preview --worker-name docs --name <alias>`, and sets `workers_dev: false` in wrangler.jsonc.

Requires the `docs` Worker to be recreated to support the new Previews feature.