### PR TITLE
Fix RTL fallback card navigation

### DIFF
--- a/src/components/NavGrid/CardsNav.astro
+++ b/src/components/NavGrid/CardsNav.astro
@@ -22,9 +22,11 @@ export interface Props {
 const { links, size, class: classes } = Astro.props as Props;
 
 const currentPage = new URL(Astro.request.url).pathname;
+// Fallback pages can render English content while their navigation labels use the page locale.
+const textDirection = Astro.locals.t.dir();
 ---
 
-<section class:list={['cards-nav', classes, 'not-content']}>
+<section dir={textDirection} class:list={['cards-nav', classes, 'not-content']}>
 	<slot />
 	<Grid {size}>
 		{


### PR DESCRIPTION
## Summary

- set the CardsNav direction from Starlight’s active translation locale
- ensure Arabic UI labels in fallback-page navigation render RTL even when the fallback content inherits LTR direction

## Root cause

Fallback pages render English content, so the surrounding content direction can be LTR. CardsNav includes UI strings translated for the requested page locale, but previously inherited that LTR direction and reordered/wrapped RTL labels incorrectly.

## Validation

- `pnpm exec prettier --check src/components/NavGrid/CardsNav.astro`
- `pnpm check`
- `pnpm lint:eslint`
- local smoke test: `/ar/guides/deploy/` renders `<section dir="rtl" class="cards-nav …">`

Closes #12777
