### PR TITLE
fix: redirect old solidjs documentation links to new url [i18nIgnore]

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/en/guides/integrations-guide/solid-js.mdx
@@ -231,8 +231,8 @@ Feel free to add additional Suspense boundaries according to your preference.
 
 [astro-client-only]: /en/reference/directives-reference/#clientonly
 
-[solid-render-to-string-async]: https://www.solidjs.com/docs/latest/api#rendertostringasync
+[solid-render-to-string-async]: https://docs.solidjs.com/reference/rendering/render-to-string-async
 
-[solid-create-resource]: https://www.solidjs.com/docs/latest/api#createresource
+[solid-create-resource]: https://docs.solidjs.com/reference/basic-reactivity/create-resource
 
-[solid-lazy-components]: https://www.solidjs.com/docs/latest/api#lazy
+[solid-lazy-components]: https://docs.solidjs.com/reference/component-apis/lazy

--- a/src/content/docs/en/guides/typescript.mdx
+++ b/src/content/docs/en/guides/typescript.mdx
@@ -83,7 +83,7 @@ To check that the plugin is working, create a `.ts` file and import an Astro com
 
 ### UI Frameworks
 
-If your project uses a [UI framework](/en/guides/framework-components/), additional settings depending on the framework might be needed. Please see your framework's TypeScript documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
+If your project uses a [UI framework](/en/guides/framework-components/), additional settings depending on the framework might be needed. Please see your framework's TypeScript documentation for more information. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
 
 ## Type Imports
 

--- a/src/content/docs/en/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/en/recipes/making-toolbar-apps.mdx
@@ -271,7 +271,7 @@ The following steps will use TypeScript to do this, but any other tools that com
       </Fragment>
     </PackageManagerTabs>
 
-2. Create a `tsconfig.json` file in the root of your toolbar app's folder with the appropriate settings to build and for the framework you're using ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript)). For example, for Preact:
+2. Create a `tsconfig.json` file in the root of your toolbar app's folder with the appropriate settings to build and for the framework you're using ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript)). For example, for Preact:
 
     ```json title="my-toolbar-app/tsconfig.json"
     {

--- a/src/content/docs/en/recipes/sharing-state-islands.mdx
+++ b/src/content/docs/en/recipes/sharing-state-islands.mdx
@@ -26,7 +26,7 @@ The [Nano Stores](https://github.com/nanostores/nanostores) library allows you t
 
 Still, there are a number of alternatives you can explore. These include:
 - [Svelte's built-in stores](https://svelte.dev/tutorial/writable-stores)
-- [Solid signals](https://www.solidjs.com/docs/latest) outside of a component context
+- [Solid signals](https://docs.solidjs.com/reference/basic-reactivity/create-signal) outside of a component context
 - [Vue's reactivity API](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api)
 - [Sending custom browser events](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events) between components
 

--- a/src/content/docs/es/guides/typescript.mdx
+++ b/src/content/docs/es/guides/typescript.mdx
@@ -85,7 +85,7 @@ Para comprobar que el plugin funciona, crea un archivo `.ts` e importa un compon
 
 ### Frameworks de UI
 
-Si tu proyecto usa una [framework de UI](/es/guides/framework-components/), es posible que se necesiten ajustes adicionales en función del framework. Consulta la documentación de TypeScript de tu framework para obtener más información. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
+Si tu proyecto usa una [framework de UI](/es/guides/framework-components/), es posible que se necesiten ajustes adicionales en función del framework. Consulta la documentación de TypeScript de tu framework para obtener más información. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
 
 ## Importaciones de tipos
 

--- a/src/content/docs/es/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/es/recipes/making-toolbar-apps.mdx
@@ -269,7 +269,7 @@ Los siguientes pasos usarán TypeScript para hacerlo, pero cualquier otra herram
     </PackageManagerTabs>
 
 
-2. Crea un archivo `tsconfig.json` en la raíz de tu directorio de aplicación de barra de herramientas con las configuraciones apropiadas para hacer un build y para el framework que estés usando ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript)). Por ejemplo, para Preact:
+2. Crea un archivo `tsconfig.json` en la raíz de tu directorio de aplicación de barra de herramientas con las configuraciones apropiadas para hacer un build y para el framework que estés usando ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript)). Por ejemplo, para Preact:
 
     ```json title="my-toolbar-app/tsconfig.json"
     {

--- a/src/content/docs/fr/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/solid-js.mdx
@@ -231,8 +231,8 @@ N'hésitez pas à ajouter d'autres limites de Suspense selon vos préférences.
 
 [astro-client-only]: /fr/reference/directives-reference/#clientonly
 
-[solid-render-to-string-async]: https://www.solidjs.com/docs/latest/api#rendertostringasync
+[solid-render-to-string-async]: https://docs.solidjs.com/reference/rendering/render-to-string-async
 
-[solid-create-resource]: https://www.solidjs.com/docs/latest/api#createresource
+[solid-create-resource]: https://docs.solidjs.com/reference/basic-reactivity/create-resource
 
-[solid-lazy-components]: https://www.solidjs.com/docs/latest/api#lazy
+[solid-lazy-components]: https://docs.solidjs.com/reference/component-apis/lazy

--- a/src/content/docs/fr/guides/typescript.mdx
+++ b/src/content/docs/fr/guides/typescript.mdx
@@ -83,7 +83,7 @@ Pour vérifier que le module d'extension fonctionne, créez un fichier `.ts` et 
 
 ### Frameworks UI
 
-Si votre projet utilise un [framework UI](/fr/guides/framework-components/), des paramètres supplémentaires dépendant du framework peuvent être nécessaires. Veuillez consulter la documentation TypeScript de votre framework pour plus d'informations. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
+Si votre projet utilise un [framework UI](/fr/guides/framework-components/), des paramètres supplémentaires dépendant du framework peuvent être nécessaires. Veuillez consulter la documentation TypeScript de votre framework pour plus d'informations. ([Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
 
 ## Importations de types
 

--- a/src/content/docs/fr/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/fr/recipes/making-toolbar-apps.mdx
@@ -271,7 +271,7 @@ Les étapes suivantes utiliseront TypeScript pour y parvenir, mais n'importe que
       </Fragment>
     </PackageManagerTabs>
 
-2. Créez un fichier `tsconfig.json` à la racine du dossier de votre application de barre d'outils avec les réglages appropriés pour la compilaton et pour le framework que vous utilisez ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript)). Par exemple, pour Preact:
+2. Créez un fichier `tsconfig.json` à la racine du dossier de votre application de barre d'outils avec les réglages appropriés pour la compilaton et pour le framework que vous utilisez ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript)). Par exemple, pour Preact:
 
     ```json title="my-toolbar-app/tsconfig.json"
     {

--- a/src/content/docs/fr/recipes/sharing-state-islands.mdx
+++ b/src/content/docs/fr/recipes/sharing-state-islands.mdx
@@ -26,7 +26,7 @@ La bibliothèque [Nano Stores](https://github.com/nanostores/nanostores) vous pe
 
 Il existe néanmoins un certain nombre d'alternatives que vous pouvez explorer. En voici quelques-unes :
 - Les [magasins intégrés de Svelte](https://svelte.dev/tutorial/writable-stores)
-- [Les signaux de SolidJS](https://www.solidjs.com/docs/latest) en dehors du contexte d'un composant
+- [Les signaux de SolidJS](https://docs.solidjs.com/configuration/typescript) en dehors du contexte d'un composant
 - [L'API de réactivité de Vue](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api)
 - [L'envoi d'événements de navigateur personnalisés](https://developer.mozilla.org/fr/docs/Web/Events/Creating_and_triggering_events) entre les composants
 
@@ -55,7 +55,7 @@ Si vous voulez éviter les bibliothèques tierces, les [magasins Svelte](https:/
 <details>
 <summary>**🙋 Comment les signaux Solid sont-ils différents de Nano Stores ?**</summary>
 
-Si vous utilisez Solid depuis un certain temps, vous avez peut-être essayé de déplacer les [signaux](https://www.solidjs.com/docs/latest#createsignal) ou [magasins](https://www.solidjs.com/docs/latest#createstore) en dehors de vos composants. C'est un excellent moyen de partager l'état entre les îlots de composants Solid ! Essayez d'exporter des signaux à partir d'un fichier partagé :
+Si vous utilisez Solid depuis un certain temps, vous avez peut-être essayé de déplacer les [signaux](https://docs.solidjs.com/reference/basic-reactivity/create-signal) ou [magasins](https://docs.solidjs.com/reference/store-utilities/create-store) en dehors de vos composants. C'est un excellent moyen de partager l'état entre les îlots de composants Solid ! Essayez d'exporter des signaux à partir d'un fichier partagé :
 
 ```js
 // sharedStore.js

--- a/src/content/docs/ja/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/ja/guides/integrations-guide/solid-js.mdx
@@ -231,8 +231,8 @@ function CharacterName() {
 
 [astro-client-only]: /ja/reference/directives-reference/#clientonly
 
-[solid-render-to-string-async]: https://www.solidjs.com/docs/latest/api#rendertostringasync
+[solid-render-to-string-async]: https://docs.solidjs.com/reference/rendering/render-to-string-async
 
-[solid-create-resource]: https://www.solidjs.com/docs/latest/api#createresource
+[solid-create-resource]: https://docs.solidjs.com/reference/basic-reactivity/create-resource
 
-[solid-lazy-components]: https://www.solidjs.com/docs/latest/api#lazy
+[solid-lazy-components]: https://docs.solidjs.com/reference/component-apis/lazy

--- a/src/content/docs/ja/guides/typescript.mdx
+++ b/src/content/docs/ja/guides/typescript.mdx
@@ -83,7 +83,7 @@ Astroには、拡張可能な3つの`tsconfig.json`テンプレート、`base`�
 
 ### UIフレームワーク
 
-プロジェクトで[UIフレームワーク](/ja/guides/framework-components/)を使っている場合は、フレームワークに応じた追加の設定が必要になることがあります。詳しくは、各フレームワークのTypeScriptドキュメントを参照してください。（[Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript)、[React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://www.solidjs.com/guides/typescript)、[Svelte](https://svelte.dev/docs/svelte/typescript)）
+プロジェクトで[UIフレームワーク](/ja/guides/framework-components/)を使っている場合は、フレームワークに応じた追加の設定が必要になることがあります。詳しくは、各フレームワークのTypeScriptドキュメントを参照してください。（[Vue](https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript)、[React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://docs.solidjs.com/configuration/typescript)、[Svelte](https://svelte.dev/docs/svelte/typescript)）
 
 ## 型のインポート
 

--- a/src/content/docs/ko/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/ko/guides/integrations-guide/solid-js.mdx
@@ -231,8 +231,8 @@ function CharacterName() {
 
 [astro-client-only]: /ko/reference/directives-reference/#clientonly
 
-[solid-render-to-string-async]: https://www.solidjs.com/docs/latest/api#rendertostringasync
+[solid-render-to-string-async]: https://docs.solidjs.com/reference/rendering/render-to-string-async
 
-[solid-create-resource]: https://www.solidjs.com/docs/latest/api#createresource
+[solid-create-resource]: https://docs.solidjs.com/reference/basic-reactivity/create-resource
 
-[solid-lazy-components]: https://www.solidjs.com/docs/latest/api#lazy
+[solid-lazy-components]: https://docs.solidjs.com/reference/component-apis/lazy

--- a/src/content/docs/ko/guides/typescript.mdx
+++ b/src/content/docs/ko/guides/typescript.mdx
@@ -83,7 +83,7 @@ Astro에는 확장 가능한 세 가지 `tsconfig.json` 템플릿인 `base`, `st
 
 ### UI 프레임워크
 
-프로젝트에서 [UI 프레임워크](/ko/guides/framework-components/)를 사용하는 경우 프레임워크에 따라 추가 설정이 필요할 수 있습니다. 자세한 내용은 프레임워크의 TypeScript 문서를 참조하세요. ([Vue](https://ko.vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript/), [Solid](https://www.solidjs.com/guides/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
+프로젝트에서 [UI 프레임워크](/ko/guides/framework-components/)를 사용하는 경우 프레임워크에 따라 추가 설정이 필요할 수 있습니다. 자세한 내용은 프레임워크의 TypeScript 문서를 참조하세요. ([Vue](https://ko.vuejs.org/guide/typescript/overview.html#using-vue-with-typescript), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript/), [Solid](https://docs.solidjs.com/configuration/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
 
 ## 타입 가져오기
 

--- a/src/content/docs/ko/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/ko/recipes/making-toolbar-apps.mdx
@@ -271,7 +271,7 @@ Astro는 개발 툴바 앱에서 JSX 코드를 사전 처리하지 않으므로 
       </Fragment>
     </PackageManagerTabs>
 
-2. 빌드할 적절한 설정과 사용 중인 프레임워크 ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://www.solidjs.com/guides/typescript))를 사용하여 도구 모음 앱 폴더의 루트에 `tsconfig.json` 파일을 만듭니다. 예를 들어 Preact의 경우:
+2. 빌드할 적절한 설정과 사용 중인 프레임워크 ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript), [Solid](https://docs.solidjs.com/configuration/typescript))를 사용하여 도구 모음 앱 폴더의 루트에 `tsconfig.json` 파일을 만듭니다. 예를 들어 Preact의 경우:
 
     ```json title="my-toolbar-app/tsconfig.json"
     {

--- a/src/content/docs/ko/recipes/sharing-state-islands.mdx
+++ b/src/content/docs/ko/recipes/sharing-state-islands.mdx
@@ -26,7 +26,7 @@ Astro는 공유 클라이언트 측 스토리지를 위한 다른 솔루션인 [
 
 그래도 탐색할 수 있는 대안이 많이 있습니다. 여기에는 다음이 포함됩니다.
 - [Svelte의 내장 stores](https://svelte.dev/tutorial/writable-stores)
-- 컴포넌트 컨텍스트 외부 [Solid signals](https://www.solidjs.com/docs/latest)
+- 컴포넌트 컨텍스트 외부 [Solid signals](https://docs.solidjs.com/reference/basic-reactivity/create-signal)
 - [Vue의 reactivity API](https://ko.vuejs.org/guide/scaling-up/state-management#simple-state-management-with-reactivity-api)
 - 컴포넌트 간 [사용자 정의 브라우저 이벤트 전송](https://developer.mozilla.org/ko/docs/Web/Events/Creating_and_triggering_events)
 
@@ -55,7 +55,7 @@ Nano Stores는 `<script>` 태그에서 [`.astro` 컴포넌트 간 상태를 공�
 <details>
 <summary>**🙋 Solid signals는 Nano Stores와 어떻게 비교됩니까?**</summary>
 
-한동안 Solid를 사용해 본 적이 있다면 컴포넌트 외부에서 [signals](https://www.solidjs.com/docs/latest#createsignal) 또는 [stores](https://www.solidjs.com/docs/latest#createstore)를 이동해 보셨을 것입니다. 이는 Solid 아일랜드 간 상태를 공유하는 좋은 방법입니다! 공유 파일에서 signals를 내보내보세요.
+한동안 Solid를 사용해 본 적이 있다면 컴포넌트 외부에서 [signals](https://www.solidjs.com/docs/latest#createsignal) 또는 [stores](https://docs.solidjs.com/reference/store-utilities/create-store)를 이동해 보셨을 것입니다. 이는 Solid 아일랜드 간 상태를 공유하는 좋은 방법입니다! 공유 파일에서 signals를 내보내보세요.
 
 ```js
 // sharedStore.js

--- a/src/content/docs/pt-br/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/pt-br/recipes/making-toolbar-apps.mdx
@@ -264,7 +264,7 @@ As etapas a seguir usarão o TypeScript para fazer isso, mas qualquer outra ferr
       </Fragment>
     </PackageManagerTabs>
 
-2. Crie um arquivo `tsconfig.json` na raiz da pasta do seu aplicativo de barra de ferramentas com as configurações apropriadas para o build e para o framework que você está usando ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript) e [Solid](https://www.solidjs.com/guides/typescript)). Por exemplo, para o Preact:
+2. Crie um arquivo `tsconfig.json` na raiz da pasta do seu aplicativo de barra de ferramentas com as configurações apropriadas para o build e para o framework que você está usando ([React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript) e [Solid](https://docs.solidjs.com/configuration/typescript)). Por exemplo, para o Preact:
 
     ```json title="meu-app-toolbar/tsconfig.json"
     {

--- a/src/content/docs/ru/guides/typescript.mdx
+++ b/src/content/docs/ru/guides/typescript.mdx
@@ -83,7 +83,7 @@ Astro поставляется со встроенной поддержкой [T
 
 ### UI-фреймворки
 
-Если ваш проект использует [UI-фреймворк](/ru/guides/framework-components/), могут потребоваться дополнительные настройки в зависимости от фреймворка. Подробности см. в документации TypeScript для вашего фреймворка. ([Vue](https://ru.vuejs.org/guide/typescript/overview), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript/?lang=ru), [Solid](https://www.solidjs.com/guides/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
+Если ваш проект использует [UI-фреймворк](/ru/guides/framework-components/), могут потребоваться дополнительные настройки в зависимости от фреймворка. Подробности см. в документации TypeScript для вашего фреймворка. ([Vue](https://ru.vuejs.org/guide/typescript/overview), [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup), [Preact](https://preactjs.com/guide/v10/typescript/?lang=ru), [Solid](https://docs.solidjs.com/configuration/typescript), [Svelte](https://svelte.dev/docs/svelte/typescript))
 
 ## Импорты типов
 

--- a/src/content/docs/zh-cn/guides/integrations-guide/solid-js.mdx
+++ b/src/content/docs/zh-cn/guides/integrations-guide/solid-js.mdx
@@ -224,8 +224,8 @@ function CharacterName() {
 
 [astro-client-only]: /zh-cn/reference/directives-reference/#clientonly
 
-[solid-render-to-string-async]: https://www.solidjs.com/docs/latest/api#rendertostringasync
+[solid-render-to-string-async]: https://docs.solidjs.com/reference/rendering/render-to-string-async
 
-[solid-create-resource]: https://www.solidjs.com/docs/latest/api#createresource
+[solid-create-resource]: https://docs.solidjs.com/reference/basic-reactivity/create-resource
 
-[solid-lazy-components]: https://www.solidjs.com/docs/latest/api#lazy
+[solid-lazy-components]: https://docs.solidjs.com/reference/component-apis/lazy

--- a/src/content/docs/zh-cn/guides/typescript.mdx
+++ b/src/content/docs/zh-cn/guides/typescript.mdx
@@ -84,7 +84,7 @@ Astro 中包含三个可扩展的 `tsconfig.json` 模板：`base`、`strict` 和
 
 ### UI 框架
 
-如果你的项目使用了 [UI 框架](/zh-cn/guides/framework-components/)，则可能需要根据框架的不同进行额外的设置。请参阅你使用的框架的文档中关于 TypeScript 的相关文档以获取更多信息。（[Vue](https://cn.vuejs.org/guide/typescript/overview.html)、[React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://www.solidjs.com/guides/typescript)、[Svelte](https://svelte.dev/docs/svelte/typescript)）
+如果你的项目使用了 [UI 框架](/zh-cn/guides/framework-components/)，则可能需要根据框架的不同进行额外的设置。请参阅你使用的框架的文档中关于 TypeScript 的相关文档以获取更多信息。（[Vue](https://cn.vuejs.org/guide/typescript/overview.html)、[React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://docs.solidjs.com/configuration/typescript)、[Svelte](https://svelte.dev/docs/svelte/typescript)）
 
 ## 类型导入
 

--- a/src/content/docs/zh-cn/recipes/making-toolbar-apps.mdx
+++ b/src/content/docs/zh-cn/recipes/making-toolbar-apps.mdx
@@ -271,7 +271,7 @@ Astro 在开发工具栏应用中不会预处理 JSX 代码，因此需要一个
       </Fragment>
     </PackageManagerTabs>
 
-2. 在你的工具栏应用的文件夹根目录中创建一个 `tsconfig.json` 文件，并配置适合你所使用框架的设置（例如 [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://www.solidjs.com/guides/typescript)）。以 Preact 为例：
+2. 在你的工具栏应用的文件夹根目录中创建一个 `tsconfig.json` 文件，并配置适合你所使用框架的设置（例如 [React](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup)、[Preact](https://preactjs.com/guide/v10/typescript)、[Solid](https://docs.solidjs.com/configuration/typescript)）。以 Preact 为例：
 
     ```json title="my-toolbar-app/tsconfig.json"
     {

--- a/src/content/docs/zh-cn/recipes/sharing-state-islands.mdx
+++ b/src/content/docs/zh-cn/recipes/sharing-state-islands.mdx
@@ -26,7 +26,7 @@ Astro 推荐了一个不同的客户端共享存储的解决方案： [**Nano St
 
 尽管如此，你仍然可以探索一些替代方案。这些方法包括：
 - [Svelte 的内置 stores](https://svelte.dev/tutorial/writable-stores)
-- [Solid signals](https://www.solidjs.com/docs/latest) 组件之外的上下文
+- [Solid signals](https://docs.solidjs.com/reference/basic-reactivity/create-signal) 组件之外的上下文
 - [Vue 的响应式 API](https://cn.vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api)
 - 在组件之间 [发送自定义浏览器事件](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events) 
 
@@ -57,7 +57,7 @@ b）你想要在 Svelte 和其他 UI 框架如 Preact 或者 Vue 之间进行通
 <details>
 <summary>**🙋 Solid signals 和 Nano Stores 相比如何？**</summary>
 
-如果你已经使用 Solid 有一段时间了，你可能试着将 [signals](https://www.solidjs.com/docs/latest#createsignal) 或者 [stores](https://www.solidjs.com/docs/latest#createstore) 移出你的组件。这是一个很棒的方式来在 Solid islands 之间共享状态！尝试从一个共享的文件中导出 signals：
+如果你已经使用 Solid 有一段时间了，你可能试着将 [signals](https://docs.solidjs.com/reference/basic-reactivity/create-signal) 或者 [stores](https://docs.solidjs.com/reference/store-utilities/create-store) 移出你的组件。这是一个很棒的方式来在 Solid islands 之间共享状态！尝试从一个共享的文件中导出 signals：
 
 ```js
 // sharedStore.js


### PR DESCRIPTION
#### Description

This PR changes SolidJS' documentation, redirecting old URLs to new one (hosted under https://docs.solidjs.com)

This is done manually via editor global search and includes other languages. I naturally don't understand all the languages that I touch, but I can infer from the old URL which URL I should replace. 

#### References

- Discord username: `e926` (ID: `189769721653100546`)
