### PR TITLE
Recommend router-based route protection over pathname-string auth checks

### DIFF
--- a/src/content/docs/en/guides/authentication.mdx
+++ b/src/content/docs/en/guides/authentication.mdx
@@ -177,7 +177,9 @@ async function requireAuth(c, next) {
 ```
 
 :::caution
-Do not authorize requests by matching `context.url.pathname` against a string (for example `context.url.pathname === "/dashboard"` or `context.url.pathname.startsWith("/dashboard")`). The public pathname a middleware sees is not guaranteed to be the same as the route Astro matches internally: a configured `base`, URL encoding, and duplicate slashes can all cause them to differ. An attacker can exploit that gap to reach a protected route with a pathname your check does not recognize. Gate authorization on a router that matches routes for you instead.
+The public pathname a middleware sees is not guaranteed to be the same as the route Astro matches internally: a configured `base`, URL encoding, and duplicate slashes can all cause them to differ. An attacker can exploit that gap to reach a protected route with a pathname your check does not recognize.
+
+Do not authorize requests by matching `context.url.pathname` against a string (e.g. `context.url.pathname === "/dashboard"` or `context.url.pathname.startsWith("/dashboard")`). Instead, restrict access on a router that matches routes for you.
 :::
 
 ### Next Steps

--- a/src/content/docs/en/guides/authentication.mdx
+++ b/src/content/docs/en/guides/authentication.mdx
@@ -149,23 +149,36 @@ const session = await auth.api.getSession({
 <p>{session.user?.name}</p>
 ```
 
-You can also use the `auth` object to protect your routes using middleware. The following example checks whether a user trying to access a logged-in dashboard route is authenticated, and redirects them to the home page if not.
+You can also use the `auth` object to protect your routes. The following example uses [Astro's advanced routing](/en/guides/routing/#advanced-routing) with [Hono](https://hono.dev/) to require an authenticated session for every route under `/dashboard`, redirecting to the home page otherwise:
 
-```ts title="src/middleware.ts"
-import { auth } from "../../../auth"; // import your Better Auth instance
-import { defineMiddleware } from "astro:middleware";
- 
-export const onRequest = defineMiddleware(async (context, next) => {
-	const isAuthed = await auth.api
-		.getSession({
-			headers: context.request.headers,
-		})
-	if (context.url.pathname === "/dashboard" && !isAuthed) {
-		return context.redirect("/");
+```ts title="src/fetch.ts"
+import { Hono } from "hono";
+import { astro } from "astro/hono";
+import { auth } from "../auth"; // import your Better Auth instance
+
+const app = new Hono();
+
+// Protect every route under /dashboard.
+app.use("/dashboard", requireAuth);
+app.use("/dashboard/*", requireAuth);
+
+// Run Astro's built-in pipeline for all other requests.
+app.use(astro());
+
+export default app;
+
+async function requireAuth(c, next) {
+	const session = await auth.api.getSession({ headers: c.req.raw.headers });
+	if (!session) {
+		return c.redirect("/");
 	}
 	return next();
-});
+}
 ```
+
+:::caution
+Do not authorize requests by matching `context.url.pathname` against a string (for example `context.url.pathname === "/dashboard"` or `context.url.pathname.startsWith("/dashboard")`). The public pathname a middleware sees is not guaranteed to be the same as the route Astro matches internally: a configured `base`, URL encoding, and duplicate slashes can all cause them to differ. An attacker can exploit that gap to reach a protected route with a pathname your check does not recognize. Gate authorization on a router that matches routes for you instead.
+:::
 
 ### Next Steps
 

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -672,7 +672,9 @@ export default {
 ```
 
 :::caution
-Do not use pre-processing to authorize requests by matching the request pathname against a string (for example `url.pathname.startsWith('/dashboard')`). The pathname of the incoming request is not guaranteed to be the same as the route Astro matches internally, so a check like this can be bypassed. To guard routes, match them with a router that owns route matching, such as [Hono](#using-with-hono).
+The pathname of the incoming request is not guaranteed to be the same as the route Astro matches internally, so a check such as `url.pathname.startsWith('/dashboard')` can be bypassed.
+
+Do not use pre-processing to authorize requests by matching the request pathname against a string. To guard routes, match them with a router that owns route matching, such as [Hono](#using-with-hono).
 :::
 
 #### Composing individual handlers

--- a/src/content/docs/en/guides/routing.mdx
+++ b/src/content/docs/en/guides/routing.mdx
@@ -648,9 +648,9 @@ You can do this in two ways:
 
 #### Running the full pipeline with `astro()`
 
-Use [`astro()`](/en/reference/modules/astro-fetch/#astro) when you want to keep Astro's built-in routing behavior, but need custom logic around it. This approach preserves the default pipeline order and lets you add pre-processing and post-processing in one place. For many use cases, such as adding auth guards, request logging, and custom headers, `astro()` is all you need.
+Use [`astro()`](/en/reference/modules/astro-fetch/#astro) when you want to keep Astro's built-in routing behavior, but need custom logic around it. This approach preserves the default pipeline order and lets you add pre-processing and post-processing in one place. For many use cases, such as request logging and custom headers, `astro()` is all you need.
 
-The following example checks if a user can access a dashboard before running the Astro pipeline, and adds a custom header to the response once Astro has finished running:
+The following example logs each incoming request before running the Astro pipeline, and adds a custom header to the response once Astro has finished running:
 
 ```ts title="src/fetch.ts"
 import { FetchState, astro } from 'astro/fetch';
@@ -660,16 +660,7 @@ export default {
     const state = new FetchState(request);
 
     // Custom pre-processing, runs before any Astro handler
-    const url = new URL(request.url);
-    if (url.pathname.startsWith('/dashboard')) {
-      const cookie = request.headers.get('cookie') ?? '';
-      if (!cookie.includes('session=')) {
-        return new Response(null, {
-          status: 302,
-          headers: { Location: '/login' },
-        });
-      }
-    }
+    console.log(`${request.method} ${new URL(request.url).pathname}`);
 
     const response = await astro(state);
 
@@ -679,6 +670,10 @@ export default {
   },
 };
 ```
+
+:::caution
+Do not use pre-processing to authorize requests by matching the request pathname against a string (for example `url.pathname.startsWith('/dashboard')`). The pathname of the incoming request is not guaranteed to be the same as the route Astro matches internally, so a check like this can be bypassed. To guard routes, match them with a router that owns route matching, such as [Hono](#using-with-hono).
+:::
 
 #### Composing individual handlers
 
@@ -732,4 +727,32 @@ app.use(pages());
 app.use(i18n());
 
 export default app;
+```
+
+You can also guard protected routes by registering an authorization check on the Hono routes you want to protect:
+
+```ts title="src/fetch.ts"
+import { Hono } from 'hono';
+import { actions, middleware, pages, i18n } from 'astro/hono';
+import { isLoggedIn } from './lib/auth';
+
+const app = new Hono();
+
+// Guard every route under /dashboard.
+app.use('/dashboard', requireAuth);
+app.use('/dashboard/*', requireAuth);
+
+app.use(actions());
+app.use(middleware());
+app.use(pages());
+app.use(i18n());
+
+export default app;
+
+async function requireAuth(c, next) {
+  if (!(await isLoggedIn(c.req.raw))) {
+    return c.redirect('/login');
+  }
+  return next();
+}
 ```


### PR DESCRIPTION

#### Description (required)

In the path we have documenting using patterns like `context.url.pathname.startsWith('/dashboard')` to only apply auth requirements to certain routes. This had led to numerous security issues such as double-encoded URLs, base-stripped URLs not matching the string check, etc. It was a mistake for Astro to make Astro.url by anything other than the raw request URL. We have attempted to "normalize" this value for users to match what they expect. If the user is going to the `dashboard.astro` route they expect the URL to also be `/dashboard`. But this means that Astro has taken on the burden of the pathname not actually matching user expectations.

I hope to make a breaking change to how Astro.url works in 8.0 so that we no longer normalize the value for the user at all. In the mean time I want to immediately move away from documenting a bad practice. Instead if you want to apply middleware to certain routes, use a router like Hono. 

This updates the docs both to show the preferred method, as well as to discourage the old.

#### References

Not related to any pull-requests or Astro issues.