### PR TITLE
Fix TypeScript errors in `routing-reference.mdx`

### DIFF
--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -153,8 +153,8 @@ For example, if you generate pages with data fetched from a remote API, you can 
 ```astro title="src/pages/posts/[id].astro" {9}
 ---
 export async function getStaticPaths() {
-  const response = await fetch('...');
-  const data = await response.json();
+  const response = await fetch("...");
+  const data: any[] = await response.json();
 
   return data.map((post) => {
     return {
@@ -167,6 +167,7 @@ export async function getStaticPaths() {
 const { id } = Astro.params;
 const { post } = Astro.props;
 ---
+
 <h1>{id}: {post.name}</h1>
 ```
 
@@ -189,11 +190,12 @@ The following example shows how to localize your route segments and return an ar
 
 ```astro title="src/pages/[...locale]/[files]/[slug].astro" "routePattern" "getLocalizedData"
 ---
+import type { GetStaticPathsOptions } from "astro";
 import { getLocalizedData } from "../../../utils/i18n";
 
-export async function getStaticPaths({ routePattern }) {
-  const response = await fetch('...');
-  const data = await response.json();
+export async function getStaticPaths({ routePattern }: GetStaticPathsOptions) {
+  const response = await fetch("...");
+  const data: any[] = await response.json();
 
   console.log(routePattern); // [...locale]/[files]/[slug]
 
@@ -220,16 +222,18 @@ The following example fetches and passes 150 items to the `paginate` function, a
 
 ```astro title="src/pages/pokemon/[page].astro"
 ---
-export async function getStaticPaths({ paginate }) {
+import type { GetStaticPathsOptions } from "astro";
+
+export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
   // Load your data with fetch(), getCollection(), etc.
   const response = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=150`);
   const result = await response.json();
   const allPokemon = result.results;
 
   // Return a paginated collection of paths for all items
-  return paginate(allPokemon, { 
+  return paginate(allPokemon, {
     pageSize: 10,
-    format: (url) => `${url}.html`
+    format: (url) => `${url}.html`,
   });
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)


Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes code snippets in `routing-reference.mdx`:
- In "Data passing with `props`": data is implicitly `any` so TypeScript complains about `post`. If we add the type on `post`, TS still complains because it thinks `post` is `never`; we need to type `data`.
- In `routePattern`: same issue with `data`, and TypeScript complains with `Binding element 'routePattern' implicitly has an 'any' type` if we don't use `GetStaticPathsOptions`.
- In `paginate()`: same, we need `GetStaticPathsOptions` (or `satisfies GetStaticPaths`)

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14089
