### PR TITLE
Fix TypeScript errors in code snippets of imports reference

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -8,7 +8,7 @@ import ReadMore from '~/components/ReadMore.astro'
 
 Astro supports most static assets with zero configuration required. You can use the `import` statement anywhere in your project JavaScript (including your Astro frontmatter) and Astro will include a built, optimized copy of that static asset in your final build. `@import` is also supported inside of CSS & `<style>` tags.
 
-## Supported File Types
+## Supported file types
 
 The following file types are supported out-of-the-box by Astro:
 
@@ -81,7 +81,7 @@ import MyComponent from "./MyComponent"; // MyComponent.tsx
 <ReadMore>Read more about [TypeScript support in Astro](/en/guides/typescript/).</ReadMore>
 
 
-### NPM Packages
+### NPM packages
 
 If you've installed an NPM package, you can import it in Astro.
 
@@ -133,7 +133,7 @@ Astro supports CSS Modules using the `[name].module.css` naming convention. Like
 
 CSS Modules help you enforce component scoping & isolation on the frontend with uniquely-generated class names for your stylesheets.
 
-### Other Assets
+### Other assets
 
 ```astro
 ---
@@ -247,7 +247,7 @@ const components: AstroInstance[] = Object.values(
 }
 ```
 
-### Supported Values
+### Supported values
 
 Vite's `import.meta.glob()` function only supports static string literals. It does not support dynamic variables and string interpolation.
 
@@ -344,13 +344,13 @@ const data = import.meta.glob<CustomDataFile>('../data/**/*.js');
 ---
 ```
 
-### Glob Patterns
+### Glob patterns
 
 A glob pattern is a file path that supports special wildcard characters. This is used to reference multiple files in your project at once.
 
 For example, the glob pattern `./pages/**/*.{md,mdx}` starts within the pages subdirectory, looks through all of its subdirectories (`/**`), and matches any filename (`/*`) that ends in either `.md` or `.mdx` (`.{md,mdx}`).
 
-#### Glob Patterns in Astro
+#### Glob patterns in Astro
 
 To use with `import.meta.glob()`, the glob pattern must be a string literal and cannot contain any variables.
 
@@ -375,7 +375,7 @@ const wasm = await WebAssembly.instantiateStreaming(fetch('/example.wasm'));
 Astro supports loading WASM files directly into your application using the browser’s [`WebAssembly`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly) API.
 
 
-## Node Builtins
+## Node builtins
 
 Astro supports Node.js built-ins, with some limitations, using Node’s newer `node:` prefix. There may be differences between development and production, and some features may be incompatible with on-demand rendering. Some [adapters](/en/guides/on-demand-rendering/) may also be incompatible with these built-ins modules or require configuration to support a subset (e.g., [Cloudflare Workers](/en/guides/integrations-guide/cloudflare/) or [Deno](https://github.com/denoland/deno-astro-adapter)).
 

--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -31,10 +31,10 @@ You can place any static asset in the [`public/` directory](/en/basics/project-s
 You can reference a `public/` file by a URL path directly in your HTML templates.
 
 ```astro
-// To link to /public/reports/annual/2024.pdf
+{/* To link to /public/reports/annual/2024.pdf */}
 Download the <a href="/reports/annual/2024.pdf">2024 annual statement as a PDF</a>.
 
-// To display /public/assets/cats/ginger.jpg
+{/* To display /public/assets/cats/ginger.jpg */}
 <img src="/assets/cats/ginger.jpg" alt="An orange cat sleeping on a bed.">
 ```
 
@@ -118,13 +118,15 @@ Astro supports importing CSS files directly into your application. Imported styl
 
 ### CSS Modules
 
-```jsx
+```astro
+---
 // 1. Converts './style.module.css' classnames to unique, scoped values.
 // 2. Returns an object mapping the original classnames to their final, scoped value.
 import styles from './style.module.css';
+---
 
-// This example uses JSX, but you can use CSS Modules with any framework.
-return <div className={styles.error}>Your Error Message</div>;
+{/* This example uses Astro, but you can use CSS Modules with any framework. */}
+<div className={styles.error}>Your Error Message</div>
 ```
 
 Astro supports CSS Modules using the `[name].module.css` naming convention. Like any CSS file, importing one will automatically apply that CSS to the page. However, CSS Modules export a special default `styles` object that maps your original classnames to unique identifiers.
@@ -133,15 +135,17 @@ CSS Modules help you enforce component scoping & isolation on the frontend with 
 
 ### Other Assets
 
-```jsx
+```astro
+---
 // Returns an object with `src` and other properties
 import imgReference from './image.png';
 import svgReference from './image.svg';
+---
 
-// HTML or UI Framework components use this to render the image
+{/* HTML or UI Framework components use this to render the image */}
 <img src={imgReference.src} alt="image description" />;
 
-// The Astro `<Image />` and `<Picture />` components access `src` by default
+{/* The Astro `<Image />` and `<Picture />` components access `src` by default */}
 <Image src={imgReference} alt="image description">
 ```
 
@@ -203,34 +207,44 @@ import logoUrl from '@assets/logo.png?url';
 ```astro title="src/components/my-component.astro" {3,4}
 ---
 // imports all files that end with `.md` in `./src/pages/post/`
-const matches = import.meta.glob('../pages/post/*.md', { eager: true }); 
+const matches = import.meta.glob("../pages/post/*.md", { eager: true });
 const posts = Object.values(matches);
 ---
+
 <!-- Renders an <article> for the first 5 blog posts -->
 <div>
-{posts.slice(0, 4).map((post) => (
-  <article>
-    <h2>{post.frontmatter.title}</h2>
-    <p>{post.frontmatter.description}</p>
-    <a href={post.url}>Read more</a>
-  </article>
-))}
+  {
+    posts.slice(0, 4).map((post: any) => (
+      <article>
+        <h2>{post.frontmatter.title}</h2>
+        <p>{post.frontmatter.description}</p>
+        <a href={post.url}>Read more</a>
+      </article>
+    ))
+  }
 </div>
 ```
 
 Astro components imported using `import.meta.glob` are of type [`AstroInstance`](#astro-files). You can render each component instance using its `default` property:
 
-```astro title="src/pages/component-library.astro" {8}
+```astro title="src/pages/component-library.astro" {14}
 ---
+import type { AstroInstance } from "astro";
+
 // imports all files that end with `.astro` in `./src/components/`
-const components = Object.values(import.meta.glob('../components/*.astro', { eager: true }));
+const components: AstroInstance[] = Object.values(
+  import.meta.glob("../components/*.astro", { eager: true }),
+);
 ---
-<!-- Display all of our components -->
-{components.map((component) => (
-  <div>
-    <component.default size={24} />
-  </div>
-))}
+
+{/* Display all of our components */}
+{
+  components.map((component) => (
+    <div>
+      <component.default size={24} />
+    </div>
+  ))
+}
 ```
 
 ### Supported Values
@@ -239,18 +253,23 @@ Vite's `import.meta.glob()` function only supports static string literals. It do
 
 A common workaround is to instead import a larger set of files that includes all the files you need, then filter them:
 
-```astro {6-7}
+```astro {5-10} title="src/components/featured.astro"
 ---
-// src/components/featured.astro
 const { postSlug } = Astro.props;
 const pathToMyFeaturedPost = `src/pages/blog/${postSlug}.md`;
 
-const posts = Object.values(import.meta.glob("../pages/blog/*.md", { eager: true }));
-const myFeaturedPost = posts.find(post => post.file.includes(pathToMyFeaturedPost));
+const posts = Object.values(
+  import.meta.glob("../pages/blog/*.md", { eager: true }),
+);
+const myFeaturedPost: any = posts.find((post: any) =>
+  post.file.includes(pathToMyFeaturedPost),
+);
 ---
 
 <p>
-  Take a look at my favorite post, <a href={myFeaturedPost.url}>{myFeaturedPost.frontmatter.title}</a>!
+  Take a look at my favorite post, <a href={myFeaturedPost.url}
+    >{myFeaturedPost.frontmatter.title}</a
+  >!
 </p>
 ```
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates our [Imports reference](https://docs.astro.build/en/guides/imports/) to:
- Fix TypeScript errors
  - `//` comments are invalid in the template part, we need HTML or JSX comments (No one will probably copy/paste those, but we should show valid syntax)
  - CSS Modules: this is not a valid JSX example (`return` comes from nowhere), and this works too in an Astro file. So, converting the code snippet seems the easiest way.
  - Other Assets: [`<Image />` is not available in UI frameworks](https://docs.astro.build/en/guides/images/#images-in-ui-framework-components), so the code snippet should use an `.astro` file, and not `jsx`.
  - import.meta.glob: TypeScript complains about `post.`, we need `any` + formatting
  - import.meta.glob: in the second snippet, TypeScript complains about `component`. Since we have a public type, I used it instead of `any`. I also converted the comment to a JSX one because the formatter wants to put the opening brace on the same line as the comment: `-->{`
  - Supported Values: we need two `any` to prevent TypeScript errors on `post.*` and `myFeaturedPost.*` + formatting
- Use a consistent sentence case for headings (the only exception I haven't updated is "CSS Modules" because it seems this is the correct casing: https://github.com/css-modules/css-modules/tree/master)

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089