### PR TITLE
Fix: Flawed CSS Example

### DIFF
--- a/src/content/docs/en/tutorial/3-components/3.mdx
+++ b/src/content/docs/en/tutorial/3-components/3.mdx
@@ -140,7 +140,6 @@ Since your site will be viewed on different devices, it's time to create a page 
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 


### PR DESCRIPTION
#### Description

Removed `display: none` from `.nav-links` so that the navigation remains visible on mobile devices.

Previously, `.nav-links` was hidden by default and only displayed at screen widths of 636px and above. As a result, the navigation was completely inaccessible on mobile devices.

This change makes the navigation links visible on smaller screens while preserving the existing desktop styling.

This change only affects documentation.



- Discord Username: `ujjwal_gupta`