### PR TITLE
i18n(es): add `guides/deploy/zephyr.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/zephyr.mdx
+++ b/src/content/docs/es/guides/deploy/zephyr.mdx
@@ -1,0 +1,145 @@
+---
+title: Despliega tu sitio Astro en Zephyr Cloud
+description: Cómo desplegar tu sitio Astro en la web usando Zephyr Cloud.
+sidebar:
+  label: Zephyr Cloud
+type: deploy
+logo: zephyr
+supports: ['static']
+i18nReady: true
+---
+
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes usar [Zephyr Cloud](https://zephyr-cloud.io) para desplegar un sitio de Astro con gestión inteligente de recursos, análisis detallados de compilación y soporte de primer nivel para arquitecturas de Module Federation.
+
+Zephyr opera bajo un modelo de **Trae tu propia nube (BYOC)**, despliega en la [nube compatible](https://docs.zephyr-cloud.io/cloud) de tu elección a través de una interfaz unificada y sin dependencia de un único proveedor. Cambia de proveedor en cualquier momento sin alterar tu flujo de trabajo de despliegue.
+
+## Cómo desplegar
+
+### Instalación automática
+
+<Steps>
+1. Añade la integración de Zephyr a tu proyecto de Astro con el siguiente comando. Esto instalará la integración y actualizará tu archivo `astro.config.mjs` automáticamente:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npx with-zephyr@latest
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm dlx with-zephyr@latest
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn dlx with-zephyr@latest
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+2. Compila y despliega tu sitio Astro:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run build
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm run build
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn run build
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+3. ¡Tu aplicación ya está desplegada! Zephyr te proporcionará una URL de despliegue y análisis detallados de la compilación.
+</Steps>
+
+### Instalación manual
+
+<Steps>
+1. Instala la integración de Zephyr para Astro:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm install zephyr-astro-integration
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm add zephyr-astro-integration
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn add zephyr-astro-integration
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+2. Añade la integración a tu archivo `astro.config.mjs`:
+
+    ```js
+    import { defineConfig } from 'astro/config';
+    import { withZephyr } from 'zephyr-astro-integration';
+
+    export default defineConfig({
+      integrations: [
+        withZephyr(),
+      ],
+    });
+    ```
+
+3. Compila y despliega tu sitio Astro:
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run build
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm run build
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn run build
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+4. ¡Tu aplicación ya está desplegada! Zephyr te proporcionará una URL de despliegue y análisis detallados de la compilación.
+</Steps>
+
+### Más detalles
+
+Para obtener información más detallada, consulta la [documentación de Zephyr Cloud sobre despliegues con Astro](https://docs.zephyr-cloud.io/meta-frameworks/astro).
+
+## Qué ocurre durante el despliegue
+
+Cuando compilas tu sitio Astro con la integración de Zephyr, se lleva a cabo el siguiente proceso:
+
+1. **Extracción del contexto de compilación**: Zephyr captura la información de Git (commit, rama, autor) y los metadatos del paquete
+2. **Hashing de recursos**: A todos los resultados de la compilación se les asigna un hash mediante SHA-256 para un almacenamiento direccionable por contenido
+3. **Detección de deltas**: Zephyr consulta el edge de la CDN para identificar qué recursos ya existen
+4. **Subida optimizada**: Solo se suben los recursos nuevos o modificados
+5. **Creación de instantánea**: Se crea una instantánea de despliegue inmutable con todas las referencias a los recursos
+6. **Subida de analíticas**: Las estadísticas de compilación, los gráficos de módulos y la información de dependencias se envían al panel de control
+7. **Despliegue en la CDN**: Los recursos se publican en tu CDN configurada con cabeceras de caché permanentes
+
+## Recursos oficiales
+
+- [Documentación de Zephyr Cloud](https://docs.zephyr-cloud.io)
+- [Integración de Zephyr con Astro en GitHub](https://github.com/ZephyrCloudIO/zephyr-packages/tree/main/libs/zephyr-astro-integration)
+- [Plataforma Zephyr Cloud](https://zephyr-cloud.io)


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/deploy/zephyr.mdx`.
