### PR TITLE
docs: clarify getImage() options as UnresolvedImageTransform

### DIFF
--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -646,7 +646,7 @@ If you need the resulting image URL client-side, you can [pass the `src` from a 
 
 The `getImage()` function is intended for generating images destined to be used somewhere else than directly in HTML, for example in an [API Route](/en/guides/endpoints/#server-endpoints-api-routes). It also allows you to create your own custom `<Image />` component.
 
-This takes an options object with the [same properties as the Image component](#image-) (except `alt`) and returns a [`GetImageResult` object](#getimageresult).
+This takes an options object of type [`UnresolvedImageTransform`](#unresolvedimagetransform) and returns a [`GetImageResult`](#getimageresult) object.
 
 The following example generates an AVIF `background-image` for a `<div />`:
 
@@ -877,7 +877,7 @@ See [`getConfiguredImageService()`](#getconfiguredimageservice) from `astro:asse
 **Type:** <code>(options: <a href="#unresolvedimagetransform">UnresolvedImageTransform</a>, imageConfig: <a href="/en/reference/configuration-reference/#image-options">AstroConfig['image']</a>) => Promise\<<a href="#getimageresult">GetImageResult</a>\></code>
 </p>
 
-A function similar to [`getImage()`](#getimage) from `astro:assets` with two required arguments: an `options` object with [the same properties as the Image component](#image-) and a second object for the [image configuration](/en/reference/configuration-reference/#image-options).
+A function similar to [`getImage()`](#getimage) from `astro:assets` with two required arguments: an `options` object of type [`UnresolvedImageTransform`](#unresolvedimagetransform) and a second object for the [image configuration](/en/reference/configuration-reference/#image-options).
 
 ### `isLocalService()`
 
@@ -1509,6 +1509,16 @@ Defines a list of allowed values for the `object-fit` CSS property, extensible w
 </p>
 
 Controls the value for the `object-position` CSS property.
+
+#### `ImageTransform.background`
+
+<p>
+
+**Type:** `string | undefined`<br />
+<Since v="5.17.0" />
+</p>
+
+The background color to use when flattening an image to the requested output `format`. Useful when converting images with transparency (e.g. PNG) to a format that does not support an alpha channel (e.g. JPEG).
 
 ### `UnresolvedImageTransform`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Corrects the `getImage()` reference so it no longer claims options match the `<Image />` component props (except `alt`).

- Both `getImage()` descriptions now point readers to the `UnresolvedImageTransform` type already shown in the signature.
- Documents `ImageTransform.background` in the type reference (present in Astro’s `ImageTransform` type since 5.17.0).

This avoids listing “excluded” component-only props, which was the approach requested against in review of a prior closed PR for this issue (#13786).

Verified against the installed `astro` package types: `getImage(options: UnresolvedImageTransform)` and `ImageTransform.background?: string`.

#### References

- Closes #13301
- Related to review feedback on #13786

#### Verification

- `git diff --check` — clean
- `pnpm exec prettier --check src/content/docs/en/reference/modules/astro-assets.mdx` — pass
- `pnpm run check` (`astro check`) — 0 errors
- `pnpm run lint:slugcheck` — no mismatched slugs
- `pnpm run build` (local, `SKIP_OG=true`) — success; rendered page shows:
  - “options object of type UnresolvedImageTransform”
  - no remaining “same properties as the Image component” wording
  - `#imagetransformbackground` section present
- English source only (`src/content/docs/en/`); intentionally triggers Lunaria (content change for translators)

#### AI note

Drafted with AI assistance; wording and scope checked against the issue thread, prior review feedback on #13786, and local Astro type declarations. Local checks and build verification were run before this update.