### PR TITLE
i18n(es): add `guides/deploy/render.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/render.mdx
+++ b/src/content/docs/es/guides/deploy/render.mdx
@@ -1,0 +1,30 @@
+---
+title: Despliega tu sitio de Astro en Render
+description: Cómo desplegar tu sitio de Astro en la web usando Render.
+sidebar:
+  label: Render
+type: deploy
+logo: render
+supports: ['static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes desplegar tu proyecto de Astro en [Render](https://render.com/), un servicio para crear sitios web que incluye certificados TLS gratuitos, una CDN global, protección DDoS, redes privadas y despliegues automáticos desde Git.
+
+## Cómo desplegar
+
+<Steps>
+1. Crea una [cuenta de render.com](https://dashboard.render.com/) e inicia sesión
+
+2. Haz clic en el botón **New +** desde tu panel de control y selecciona **Static Site**
+
+3. Conecta tu repositorio de [GitHub](https://github.com/) o [GitLab](https://about.gitlab.com/) o, como alternativa, introduce la URL de un repositorio público
+
+4. Asigna un nombre a tu sitio web, selecciona la rama y especifica el comando de construcción y el directorio de publicación
+
+   - **Build Command:** `npm run build`
+   - **Publish Directory:** `dist`, para sitios estáticos; `dist/client` si tienes páginas renderizadas bajo demanda.
+
+5. Haz clic en el botón **Create Static Site**
+</Steps>


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/render.mdx`.
