### PR TITLE
Update Sätteri recipes to use root visitors

### DIFF
--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -121,8 +121,8 @@ This recipe calculates time based on your repository’s Git history and may not
         import { fileURLToPath } from "node:url";
         import { defineMdastPlugin } from "satteri";
 
-        export const mdastModifiedTimeFileSystemPlugin = defineMdastPlugin({
-          name: "mdast-modified-time-filesystem",
+        export const mdastModifiedTimePlugin = defineMdastPlugin({
+          name: "mdast-modified-time",
           before(node, context) {
             if (!context.fileURL) return;
 

--- a/src/content/docs/en/recipes/modified-time.mdx
+++ b/src/content/docs/en/recipes/modified-time.mdx
@@ -80,10 +80,8 @@ This recipe calculates time based on your repository’s Git history and may not
 
         export const mdastModifiedTimePlugin = defineMdastPlugin({
           name: "mdast-modified-time",
-          text(node, context) {
-            // Check if `lastModified` is already set for this file.
-            const isLastModifiedSet = !!context.data.astro?.frontmatter.lastModified;
-            if (isLastModifiedSet || !context.fileURL) return;
+          before(root, context) {
+            if (!context.fileURL) return;
 
             const filepath = fileURLToPath(context.fileURL);
             const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
@@ -123,12 +121,10 @@ This recipe calculates time based on your repository’s Git history and may not
         import { fileURLToPath } from "node:url";
         import { defineMdastPlugin } from "satteri";
 
-        export const mdastModifiedTimePlugin = defineMdastPlugin({
-          name: "mdast-modified-time",
-          text(node, context) {
-            // Check if `lastModified` is already set for this file.
-            const isLastModifiedSet = !!context.data.astro?.frontmatter.lastModified;
-            if (isLastModifiedSet || !context.fileURL) return;
+        export const mdastModifiedTimeFileSystemPlugin = defineMdastPlugin({
+          name: "mdast-modified-time-filesystem",
+          before(node, context) {
+            if (!context.fileURL) return;
 
             const filepath = fileURLToPath(context.fileURL);
             const result = statSync(filepath);

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -77,10 +77,6 @@ Create a [mdast plugin](/en/guides/markdown-content/#markdown-processor-plugins)
         export const mdastReadingTimePlugin = defineMdastPlugin({
           name: "mdast-reading-time",
           after(root, context) {
-            // Check if `minutesRead` is already set for this file.
-            const isMinutesReadSet = !!context.data.astro?.frontmatter.minutesRead;
-            if (isMinutesReadSet) return;
-
             const textOnPage = context.textContent(root);
             const readingTime = getReadingTime(textOnPage);
 

--- a/src/content/docs/en/recipes/reading-time.mdx
+++ b/src/content/docs/en/recipes/reading-time.mdx
@@ -72,30 +72,16 @@ Create a [mdast plugin](/en/guides/markdown-content/#markdown-processor-plugins)
       <Fragment slot="satteri">
         ```js title="src/mdast/mdast-reading-time.ts"
         import getReadingTime from "reading-time";
-        import { defineMdastPlugin, type MdastNode } from "satteri";
-
-        const findRoot = (
-          startNode: Readonly<MdastNode>,
-          getParent: (node: Readonly<MdastNode>) => Readonly<MdastNode> | undefined,
-        ): Readonly<MdastNode> => {
-          let root = startNode;
-          let ancestor = getParent(root);
-          while (ancestor !== undefined) {
-            root = ancestor;
-            ancestor = getParent(root);
-          }
-          return root;
-        };
+        import { defineMdastPlugin } from "satteri";
 
         export const mdastReadingTimePlugin = defineMdastPlugin({
           name: "mdast-reading-time",
-          text(node, context) {
+          after(root, context) {
             // Check if `minutesRead` is already set for this file.
             const isMinutesReadSet = !!context.data.astro?.frontmatter.minutesRead;
             if (isMinutesReadSet) return;
 
-            const tree = findRoot(node, (n) => context.parent(n));
-            const textOnPage = context.textContent(tree);
+            const textOnPage = context.textContent(root);
             const readingTime = getReadingTime(textOnPage);
 
             if (context.data.astro !== undefined) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Since [`astro@7.2.4`](https://github.com/withastro/astro/pull/17739) and [`satteri@0.10.2`](https://github.com/bruits/satteri/blob/main/packages/satteri/CHANGELOG.md#0102--2026-08-18), the Sätteri processor support root visitors. Both hook runs once per file, so we no longer need to check if the property is already set!

- Update `recipes/modified-time.mdx` to use the `before()` hook: I don't think we need to wait for other plugins to run for this one.
- Update `recipes/reading-time.mdx` to remove the previous `findRoot()` function and use the `after()` hook instead: ~~we need to wait for other plugins to run. Another plugin could inject more content into the tree.~~ (don't trust me, read Erika's comment instead!)

You can double check how it works with this [Stackblitz repro](https://stackblitz.com/edit/astro-docs-satteri-recipes?file=package.json,src%2Fmdast%2Fmdast-reading-time.ts,src%2Fmdast%2Fmdast-modified-time.ts,src%2Fmdast%2Fmdast-modified-time-filesystem.ts) (well, by downloading it locally, because of the Git plugin).

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->
