### PR TITLE
i18n(es): add `guides/integrations-guide/lit.mdx`

### DIFF
--- a/src/content/docs/es/guides/integrations-guide/lit.mdx
+++ b/src/content/docs/es/guides/integrations-guide/lit.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Lit'
+description: Uso de Lit para extender el soporte de componentes en tu proyecto de Astro.
+i18nReady: true
+---
+
+:::caution[Obsoleto]
+Esta integración de Astro para habilitar el renderizado bajo demanda y la hidratación del lado del cliente para tus elementos personalizados de [Lit](https://lit.dev/) quedó obsoleta en Astro 5.0.
+:::
+
+Puedes seguir usando Lit para los componentes del cliente agregando una etiqueta de script del lado del cliente. Por ejemplo:
+
+```astro
+<script>
+  import "../components/MyTabs";
+</script>
+
+<my-tabs title="Estas son mis pestañas">...</my-tabs>
+```
+
+Si te interesa mantener una integración de Lit por tu cuenta, podrías usar la [última versión publicada de `@astrojs/lit`](https://github.com/withastro/astro/tree/astro%404.13.0/packages/integrations/lit) como punto de partida y actualizar los paquetes correspondientes.


### PR DESCRIPTION
#### Description (required)

Adds the Spanish translation of `guides/integrations-guide/lit.mdx`.