### PR TITLE
Fix: add missing hyphens in compound adjectives (client-side)

### DIFF
--- a/src/content/docs/en/guides/backend/firebase.mdx
+++ b/src/content/docs/en/guides/backend/firebase.mdx
@@ -23,7 +23,7 @@ See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/fir
 - A [Firebase project with a web app configured](https://firebase.google.com/docs/web/setup).
 - An Astro project with [`output: 'server'` for on-demand rendering](/en/guides/on-demand-rendering/) enabled.
 - Firebase credentials: You will need two sets of credentials to connect Astro to Firebase:
-  - Web app credentials: These credentials will be used by the client side of your app. You can find them in the Firebase console under *Project settings > General*. Scroll down to the **Your apps** section and click on the **Web app** icon.
+  - Web app credentials: These credentials will be used by the client-side of your app. You can find them in the Firebase console under *Project settings > General*. Scroll down to the **Your apps** section and click on the **Web app** icon.
   - Project credentials: These credentials will be used by the server side of your app. You can generate them in the Firebase console under *Project settings > Service accounts > Firebase Admin SDK > Generate new private key*.
 
 ### Adding Firebase credentials
@@ -83,7 +83,7 @@ Your project should now include these new files:
 
 To connect Astro with Firebase, install the following packages using the single command below for your preferred package manager:
 
-- `firebase` - the Firebase SDK for the client side
+- `firebase` - the Firebase SDK for the client-side
 - `firebase-admin` - the Firebase Admin SDK for the server side
 
 <PackageManagerTabs>

--- a/src/content/docs/en/reference/experimental-flags/client-prerender.mdx
+++ b/src/content/docs/en/reference/experimental-flags/client-prerender.mdx
@@ -19,7 +19,7 @@ Enables pre-rendering your prefetched pages on the client in supported browsers.
 This feature uses the experimental [Speculation Rules Web API](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) and enhances the default `prefetch` behavior globally to prerender links on the client.
 You may wish to review the [possible risks when prerendering on the client](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prefetching) before enabling this feature.
 
-Enable client side prerendering in your `astro.config.mjs` along with any desired `prefetch` configuration options:
+Enable client-side prerendering in your `astro.config.mjs` along with any desired `prefetch` configuration options:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -38,6 +38,6 @@ export default defineConfig({
 Continue to use the `data-astro-prefetch` attribute on any `<a />` link on your site to opt in to prefetching.
 Instead of appending a `<link>` tag to the head of the document or fetching the page with JavaScript, a `<script>` tag will be appended with the corresponding speculation rules.
 
-Client side prerendering requires browser support. If the Speculation Rules API is not supported, `prefetch` will fallback to the supported strategy.
+Client-side prerendering requires browser support. If the Speculation Rules API is not supported, `prefetch` will fallback to the supported strategy.
 
 See the [Prefetch Guide](/en/guides/prefetch/) for more `prefetch` options and usage.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR closes an issue, add the issue number below. -->
- Closes #...
<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to ...
<!-- If this PR needs to be merged for a specific Astro release, add the version below. -->
- For Astro version `x.x.x`
<!-- First-time contributor to Astro Docs? Add your Discord username below so we can welcome you on the Astro Discord (https://astro.build/chat)! -->
- Discord username: ...
