### PR TITLE
docs: fix outdated astro:assets imports

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v6.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v6.mdx
@@ -715,22 +715,25 @@ import { ClientRouter } from 'astro:transitions';
 
 In Astro 5.6.2, the `emitESMImage()` function was deprecated in favor of `emitImageMetadata()`, which removes two deprecated arguments that were not meant to be exposed for public use: `_watchMode` and `experimentalSvgEnabled`.
 
-Astro 6.0 removes `emitESMImage()` entirely. Update to `emitImageMetadata()` to keep your current behavior.
+Astro 6.0 removes both `emitESMImage()` and `emitImageMetadata()`. Use `imageMetadata()` to read image metadata instead.
 
 #### What should I do?
 
-Replace all occurrences of the `emitESMImage()` with `emitImageMetadata()` and remove unused arguments:
+Replace all occurrences of `emitESMImage()` with `imageMetadata()` and pass it the image data:
 
-```ts del={1,5} ins={2,6}
+```ts del={1,5} ins={2-3,6}
 import { emitESMImage } from 'astro/assets/utils';
-import { emitImageMetadata } from 'astro/assets/utils';
+import { readFile } from 'node:fs/promises';
+import { imageMetadata } from 'astro/assets/utils';
 
 const imageId = '/images/photo.jpg';
 const result = await emitESMImage(imageId, false, false);
-const result = await emitImageMetadata(imageId);
+const result = await imageMetadata(await readFile(imageId), imageId);
 ```
 
-<ReadMore>Read more about [`emitImageMetadata()`](/en/reference/modules/astro-assets/#emitimagemetadata).</ReadMore>
+Unlike `emitImageMetadata()`, `imageMetadata()` does not emit a file or return `src` and `fsPath` properties.
+
+<ReadMore>Read more about [`imageMetadata()`](/en/reference/modules/astro-assets/#imagemetadata).</ReadMore>
 
 ### Removed: `Astro.glob()`
 

--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -26,6 +26,8 @@ import {
   getImage,
   inferRemoteSize,
   getConfiguredImageService,
+  propsToFilename,
+  hashTransform,
   imageConfig,
   fontData,
   experimental_getFontFileURL,
@@ -914,21 +916,14 @@ The following helpers are imported from the `utils` directory in the regular ass
 ```ts
 import { 
   isRemoteAllowed,
-  matchHostname,
-  matchPathname,
   matchPattern,
-  matchPort,
-  matchProtocol,
   isESMImportedImage,
   isRemoteImage,
   resolveSrc,
   imageMetadata,
-  emitImageMetadata,
   emitClientAsset,
   getOrigQueryParams,
   inferRemoteSize,
-  propsToFilename,
-  hashTransform,
 } from "astro/assets/utils";
 ```
 
@@ -959,45 +954,6 @@ const remotePatterns = [
 isRemoteAllowed(url.href, { domains, remotePatterns }); // Output: `true`
 ```
 
-### `matchHostname()`
-
-<p>
-
-**Type:** `(url: URL, hostname?: string, allowWildcard = false) => boolean`<br />
-<Since v="4.0.0" />
-</p>
-
-Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
-
-```ts
-import { matchHostname } from 'astro/assets/utils';
-
-const url = new URL('https://sub.example.com/path/to/resource');
-
-matchHostname(url, 'example.com'); // Output: `false`
-matchHostname(url, 'example.com', true); // Output: `true`
-```
-
-### `matchPathname()`
-
-<p>
-
-**Type:** `(url: URL, pathname?: string, allowWildcard = false) => boolean`<br />
-<Since v="4.0.0" />
-</p>
-
-Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
-
-```ts
-import { matchPathname } from 'astro/assets/utils';
-
-const testURL = new URL('https://example.com/images/photo.jpg');
-
-matchPathname(testURL, '/images/photo.jpg'); // Output: `true`
-matchPathname(testURL, '/images/'); // Output: `false`
-matchPathname(testURL, '/images/*', true); // Output: `true`
-```
-
 ### `matchPattern()`
 
 <p>
@@ -1019,48 +975,6 @@ const remotePattern = {
 };
 
 matchPattern(url, remotePattern); // Output: `true`
-```
-
-### `matchPort()`
-
-<p>
-
-**Type:** `(url: URL, port?: string) => boolean`<br />
-**Default:** `true`<br />
-<Since v="4.0.0" />
-</p>
-
-Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
-
-```ts
-import { matchPort } from 'astro/assets/utils';
-
-const urlWithPort = new URL('https://example.com:8080/resource');
-const urlWithoutPort = new URL('https://example.com/resource');
-
-matchPort(urlWithPort, '8080'); // Output: `true`
-matchPort(urlWithoutPort, '8080'); // Output: `false`
-```
-
-### `matchProtocol()`
-
-<p>
-
-**Type:** `(url: URL, protocol?: string) => boolean`<br />
-**Default:** `true`<br />
-<Since v="4.0.0" />
-</p>
-
-Compares the protocol of the provided URL with a specified protocol. This returns `true` if the protocol matches or if no protocol is provided.
-
-```ts
-import { matchProtocol } from 'astro/assets/utils';
-
-const secureUrl = new URL('https://example.com/resource');
-const regularUrl = new URL('http://example.com/resource');
-
-matchProtocol(secureUrl, 'https'); // Output: `true`
-matchProtocol(regularUrl, 'https'); // Output: `false`
 ```
 
 ### `isESMImportedImage()`
@@ -1163,32 +1077,6 @@ const metadata = await imageMetadata(binaryImage, sourcePath);
 // }
 ```
 
-### `emitImageMetadata()`
-
-<p>
-
-**Type:** <code>(id: string | undefined, fileEmitter?: Rollup.EmitFile) => Promise\<(<a href="#imagemetadata-1">ImageMetadata</a> & \{ contents?: Buffer \}) | undefined\></code><br />
-<Since v="5.7.0" />
-</p>
-
-Processes an image file and emits its metadata and optionally its contents. In build mode, the function uses `fileEmitter` to generate an asset reference. In development mode, it resolves to a local file URL with query parameters for metadata.
-
-```ts
-import { emitImageMetadata } from 'astro/assets/utils';
-
-const imageId = '/images/photo.jpg';
-const metadata = await emitImageMetadata(imageId);
-// Example value:
-// {
-//    src: '/@fs/home/username/dev/astro-project/src/images/photo.jpg?origWidth=800&origHeight=600&origFormat=jpg',
-//    width: 800,
-//    height: 600,
-//    format: 'jpg',
-//    contents: Uint8Array([...])
-// }
-```
-
-
 ### `emitClientAsset()`
 
 <p>
@@ -1266,6 +1154,10 @@ const imageSize = await inferRemoteSize(remoteImageUrl);
 // }
 ```
 
+## Additional imports from `astro:assets`
+
+The following helpers are also imported from `astro:assets`:
+
 ### `propsToFilename()`
 
 <p>
@@ -1286,7 +1178,7 @@ The formatted filename follows this structure:
 - `outputExtension`: The desired output file extension derived from the `transform.format` or the original file extension.
 
 ```ts
-import { propsToFilename } from 'astro/assets/utils';
+import { propsToFilename } from 'astro:assets';
 
 const filePath = '/images/photo.jpg';
 const transform = { format: 'png', src: filePath };
@@ -1307,7 +1199,7 @@ const filename = propsToFilename(filePath, transform, hash);
 Transforms the provided `transform` object into a hash string based on selected properties and the specified `imageService`.
 
 ```ts
-import { hashTransform } from 'astro/assets/utils';
+import { hashTransform } from 'astro:assets';
 
 const transform = {
   src: '/images/photo.jpg',
@@ -1509,6 +1401,16 @@ Defines a list of allowed values for the `object-fit` CSS property, extensible w
 </p>
 
 Controls the value for the `object-position` CSS property.
+
+#### `ImageTransform.background`
+
+<p>
+
+**Type:** `string | undefined`<br />
+<Since v="5.17.0" />
+</p>
+
+The background color to use when flattening an image to transform it into the requested output `format`.
 
 ### `UnresolvedImageTransform`
 


### PR DESCRIPTION
#### Description (required)

Updates the `astro:assets` reference to match the current public API.

- Removes undocumented exports from `astro/assets/utils`.
- Documents `propsToFilename` and `hashTransform` as imports from `astro:assets`.
- Documents `ImageTransform.background` and corrects the v6 migration from `emitESMImage()` to `imageMetadata()`.

The outdated imports caused TypeScript errors for readers following the examples.

#### References

- Closes #14281

#### Verification

- `git diff --check`
- `pnpm run check`
- `pnpm exec prettier --check src/content/docs/en/reference/modules/astro-assets.mdx src/content/docs/en/guides/upgrade-to/v6.mdx`
- Confirmed the documented exports against Astro's installed type declarations.

#### AI note

Drafted with AI assistance; reviewed by me (KesleyDavid).
