### PR TITLE
docs(recipes/bun): Differentiate risk level in using `bun` as pkg manager vs runtime

### DIFF
--- a/src/content/docs/en/recipes/bun.mdx
+++ b/src/content/docs/en/recipes/bun.mdx
@@ -8,7 +8,12 @@ i18nReady: true
 [Bun](https://bun.sh/) is an all-in-one JavaScript runtime & toolkit. See [Bun's documentation](https://bun.sh/docs) for more information.
 
 :::caution
-Using Bun with Astro may reveal rough edges. Some integrations may not work as expected. Consult [Bun's official documentation for working with Astro](https://bun.sh/guides/ecosystem/astro) for details.
+Bun is safe to use as your package manager (`bun install`) or script runner (`bun run` or `bunx`) in Astro projects. Think of it as a drop-in replacement for npm/pnpm/yarn.
+
+Using Bun as your runtime (via the `--bun` flag, or a Bun-specific adapter) is _riskier_ since Bun doesn't yet have full Node.js compatibility.
+
+If you hit a runtime issue, consider running your dev/build/deploy commands under Node while keeping Bun for installs.
+Consult [Bun's official documentation for working with Astro](https://bun.sh/guides/ecosystem/astro) for details.
 
 If you have any problems using Bun, please [open an Issue on GitHub with Bun directly](https://github.com/oven-sh/bun/issues/new/choose).
 :::


### PR DESCRIPTION
## Description
Follow-up suggestion to improve the clarity of the following caution in regard to using Bun in Astro projects:
> [!CAUTION]
> _Using Bun with Astro may reveal rough edges. Some integrations may not work as expected._

Minor room for improvement was identified in collaboration with @delucis on the PR referenced below.

The added context provided in this PR should help users make a definitive decision, especially if they refer to Bun's official [Astro guide](https://bun.com/docs/guides/ecosystem/astro), which prompts them to use Bun as a runtime (via the `--bun` flag).

> [!NOTE]
> By default, Bun respects the Node shebang (#!/usr/bin/env node) found at the top of executable files and automatically passes execution over to the system's Node.js runtime. To bypass this and force execution inside the Bun runtime, you must use the `--bun` flag

## Docs
- Bun's Astro [guide](https://bun.com/docs/guides/ecosystem/astro)
- Astro's Bun [recipe](https://docs.astro.build/en/recipes/bun/)

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## References
- Closes: `N/A`
- Related to **Closed PR** [14286](https://github.com/withastro/docs/pull/14286)
- For Astro version `latest`
- Discord username: `@sweugene`
