### PR TITLE
Fix code snippets in the Image Service reference

### DIFF
--- a/src/content/docs/en/reference/image-service-reference.mdx
+++ b/src/content/docs/en/reference/image-service-reference.mdx
@@ -65,6 +65,7 @@ To create your own local service, you can point to the [built-in endpoint](https
 
 ```ts
 import type { ImageTransform, LocalImageService, AstroConfig } from "astro";
+import { mySuperLibraryThatEncodesImages } from "@example/my-super-library";
 
 const service: LocalImageService<AstroConfig["image"]> = {
   getURL(options: ImageTransform, imageConfig) {
@@ -135,22 +136,44 @@ To access the image service config ([`image.service.config`](/en/reference/confi
 
 ```ts title="src/api/my_custom_endpoint_that_transforms_images.ts"
 import type { APIRoute } from "astro";
-import { getConfiguredImageService, imageConfig } from 'astro:assets';
+import { isLocalService } from "astro/assets";
+import { getConfiguredImageService, imageConfig } from "astro:assets";
+import * as mime from "mrmime";
+import { getImageBuffer } from "./my-custom-image-fetcher.js";
 
 export const GET: APIRoute = async ({ request }) => {
   const imageService = await getConfiguredImageService();
 
-  const imageTransform = imageService.parseURL(new URL(request.url), imageConfig);
-  // ... fetch the image from imageTransform.src and store it in inputBuffer
-  const { data, format } = await imageService.transform(inputBuffer, imageTransform, imageConfig);
-  return new Response(data, {
-			status: 200,
-			headers: {
-				'Content-Type': mime.getType(format) || ''
-      }
-    }
+  if (!isLocalService(imageService)) {
+    return new Response(
+      "This endpoint only works with a local image service.",
+      { status: 400 },
+    );
+  }
+
+  const imageTransform = await imageService.parseURL(
+    new URL(request.url),
+    imageConfig,
   );
-}
+
+  if (!imageTransform) {
+    return new Response("Invalid image URL.", { status: 400 });
+  }
+
+  // ... fetch the image from imageTransform.src and store it in inputBuffer
+  const inputBuffer = await getImageBuffer(imageTransform.src);
+  const { data, format } = await imageService.transform(
+    inputBuffer,
+    imageTransform,
+    imageConfig,
+  );
+  return new Response(new Uint8Array(data), {
+    status: 200,
+    headers: {
+      "Content-Type": mime.lookup(format) || "",
+    },
+  });
+};
 ```
 
 [See the built-in endpoint](https://github.com/withastro/astro/blob/main/packages/astro/src/assets/endpoint/generic.ts) for a full example.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Follow-up of https://github.com/withastro/docs/pull/14089. TL;DR: Improve UX by preventing the appearance of red squiggles (TS) and visual changes (formatting with Astro extension) when the user copies and pastes a code snippet.

Formats and fixes code snippets in `src/content/docs/en/reference/image-service-reference.mdx`:
- "Local Services": nit, missing fake import
- "getConfiguredImageService & imageConfig":
  - [`ImageService`](https://github.com/withastro/astro/blob/caace2ec6e93139e18833e31f02f229ec2c90dc6/packages/astro/src/assets/services/service.ts#L17) is a union, and both [`parseUrl`](https://github.com/withastro/astro/blob/caace2ec6e93139e18833e31f02f229ec2c90dc6/packages/astro/src/assets/services/service.ts#L110-L113) and [`transform`](https://github.com/withastro/astro/blob/caace2ec6e93139e18833e31f02f229ec2c90dc6/packages/astro/src/assets/services/service.ts#L118-L122) are only available on `LocalImageService`.
  - `parseUrl` can return a `Promise` or `undefined`, we need an `await` and a check before using its result
  - missing import for `mime` (same package as [the one used in core](https://github.com/withastro/astro/blob/caace2ec6e93139e18833e31f02f229ec2c90dc6/packages/astro/src/assets/endpoint/generic.ts#L5))
  - `data` in the returned `Response` is typed as `Uint8Array<ArrayBufferLike>` and this is not compatible with `BodyInit`. I'm not sure what is better between using `new Uint8Array(data)`, `as BodyInit`, and `as Uint8Array<ArrayBuffer>`.

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14089