### PR TITLE
feat: improve logger reference docs

### DIFF
--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -47,7 +47,7 @@ export default defineConfig({
 
 ### The logger implementation
 
-The logger implementation handles the logging logic. You implement it in your logger module by exporting a default function that takes the [config](#config) as a parameter and returns an [`AstroLoggerDestination` object](#astrologgerdestination) with the required `write()` function.
+The logger implementation handles the logging logic. You implement it in your logger module by exporting a default function that takes the [config](#the-logger-config) as a parameter and returns an [`AstroLoggerDestination` object](#astrologgerdestination) with the required `write()` function.
 
 The following example implements a minimal logger that takes the log `level` from its config into account:
 

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -5,6 +5,7 @@ sidebar:
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <p>
   <Since v="7.0.0" />
@@ -17,13 +18,20 @@ This API includes three ready-to-use loggers and allows you to integrate your ow
 
 ## Custom loggers
 
-You can create a custom logger by providing the correct configuration to the `logger` setting. It accepts an object with a mandatory `entrypoint`, the module where the logger is exported, and an optional configuration to pass to the logger. The configuration must be serializable.
+If you do not wish to use one of the [built-in loggers](#built-in-loggers), you can build your own.
 
-The logger function must be exported as `default`.
+A custom logger is made of two parts:
+
+- The [logger config](#the-logger-config), which lets Astro know what implementation to use and what config to forward
+- The [logger implementation](#the-logger-implementation), which handles the logging logic
 
 When you define a custom logger, you are in charge of all logs, even the ones emitted by Astro.
 
-The following example defines a custom logger exported by the `@org/custom-logger` package and accepting only one parameter to configure the logging `level`:
+### The logger config
+
+The `logger` config is an object containing a required [`entrypoint`](#entrypoint) and an optional [`config`](#config).
+
+The following example configures a custom logger exported by the `@org/custom-logger` package and passes it a `level` option:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -38,7 +46,68 @@ export default defineConfig({
 });
 ```
 
-The following example implements a minimal logger returning an [`AstroLoggerDestination` object](#astrologgerdestination) with the required `write()` function:
+#### `entrypoint`
+
+<p>
+
+**Type:** `string | URL`
+<Since v="7.0.0" />
+</p>
+
+Defines the entrypoint for the [logger implementation](#the-logger-implementation).
+
+This can be a `URL`, or a `string` that is either a package import or a path relative to your project root:
+
+<Tabs>
+
+<TabItem label="Package import">
+
+```js title="astro.config.mjs"
+logger: {
+  entrypoint: "@org/custom-logger"
+}
+```
+
+</TabItem>
+
+<TabItem label="Relative path">
+
+```js title="astro.config.mjs"
+logger: {
+  entrypoint: "./src/custom-logger.ts"
+}
+```
+
+</TabItem>
+
+<TabItem label="URL">
+
+```js title="astro.config.mjs"
+logger: {
+  entrypoint: new URL("./custom-logger.ts", import.meta.url)
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+#### `config`
+
+<p>
+
+**Type:** `Record<string, unknown> | undefined`<br />
+**Default:** `{}`
+<Since v="7.0.0" />
+</p>
+
+Defines the serializable config passed to the [logger implementation](#the-logger-implementation).
+
+### The logger implementation
+
+The logger implementation handles the logging logic. You implement it in your logger module by exporting a default function that takes the [config](#config) as a parameter and returns an [`AstroLoggerDestination` object](#astrologgerdestination) with the required `write()` function.
+
+The following example implements a minimal logger that takes the log `level` from its config into account:
 
 ```ts title="@org/custom-logger/index.ts"
 import type { AstroLoggerLevel, AstroLoggerDestination } from "astro";

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -5,7 +5,6 @@ sidebar:
 i18nReady: true
 ---
 import Since from '~/components/Since.astro';
-import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <p>
   <Since v="7.0.0" />
@@ -29,7 +28,7 @@ When you define a custom logger, you are in charge of all logs, even the ones em
 
 ### The logger config
 
-The `logger` config is an object containing a required [`entrypoint`](#entrypoint) and an optional [`config`](#config).
+The [`logger` config](/en/reference/configuration-reference/#logger-options) is an object containing a required [`entrypoint`](/en/reference/configuration-reference/#loggerentrypoint) and an optional [`config`](/en/reference/configuration-reference/#loggerconfig).
 
 The following example configures a custom logger exported by the `@org/custom-logger` package and passes it a `level` option:
 
@@ -45,63 +44,6 @@ export default defineConfig({
   }
 });
 ```
-
-#### `entrypoint`
-
-<p>
-
-**Type:** `string | URL`
-<Since v="7.0.0" />
-</p>
-
-Defines the entrypoint for the [logger implementation](#the-logger-implementation).
-
-This can be a `URL`, or a `string` that is either a package import or a path relative to your project root:
-
-<Tabs>
-
-<TabItem label="Package import">
-
-```js title="astro.config.mjs"
-logger: {
-  entrypoint: "@org/custom-logger"
-}
-```
-
-</TabItem>
-
-<TabItem label="Relative path">
-
-```js title="astro.config.mjs"
-logger: {
-  entrypoint: "./src/custom-logger.ts"
-}
-```
-
-</TabItem>
-
-<TabItem label="URL">
-
-```js title="astro.config.mjs"
-logger: {
-  entrypoint: new URL("./custom-logger.ts", import.meta.url)
-}
-```
-
-</TabItem>
-
-</Tabs>
-
-#### `config`
-
-<p>
-
-**Type:** `Record<string, unknown> | undefined`<br />
-**Default:** `{}`
-<Since v="7.0.0" />
-</p>
-
-Defines the serializable config passed to the [logger implementation](#the-logger-implementation).
 
 ### The logger implementation
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improves the logger reference to match font providers / session drivers. This is done because the linked PR fixes relative entrypoint paths

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR closes an issue, add the issue number below. -->
<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/astro/pull/17480
<!-- If this PR needs to be merged for a specific Astro release, add the version below. -->
- For Astro version `7.1.4`
<!-- First-time contributor to Astro Docs? Add your Discord username below so we can welcome you on the Astro Discord (https://astro.build/chat)! -->