### PR TITLE
docs: Highlight option to opt in to use `bun` runtime over `node` default

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -84,6 +84,21 @@ bun run build
 
 When the build is finished, run the appropriate preview command (e.g. `bun run preview`) in your terminal and you can view the built version of your site locally in the same browser preview window.
 
+> [!NOTE]
+> By default, Bun runs the dev server with Node.js. To use the Bun runtime instead to run the dev server or build, pass the `--bun` flag.
+
+### Run dev server
+
+```bash
+bun run --bun dev
+```
+
+### Build site
+
+```bash
+bun run --bun build
+```
+
 ## Testing
 
 Bun ships with a fast, built-in, Jest-compatible test runner through the [`bun test` command](https://bun.sh/docs/cli/test). You can also use any other [testing tools for Astro](/en/guides/testing/).


### PR DESCRIPTION
## Description
Minor addition to the docs to inform users to opt in to use Bun as a runtime for the dev server, builds, and previews.

By default, Bun respects the Node shebang (#!/usr/bin/env node) found at the top of executable files and automatically passes execution over to the system's Node.js runtime. To bypass this and force execution inside the Bun runtime, you must use the `--bun` flag

> [!NOTE]
> This option is described in the official Bun recipe [docs](https://docs.astro.build/en/recipes/bun/) but is missing in the corresponding Astro docs.

## Docs
- Bun's Astro [guide](https://bun.com/docs/guides/ecosystem/astro)
- Astro's Bun [recipe](https://docs.astro.build/en/recipes/bun/)

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## References
- Closes: `N/A`
- Related to `N/A`
- For Astro version `latest`
- Discord username: `@sweugene`
