### PR TITLE
Fix: mobile nav CSS example and code highlights across tutorial locales

### DIFF
--- a/src/content/docs/de/tutorial/3-components/3.mdx
+++ b/src/content/docs/de/tutorial/3-components/3.mdx
@@ -114,7 +114,7 @@ Da deine Website auf verschiedenen Geräten angesehen wird, ist es an der Zeit, 
     Beginne damit zu definieren, was auf kleinen Bildschirmgrößen passieren soll! Kleinere Bildschirmgrößen erfordern einfachere Layouts. Passe dann deine Styles an, um größere Geräte zu berücksichtigen. Wenn du zuerst ein kompliziertes Layout entwirfst, musst du später daran feilen, um es wieder zu vereinfachen.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -142,7 +142,6 @@ Da deine Website auf verschiedenen Geräten angesehen wird, ist es an der Zeit, 
       width: 100%;
       left: 48px;
       background-color: #ff9776;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/de/tutorial/3-components/4.mdx
+++ b/src/content/docs/de/tutorial/3-components/4.mdx
@@ -61,7 +61,7 @@ Erstelle eine `<Menu />`-Komponente, um dein mobiles Menü zu öffnen und zu sch
 
 4. Füge die folgenden Styles für deine Menü-Komponente hinzu, einschließlich einiger responsiver Styles:
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* Navigation-Styles */
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/en/tutorial/3-components/3.mdx
+++ b/src/content/docs/en/tutorial/3-components/3.mdx
@@ -113,7 +113,7 @@ Since your site will be viewed on different devices, it's time to create a page 
     Start by defining what should happen on small screen sizes first! Smaller screen sizes require simpler layouts. Then, adjust your styles to accommodate larger devices. If you design the complicated case first, then you have to work to try to make it simple again.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -140,7 +140,6 @@ Since your site will be viewed on different devices, it's time to create a page 
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/en/tutorial/3-components/4.mdx
+++ b/src/content/docs/en/tutorial/3-components/4.mdx
@@ -30,19 +30,19 @@ Create a `<Menu />` component to open and close your mobile menu.
 
 <Steps>
 1. Create a file named `Menu.astro` in `src/components/`
-  
+
 
 2. Copy the following code into your component. It creates a button that will be used to toggle the visibility of the navigation links on mobile devices. (You will add the new CSS styles to `global.css` later.)
 
     ```astro title="src/components/Menu.astro"
-    --- 
+    ---
     ---
     <button aria-expanded="false" aria-controls="main-menu" class="menu">
       Menu
     </button>
     ```
 
-3. Place this new `<Menu />` component just before your `<Navigation />` component in `Header.astro`. 
+3. Place this new `<Menu />` component just before your `<Navigation />` component in `Header.astro`.
 
     <details>
     <summary>Show me the code!</summary>
@@ -63,7 +63,7 @@ Create a `<Menu />` component to open and close your mobile menu.
 
 4. Add the following styles for your Menu component, including some responsive styles:
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* nav styles */
     .menu {
       background-color: #0d0950;
@@ -124,7 +124,7 @@ Create a `<Menu />` component to open and close your mobile menu.
 
 ## Write your first script tag
 
-Your header is not yet **interactive** because it can't respond to user input, like clicking on the menu to show or hide the navigation links. 
+Your header is not yet **interactive** because it can't respond to user input, like clicking on the menu to show or hide the navigation links.
 
 Adding a `<script>` tag provides client-side JavaScript to "listen" for a user event and then respond accordingly.
 
@@ -180,7 +180,7 @@ Instead of writing your JavaScript directly on each page, you can move the conte
     </body>
     ```
 
-3. Check your browser preview again at a smaller size and verify that the menu still opens and closes your navigation links. 
+3. Check your browser preview again at a smaller size and verify that the menu still opens and closes your navigation links.
 
 
 4. Add the same `<script>` with import to your other two pages, `about.astro` and `blog.astro` and verify that you have a responsive, interactive header on each page.
@@ -201,7 +201,7 @@ You had previously used some JavaScript to build parts of your site:
 - Mapping through a list of skills on the About page
 - Conditionally displaying HTML elements
 
-Those commands are all executed at build time to create static HTML for your site, and then the code is "thrown away." 
+Those commands are all executed at build time to create static HTML for your site, and then the code is "thrown away."
 
 **The JavaScript in a `<script>` tag is sent to the browser**, and is available to run, based on user interactions like refreshing a page or toggling an input.
 :::

--- a/src/content/docs/es/tutorial/3-components/3.mdx
+++ b/src/content/docs/es/tutorial/3-components/3.mdx
@@ -116,7 +116,7 @@ Dado que tu sitio se verá en distintos dispositivos, ¡es hora de crear una nav
     Empieza por definir qué debe ocurrir en las pantallas pequeñas. Las pantallas pequeñas requieren diseños más sencillos. A continuación, ajusta tus estilos para adaptarse a dispositivos más grandes. Si diseñas primero el caso complicado, luego tendrás que trabajar para intentar hacerlo sencillo de nuevo.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -143,7 +143,6 @@ Dado que tu sitio se verá en distintos dispositivos, ¡es hora de crear una nav
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/es/tutorial/3-components/4.mdx
+++ b/src/content/docs/es/tutorial/3-components/4.mdx
@@ -61,7 +61,7 @@ Crea un componente `<Menu />` para abrir y cerrar tu menú móvil.
 
 4. Añade los siguientes estilos para tu componente menu, incluyendo algunos estilos responsivos:
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* estilos de la barra de navegación*/
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/fr/tutorial/3-components/3.mdx
+++ b/src/content/docs/fr/tutorial/3-components/3.mdx
@@ -113,7 +113,7 @@ import Badge from "~/components/Badge.astro"
     Commencez par définir ce qui doit se passer sur les petits écrans en premier ! Les écrans plus petits nécessitent des mises en page plus simples. Ensuite, ajustez vos styles pour les appareils plus grands. Si vous concevez d'abord le cas compliqué, vous devrez ensuite essayer de le rendre à nouveau simple.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -140,7 +140,6 @@ import Badge from "~/components/Badge.astro"
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/fr/tutorial/3-components/4.mdx
+++ b/src/content/docs/fr/tutorial/3-components/4.mdx
@@ -63,7 +63,7 @@ Créez un composant `<Menu />` pour ouvrir et fermer votre menu mobile.
 
 4. Ajoutez les styles suivants pour votre composant Menu, y compris certains styles adaptatifs :
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* Styles de la navigation */
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/ja/tutorial/3-components/3.mdx
+++ b/src/content/docs/ja/tutorial/3-components/3.mdx
@@ -112,7 +112,7 @@ import Badge from "~/components/Badge.astro"
     最初は小さい画面サイズのデザインから始めましょう！小さい画面サイズはシンプルなレイアウトが必要です。その後、スタイルを調整して大きなデバイスに対応します。複雑な場合のデザインから始めてしまうと、それをまたシンプルにするための努力が必要になります。
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -139,7 +139,6 @@ import Badge from "~/components/Badge.astro"
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/ja/tutorial/3-components/4.mdx
+++ b/src/content/docs/ja/tutorial/3-components/4.mdx
@@ -62,7 +62,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 4. レスポンシブなスタイルを含む以下のメニューコンポーネント用スタイルを追加します。
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* ナビゲーションのスタイル */
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/ko/tutorial/3-components/3.mdx
+++ b/src/content/docs/ko/tutorial/3-components/3.mdx
@@ -110,7 +110,7 @@ import Badge from "~/components/Badge.astro"
     먼저 작은 화면 크기에서 어떤 일이 발생해야 하는지 정의하는 것부터 시작하세요! 화면 크기가 작을수록 더 간단한 레이아웃이 필요합니다. 그런 다음 더 큰 장치에 맞게 스타일을 조정하세요. 복잡한 케이스를 먼저 디자인했다면, 다시 단순하게 만들려고 노력해야 합니다.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -137,7 +137,6 @@ import Badge from "~/components/Badge.astro"
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/ko/tutorial/3-components/4.mdx
+++ b/src/content/docs/ko/tutorial/3-components/4.mdx
@@ -59,7 +59,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 4. 메뉴 컴포넌트에 다음 스타일을 추가하세요. 여기에는 반응형 스타일도 포함됩니다.
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* nav 스타일 */
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/pt-br/tutorial/3-components/3.mdx
+++ b/src/content/docs/pt-br/tutorial/3-components/3.mdx
@@ -116,7 +116,7 @@ Já que o seu site será visto em diferentes dispositivos, é hora de criar uma 
     Comece definindo o que deve acontecer em tamanhos de tela menores primeiro! Tamanhos de tela menores demandam layouts mais simples. E então, ajuste seus estilos para acomodarem dispositivos maiores. Se você projetar para os casos mais complicados primeiro, você terá que trabalhar para tentar torná-lo simples novamente.
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -143,7 +143,6 @@ Já que o seu site será visto em diferentes dispositivos, é hora de criar uma 
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/pt-br/tutorial/3-components/4.mdx
+++ b/src/content/docs/pt-br/tutorial/3-components/4.mdx
@@ -63,7 +63,7 @@ Crie um componente `<Menu />` para abrir e fechar sua navegação móvel.
 
 4. Adicione os seguintes estilos ao seu componente de Menu, incluindo alguns estilos responsivos:
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* estilos da navegação */
     .menu {
       background-color: #0d0950;

--- a/src/content/docs/zh-cn/tutorial/3-components/3.mdx
+++ b/src/content/docs/zh-cn/tutorial/3-components/3.mdx
@@ -109,7 +109,7 @@ import Badge from "~/components/Badge.astro"
     首先定义在较小屏幕尺寸上应该渲染的布局！较小的屏幕尺寸需要更简单的布局，然后，调整你的样式以适应较大的设备。如果你先设计复杂情况，那么接下来你反而要努力将其简化。
     :::
 
-    ```css title="src/styles/global.css" ins={23-60}
+    ```css title="src/styles/global.css" ins={23-59}
     html {
       background-color: #f1f5f9;
       font-family: sans-serif;
@@ -136,7 +136,6 @@ import Badge from "~/components/Badge.astro"
 
     .nav-links {
       width: 100%;
-      display: none;
       margin: 0;
     }
 

--- a/src/content/docs/zh-cn/tutorial/3-components/4.mdx
+++ b/src/content/docs/zh-cn/tutorial/3-components/4.mdx
@@ -58,7 +58,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 4. 为你的 Menu 组件添加以下样式，包括一些响应式样式：
 
-    ```css title="src/styles/global.css" ins={2-9, 33-35, 51-53}
+    ```css title="src/styles/global.css" ins={2-9, 13, 33-35, 51-53}
     /* 导航样式 */
     .menu {
       background-color: #0d0950;


### PR DESCRIPTION
#### Description (required)

- **Problem**: In Unit 3 of the tutorial (`tutorial/3-components/3.mdx`), `display: none` was previously applied to `.nav-links` before the `<Menu />` component is introduced. This made the navigation links completely invisible on mobile viewports without any button to reveal them.
- **Fix**:
  - Removed `display: none` from `.nav-links` in `3.mdx` so navigation links remain visible on mobile until the menu button is built.
  - Adjusted the line insertion highlight in `3.mdx` from `ins={23-60}` to `ins={23-59}`.
  - In `4.mdx` (where `<Menu />` is created and `display: none` is added to `.nav-links`), updated the highlight range to `ins={2-9, 13, 33-35, 51-53}` to properly highlight the newly added `display: none` on line 13.
  - Applied the fix consistently across all applicable localized tutorial files (`de`, `en`, `es`, `fr`, `ja`, `ko`, `pt-br`, `zh-cn`).
#### References

- Related to PR: #14438 
- Discord username: `ujjwal_gupta`