### PR TITLE
i18n(es): add `guides/deploy/stormkit.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/stormkit.mdx
+++ b/src/content/docs/es/guides/deploy/stormkit.mdx
@@ -1,0 +1,30 @@
+---
+title: Despliega tu sitio de Astro en Stormkit
+description: Despliega tu sitio de Astro en Stormkit
+sidebar:
+  label: Stormkit
+type: deploy
+logo: stormkit
+supports: ['static']
+i18nReady: true
+---
+import ReadMore from '~/components/ReadMore.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes desplegar tu proyecto de Astro en [Stormkit](https://stormkit.io/), una plataforma de despliegue para sitios web estáticos, aplicaciones de página única (SPAs), y funciones serverless.
+
+## Cómo desplegar
+
+<Steps>
+1. [Inicia sesión en Stormkit](https://app.stormkit.io/auth).
+
+2. Usando la interfaz de usuario, importa tu proyecto de Astro desde uno de los tres proveedores de Git compatibles (GitHub, GitLab, o Bitbucket).
+
+3. Navega al entorno de producción del proyecto en Stormkit o crea un nuevo entorno si es necesario.
+
+4. Verifica el comando de compilación en tu [configuración de Stormkit](https://stormkit.io/docs/deployments/configuration). Por defecto, Stormkit CI ejecutará `npm run build`, pero puedes especificar un comando de compilación personalizado en esta página.
+
+5. Haz clic en el botón **Deploy Now** para desplegar tu sitio.
+</Steps>
+
+<ReadMore>Lee más en la [Documentación de Stormkit](https://stormkit.io/docs).</ReadMore>


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/stormkit.mdx`.
