### PR TITLE
Document `session: false` opt-out and session runtime tree-shaking

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
+++ b/src/content/docs/en/guides/integrations-guide/cloudflare.mdx
@@ -354,6 +354,8 @@ const cart = await Astro.session?.get('cart');
 
 By default, the KV binding is named `SESSION`. To use a different name, set the [`sessionKVBindingName`](#sessionkvbindingname) option in the adapter config.
 
+If your project does not use sessions, you can set [`session: false`](/en/guides/sessions/#disabling-sessions) in your Astro config. The adapter will not configure a KV binding, no KV namespace will be provisioned when you deploy, and the session runtime will be excluded from your Worker bundle.
+
 :::note
 Writes to Cloudflare KV are [eventually consistent](https://developers.cloudflare.com/kv/concepts/how-kv-works/#consistency) between regions. This means that changes are available immediately within the same region but may take up to 60 seconds to propagate globally. This won't affect most users as they are unlikely to switch regions between requests, but it may be a consideration for some use cases, such as VPN users.
 :::

--- a/src/content/docs/en/guides/integrations-guide/netlify.mdx
+++ b/src/content/docs/en/guides/integrations-guide/netlify.mdx
@@ -216,6 +216,8 @@ The Astro [Sessions API](/en/guides/sessions/) allows you to easily store user d
 
 Astro automatically configures [Netlify Blobs](https://docs.netlify.com/blobs/overview/) for session storage when using the Netlify adapter. If you would prefer to use a different session storage driver, you can specify it in your Astro config. See [the `session` configuration reference](/en/reference/configuration-reference/#sessiondriver) for more details.
 
+If your project does not use sessions, you can set [`session: false`](/en/guides/sessions/#disabling-sessions) in your Astro config. The adapter will not configure Netlify Blobs for session storage, and the session runtime will be excluded from your function bundle.
+
 ### Caching Pages
 
 On-demand rendered pages without any dynamic content can be cached to improve performance and lower resource usage.

--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -295,6 +295,8 @@ The Astro [Sessions API](/en/guides/sessions/) allows you to easily store user d
 
 Astro uses the local filesystem for session storage when using the Node adapter. If you would prefer to use a different session storage driver, you can specify it in your Astro config. See [the `session` configuration reference](/en/reference/configuration-reference/#sessiondriver) for more details.
 
+If your project does not use sessions, you can set [`session: false`](/en/guides/sessions/#disabling-sessions) in your Astro config. The adapter will not configure the filesystem session driver, and the session runtime will be excluded from your server bundle.
+
 ## Environment variables
 
 When using the [`astro:env`](/en/guides/environment-variables/#type-safe-environment-variables) secrets or `process.env` at runtime, neither Astro nor the adapter loads environment variables for you. 

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -110,6 +110,30 @@ The following example takes advantage of [Unstorage compatibility](/en/reference
     ```
 </Steps>
 
+## Disabling sessions
+
+<p>
+<Since v="7.2.0" />
+</p>
+
+If your project does not use sessions, you can set `session: false` to opt out of session support entirely:
+
+```js title="astro.config.mjs" ins={4}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  session: false,
+});
+```
+
+When sessions are disabled, adapters that normally provide a default session driver (e.g. [Node](/en/guides/integrations-guide/node/#sessions), [Cloudflare](/en/guides/integrations-guide/cloudflare/#sessions), and [Netlify](/en/guides/integrations-guide/netlify/#sessions)) will not configure one, and the session runtime and its dependencies are excluded from your server bundle. This can be useful for serverless and edge runtimes, where a smaller bundle reduces cold start time.
+
+`Astro.session` and `context.session` will be `undefined`, exactly as in a project with no session storage configured. Code that checks for session availability (e.g. `Astro.session?.get()`) continues to work without changes.
+
+:::note
+The session runtime is automatically excluded from your server bundle whenever no session driver is configured, even without setting `session: false`. Setting `session: false` additionally tells your adapter not to provide its default driver.
+:::
+
 ## Interacting with session data
 
 The [`session` object](/en/reference/api-reference/#session) allows you to interact with the stored user state (e.g. adding items to a shopping cart) and the session ID (e.g. deleting the session ID cookie when logging out). The object is accessible as `Astro.session` in your Astro components and pages and as `context.session` object in API endpoints, middleware, and actions.

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -116,7 +116,7 @@ The following example takes advantage of [Unstorage compatibility](/en/reference
 <Since v="7.2.0" />
 </p>
 
-If your project does not use sessions, you can set `session: false` to opt out of session support entirely:
+The session runtime is automatically excluded from your server bundle whenever no session driver is configured. Setting `session: false` additionally tells your adapter not to provide its default driver, opting your project out of session support entirely:
 
 ```js title="astro.config.mjs" ins={4}
 import { defineConfig } from 'astro/config';
@@ -126,11 +126,7 @@ export default defineConfig({
 });
 ```
 
-When sessions are disabled, adapters that normally provide a default session driver (e.g. [Node](/en/guides/integrations-guide/node/#sessions), [Cloudflare](/en/guides/integrations-guide/cloudflare/#sessions), and [Netlify](/en/guides/integrations-guide/netlify/#sessions)) will not configure one, and the session runtime and its dependencies are excluded from your server bundle. This can be useful for serverless and edge runtimes, where a smaller bundle reduces cold start time.
-
-:::note
-The session runtime is automatically excluded from your server bundle whenever no session driver is configured, even without setting `session: false`. Setting `session: false` additionally tells your adapter not to provide its default driver.
-:::
+Adapters that normally provide a default session driver (e.g. [Node](/en/guides/integrations-guide/node/#sessions), [Cloudflare](/en/guides/integrations-guide/cloudflare/#sessions), and [Netlify](/en/guides/integrations-guide/netlify/#sessions)) will not configure one. This can be useful for serverless and edge runtimes, where a smaller bundle reduces cold start time.
 
 ## Interacting with session data
 

--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -110,7 +110,7 @@ The following example takes advantage of [Unstorage compatibility](/en/reference
     ```
 </Steps>
 
-## Disabling sessions
+### Disabling sessions
 
 <p>
 <Since v="7.2.0" />
@@ -127,8 +127,6 @@ export default defineConfig({
 ```
 
 When sessions are disabled, adapters that normally provide a default session driver (e.g. [Node](/en/guides/integrations-guide/node/#sessions), [Cloudflare](/en/guides/integrations-guide/cloudflare/#sessions), and [Netlify](/en/guides/integrations-guide/netlify/#sessions)) will not configure one, and the session runtime and its dependencies are excluded from your server bundle. This can be useful for serverless and edge runtimes, where a smaller bundle reduces cold start time.
-
-`Astro.session` and `context.session` will be `undefined`, exactly as in a project with no session storage configured. Code that checks for session availability (e.g. `Astro.session?.get()`) continues to work without changes.
 
 :::note
 The session runtime is automatically excluded from your server bundle whenever no session driver is configured, even without setting `session: false`. Setting `session: false` additionally tells your adapter not to provide its default driver.

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -893,7 +893,7 @@ Allows customizing how the cookie is serialized.
 
 <p>
 
-**Type:** `AstroSession`
+**Type:** `AstroSession | undefined`
 
 <Since v="5.7.0" />
 
@@ -901,7 +901,7 @@ Allows customizing how the cookie is serialized.
 
 `session` is an object that allows data to be stored between requests for [routes rendered on demand](/en/guides/on-demand-rendering/). It is associated with a cookie that contains the session ID only: the data itself is not stored in the cookie.
 
-The session is created when first used, and the session cookie is automatically set. The `session` object is `undefined` if no session storage has been configured, or if the current route is prerendered, and will log an error if you try to use it.
+The session is created when first used, and the session cookie is automatically set. The `session` object is `undefined` if no session storage has been configured, if [sessions are disabled](/en/guides/sessions/#disabling-sessions) with `session: false`, or if the current route is prerendered, and will log an error if you try to use it.
 
 See [the session guide](/en/guides/sessions/) for more information on how to use sessions in your Astro project.
 

--- a/src/content/docs/en/reference/api-reference.mdx
+++ b/src/content/docs/en/reference/api-reference.mdx
@@ -901,7 +901,7 @@ Allows customizing how the cookie is serialized.
 
 `session` is an object that allows data to be stored between requests for [routes rendered on demand](/en/guides/on-demand-rendering/). It is associated with a cookie that contains the session ID only: the data itself is not stored in the cookie.
 
-The session is created when first used, and the session cookie is automatically set. The `session` object is `undefined` if no session storage has been configured, if [sessions are disabled](/en/guides/sessions/#disabling-sessions) with `session: false`, or if the current route is prerendered, and will log an error if you try to use it.
+The session is created when first used, and the session cookie is automatically set. The `session` object is `undefined` and will log an error when used in the following cases: no session storage has been configured, [sessions are disabled](/en/guides/sessions/#disabling-sessions), or the current route is prerendered.
 
 See [the session guide](/en/guides/sessions/) for more information on how to use sessions in your Astro project.
 

--- a/src/content/docs/en/reference/modules/astro-fetch.mdx
+++ b/src/content/docs/en/reference/modules/astro-fetch.mdx
@@ -256,6 +256,8 @@ await sessions(state);
 // ...render pipeline...
 ```
 
+If no session driver is configured, or sessions are [disabled](/en/guides/sessions/#disabling-sessions) with `session: false`, this handler registers no provider and `ctx.session` will be `undefined`.
+
 ### `trailingSlash()`
 
 <p>

--- a/src/content/docs/en/reference/modules/astro-fetch.mdx
+++ b/src/content/docs/en/reference/modules/astro-fetch.mdx
@@ -256,7 +256,7 @@ await sessions(state);
 // ...render pipeline...
 ```
 
-If no session driver is configured, or sessions are [disabled](/en/guides/sessions/#disabling-sessions) with `session: false`, this handler registers no provider and `ctx.session` will be `undefined`.
+This handler registers no provider when no session driver is configured, or when [sessions are disabled](/en/guides/sessions/#disabling-sessions). In both cases, `ctx.session` will be `undefined`.
 
 ### `trailingSlash()`
 


### PR DESCRIPTION
Accompanies withastro/astro#16871.

#### Description (required)

Documents [withastro/astro#16871](https://github.com/withastro/astro/pull/16871), which adds a `session: false` config option to opt out of session support entirely, and tree-shakes the session runtime (`AstroSession` + `unstorage`) out of the SSR bundle for any project where no session driver is wired.

Changes (English only):

- **`guides/sessions.mdx`**: new "Disabling sessions" section (`<Since v="7.2.0" />`) covering the `session: false` option, that adapters skip wiring their default driver, that `Astro.session`/`context.session` are `undefined` (same as a project without sessions configured, so `Astro.session?.get()` feature detection keeps working), and a note that the runtime is tree-shaken automatically for any driver-less project even without the flag.
- **`reference/api-reference.mdx`**: `session` type corrected to `AstroSession | undefined`, and the disabled case added to the list of situations where `session` is `undefined`.
- **`guides/integrations-guide/cloudflare.mdx`**: note in the Sessions section that `session: false` means no KV binding is configured, no KV namespace is provisioned on deploy, and the session runtime is excluded from the Worker bundle.
- **`guides/integrations-guide/netlify.mdx`**: note that `session: false` means Netlify Blobs is not configured for session storage and the runtime is excluded from the function bundle.
- **`guides/integrations-guide/node.mdx`**: note that `session: false` means the filesystem driver is not configured and the runtime is excluded from the server bundle.
- **`reference/modules/astro-fetch.mdx`**: note on the `sessions()` pipeline handler that it registers no provider (and `ctx.session` is `undefined`) when no driver is configured or sessions are disabled.

#### References

- Related to https://github.com/withastro/astro/pull/16871
- For Astro version `7.2.0` (and `@astrojs/cloudflare` `14.2.0`, `@astrojs/netlify` `8.2.0`, `@astrojs/node` `11.1.0`)


Discord username: adam.chal