### PR TITLE
docs: update stale community event reference

### DIFF
--- a/src/content/docs/en/concepts/why-astro.mdx
+++ b/src/content/docs/en/concepts/why-astro.mdx
@@ -85,6 +85,6 @@ We strongly believe that Astro is only a successful project if people love using
 
 Astro invests in developer tools like a great CLI experience from the moment you open your terminal, an official VS Code extension for syntax highlighting, TypeScript and Intellisense, and documentation actively maintained by hundreds of community contributors and available in 14 languages.
 
-Our welcoming, respectful, inclusive community on Discord is ready to provide support, motivation, and encouragement. Open a `#support` thread to get help with your project. Visit our dedicated `#showcase` channel for sharing your Astro sites, blog posts, videos, and even work-in-progress for safe feedback and constructive criticism. Participate in regular live events such as our weekly community call, "Talking and Doc'ing," and API/bug bashes.
+Our welcoming, respectful, inclusive community on Discord is ready to provide support, motivation, and encouragement. Open a `#support` thread to get help with your project. Visit our dedicated `#showcase` channel for sharing your Astro sites, blog posts, videos, and even work-in-progress for safe feedback and constructive criticism. Participate in occasional live events such as API/bug bashes.
 
 As an open-source project, we welcome contributions of all types and sizes from community members of all experience levels. You are invited to join in roadmap discussions to shape the future of Astro, and we hope you'll contribute fixes and features to the core codebase, compiler, docs, language tools, websites, and other projects.


### PR DESCRIPTION
#### Description (required)

Updates the `Why Astro?` page to remove references to discontinued community events and describes API/bug bashes as occasional.

#### References

- Closes #14331

#### Verification

- `git diff --check`
- `pnpm run check`
- Prettier check for `src/content/docs/en/concepts/why-astro.mdx`

#### AI note

Drafted with AI assistance; reviewed by me (KesleyDavid).
