### PR TITLE
Fix a v7 upgrade guide code snippet related to whitespace handling

### DIFF
--- a/src/content/docs/en/guides/upgrade-to/v7.mdx
+++ b/src/content/docs/en/guides/upgrade-to/v7.mdx
@@ -284,7 +284,7 @@ If you notice that some spaces are missing, identify the components and pages wh
 ```astro title="src/components/Example.astro" del={1-2} ins={3}
 <span>hello</span>
 <em>world</em>
-<span>hello</span> <em>world</em>
+<span>hello</span>{" "}<em>world</em>
 ```
 
 If you prefer to keep the previous behavior, set `compressHTML` to `true`. You can also use `compressHTML: false` to preserve all whitespace.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Fixes a code snippet meant to illustrate the use of `{" "}` but where we're using a regular space.

Context: I saw a post on Bluesky thanking the author for this post: https://cassidoo.co/post/astro-7-whitespace/ and I was wondering what could be improved in our v7 upgrade guide if this isn't clear enough. The content seems about the same; only the tone/verbosity seems different. So, I'm not sure what can be improved here... But, I noticed a confusing code snippet!

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->
