### PR TITLE
i18n(es): add `guides/deploy/microsoft-azure.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/microsoft-azure.mdx
+++ b/src/content/docs/es/guides/deploy/microsoft-azure.mdx
@@ -1,0 +1,55 @@
+---
+title: Despliega tu sitio de Astro en Microsoft Azure
+description: Cómo desplegar tu sitio de Astro en la web usando Microsoft Azure.
+sidebar:
+  label: Microsoft Azure
+type: deploy
+logo: microsoft-azure
+supports: ['static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+[Azure](https://azure.microsoft.com/) es una plataforma en la nube de Microsoft. Puedes desplegar tu sitio de Astro con el servicio [Static Web Apps](https://aka.ms/staticwebapps) de Microsoft Azure.
+
+Esta guía te explica cómo desplegar tu sitio de Astro alojado en GitHub utilizando Visual Studio Code. Por favor, consulta las guías de Microsoft para utilizar una [tarea de Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-static-web-app-v0?view=azure-pipelines) para otras configuraciones.
+
+## Requisitos previos
+
+Para seguir esta guía, necesitarás:
+
+- Una cuenta de Azure y una clave de suscripción. Puedes crear una [cuenta gratuita de Azure aquí](https://azure.microsoft.com/free).
+- El código de tu aplicación subido a [GitHub](https://github.com/).
+- La [extensión de SWA](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) en [Visual Studio Code](https://code.visualstudio.com/).
+
+## Cómo desplegar
+
+<Steps>
+1. Abre tu proyecto en VS Code.
+
+2. Abre la extensión Static Web Apps, inicia sesión en Azure y haz clic en el botón **+** para crear una nueva Static Web App. Se te pedirá que indiques qué clave de suscripción deseas usar.
+
+3. Sigue el asistente iniciado por la extensión para asignarle un nombre a tu aplicación, elegir un ajuste preestablecido de framework y especificar la raíz de la aplicación (generalmente `/`) y la ubicación de los archivos compilados (usa `/dist`). Astro no aparece en las plantillas predefinidas de Azure, por lo que tendrás que seleccionar `custom`. El asistente se ejecutará y creará una [GitHub Action](https://github.com/features/actions) en la carpeta `.github` de tu repo. (Esta carpeta se creará automáticamente si aún no existe.) 
+</Steps>
+
+La GitHub Action desplegará tu aplicación (puedes ver su progreso en la pestaña Actions de tu repositorio en GitHub). Cuando finalice con éxito, podrás ver tu aplicación en la dirección que se muestra en la ventana de progreso de la extensión de SWA haciendo clic en el botón **Browse Website** (este aparecerá después de que la GitHub Action se haya ejecutado).
+
+## Problemas conocidos
+
+El archivo YAML de la GitHub Action que se genera automáticamente asume el uso de Node 14. Esto provoca que la compilación de Astro falle. Para resolverlo, actualiza el archivo package.json de tu proyecto con este fragmento.
+
+```
+  "engines": {
+    "node": ">=22.12.0"
+  },
+```
+
+## Recursos oficiales
+
+- [Documentación de Microsoft Azure Static Web Apps](https://learn.microsoft.com/en-us/azure/static-web-apps/)
+
+## Recursos de la comunidad
+
+- [Despliegue de un sitio web Astro en Azure Static Web Apps](https://www.blueboxes.co.uk/deploying-an-astro-website-to-azure-static-web-apps)
+- [Despliegue de un sitio estático Astro en Azure Static Web Apps usando GitHub Actions](https://agramont.net/blog/create-static-site-astro-azure-ssg/#automate-deployment-with-github-actions)
+- [Despliegue de un sitio Astro en Azure Static Web Apps con la CLI desde GitHub Actions](https://www.eliostruyf.com/deploy-astro-azure-static-web-apps-github-cli/)


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/microsoft-azure.mdx`.