### PR TITLE
fix two code snippets in the Imports reference

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -126,7 +126,7 @@ import styles from './style.module.css';
 ---
 
 {/* This example uses Astro, but you can use CSS Modules with any framework. */}
-<div className={styles.error}>Your Error Message</div>
+<div class={styles.error}>Your Error Message</div>
 ```
 
 Astro supports CSS Modules using the `[name].module.css` naming convention. Like any CSS file, importing one will automatically apply that CSS to the page. However, CSS Modules export a special default `styles` object that maps your original classnames to unique identifiers.
@@ -143,7 +143,7 @@ import svgReference from './image.svg';
 ---
 
 {/* HTML or UI Framework components use this to render the image */}
-<img src={imgReference.src} alt="image description" />;
+<img src={imgReference.src} alt="image description" />
 
 {/* The Astro `<Image />` and `<Picture />` components access `src` by default */}
 <Image src={imgReference} alt="image description">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In #14249 I converted two code snippets to use Astro instead of JSX, but I missed two things:
- `className` should be `class` now
- an unwanted semicolon

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14249
