### PR TITLE
Remove `getFallback()` from the view transitions router docs

### DIFF
--- a/src/content/docs/en/reference/modules/astro-transitions.mdx
+++ b/src/content/docs/en/reference/modules/astro-transitions.mdx
@@ -113,7 +113,6 @@ import { slide } from 'astro:transitions';
 
 ```ts
 import {
-  getFallback,
   navigate,
   supportsViewTransitions,
   swapFunctions,
@@ -221,19 +220,6 @@ Whether or not view transitions are supported and enabled in the current browser
 </p>
 
 Whether or not the current page has view transitions enabled for client-side navigation. This can be used to make components that behave differently when they are used on pages with view transitions.
-
-### `getFallback()`
-
-<p>
-
-**Type:** <code>() => <a href="#fallback">Fallback</a></code><br />
-**Default:** `animate`<br />
-<Since v="3.6.0" />
-</p>
-
-Returns the fallback strategy to use (`animate` by default) in browsers that do not support view transitions.
-
-<ReadMore>See the guide on [Fallback control](/en/guides/view-transitions/#fallback-control) for how to choose and configure the fallback behavior.</ReadMore>
 
 ### `swapFunctions`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

As discussed in https://github.com/withastro/astro/pull/17483, the `getFallback()` helper is no longer public since 2023 and, as no one complained, we should just remove it from the docs.

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR closes an issue, add the issue number below. -->
- Closes https://github.com/withastro/astro/issues/17482, https://github.com/withastro/astro/pull/17483
