### PR TITLE
i18n(es): add `guides/deploy/heroku.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/heroku.mdx
+++ b/src/content/docs/es/guides/deploy/heroku.mdx
@@ -1,0 +1,66 @@
+---
+title: Despliega tu sitio Astro en Heroku
+description: Cómo desplegar tu sitio Astro en la web usando Heroku.
+sidebar:
+  label: Heroku
+type: deploy
+logo: heroku
+supports: ['static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+[Heroku](https://www.heroku.com/) es una plataforma como servicio para crear, ejecutar y gestionar aplicaciones modernas en la nube. Puedes desplegar un sitio de Astro en Heroku utilizando esta guía.
+
+:::caution
+Las siguientes instrucciones utilizan [el obsoleto `heroku-static-buildpack`](https://github.com/heroku/heroku-buildpack-static#warning-heroku-buildpack-static-is-deprecated). Por favor, [consulta la documentación de Heroku para usar `heroku-buildpack-nginx`](https://github.com/dokku/heroku-buildpack-nginx) en su lugar.
+:::
+
+## Cómo desplegar
+
+<Steps>
+1. Instala la [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
+
+2. Crea una cuenta de Heroku [registrándote aquí](https://signup.heroku.com/).
+
+3. Ejecuta `heroku login` e introduce tus credenciales de Heroku:
+
+   ```bash
+   $ heroku login
+   ```
+
+4. Crea un archivo llamado `static.json` en la raíz de tu proyecto con el siguiente contenido:
+
+   ```json title="static.json"
+   {
+     "root": "./dist"
+   }
+   ```
+
+   Esta es la configuración de tu sitio; lee más en [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static).
+
+5. Configura tu repositorio remoto de Git en Heroku:
+
+   ```bash
+   # cambio de versión
+   $ git init
+   $ git add .
+   $ git commit -m "Mi sitio listo para el despliegue."
+
+   # crea una nueva aplicación con un nombre específico
+   $ heroku apps:create example
+
+   # define el buildpack para sitios estáticos
+   $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-static.git
+   ```
+
+6. Despliega tu sitio:
+
+   ```bash
+   # publica el sitio
+   $ git push heroku master
+
+   # abre el navegador para ver la versión del Dashboard de Heroku CI
+   $ heroku open
+   ```
+</Steps>


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/heroku.mdx`.