### PR TITLE
docs: fix Unstorage session driver examples

### DIFF
--- a/src/content/docs/en/guides/sessions.mdx
+++ b/src/content/docs/en/guides/sessions.mdx
@@ -83,10 +83,22 @@ The following example takes advantage of [Unstorage compatibility](/en/reference
     import { REDIS_HOST, REDIS_PORT } from "astro:env";
 
     export default function (): SessionDriver {
-      return redisDriver({
+      const driver = redisDriver({
         host: REDIS_HOST,
         port: REDIS_PORT,
       });
+
+      return {
+        async getItem(key) {
+          return await driver.getItem(key);
+        },
+        async setItem(key, value) {
+          await driver.setItem?.(key, value, {});
+        },
+        async removeItem(key) {
+          await driver.removeItem?.(key, {});
+        },
+      };
     }
     ```
 

--- a/src/content/docs/en/reference/session-driver-reference.mdx
+++ b/src/content/docs/en/reference/session-driver-reference.mdx
@@ -159,33 +159,44 @@ Defines a function that removes session data by key.
 
 ## Unstorage compatibility
 
-Unstorage driver types are compatible with Astro's `SessionDriver` type.
+You can use an [unstorage](https://unstorage.unjs.io/) package export as a session driver [entrypoint](#entrypoint). For example:
 
-That means you can use an unstorage package export as an [entrypoint](#entrypoint). For example:
-
-```ts title="driver/config.ts" {5}
+```ts title="driver/config.ts" {5-7}
 import type { SessionDriverConfig } from 'astro'
 
 export function configuredRedisDriver(): SessionDriverConfig {
     return {
         entrypoint: 'unstorage/drivers/redis',
         config: {
-            tls: true
+            // Options are forwarded to the unstorage Redis driver (see its RedisOptions type)
+            ttl: 60 * 60 * 24 * 7, // 7 days
         }
     }
 }
 ```
 
-Alternatively, you can import and use an unstorage driver directly in the implementation. For example:
+Alternatively, you can import an unstorage driver in the implementation and adapt it to Astro's `SessionDriver` interface. For example:
 
-```ts title="driver/runtime.ts" {2}
+```ts title="driver/runtime.ts"
 import type { SessionDriver } from 'astro'
-import redisDriver from "unstorage/drivers/redis";
+import redisDriver, { type RedisOptions } from 'unstorage/drivers/redis'
 
-export default function(config): SessionDriver {
-    return redisDriver({
+export default function (config: RedisOptions): SessionDriver {
+    const driver = redisDriver({
         ...config,
-        tls: true
+        ttl: config.ttl ?? 60 * 60 * 24 * 7, // default to 7 days
     })
+
+    return {
+        async getItem(key) {
+            return await driver.getItem(key)
+        },
+        async setItem(key, value) {
+            await driver.setItem?.(key, value, {})
+        },
+        async removeItem(key) {
+            await driver.removeItem?.(key, {})
+        },
+    }
 }
 ```


### PR DESCRIPTION
## Changes

Fixes https://github.com/withastro/docs/issues/14339

Per maintainer guidance on that issue:

- Replace invalid Redis `tls` example option with `ttl`
- Type the Redis driver `config` parameter as `RedisOptions`
- Adapt unstorage drivers to Astro's `SessionDriver` interface in the "Alternatively" / sessions guide examples so the snippets typecheck

Also softens the claim that Unstorage driver types are directly compatible with `SessionDriver`, since that is what caused the TypeScript errors.

## Notes

- English docs only (`src/content/docs/en/…`). Code sample changes should be translated.
- Broader Unstorage/`SessionDriver` type alignment is tracked upstream: https://github.com/unjs/unstorage/issues/805
