### PR TITLE
docs: fix unstorage session driver example

### DIFF
--- a/src/content/docs/en/reference/session-driver-reference.mdx
+++ b/src/content/docs/en/reference/session-driver-reference.mdx
@@ -159,9 +159,7 @@ Defines a function that removes session data by key.
 
 ## Unstorage compatibility
 
-Unstorage driver types are compatible with Astro's `SessionDriver` type.
-
-That means you can use an unstorage package export as an [entrypoint](#entrypoint). For example:
+Unstorage drivers can be used as an [entrypoint](#entrypoint) for an Astro session driver. For example:
 
 ```ts title="driver/config.ts" {5}
 import type { SessionDriverConfig } from 'astro'
@@ -170,22 +168,8 @@ export function configuredRedisDriver(): SessionDriverConfig {
     return {
         entrypoint: 'unstorage/drivers/redis',
         config: {
-            tls: true
+            ttl: 60 * 60 * 24 * 7, // default to 7 days
         }
     }
-}
-```
-
-Alternatively, you can import and use an unstorage driver directly in the implementation. For example:
-
-```ts title="driver/runtime.ts" {2}
-import type { SessionDriver } from 'astro'
-import redisDriver from "unstorage/drivers/redis";
-
-export default function(config): SessionDriver {
-    return redisDriver({
-        ...config,
-        tls: true
-    })
 }
 ```


### PR DESCRIPTION
#### Description (required)

Updates the Unstorage compatibility example to document the supported entrypoint configuration pattern.

- Removes the direct-driver example, whose return type does not satisfy Astro's `SessionDriver` contract.
- Replaces the invalid Redis `tls` option with a `ttl` value.

This prevents readers from copying an example that produces TypeScript errors.

#### References

- Closes #14339

#### Verification

- `git diff --check`
- `pnpm run check`
- `pnpm exec prettier --check src/content/docs/en/reference/session-driver-reference.mdx`

#### AI note

Drafted with AI assistance; reviewed by me (KesleyDavid).
