### PR TITLE
Fix code snippets errors (TS) in the Logger and Programmatic APIs

### DIFF
--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -51,22 +51,17 @@ The logger implementation handles the logging logic. You implement it in your lo
 
 The following example implements a minimal logger that takes the log `level` from its config into account:
 
-```ts title="@org/custom-logger/index.ts"
-import type {
-  AstroLoggerLevel,
-  AstroLoggerDestination,
-  AstroLoggerMessage,
-} from "astro";
+```ts title="@org/custom-logger/index.js"
 import { matchesLevel } from "astro/logger";
 
-type LoggerOptions = {
-  level: AstroLoggerLevel;
-};
-
-function orgLogger(
-  options: Partial<LoggerOptions> = {},
-): AstroLoggerDestination<AstroLoggerMessage> {
-  const { level = "info" } = options;
+/**
+ * Minimal example of a custom logger implementation.
+ *
+ * @param {Object} [options] - The logger options.
+ * @param {import("astro").AstroLoggerLevel} [options.level] - The minimum level of logs. Defaults to "info".
+ * @returns {import("astro").AstroLoggerDestination} The custom logger destination.
+ */
+function orgLogger({ level } = { level: "info" }) {
   return {
     write(message) {
       // Use this utility to understand if the message should be printed

--- a/src/content/docs/en/reference/logger-reference.mdx
+++ b/src/content/docs/en/reference/logger-reference.mdx
@@ -52,23 +52,29 @@ The logger implementation handles the logging logic. You implement it in your lo
 The following example implements a minimal logger that takes the log `level` from its config into account:
 
 ```ts title="@org/custom-logger/index.ts"
-import type { AstroLoggerLevel, AstroLoggerDestination } from "astro";
-import { matchesLevel } from "astro/logger"; 
+import type {
+  AstroLoggerLevel,
+  AstroLoggerDestination,
+  AstroLoggerMessage,
+} from "astro";
+import { matchesLevel } from "astro/logger";
 
 type LoggerOptions = {
-  level: AstroLoggerLevel
-}
+  level: AstroLoggerLevel;
+};
 
-function orgLogger(options: LoggerOptions = {}): AstroLoggerDestination {
-  const { level = 'info' } = options;
+function orgLogger(
+  options: Partial<LoggerOptions> = {},
+): AstroLoggerDestination<AstroLoggerMessage> {
+  const { level = "info" } = options;
   return {
     write(message) {
-      // Use this utility to understand if the message should be printed 
+      // Use this utility to understand if the message should be printed
       if (matchesLevel(message.level, level)) {
         // log message somewhere and take the level into consideration
       }
-    }
-  }
+    },
+  };
 }
 
 export default orgLogger;

--- a/src/content/docs/en/reference/programmatic-reference.mdx
+++ b/src/content/docs/en/reference/programmatic-reference.mdx
@@ -197,40 +197,44 @@ Takes an Astro configuration object and a partial object containing any set of v
 - All other options override the existing config.
 
 ```ts
+import mdx from "@astrojs/mdx";
+import partytown from "@astrojs/partytown";
+import type { AstroInlineConfig } from "astro";
 import { mergeConfig } from "astro/config";
 
-mergeConfig(
-  {
-    output: "static",
-    site: "https://example.com",
-    integrations: [partytown()],
-    server: ({command}) => ({
-      port: command === "dev" ? 4321 : 1234,
-    }),
-    build: {
-      client: "./custom-client",
-    },
+const defaultConfig: AstroInlineConfig = {
+  output: "static",
+  site: "https://example.com",
+  integrations: [partytown()],
+  server: ({ command }) => ({
+    port: command === "dev" ? 4321 : 1234,
+  }),
+  build: {
+    client: "./custom-client",
   },
-  {
-    output: "server",
-    base: "/astro",
-    integrations: [mdx()],
-    server: ({command}) => ({
-      host: command === "dev" ? "localhost" : "site.localhost",
-    }),
-    build: {
-      server: "./custom-server",
-    },
-  }
-);
+};
 
-// Result is equivalent to:
+const overrideConfig: AstroInlineConfig = {
+  output: "server",
+  base: "/astro",
+  integrations: [mdx()],
+  server: ({ command }) => ({
+    host: command === "dev" ? "localhost" : "site.localhost",
+  }),
+  build: {
+    server: "./custom-server",
+  },
+};
+
+const finalConfig = mergeConfig(defaultConfig, overrideConfig);
+
+// `finalConfig` is equivalent to:
 {
   output: "server",
   site: "https://example.com",
   base: "/astro",
   integrations: [partytown(), mdx()],
-  server: ({command}) => ({
+  server: ({ command }) => ({
     port: command === "dev" ? 4321 : 1234,
     host: command === "dev" ? "localhost" : "site.localhost",
   }),
@@ -258,10 +262,14 @@ The returned promise resolves to the validated configuration, filled with all de
 
 ```ts
 import { validateConfig } from "astro/config";
+import partytown from "@astrojs/partytown";
+import { rm } from "node:fs/promises";
 
-const config = await validateConfig({
-  integrations: [partytown()],
-}, "./my-project", "build");
+const config = await validateConfig(
+  { integrations: [partytown()] },
+  "./my-project",
+  "build",
+);
 
 // defaults are applied
 await rm(config.outDir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes code snippets in:
- `src/content/docs/en/reference/logger-reference.mdx`:
  - "The logger implementation": we need `Partial` as we use an empty object instead of default options, and without passing `AstroLoggerMessage` to the generic `AstroLoggerDestination`, TS complains that `message` is unknown
- `src/content/docs/en/reference/programmatic-reference.mdx`:
  - `mergeConfig()`: missing imports, and without explicitly typing the objects, TS complains with `Types of property 'output' are incompatible`.
  - `validateConfig()`: missing imports


<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/docs/pull/14089