### PR TITLE
i18n(fr): update `recipes/modified-time.mdx`

### DIFF
--- a/src/content/docs/fr/recipes/modified-time.mdx
+++ b/src/content/docs/fr/recipes/modified-time.mdx
@@ -1,13 +1,13 @@
 ---
-title: Ajouter l'heure de la dernière modification
-description: Créez un module d'extension Remark pour ajouter l'heure de la dernière modification à votre Markdown et MDX.
+title: Ajouter la date de la dernière modification
+description: Créez un module d'extension de processeur Markdown afin d'ajouter la date de la dernière modification à votre Markdown et MDX.
 i18nReady: true
 type: recipe
 ---
 import { Steps } from '@astrojs/starlight/components';
 import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
 
-Apprenez à créer un [module d'extension Remark](https://github.com/remarkjs/remark) qui ajoute l'heure de la dernière modification en tant que [propriété personnalisée du frontmatter](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter) de vos fichiers Markdown et MDX. Utilisez cette propriété pour afficher l'heure de modification dans vos pages.
+Apprenez à créer un [module d'extension mdast](/fr/guides/markdown-content/#modules-dextension-pour-les-processeurs-markdown) qui ajoute la date de la dernière modification en tant que [propriété personnalisée du frontmatter](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter) de vos fichiers Markdown et MDX. Utilisez cette propriété pour afficher la date de modification dans vos pages.
 
 :::note[Utiliser l'historique Git]
 Cette recette calcule la date en fonction de l'historique Git de votre dépôt, et celle-ci peut ne pas être précise sur certaines plateformes de déploiement. Votre hébergeur peut effectuer des **clones superficiels** qui ne récupèrent pas l'historique Git complet.
@@ -16,136 +16,245 @@ Cette recette calcule la date en fonction de l'historique Git de votre dépôt, 
 ## Recette
 
 <Steps>
-1. Installez [`Day.js`](https://www.npmjs.com/package/dayjs) pour modifier et formater les heures, et [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) pour utiliser le [processeur `unified()`](/fr/guides/markdown-content/#configurer-un-processeur-markdown) :
+1. Installez les paquets suivants en fonction du processeur Markdown utilisé :
 
-   <PackageManagerTabs>
-     <Fragment slot="npm">
-       ```shell
-       npm install dayjs @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="pnpm">
-       ```shell
-       pnpm add dayjs @astrojs/markdown-remark
-       ```
-     </Fragment>
-     <Fragment slot="yarn">
-       ```shell
-       yarn add dayjs @astrojs/markdown-remark
-       ```
-     </Fragment>
-   </PackageManagerTabs>
+    <MarkdownProcessorTabs>
+      <Fragment slot="satteri">
+        - [`Day.js`](https://www.npmjs.com/package/dayjs) pour modifier et formater les dates
+        - [`@astrojs/markdown-satteri`](https://www.npmjs.com/package/@astrojs/markdown-satteri) pour configurer le [processeur `satteri()`](/fr/guides/markdown-content/#configurer-un-processeur-markdown)
+        - [`satteri`](https://www.npmjs.com/package/satteri) pour créer un [module d'extension `mdast` pour Sätteri](https://satteri.bruits.org/docs/plugins/#mdast-plugins)
 
-2. Créer un module d'extension Remark
+        <PackageManagerTabs>
+          <Fragment slot="npm">
+            ```shell
+            npm install dayjs @astrojs/markdown-satteri satteri
+            ```
+          </Fragment>
+          <Fragment slot="pnpm">
+            ```shell
+            pnpm add dayjs @astrojs/markdown-satteri satteri
+            ```
+          </Fragment>
+          <Fragment slot="yarn">
+            ```shell
+            yarn add dayjs @astrojs/markdown-satteri satteri
+            ```
+          </Fragment>
+        </PackageManagerTabs>
+      </Fragment>
+      <Fragment slot="unified">
+        - [`Day.js`](https://www.npmjs.com/package/dayjs) pour modifier et formater les dates
+        - [`@astrojs/markdown-remark`](https://www.npmjs.com/package/@astrojs/markdown-remark) pour utiliser le [processeur `unified()`](/fr/guides/markdown-content/#configurer-un-processeur-markdown)
 
-   Ce module d'extension utilise `execSync` pour lancer une commande Git qui renvoie l'horodatage du dernier commit au format ISO 8601. L'horodatage est ensuite ajouté au frontmatter du fichier.
+        <PackageManagerTabs>
+          <Fragment slot="npm">
+            ```shell
+            npm install dayjs @astrojs/markdown-remark
+            ```
+          </Fragment>
+          <Fragment slot="pnpm">
+            ```shell
+            pnpm add dayjs @astrojs/markdown-remark
+            ```
+          </Fragment>
+          <Fragment slot="yarn">
+            ```shell
+            yarn add dayjs @astrojs/markdown-remark
+            ```
+          </Fragment>
+        </PackageManagerTabs>
+      </Fragment>
+    </MarkdownProcessorTabs>
 
-     ```js title="remark-modified-time.mjs"
-     import { execSync } from "node:child_process";
+2. Créez un module d'extension mdast.
 
-     export function remarkModifiedTime() {
-       return function (tree, file) {
-         const filepath = file.history[0];
-         const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
-         file.data.astro.frontmatter.lastModified = result.toString();
-       };
-     }
-     ```
-		<details>
-		<summary>Utiliser le système de fichiers au lieu de Git</summary>
+    Ce module d'extension utilise `execSync` pour exécuter une commande Git qui renvoie l'horodatage du dernier commit au format ISO 8601. L'horodatage est ensuite ajouté au frontmatter du fichier.
 
-		 Bien que l'utilisation de Git soit la méthode recommandée pour obtenir la date de dernière modification d'un fichier, il est possible d'utiliser l'heure de modification du système de fichiers.
-     Ce module d'extension utilise `statSync` pour obtenir l'heure de modification (`mtime`) du fichier au format ISO 8601. L'horodatage est ensuite ajouté au frontmatter du fichier.
-     
-     ```js title="remark-modified-time.mjs"
-     import { statSync } from "fs";
+    <MarkdownProcessorTabs>
+      <Fragment slot="satteri">
+        ```js title="src/mdast/mdast-modified-time.ts"
+        import { execSync } from "node:child_process";
+        import { fileURLToPath } from "node:url";
+        import { defineMdastPlugin } from "satteri";
 
-     export function remarkModifiedTime() {
-       return function (tree, file) {
-         const filepath = file.history[0];
-         const result = statSync(filepath);
-         file.data.astro.frontmatter.lastModified = result.mtime.toISOString();
-       };
-     }
-     ```
-		</details>
+        export const mdastModifiedTimePlugin = defineMdastPlugin({
+          name: "mdast-modified-time",
+          text(node, context) {
+            // Vérifier si `lastModified` est déjà défini pour ce fichier.
+            const isLastModifiedSet = !!context.data.astro?.frontmatter.lastModified;
+            if (isLastModifiedSet || !context.fileURL) return;
 
-3. Ajouter le module d'extension à votre configuration
+            const filepath = fileURLToPath(context.fileURL);
+            const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
 
-   ```js title="astro.config.mjs"
-   import { unified } from '@astrojs/markdown-remark';
-   import { defineConfig } from 'astro/config';
-   import { remarkModifiedTime } from './remark-modified-time.mjs';
+            if (context.data.astro !== undefined) {
+              context.data.astro.frontmatter.lastModified = result.toString();
+            }
+          },
+        });
+        ```
+      </Fragment>
+      <Fragment slot="unified">
+        ```js title="remark-modified-time.mjs"
+        import { execSync } from "node:child_process";
 
-   export default defineConfig({
-     markdown: {
-       processor: unified({
-         remarkPlugins: [remarkModifiedTime],
-       }),
-     },
-   });
-   ```
+        export function remarkModifiedTime() {
+          return function (tree, file) {
+            const filepath = file.history[0];
+            const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+            file.data.astro.frontmatter.lastModified = result.toString();
+          };
+        }
+        ```
+      </Fragment>
+    </MarkdownProcessorTabs>
 
-   Désormais, tous les documents Markdown auront une propriété `lastModified` dans leur frontmatter.
+    <details>
+    <summary>Utiliser le système de fichiers au lieu de Git</summary>
 
-4. Afficher l'heure de la dernière modification
+    Bien que l'utilisation de Git soit la méthode recommandée pour obtenir l'horodatage de la dernière modification d'un fichier, il est possible d'utiliser la date de modification du fichier dans le système de fichiers.
+    Ce module d'extension utilise `statSync` pour obtenir la date de modification (`mtime`) du fichier au format ISO 8601. L'horodatage est ensuite ajouté au frontmatter du fichier.
 
-   Si votre contenu est stocké dans une [collection de contenu](/fr/guides/content-collections/), accédez au `remarkPluginFrontmatter` depuis la fonction `render(entry)`. Affichez ensuite `lastModified` dans votre modèle à l'endroit où vous voulez qu'il apparaisse.
+    <MarkdownProcessorTabs>
+      <Fragment slot="satteri">
+        ```js title="src/mdast/mdast-modified-time.ts"
+        import { statSync } from "node:fs";
+        import { fileURLToPath } from "node:url";
+        import { defineMdastPlugin } from "satteri";
 
-   ```astro title="src/pages/posts/[slug].astro" {3-4,6,17,19-21,28}
-   ---
-   import { getCollection, render } from 'astro:content';
-   import dayjs from "dayjs";
-   import utc from "dayjs/plugin/utc";
+        export const mdastModifiedTimePlugin = defineMdastPlugin({
+          name: "mdast-modified-time",
+          text(node, context) {
+            // Vérifier si `lastModified` est déjà défini pour ce fichier.
+            const isLastModifiedSet = !!context.data.astro?.frontmatter.lastModified;
+            if (isLastModifiedSet || !context.fileURL) return;
 
-   dayjs.extend(utc);
+            const filepath = fileURLToPath(context.fileURL);
+            const result = statSync(filepath);
 
-   export async function getStaticPaths() {
-     const blog = await getCollection('blog');
-     return blog.map(entry => ({
-       params: { slug: entry.id },
-       props: { entry },
-     }));
-   }
+            if (context.data.astro !== undefined) {
+              context.data.astro.frontmatter.lastModified = result.mtime.toISOString();
+            }
+          },
+        });
+        ```
+      </Fragment>
+      <Fragment slot="unified">
+        ```js title="remark-modified-time.mjs"
+        import { statSync } from "node:fs";
 
-   const { entry } = Astro.props;
-   const { Content, remarkPluginFrontmatter } = await render(entry);
+        export function remarkModifiedTime() {
+          return function (tree, file) {
+            const filepath = file.history[0];
+            const result = statSync(filepath);
+            file.data.astro.frontmatter.lastModified = result.mtime.toISOString();
+          };
+        }
+        ```
+      </Fragment>
+    </MarkdownProcessorTabs>
+    </details>
 
-   const lastModified = dayjs(remarkPluginFrontmatter.lastModified)
-     .utc()
-     .format("HH:mm:ss DD MMMM YYYY UTC");
-   ---
+3. Ajoutez le module d'extension à votre configuration :
 
-   <html>
-     <head>...</head>
-     <body>
-       ...
-       <p>Dernière modification : {lastModified}</p>
-       ...
-     </body>
-   </html>
-   ```
+    <MarkdownProcessorTabs>
+      <Fragment slot="satteri">
+        ```js title="astro.config.mjs"
+        import { satteri } from "@astrojs/markdown-satteri";
+        import { defineConfig } from "astro/config";
+        import { mdastModifiedTimePlugin } from "./src/mdast/mdast-modified-time";
 
-   Si vous utilisez une [mise en page Markdown](/fr/basics/layouts/#mises-en-page-markdown), utilisez la propriété du frontmatter `lastModified` accessible depuis `Astro.props` dans votre modèle de mise en page.
+        export default defineConfig({
+          markdown: {
+            processor: satteri({
+              mdastPlugins: [mdastModifiedTimePlugin],
+            }),
+          },
+        });
+        ```
+      </Fragment>
+      <Fragment slot="unified">
+        ```js title="astro.config.mjs"
+        import { unified } from "@astrojs/markdown-remark";
+        import { defineConfig } from "astro/config";
+        import { remarkModifiedTime } from "./remark-modified-time.mjs";
 
-   ```astro title="src/layouts/BlogLayout.astro" {2-3,5,7-9,15}
-   ---
-   import dayjs from "dayjs";
-   import utc from "dayjs/plugin/utc";
+        export default defineConfig({
+          markdown: {
+            processor: unified({
+              remarkPlugins: [remarkModifiedTime],
+            }),
+          },
+        });
+        ```
+      </Fragment>
+    </MarkdownProcessorTabs>
 
-   dayjs.extend(utc);
+    Désormais, tous les documents Markdown auront une propriété `lastModified` dans leur frontmatter.
 
-   const lastModified = dayjs()
-     .utc(Astro.props.frontmatter.lastModified)
-     .format("HH:mm:ss DD MMMM YYYY UTC");
-   ---
+4. Affichez la date de la dernière modification
 
-   <html>
-     <head>...</head>
-     <body>
-       <p>{lastModified}</p>
-       <slot />
-     </body>
-   </html>
-   ```
+    Si votre contenu est stocké dans une [collection de contenu](/fr/guides/content-collections/), accédez à [`remarkPluginFrontmatter` depuis la fonction `render()`](/fr/reference/modules/astro-content/#render). Ensuite, affichez `lastModified` dans votre modèle à l'endroit où vous souhaitez qu'il apparaisse.
+
+    ```astro title="src/pages/posts/[slug].astro" {3-4,6,17,19-21,31}
+    ---
+    import { getCollection, render } from "astro:content";
+    import dayjs from "dayjs";
+    import utc from "dayjs/plugin/utc";
+
+    dayjs.extend(utc);
+
+    export async function getStaticPaths() {
+      const blog = await getCollection("blog");
+      return blog.map((entry) => ({
+        params: { slug: entry.id },
+        props: { entry },
+      }));
+    }
+
+    const { entry } = Astro.props;
+    const { Content, remarkPluginFrontmatter } = await render(entry);
+
+    const lastModified = dayjs(remarkPluginFrontmatter.lastModified)
+      .utc()
+      .format("HH:mm:ss DD MMMM YYYY UTC");
+    ---
+
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <title>{entry.data.title}</title>
+      </head>
+      <body>
+        <title>{entry.data.title}</title>
+        <p>Dernière modification : {lastModified}</p>
+        <Content />
+      </body>
+    </html>
+    ```
+
+    Si vous utilisez une [mise en page Markdown](/fr/basics/layouts/#mises-en-page-markdown), utilisez la propriété `lastModified` du frontmatter accessible depuis `Astro.props` dans votre modèle de mise en page.
+
+    ```astro title="src/layouts/BlogLayout.astro" {2-3,5,7-9,17}
+    ---
+    import dayjs from "dayjs";
+    import utc from "dayjs/plugin/utc";
+
+    dayjs.extend(utc);
+
+    const lastModified = dayjs()
+      .utc(Astro.props.frontmatter.lastModified)
+      .format("HH:mm:ss DD MMMM YYYY UTC");
+    ---
+
+    <html>
+      <head>
+        <meta charset="utf-8" />
+      </head>
+      <body>
+        <p>{lastModified}</p>
+        <slot />
+      </body>
+    </html>
+    ```
 </Steps>

--- a/src/content/docs/fr/recipes/modified-time.mdx
+++ b/src/content/docs/fr/recipes/modified-time.mdx
@@ -5,7 +5,8 @@ i18nReady: true
 type: recipe
 ---
 import { Steps } from '@astrojs/starlight/components';
-import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro'
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+import MarkdownProcessorTabs from '~/components/tabs/MarkdownProcessorTabs.astro';
 
 Apprenez à créer un [module d'extension mdast](/fr/guides/markdown-content/#modules-dextension-pour-les-processeurs-markdown) qui ajoute la date de la dernière modification en tant que [propriété personnalisée du frontmatter](/fr/guides/markdown-content/#modification-programmatique-du-frontmatter) de vos fichiers Markdown et MDX. Utilisez cette propriété pour afficher la date de modification dans vos pages.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `recipes/modified-time.mdx`
- with changes from #14277
- to fix:
  - the inconsistent use of the infinitive/imperative in steps
  - the translation for "time": this is not the hour but the date (including the hour obviously)
- replace a few words (e.g. "exécutez" is more natural than "lancez")

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14277