### PR TITLE
i18n(fr): translate `errors/no-manifest-available.mdx`

### DIFF
--- a/src/content/docs/fr/reference/error-reference.mdx
+++ b/src/content/docs/fr/reference/error-reference.mdx
@@ -105,6 +105,7 @@ La référence suivante est une liste complète des erreurs que vous pouvez renc
 - [**UnavailableAstroGlobal**](/fr/reference/errors/unavailable-astro-global/)<br/>Objet global Astro indisponible dans `getStaticPaths()`.
 - [**UnableToLoadLogger**](/fr/reference/errors/unable-to-load-logger/)<br/>Impossible de charger le journaliseur.
 - [**LoggerConfigurationNotSerializable**](/fr/reference/errors/logger-configuration-not-serializable/)<br/>La configuration du journaliseur n'est pas sérialisable.
+- [**NoManifestAvailable**](/fr/reference/errors/no-manifest-available/)<br/>Aucun manifeste disponible.
 
 ## Erreurs de CSS
 

--- a/src/content/docs/fr/reference/errors/no-manifest-available.mdx
+++ b/src/content/docs/fr/reference/errors/no-manifest-available.mdx
@@ -1,0 +1,12 @@
+---
+title: Aucun manifeste disponible.
+i18nReady: true
+githubURL: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
+---
+
+> `new FetchState(request)` was called outside of an Astro server, so no manifest is available.
+
+## Qu'est-ce qui a mal tourné ?
+`new FetchState(request)` ne peut être utilisé qu'au sein d'un serveur Astro — la sortie du serveur compilé ou le serveur de développement — où Astro fournit le manifeste décrivant votre site. Cette erreur signifie qu'il a été appelé ailleurs, par exemple dans un script Node simple qui importe `astro/fetch`.
+
+Si cette erreur se produit à l'intérieur d'un serveur compilé avec Astro, veuillez [ouvrir un ticket](https://astro.build/issues/).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Translates the new `no-manifest-available.mdx` error and updates the `error-reference.mdx` list.

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14405