### PR TITLE
i18n(es): add `guides/deploy/surge.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/surge.mdx
+++ b/src/content/docs/es/guides/deploy/surge.mdx
@@ -1,0 +1,37 @@
+---
+title: Despliega tu sitio de Astro en Surge
+description: Cómo desplegar tu sitio de Astro en la web usando Surge
+sidebar:
+  label: Surge
+type: deploy
+logo: surge
+supports: ['static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes desplegar tu proyecto de Astro en [Surge](https://surge.sh/), una plataforma de publicación web de un solo comando diseñada para desarrolladores front-end.
+
+## Cómo desplegar
+
+<Steps>
+1. Instala [la CLI de Surge](https://www.npmjs.com/package/surge) de forma global desde la terminal, si aún no lo has hecho.
+
+    ```shell
+    npm install -g surge
+    ```
+
+2. Construye tu sitio de Astro desde el directorio raíz de tu proyecto.
+
+    ```shell
+    npm run build
+    ```
+
+3. Despliega en Surge usando la CLI.
+
+    ```shell
+    surge dist
+    ```
+
+    Puedes [usar un dominio personalizado con Surge](http://surge.sh/help/adding-a-custom-domain) al desplegar ejecutando `surge dist yourdomain.com`.
+</Steps>


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/surge.mdx`.