### PR TITLE
docs: add CMS Brew stub guide

### DIFF
--- a/src/content/docs/en/guides/cms/brew.mdx
+++ b/src/content/docs/en/guides/cms/brew.mdx
@@ -1,0 +1,22 @@
+---
+title: CMS Brew
+description: Add content to your Astro project using CMS Brew.
+sidebar:
+  label: CMS Brew
+type: cms
+slug: brew
+stub: true
+i18nReady: true
+---
+
+CMS Brew is a Git-backed content management system for Astro projects.
+
+This guide is coming soon.
+
+## Official website
+
+- https://cmsbrew.com
+
+## Resources
+
+- https://cmsbrew.com/docs


### PR DESCRIPTION
## Summary

Adds a stub guide for CMS Brew under the CMS guides section.

### Changes

- Add `brew.mdx`
- Include frontmatter for the guide
- Add official website and documentation links
- Mark the guide as a stub for future expansion

## Checklist

- [x] Documentation only
- [x] No breaking changes