### PR TITLE
Fix code snippets in the Dev Toolbar App reference

### DIFF
--- a/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
+++ b/src/content/docs/en/reference/dev-toolbar-app-reference.mdx
@@ -185,11 +185,13 @@ A standard [ShadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowR
 
 Every app receives its own dedicated ShadowRoot for rendering its UI. Additionally, the parent element is positioned using `position: absolute;` so the app UI will not affect the layout of an Astro page.
 
-```ts title="src/my-app.js" {3}
+```ts title="src/my-app.js" {5}
+import { defineToolbarApp } from "astro/toolbar";
+
 export default defineToolbarApp({
-	init(canvas) {
-    canvas.appendChild(document.createTextNode('Hello World!'))
-  }
+  init(canvas) {
+    canvas.appendChild(document.createTextNode("Hello World!"));
+  },
 });
 ```
 
@@ -203,7 +205,9 @@ export default defineToolbarApp({
 
 A standard [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) with a few additional [helpers for client-side events](#client-side-events) that can be used to send and receive events from the Dev toolbar.
 
-```ts title="src/my-app.js" {3-8}
+```ts title="src/my-app.js" {5-10}
+import { defineToolbarApp } from "astro/toolbar";
+
 export default defineToolbarApp({
   init(canvas, app) {
     app.onToggled(({ state }) => {
@@ -226,12 +230,14 @@ export default defineToolbarApp({
 
 An object that can be used to [communicate with the server](#client-server-communication).
 
-```ts title="src/my-app.js" {3-7}
+```ts title="src/my-app.js" {5-9}
+import { defineToolbarApp } from "astro/toolbar";
+
 export default defineToolbarApp({
   init(canvas, app, server) {
-    server.send('my-message', { message: 'Hello!' });
+    server.send("my-message", { message: "Hello!" });
 
-    server.on('server-message', (data) => {
+    server.on("server-message", (data) => {
       console.log(data.message);
     });
   },
@@ -250,13 +256,17 @@ This optional function will be called when the user clicks on the app icon in th
 
 If a falsy value is returned, the toggling off will be cancelled and the app will stay enabled.
 
-```ts title="src/my-app.js" {3-6}
+```ts title="src/my-app.js" {5-10}
+import { defineToolbarApp } from "astro/toolbar";
+
 export default defineToolbarApp({
   // ...
   beforeTogglingOff() {
-    const confirmation = window.confirm('Are you sure you want to disable this app?');
+    const confirmation = window.confirm(
+      "Are you sure you want to disable this app?",
+    );
     return confirmation;
-  }
+  },
 });
 ```
 
@@ -283,9 +293,15 @@ In addition to the standard methods of an `EventTarget` ([`addEventListener`](ht
 
 Registers a callback to be called when the user clicks on the app icon in the UI to toggle the app on or off.
 
-```ts title="src/my-app.js"
-app.onToggled((options) => {
-  console.log(`The app is now ${options.state ? 'enabled' : 'disabled'}!`);
+```ts title="src/my-app.js" {5-7}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app) {
+    app.onToggled((options) => {
+      console.log(`The app is now ${options.state ? "enabled" : "disabled"}!`);
+    });
+  },
 });
 ```
 
@@ -299,9 +315,15 @@ app.onToggled((options) => {
 
 This event is fired when the user changes the placement of the Dev Toolbar. This can, for example, be used to reposition the app's UI when the toolbar is moved.
 
-```ts title="src/my-app.js"
-app.onToolbarPlacementUpdated((options) => {
-  console.log(`The toolbar is now placed at ${options.placement}!`);
+```ts title="src/my-app.js" {5-7}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app) {
+    app.onToolbarPlacementUpdated((options) => {
+      console.log(`The toolbar is now placed at ${options.placement}!`);
+    });
+  },
 });
 ```
 
@@ -315,8 +337,14 @@ app.onToolbarPlacementUpdated((options) => {
 
 Changes the state of the app. This can be used to enable or disable the app programmatically, for example, when the user clicks on a button in the app's UI.
 
-```ts title="src/my-app.js"
-app.toggleState({ state: false });
+```ts title="src/my-app.js" {5}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app) {
+    app.toggleState({ state: false });
+  },
+});
 ```
 
 ### `toggleNotification()`
@@ -329,10 +357,16 @@ app.toggleState({ state: false });
 
 Toggles a notification on the app icon. This can be used to inform the user that the app requires attention, or remove the current notification.
 
-```ts title="src/my-app.js"
-app.toggleNotification({
-  state: true,
-  level: 'warning',
+```ts title="src/my-app.js" {5-8}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app) {
+    app.toggleNotification({
+      state: true,
+      level: "warning",
+    });
+  },
 });
 ```
 
@@ -363,12 +397,14 @@ Using [Vite's methods for client-server communication](https://vite.dev/guide/ap
 
 In your app, use the [`server` object on the `init()` hook](#server) to send and receive messages to and from the server.
 
-```ts title="src/my-app.js" {3-7} "server"
+```ts title="src/my-app.js" {5-9} "server"
+import { defineToolbarApp } from "astro/toolbar";
+
 export default defineToolbarApp({
   init(canvas, app, server) {
-    server.send('my-message', { message: 'Hello!' });
+    server.send("my-message", { message: "Hello!" });
 
-    server.on('server-message', (data) => {
+    server.on("server-message", (data) => {
       console.log(data.message);
     });
   },
@@ -386,9 +422,13 @@ export default defineToolbarApp({
 Sends data to the server from logic defined in your toolbar app.
 
 ```ts title="src/my-app.js"
-init(canvas, app, server) {
-  server.send('my-app:my-message', { message: 'Hello!' });
-}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app, server) {
+    server.send("my-app:my-message", { message: "Hello!" });
+  },
+});
 ```
 
 When sending messages from the client to the server, it is good practice to prefix the event name with the app ID or other namespaces to avoid conflicts with other apps or other integrations that may be listening for messages.
@@ -404,11 +444,15 @@ When sending messages from the client to the server, it is good practice to pref
 Registers a callback to be called when the server sends a message with the specified event.
 
 ```ts title="src/my-app.js"
-init(canvas, app, server) {
-  server.on('server-message', (data) => {
-    console.log(data.message);
-  });
-}
+import { defineToolbarApp } from "astro/toolbar";
+
+export default defineToolbarApp({
+  init(canvas, app, server) {
+    server.on("server-message", (data) => {
+      console.log(data.message);
+    });
+  },
+});
 ```
 
 ### On the server


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes code snippets in `src/content/docs/en/reference/dev-toolbar-app-reference.mdx`. The snippets use `.js` so there is not much to fix here but while I was there:
- add missing imports
- In "Client-side events" subsections: it might be confusing to see `app` without any context so, I wrapped each code snippet in `defineToolbarApp()`.

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14089