### PR TITLE
Fix main entry point in wrangler.jsonc example

### DIFF
--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -83,7 +83,7 @@ To get started, you will need:
       <Fragment slot="ssr">
         ```jsonc title="wrangler.jsonc"
         {
-          "main": "dist/_worker.js/index.js",
+          "main": "@astrojs/cloudflare/entrypoints/server",
           "name": "my-astro-app",
           "compatibility_date": "YYYY-MM-DD", // Update to the day you deploy
           "compatibility_flags": [


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
Update the "main" entry point in Cloudflare deployment guide to use the new unified entry point. According to the Integration guide, the wrangler entry point was changed to `@astrojs/cloudflare/entrypoints/server` instead of `dist/_worker.js/index.js` in Astro v6.

Affected block: https://docs.astro.build/en/guides/deploy/cloudflare/#cloudflare-workers => step 3 => on demand tab.

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References
https://docs.astro.build/en/guides/integrations-guide/cloudflare/#changed-wrangler-entrypoint-configuration

<!-- Optional section. Delete any points that don’t apply. -->

<!-- First-time contributor to Astro Docs? Add your Discord username below so we can welcome you on the Astro Discord (https://astro.build/chat)! -->
- Discord username: kynsonszetau
