### PR TITLE
docs: link i18n guide to recipe and dynamic routes (#9256)

### DIFF
--- a/src/content/docs/en/guides/internationalization.mdx
+++ b/src/content/docs/en/guides/internationalization.mdx
@@ -8,10 +8,13 @@ i18nReady: true
 
 import { FileTree } from '@astrojs/starlight/components';
 import Since from '~/components/Since.astro'
+import ReadMore from '~/components/ReadMore.astro'
 
 Astro’s internationalization (i18n) features allow you to adapt your project for an international audience. This routing API helps you generate, use, and verify the URLs that your multi-language site produces.
 
 Astro's i18n routing allows you to bring your multilingual content with support for configuring a default language, computing relative page URLs, and accepting preferred languages provided by your visitor's browser. You can also specify fallback languages on a per-language basis so that your visitors can always be directed to existing content on your site.
+
+<ReadMore title="Build a full multilingual site">For UI strings, content collections, language pickers, and translated slugs, follow the step-by-step [i18n recipe](/en/recipes/i18n/). The guide below focuses on Astro's routing API; the recipe shows how to wire a complete site on top of it.</ReadMore>
 
 ## Routing Logic
 
@@ -135,6 +138,9 @@ This is the **default** value. Set this option when URLs in your default languag
 - `src/pages/about.astro` will produce the route `example.com/about/` 
 - `src/pages/fr/about.astro` will produce the route `example.com/fr/about/` 
 
+:::tip[Dynamic routes for an unprefixed default locale]
+If you prefer a single dynamic segment instead of duplicating every page at the root and under `/[locale]/`, you can generate routes with `getStaticPaths()` and pass `undefined` for the default locale. See the [i18n recipe](/en/recipes/i18n/) for a full walkthrough. On SSR deployments, avoid combining two rest-parameter segments in one path — routing becomes ambiguous at request time.
+:::
 
 #### `prefixDefaultLocale: true`
 


### PR DESCRIPTION
Fixes #9256

## Summary
- Add ReadMore callout linking the routing guide to the i18n recipe
- Document dynamic-route option for unprefixed default locales with SSR caveat

## Test plan
- [ ] Docs site builds locally
