### PR TITLE
i18n(es): add `guides/deploy/zeabur.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/zeabur.mdx
+++ b/src/content/docs/es/guides/deploy/zeabur.mdx
@@ -1,0 +1,63 @@
+---
+title: Despliega tu sitio Astro en Zeabur
+description: Cómo desplegar tu sitio Astro en la web con Zeabur.
+sidebar:
+  label: Zeabur
+type: deploy
+logo: zeabur
+supports: ['ssr', 'static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+[Zeabur](https://zeabur.com) ofrece alojamiento para aplicaciones web full-stack. Los sitios de Astro se pueden alojar tanto en modo SSR o como salida estática.
+
+Esta guía incluye instrucciones para desplegar en Zeabur a través de la interfaz de usuario de su sitio web.
+
+## Configuración del proyecto
+
+### Sitio estático
+
+Astro genera un sitio estático de forma predeterminada. No es necesaria ninguna configuración adicional para desplegar un sitio estático de Astro en Zeabur. 
+
+### Adaptador para SSR
+
+Para habilitar SSR en tu proyecto de Astro y desplegar en Zeabur:
+
+<Steps>
+1. Instala [el adaptador `@zeabur/astro-adapter`](https://www.npmjs.com/package/@zeabur/astro-adapter) en las dependencias de tu proyecto utilizando tu gestor de paquetes preferido. Si usas npm o no estás seguro, ejecuta esto en la terminal:
+
+    ```bash
+      npm install @zeabur/astro-adapter
+    ```
+
+2. Añade dos líneas nuevas al archivo de configuración de tu proyecto `astro.config.mjs`.
+
+    ```js title="astro.config.mjs" ins={2, 5-6}
+    import { defineConfig } from 'astro/config';
+    import zeabur from '@zeabur/astro-adapter/serverless';
+
+    export default defineConfig({
+      output: 'server',
+      adapter: zeabur(),
+    });
+    ```
+</Steps>
+
+## Cómo desplegar
+
+Puedes desplegar tu sitio de Astro en Zeabur si el proyecto está guardado en GitHub.
+
+<Steps>
+1. Haz clic en <kbd>Create new project</kbd> en el [panel de control de Zeabur](https://dash.zeabur.com).
+
+2. Configura la integración con GitHub e importa el repositorio.
+
+3. Zeabur detectará automáticamente que tu proyecto es un proyecto de Astro y lo compilará usando el comando `astro build`.
+
+4. Una vez completada la compilación, puedes vincular un dominio a tu sitio y visitarlo.
+</Steps>
+
+Una vez que tu proyecto haya sido importado y desplegado, todos los cambios posteriores enviados a las ramas generarán nuevas compilaciones.
+
+Obtén más información en la [Guía de Despliegue](https://zeabur.com/docs/get-started/) de Zeabur.


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/zeabur.mdx`.