### PR TITLE
Fix incorrect indefinite article before "URL" (en-only)

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -185,7 +185,7 @@ export const collections = { blog };
 
 #### Defining custom IDs
 
-When using the [`glob()` loader](#the-glob-loader) with Markdown, MDX, Markdoc, JSON, or TOML files, every content entry [`id`](/en/reference/modules/astro-content/#collectionentryid) is automatically generated in an URL-friendly format based on the content filename. This unique `id` is used to query the entry directly from your collection. It is also useful when [creating new pages and URLs from your content](#generating-routes-from-content).
+When using the [`glob()` loader](#the-glob-loader) with Markdown, MDX, Markdoc, JSON, or TOML files, every content entry [`id`](/en/reference/modules/astro-content/#collectionentryid) is automatically generated in a URL-friendly format based on the content filename. This unique `id` is used to query the entry directly from your collection. It is also useful when [creating new pages and URLs from your content](#generating-routes-from-content).
 
 You can override a single entry’s generated `id` by adding your own `slug` property to the file frontmatter or data object for JSON files. This is similar to the “permalink” feature of other web frameworks.
 

--- a/src/content/docs/en/guides/styling.mdx
+++ b/src/content/docs/en/guides/styling.mdx
@@ -249,7 +249,7 @@ import 'package-name/normalize';
 
 ### Load a static stylesheet via "link" tags
 
-You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or an URL to an external website. Relative `<link>` href values are not supported.
+You can also use the `<link>` element to load a stylesheet on the page. This should be an absolute URL path to a CSS file located in your `/public` directory, or a URL to an external website. Relative `<link>` href values are not supported.
 
 ```astro title="src/pages/index.astro" {3,5}
 <head>


### PR DESCRIPTION
Two English guide pages use "an" before "URL". "URL" is voiced "you-are-ell", which begins with a consonant sound (/j/), so the correct article is "a", not "an" (the same rule that gives us "a unique", "a one-time"). One of the sentences already writes "a URL" correctly elsewhere, so these are isolated slips.

Prose-only edits; no code samples or components touched. Title carries `en-only` so the Translation Status Tracker does not flag every locale.

Pages:
- guides/styling
- guides/content-collections
