### PR TITLE
add markdoc config option `typographer`

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -661,6 +661,37 @@ When using nested tags in Markdoc, it can be helpful to indent the content insid
 {% /custom-tag %}
 ```
 
+### `typographer`
+
+<p>
+
+**Type:** `boolean`<br />
+**Default:** `false`<br />
+<Since v="0.11.2" pkg="@astrojs/markdoc" />
+</p>
+
+Enables Markdoc's built-in support for smart quotes. Replaces straight single and double quotes with the appropriate curly quotes. 
+
+```js "ignoreIndentation: true" title="astro.config.mjs" ins={6}
+  import { defineConfig } from 'astro/config';
+  import markdoc from '@astrojs/markdoc';
+
+  export default defineConfig({
+    // ...
+    integrations: [markdoc({ typographer: true })],
+  });
+```
+
+```md title="src/content/docs/why-markdoc.mdoc"
+She continued, "You know what they said? They said, 'It's astonishing how fancy these smart quotes look!'. That's what they said."
+```
+
+The straight quotes are replaced intelligently and rendered as:
+
+```md
+She continued, “You know what they said? They said, ‘It’s astonishing how fancy these smart quotes look!’. That’s what they said.”
+```
+
 ## Examples
 
 * The [Astro Markdoc starter template](https://github.com/withastro/astro/tree/latest/examples/with-markdoc) shows how to use Markdoc files in your Astro project.

--- a/src/content/docs/en/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/en/guides/integrations-guide/markdoc.mdx
@@ -672,7 +672,7 @@ When using nested tags in Markdoc, it can be helpful to indent the content insid
 
 Enables Markdoc's built-in support for smart quotes. Replaces straight single and double quotes with the appropriate curly quotes. 
 
-```js "ignoreIndentation: true" title="astro.config.mjs" ins={6}
+```js title="astro.config.mjs" ins={6}
   import { defineConfig } from 'astro/config';
   import markdoc from '@astrojs/markdoc';
 


### PR DESCRIPTION
#### Description (required)

This describes the `typographer` option (for smart quotes) in the Markdoc integration, which has been available since @astrojs/markdoc v0.11.2, but there's no mention of it in the docs.

I'm not sure if the way I coded the example rendering is up to docs standards, but of course feel free to edit!

#### References

https://github.com/withastro/astro/pull/11450
https://github.com/withastro/astro/blob/main/packages/integrations/markdoc/CHANGELOG.md
https://github.com/withastro/astro/pull/11442