### PR TITLE
i18n(es): add `guides/deploy/deployhq.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/deployhq.mdx
+++ b/src/content/docs/es/guides/deploy/deployhq.mdx
@@ -1,0 +1,48 @@
+---
+title: Despliega tu sitio Astro con DeployHQ
+description: Cómo desplegar tu sitio Astro en la web mediante DeployHQ.
+sidebar:
+  label: DeployHQ
+type: deploy
+logo: deployhq
+supports: ['static']
+i18nReady: true
+---
+import ReadMore from '~/components/ReadMore.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes desplegar tu proyecto de Astro en tus propios servidores usando [DeployHQ](https://www.deployhq.com/), una plataforma de automatización de despliegues que compila tu código y lo envía a servidores SSH/SFTP, servidores FTP, almacenamiento en la nube (p. ej. Amazon S3, Cloudflare R2), y plataformas de alojamiento modernas (p. ej. Netlify, Heroku).
+
+:::note
+DeployHQ no aloja tu sitio. Automatiza la compilación de tu proyecto de Astro y el despliegue de los archivos generados hacia el proveedor de alojamiento o servidor que elijas.
+:::
+
+## Cómo desplegar
+
+<Steps>
+1. Si aún no tienes una, regístrate para obtener una [cuenta de DeployHQ](https://www.deployhq.com/).
+
+2. Desde la interfaz web de DeployHQ, crea un nuevo proyecto y conecta el repositorio Git de tu proyecto Astro (GitHub, GitLab, Bitbucket, o cualquier repositorio privado). También deberás autorizar a DeployHQ para que acceda a tu repositorio.
+
+3. Añade un servidor e introduce los detalles del mismo:
+
+   - Asigna un nombre a tu servidor.
+   - Selecciona tu protocolo (SSH/SFTP, FTP, o plataforma en la nube).
+   - Introduce el nombre de host, nombre de usuario y contraseña o clave SSH de tu servidor.
+   - Configura el **Deployment Path** con la raíz de tu sitio web (p. ej. `public_html/`).
+
+4. En la configuración de tu proyecto, ve a **Build Pipeline** y añade tus comandos de compilación:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+5. Haz clic en **Deploy Project**, selecciona tu servidor y haz clic en **Deploy** para iniciar tu primer despliegue.
+</Steps>
+
+Tu sitio de Astro se compilará y se desplegará en tu servidor. Puedes habilitar los despliegues automáticos para desplegar con cada push de Git o programar despliegues para momentos específicos.
+
+<ReadMore>
+  Consulta la [documentación de DeployHQ](https://www.deployhq.com/support) para obtener más información sobre las funciones avanzadas de despliegue.
+</ReadMore>


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/deployhq.mdx`.