### PR TITLE
i18n(zh-CN): add `reference/logger-reference.mdx`, `reference/renderer-reference.mdx` and `recipes/customizing-output-filenames.mdx`

### DIFF
--- a/src/content/docs/zh-cn/recipes/customizing-output-filenames.mdx
+++ b/src/content/docs/zh-cn/recipes/customizing-output-filenames.mdx
@@ -1,0 +1,108 @@
+---
+title: 自定义构建输出的文件名
+description: 了解如何使用 Vite 的 Rollup 选项，在 Astro 中更改 JavaScript、CSS 和图片等构建产物的默认命名模式。
+i18nReady: true
+type: recipe
+---
+import { Steps } from '@astrojs/starlight/components';
+import { FileTree } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
+默认情况下，`astro build` 命令会将来自[项目源代码](/zh-cn/basics/project-structure/#src)（如 `src/` 目录中的 JavaScript 和 CSS 文件）的构建产物，输出到一个使用哈希文件名的 `_astro` 目录中（例如 `_astro/index.DRf8L97S.js`），这对于长期缓存非常有利。
+
+虽然通常没有必要，但你可以在需要时自定义输出文件名。例如，当你的脚本名称可能触发广告拦截器（例如 `ads.js`），或者你想用特定的命名约定来组织资源时，这会很有帮助。通过自定义 Rollup 输出选项，你可以更好地控制项目的构建结构，从而满足特定的组织或部署需求。
+
+## 操作步骤
+
+本方案通过配置 `vite.environments.client.build.rollupOptions`，使构建产物按以下结构和命名模式输出：
+-   JavaScript 入口文件（例如与页面或布局直接关联的脚本）：`dist/js/[name]-[hash].js`
+-   JavaScript 代码分割 chunk（例如动态导入的组件或共享模块）：`dist/js/chunks/[name]-[hash].js`
+-   其他资源（例如 CSS、图片、字体）：`dist/static/[name]-[hash][extname]`（例如 `dist/static/styles-a1b2c3d4.css`、`dist/static/logo-e5f6g7h8.svg`）
+
+<Steps>
+
+1.  添加 Vite Rollup 输出选项。
+
+    修改你的 `astro.config.mjs`，加入以下 `vite.environments.client.build.rollupOptions.output` 配置。你可以在这里使用 Rollup 的 [`entryFileNames`](https://rollupjs.org/configuration-options/#output-entryfilenames)、[`chunkFileNames`](https://rollupjs.org/configuration-options/#output-chunkfilenames) 和 [`assetFileNames`](https://rollupjs.org/configuration-options/#output-assetfilenames) 为资源定义自定义命名模式：
+
+    ```javascript title="astro.config.mjs" ins
+    import { defineConfig } from 'astro/config';
+
+    export default defineConfig({
+      // ...
+      vite: {
+        environments: {
+          client: {
+            build: {
+              rollupOptions: {
+                output: {
+                  // 相对于 `outDir` 的路径名
+                  entryFileNames: 'js/[name]-[hash].js',
+                  chunkFileNames: 'js/chunks/[name]-[hash].js',
+                  assetFileNames: 'static/[name]-[hash][extname]',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    ```
+
+    此示例使用了以下文件名占位符：
+    *   `[name]`：文件的原始名称（不含扩展名和路径）。
+    *   `[hash]`：基于文件内容生成的哈希值，对缓存更新至关重要。你还可以指定长度，例如 `[hash:8]`。这能确保当你更新资源时文件名会发生变化，从而强制浏览器下载新版本，而不是继续提供过期的缓存版本。
+    *   `[extname]`：原始文件扩展名，包含前导点（例如 `.js`、`.css`、`.svg`）。
+
+    <ReadMore>
+    有关这些选项的全部可用占位符和高级模式，请参阅 [Rollup 配置文档](https://rollupjs.org/configuration-options/)。
+    </ReadMore>
+
+2.  构建你的项目。
+
+    由于这些文件名自定义仅应用于生产构建输出，你需要运行项目的构建命令：
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm run build
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm build
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn build
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+3. 构建完成后，检查你的[输出目录](/zh-cn/reference/configuration-reference/#outdir)（默认为 `dist/`）。
+
+    确认来自项目 `src` 的构建产物是否按照新的模式命名和组织。（来自 [`public/` 目录](/zh-cn/basics/project-structure/#public)的文件会直接复制到输出目录，不受这些 Rollup 命名选项的影响。）
+
+    根据项目的具体内容，你的构建文件夹现在将类似于：
+
+    <FileTree>
+    - dist/
+      - js/
+        - index-a1b2c3d4.js
+        - chunks/
+          - common-e5f6g7h8.js
+      - img/
+        - logo-i9j0k1l2.png
+      - fonts/
+        - myfont-q2w3e4r5.woff2
+      - static_assets/
+        - styles-m3n4o5p6.css
+      - index.html
+      - about/
+        - index.html
+      - ...（其他 HTML 文件和 public 资源）
+    </FileTree>
+
+</Steps>

--- a/src/content/docs/zh-cn/reference/logger-reference.mdx
+++ b/src/content/docs/zh-cn/reference/logger-reference.mdx
@@ -1,0 +1,300 @@
+---
+title: Astro 日志记录器 API
+sidebar:
+  label: 日志记录器 API
+i18nReady: true
+---
+import Since from '~/components/Since.astro';
+
+<p>
+  <Since v="7.0.0" />
+</p>
+
+
+日志记录器 API 提供了对 Astro 日志基础设施更强的控制力。这使你可以用自定义的日志实现替换默认的控制台输出，并连接到日志聚合服务。
+
+该 API 包含三个开箱即用的日志记录器，并允许你集成自己的日志记录器并将它们组合起来。
+
+## 自定义日志记录器
+
+如果你不想使用任何一个[内置日志记录器](#内置日志记录器)，你可以构建自己的日志记录器。
+
+自定义日志记录器由两部分组成：
+
+- [logger 配置](#logger-配置)，让 Astro 知道要使用哪种实现以及要转发什么配置
+- [logger 实现](#logger-实现)，负责处理日志记录逻辑
+
+当你定义了自定义日志记录器时，你将负责所有日志，包括 Astro 自己发出的日志。
+
+### logger 配置
+
+[`logger` 配置](/zh-cn/reference/configuration-reference/#logger-options) 是一个对象，包含必需的 [`entrypoint`](/zh-cn/reference/configuration-reference/#loggerentrypoint) 和可选的 [`config`](/zh-cn/reference/configuration-reference/#loggerconfig)。
+
+以下示例配置了由 `@org/custom-logger` 包导出的自定义日志记录器，并向其传递了一个 `level` 选项：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  logger: {
+    entrypoint: "@org/custom-logger",
+    config: {
+      level: "warn"
+    }
+  }
+});
+```
+
+### logger 实现
+
+日志记录器实现负责处理日志记录逻辑。你需要在日志记录器模块中实现它：导出一个默认函数，该函数接受 [config](#logger-配置) 作为参数，并返回一个带有必需的 `write()` 函数的 [`AstroLoggerDestination` 对象](#astrologgerdestination)。
+
+以下示例实现了一个最小化的日志记录器，它会考虑其配置中的日志 `level`：
+
+```ts title="@org/custom-logger/index.js"
+import { matchesLevel } from "astro/logger";
+
+/**
+ * 自定义日志记录器实现的最小示例。
+ *
+ * @param {Object} [options] - 日志记录器选项。
+ * @param {import("astro").AstroLoggerLevel} [options.level] - 日志的最低级别。默认为 "info"。
+ * @returns {import("astro").AstroLoggerDestination} 自定义日志记录器目标。
+ */
+function orgLogger({ level } = { level: "info" }) {
+  return {
+    write(message) {
+      // 使用该工具函数判断消息是否应该被打印
+      if (matchesLevel(message.level, level)) {
+        // 在某处记录消息，并将级别纳入考量
+      }
+    },
+  };
+}
+
+export default orgLogger;
+```
+
+现在，你可以使用[运行时 API](/zh-cn/reference/api-reference/#logger) 在页面渲染期间添加你自己的日志。
+
+## 日志级别
+
+级别是分配给每条消息的内部、任意的分数。当日志记录器配置了某个级别时，只有级别等于或高于该级别的消息才会被打印。
+
+共有三个级别，从最高分到最低分依次为：
+1. `error`
+2. `warn`
+3. `info`
+
+以下示例配置 JSON 日志记录器，仅打印具有 `warn` 或更高级别的消息：
+
+```js title="astro.config.mjs" {4} ins='level: "warn"'
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.json({ level: "warn" })
+});
+```
+
+`astro/logger` 包暴露了一个 [`matchesLevel()`](#matcheslevel) 辅助函数来检查日志级别。这在[构建自定义日志记录器](#自定义日志记录器)时非常有用。
+
+```js
+import { matchesLevel } from "astro/logger";
+
+matchesLevel("error", "info");
+```
+
+## 内置日志记录器
+
+Astro 提供了可供应用使用的内置日志记录器。
+
+### `logHandlers.json()`
+
+一个以 JSON 格式输出消息的日志记录器。日志看起来像这样：
+
+```json
+{ "message": "<the message>", "label": "router", "level": "info", "time": "<UNIX timestamp>"  }
+```
+
+#### JSON 日志记录器选项
+
+<p>
+  **类型：** `{ pretty: boolean; level: AstroLoggerLevel; }`<br />
+  **默认值：** `{ pretty: false, level: 'info' }`
+  <Since v="7.0.0" />
+</p>
+
+`json` 日志记录器接受以下选项：
+
+- `pretty`：为 `true` 时，JSON 日志会打印为多行。默认为 `false`。
+- `level`：应打印的日志[级别](#日志级别)。
+
+```js title="astro.config.mjs" {4} ins="json"
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.json({ pretty: true })
+});
+```
+
+### `logHandlers.console()`
+
+一个以 `console` 作为目标来打印消息的日志记录器。它会根据消息的级别使用不同的通道：
+
+- `error` 消息使用 `console.error()` 打印。
+- `warn` 消息使用 `console.warn()` 打印。
+- `info` 消息使用 `console.info()` 打印。
+
+#### Console 日志记录器选项
+
+<p>
+  **类型：** `{ level: AstroLoggerLevel }`<br />
+  **默认值：** `{ level: 'info' }`
+  <Since v="7.0.0" />
+</p>
+
+`console` 日志记录器接受以下选项：
+
+- `level`：应打印的日志[级别](#日志级别)。
+
+```js title="astro.config.mjs" {4} ins="console"
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.console({ level: 'warn' })
+});
+```
+
+### `logHandlers.node()`
+
+一个将消息打印到 [`process.stdout`](https://nodejs.org/api/process.html#processstdout) 和 [`process.stderr`](https://nodejs.org/api/process.html#processstderr) 的日志记录器。`error` 级别的消息打印到 `stderr`，其他消息打印到 `stdout`。
+
+这是 Astro 的默认日志记录器。
+
+#### Node 日志记录器选项
+
+<p>
+  **类型：** `{ level: AstroLoggerLevel }`<br />
+  **默认值：** `{ level: 'info' }`
+  <Since v="7.0.0" />
+</p>
+
+`node` 日志记录器接受以下选项：
+
+- `level`：应打印的日志[级别](#日志级别)。
+
+```js title="astro.config.mjs" {4} ins="node"
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.node({ level: 'warn' })
+});
+```
+
+### `logHandlers.compose()`
+
+一个特殊的函数，允许以任意顺序配置多个日志记录器。同一条消息会被广播到所有日志记录器。
+
+以下示例使用默认日志级别组合了 console 日志记录器和 JSON 日志记录器：
+
+```js title="astro.config.mjs"
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.compose(
+    logHandlers.console(),
+    logHandlers.json()
+  )
+});
+```
+
+## 类型参考
+
+以下类型可以从 `astro` 指定符导入。
+
+### `AstroRuntimeLogger`
+
+<p>
+
+**类型：** `{ info: (message: string) => void; warn: (message: string) => void; error: (message: string) => void; }`<br />
+<Since v="7.0.8" />
+</p>
+
+描述[运行时可用的 `logger` 方法](/zh-cn/reference/api-reference/#logger)，用于在页面渲染期间添加额外的日志。
+
+### `AstroLoggerDestination`
+
+这是自定义日志记录器必须实现的接口。
+
+#### `AstroLoggerDestination.write()`
+
+<p>
+
+  **类型：** `(message: AstroLoggerMessage) => void`
+</p>
+
+一个必需的方法，每条日志都会调用它，并接受一个 [`AstroLoggerMessage`](#astrologgermessage)。
+
+#### `AstroLoggerDestination.flush()`
+
+<p>
+
+  **类型：** `() => Promise<void> | void`
+</p>
+
+一个可选函数，在每个请求结束时调用。这对于需要在保持与目标连接存活的同时刷新日志消息的高级日志记录器非常有用。
+
+#### `AstroLoggerDestination.close()`
+
+<p>
+
+  **类型：** `() => Promise<void> | void`
+</p>
+
+一个可选函数，在服务器关闭之前调用。该函数通常由诸如 `@astrojs/node` 之类的适配器调用。
+
+### `AstroLoggerLevel`
+
+<p>
+
+**类型：** `'debug' |'info' |'warn' | 'error' | 'silent'`
+</p>
+
+指定日志的详细程度：
+- `info`、`warn` 和 `error`：定义要打印的最低[日志级别](#日志级别)。
+- `silent`：等同于 [`--silent` CLI 标志](/zh-cn/reference/cli-reference/#--silent)，启用静默日志记录。
+- `debug`：等同于 [`--debug` CLI 标志](/zh-cn/reference/cli-reference/#--verbose)，启用详细日志记录，包括 Vite 日志。
+
+### `AstroLoggerMessage`
+
+<p>
+
+  **类型：** `{ label: string | null; level: AstroLoggerLevel; message: string;	newLine: boolean; }`
+</p>
+
+传入 [`AstroLoggerDestination.write()`](#astrologgerdestinationwrite) 函数的对象：
+- `message`：被记录的消息。
+- `level`：消息的级别。
+- `label`：分配给日志消息的任意标签。
+- `newLine`：此消息是否应添加尾随换行符。
+
+## API 参考
+
+以下 API 可以从 `astro/logger` 指定符导入。
+
+### `matchesLevel()`
+
+<p>
+
+  **类型：** `matchesLevel(messageLevel: AstroLoggerLevel, configuredLevel: AstroLoggerLevel) => boolean`
+</p>
+
+给定两个[日志级别](#日志级别)，返回第一个级别是否匹配第二个级别。
+
+```js
+import { matchesLevel } from "astro/logger";
+
+matchesLevel("error", "info"); // true
+matchesLevel("info", "error"); // false
+
+```

--- a/src/content/docs/zh-cn/reference/renderer-reference.mdx
+++ b/src/content/docs/zh-cn/reference/renderer-reference.mdx
@@ -1,0 +1,330 @@
+---
+title: Astro 渲染器 API
+sidebar:
+  label: 渲染器 API
+i18nReady: true
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 3
+---
+import Since from '~/components/Since.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
+
+Astro 被设计为支持任何 UI 框架。该能力由渲染器提供，而渲染器是一种[集成](/zh-cn/reference/integrations-reference/)。请参阅[前端框架指南](/zh-cn/guides/framework-components/)，了解如何在 Astro 中使用来自不同框架的 UI 组件。
+
+## 什么是渲染器？
+
+渲染器是一种特殊的[集成](/zh-cn/reference/integrations-reference/)，它告诉 Astro 如何检测和渲染其原生无法处理的组件语法，例如 [UI 框架组件](/zh-cn/guides/framework-components/)。渲染器由两部分组成：
+- 一个在开发期间和生产构建期间导入的服务器模块，用于将组件渲染为 HTML。
+- 一个可选的、在浏览器中导入的客户端模块，用于通过[客户端指令](/zh-cn/reference/directives-reference/#客户端指令)激活（hydration）组件。
+
+## 构建渲染器
+
+当你需要为 Astro 添加对新组件语法的支持时，创建一个集成并在 [`astro:config:setup`](/zh-cn/reference/integrations-reference/#astroconfigsetup) 钩子中调用 `addRenderer()`。这允许你定义 Astro 应用于渲染组件的[服务器入口点](#构建服务器入口点)。你还可以选择性地定义用于激活的[客户端入口点](#构建客户端入口点)。
+
+以下示例展示了如何在 Astro 集成中注册一个渲染器：
+
+```ts title="my-renderer/index.js" {5-11}
+export default function createIntegration() {
+  return {
+    name: "@example/my-renderer",
+    hooks: {
+      "astro:config:setup": ({ addRenderer }) => {
+        addRenderer({
+          name: "@example/my-renderer",
+          clientEntrypoint: "@example/my-renderer/client.js",
+          serverEntrypoint: "@example/my-renderer/server.js",
+        });
+      },
+    },
+  };
+}
+```
+
+## 构建服务器入口点
+
+你需要创建一个在服务端渲染期间运行的文件，并定义如何渲染该组件语法。服务器模块必须默认导出一个实现 [`SSRLoadedRendererValue`](#ssrloadedrenderervalue) 接口的对象。
+
+以下示例展示了一个实现 `check()` 和 `renderToStaticMarkup()` 的最简服务端渲染器：
+
+```ts title="my-renderer/server.ts"
+import type { AstroComponentMetadata, NamedSSRLoadedRendererValue } from 'astro';
+
+async function check(Component: unknown) {
+  return typeof Component === 'function' && Component.name === 'MyCustomComponent';
+}
+
+async function renderToStaticMarkup(
+  Component: any,
+  props: Record<string, unknown>,
+  slots: Record<string, string>,
+  metadata?: AstroComponentMetadata,
+) {
+  const rendered = Component(props);
+
+  return {
+    attrs: metadata?.hydrate ? { 'data-my-renderer': 'true' } : undefined,
+    html: `<${rendered.tag}>${rendered.text}${slots.default ?? ''}</${rendered.tag}>`,
+  };
+}
+
+const renderer: NamedSSRLoadedRendererValue = {
+  name: 'my-renderer',
+  check,
+  renderToStaticMarkup,
+};
+
+export default renderer;
+```
+
+## 构建客户端入口点
+
+当你的渲染器支持[客户端指令](/zh-cn/reference/directives-reference/#客户端指令)时，创建一个客户端入口点，用于定义如何在浏览器中激活组件。客户端模块必须默认导出一个函数，该函数接收岛屿元素并返回一个异步的激活器函数。
+
+每当岛屿从页面中移除时，Astro 都会在岛屿的根元素上派发一个自定义的 `astro:unmount` 事件。你可以在你的客户端入口点中监听此事件，以清理任何已挂载的应用状态。
+
+以下示例展示了一个在浏览器中激活组件的最简客户端入口点：
+
+```ts title="my-renderer/client.ts"
+export default (element: HTMLElement) =>
+  async (
+    Component: any,
+    props: Record<string, unknown>,
+    slots: Record<string, string>,
+    { client }: { client: string },
+  ) => {
+    const rendered = Component({ ...props, slots });
+
+    if (client === 'only') {
+      element.innerHTML = '';
+    }
+
+    const node = document.createElement(rendered.tag);
+    node.textContent = rendered.text;
+    element.appendChild(node);
+
+    element.addEventListener('astro:unmount', () => node.remove(), { once: true });
+  };
+```
+
+## 渲染器类型参考
+
+以下类型可以从 `astro` 模块导入：
+
+```ts
+import type {
+  AstroComponentMetadata,
+  AstroRenderer,
+  NamedSSRLoadedRendererValue,
+  SSRLoadedRenderer,
+  SSRLoadedRendererValue,
+} from "astro";
+```
+
+### `AstroComponentMetadata`
+
+<p>
+
+**类型：** `{ displayName: string; hydrate?: 'load' | 'idle' | 'visible' | 'media' | 'only'; hydrateArgs?: any; componentUrl?: string; componentExport?: { value: string; namespace?: boolean }; astroStaticSlot: true; }`
+</p>
+
+包含有关正在渲染的组件的信息，包括其激活指令。
+
+#### `AstroComponentMetadata.displayName`
+
+<p>
+
+**类型：** `string`
+</p>
+
+定义组件名称，用于错误消息和调试。
+
+#### `AstroComponentMetadata.hydrate`
+
+<p>
+
+**类型：** `'load' | 'idle' | 'visible' | 'media' | 'only'`
+</p>
+
+定义组件上使用的[客户端指令](/zh-cn/reference/directives-reference/#客户端指令)。如果未提供值，组件将不会在客户端被激活。
+
+渲染器可以使用该值来有条件地包含客户端激活状态。例如，渲染器可以跳过对不会被激活的组件序列化传递状态：
+
+```ts
+async function renderToStaticMarkup(Component, props, children, metadata) {
+  const willHydrate = !!metadata?.hydrate;
+  // 如果组件不会被激活，则跳过序列化激活状态
+  return render(Component, props, { includeTransferState: willHydrate });
+}
+```
+
+#### `AstroComponentMetadata.hydrateArgs`
+
+<p>
+
+**类型：** `any`
+</p>
+
+指定传递给激活指令的附加参数。
+
+例如，它可以是 `client:media` 的媒体查询字符串（即 `"(max-width: 768px)"`），也可以是 `client:only` 的渲染器提示（即 `"react"`）。
+
+#### `AstroComponentMetadata.componentUrl`
+
+<p>
+
+**类型：** `string`
+</p>
+
+定义组件源文件的 URL。
+
+#### `AstroComponentMetadata.componentExport`
+
+<p>
+
+**类型：** `{ value: string; namespace?: boolean }`
+</p>
+
+描述组件的导出，对于被激活的组件，Astro 将在客户端加载该导出。
+
+##### `AstroComponentMetadata.componentExport.namespace`
+
+<p>
+
+**类型：** `boolean`
+</p>
+
+指示该导出是否为命名空间导出。
+
+##### `AstroComponentMetadata.componentExport.value`
+
+<p>
+
+**类型：** `string`
+</p>
+
+定义导出的名称（例如默认导出的 `"default"`）。
+
+#### `AstroComponentMetadata.astroStaticSlot`
+
+<p>
+
+**类型：** `true`
+</p>
+
+指示 Astro 对该组件支持静态插槽优化。将 [`supportsAstroStaticSlot`](#ssrloadedrenderervaluesupportsastrostaticslot) 设置为 `true` 的渲染器可以将其与 [`hydrate`](#astrocomponentmetadatahydrate) 结合使用，以确定如何渲染插槽。
+
+### `AstroRenderer`
+
+<p>
+
+**类型：** `{ name: string; clientEntrypoint?: string | URL; serverEntrypoint: string | URL; }`
+</p>
+
+描述[由集成添加的组件渲染器](/zh-cn/reference/integrations-reference/#addrenderer-选项)。
+
+#### `AstroRenderer.name`
+
+<p>
+
+**类型：** `string`
+</p>
+
+定义渲染器唯一的公开名称。
+
+#### `AstroRenderer.clientEntrypoint`
+
+<p>
+
+**类型：** `string | URL`
+</p>
+
+定义每当你的组件被使用时在客户端运行的渲染器的导入路径。
+
+#### `AstroRenderer.serverEntrypoint`
+
+<p>
+
+**类型：** `string | URL`
+</p>
+
+定义每当你的组件被使用时在服务端请求或静态构建期间运行的渲染器的导入路径。
+
+### `NamedSSRLoadedRendererValue`
+
+扩展了 [`SSRLoadedRendererValue`](#ssrloadedrenderervalue)，增加了一个必需的 `name` 属性。
+
+### `SSRLoadedRenderer`
+
+<p>
+
+**类型：** <code>Pick\<<a href="#astrorenderer">AstroRenderer</a>, 'name' | 'clientEntrypoint'\> & \{ ssr: <a href="#ssrloadedrenderervalue">SSRLoadedRendererValue</a>; \}</code>
+</p>
+
+描述可供服务器使用的渲染器。它是 [`AstroRenderer`](#astrorenderer) 的子集，并带有附加属性。
+
+#### `SSRLoadedRenderer.ssr`
+
+<p>
+
+**类型：** [`SSRLoadedRendererValue`](#ssrloadedrenderervalue)
+</p>
+
+定义服务器为该框架使用的函数和配置。
+
+### `SSRLoadedRendererValue`
+
+<p>
+
+**类型：** `object`
+</p>
+
+包含在服务器上渲染特定 UI 框架的组件所需的函数和配置。
+
+#### `SSRLoadedRendererValue.name`
+
+<p>
+
+**类型：** `string`
+</p>
+
+指定渲染器的名称标识符。
+
+#### `SSRLoadedRendererValue.check()`
+
+<p>
+
+**类型：** <code>(Component: any, props: any, slots: Record\<string, string\>, metadata?: <a href="#astrocomponentmetadata">AstroComponentMetadata</a>) => Promise\<boolean\></code>
+</p>
+
+确定渲染器是否可以处理某个组件。该函数会对每个已注册的渲染器依次调用，直到其中一个返回 `true`。
+
+#### `SSRLoadedRendererValue.renderToStaticMarkup()`
+
+<p>
+
+**类型：** <code>(Component: any, props: any, slots: Record\<string, string\>, metadata?: <a href="#astrocomponentmetadata">AstroComponentMetadata</a>) => Promise\<\{ html: string; attrs?: Record\<string, string\>; \}\></code>
+</p>
+
+在服务器上渲染框架组件，并返回生成的 HTML 字符串以及要传递给客户端入口点的任何可选属性。
+
+#### `SSRLoadedRendererValue.supportsAstroStaticSlot`
+
+<p>
+
+**类型：** `boolean`<br />
+<Since v="2.5.0" />
+</p>
+
+指示渲染器是否支持 Astro 的静态插槽优化。为 true 时，Astro 会阻止移除岛屿内的嵌套插槽。
+
+#### `SSRLoadedRendererValue.renderHydrationScript()`
+
+<p>
+
+**类型：** `() => string`<br />
+<Since v="4.1.0" />
+</p>
+
+返回一个 HTML 字符串，在该渲染器处理的第一个被激活的组件之前，每页注入一次。这对于需要页面级激活设置的渲染器非常有用。


### PR DESCRIPTION
#### Description (required)

Adds Simplified Chinese translations for the logger API reference (`reference/logger-reference.mdx`), the renderer API reference (`reference/renderer-reference.mdx`), and the "Customizing output filenames" recipe (`recipes/customizing-output-filenames.mdx`), which are currently untranslated and marked `i18nReady`.

Translations follow the [Simplified Chinese translation guide](https://github.com/withastro/docs/blob/main/i18n-guides/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87.md) (terminology, punctuation, spacing). Cross-page anchors into existing zh-CN pages were verified against the translated headings.