### PR TITLE
Add CMS Brew to the CMS guides

### DIFF
--- a/public/logos/cms-brew.svg
+++ b/public/logos/cms-brew.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="CMS Brew">
+  <g transform="translate(12 12) scale(0.85) translate(-11.7 -10.5)"
+     fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M10 2.5c-1 1-1 2 0 3s1 2 0 3M14 3c-1 1-1 1.8 0 2.8" stroke="#e2772a" stroke-width="2"/>
+    <path d="M4.5 10.5h12v4a4 4 0 0 1-4 4H8.5a4 4 0 0 1-4-4v-4Z" stroke="#faf6f0" stroke-width="2.24"/>
+    <path d="M16.5 11.5h1.6a2.4 2.4 0 0 1 0 4.8h-1" stroke="#faf6f0" stroke-width="2.24"/>
+  </g>
+</svg>

--- a/src/content/docs/en/guides/cms/cms-brew.mdx
+++ b/src/content/docs/en/guides/cms/cms-brew.mdx
@@ -1,0 +1,26 @@
+---
+title: CMS Brew & Astro
+description: Use CMS Brew to let clients edit your Astro site's content through chat, with every change committed to Git.
+sidebar:
+  label: CMS Brew
+type: cms
+stub: true
+logo: cms-brew
+---
+
+[CMS Brew](https://cmsbrew.com) is a chat-based, Git-backed CMS for client-run sites. You connect your GitHub or GitLab repository and it maps the editable content on its own, so clients can make small content changes by chatting. There are no schemas or config files to maintain, and no changes to your site's markup. Edits land as plain Git commits.
+
+## Getting started
+
+1. [Create a CMS Brew account](https://cmsbrew.com).
+
+2. Connect the repository that contains your Astro project. CMS Brew detects the editable text and images automatically, with no schema or configuration to write.
+
+3. Invite your client, or edit the content yourself. Changes made through chat are committed back to your repository as regular commits and appear on your site once it rebuilds.
+
+Larger or risky requests are held for your approval rather than applied directly, so published changes stay under your control.
+
+## Official Resources
+
+- [CMS Brew Website](https://cmsbrew.com)
+- [Live Demo](https://cmsbrew.com/demo)

--- a/src/data/logos.ts
+++ b/src/data/logos.ts
@@ -28,6 +28,7 @@ export const logos = LogoCheck({
 	cloudflare: { file: 'cloudflare-pages.svg', padding: '.1875em' },
 	cloudinary: { file: 'cloudinary.svg', padding: '.1875em' },
 	cloudray: { file: 'cloudray.svg', padding: '0' },
+	'cms-brew': { file: 'cms-brew.svg', padding: '.1em' },
 	contentful: { file: 'contentful.svg', padding: '.05em' },
 	cosmic: { file: 'cosmic.svg', padding: '.24em' },
 	'craft-cms': { file: 'craft-cms.svg', padding: '.225em' },


### PR DESCRIPTION
#### Description (required)

Adds a stub CMS guide for [CMS Brew](https://cmsbrew.com), a chat-based, Git-backed CMS for client-run sites. Clients describe a content change in chat, and the edit lands as a plain Git commit on the project's own repository, with no schema or config file to maintain.

This follows the same shape and file set as the existing third-party CMS stubs (`sitepins.mdx`, `gitcms.mdx`):

- `src/content/docs/en/guides/cms/cms-brew.mdx`, the stub guide
- `public/logos/cms-brew.svg`, transparent so the mark reads on the dark `BrandLogo` chip
- `src/data/logos.ts`, one `logoKeys` entry in alphabetical position

I left `i18nReady` unset, so the page is not added to the translation dashboard without a maintainer deciding it should be. Happy to set it if you would prefer.

#### Related issues & labels (optional)

- Closes #14294
- Suggested label: improve or update documentation
