### PR TITLE
i18n(zh-CN): update `reference/configuration-reference.mdx`

### DIFF
--- a/src/content/docs/zh-cn/reference/configuration-reference.mdx
+++ b/src/content/docs/zh-cn/reference/configuration-reference.mdx
@@ -30,9 +30,12 @@ export default defineConfig({
 你最终部署的链接。Astro 会使用这个完整的链接来生成网站地图和最终构建的规范链接。强烈建议你设置这个配置项，以获得 Astro 最佳体验。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   site: 'https://www.my-site.dev'
-}
+});
 ```
 
 
@@ -48,9 +51,12 @@ export default defineConfig({
 在下面的例子中，`astro dev` 会在 `/docs` 处启动你的服务器。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   base: '/docs'
-}
+});
 ```
 
 当使用这个选项时，你所有的静态资源导入和 URL 都需要添加 base 作为前缀。你可以通过 `import.meta.env.BASE_URL` 访问这个值。
@@ -63,19 +69,25 @@ export default defineConfig({
 
 在下面的示例中，在处理时 `import.meta.env.BASE_URL` 和 `config.base` 的值都将是 `/docs`：
 ```js
-{
-	 base: '/docs/',
-	 trailingSlash: "never"
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  base: '/docs/',
+  trailingSlash: "never"
+});
 ```
 
 在下面的示例中，在处理时 `import.meta.env.BASE_URL` 和 `config.base` 的值都将是 `/docs/`：
 
 ```js
-{
-	 base: '/docs',
-	 trailingSlash: "always"
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  base: '/docs',
+  trailingSlash: "always"
+});
 ```
 
 ### trailingSlash
@@ -97,10 +109,13 @@ export default defineConfig({
 预渲染页面上的末尾斜杠是由托管平台处理的，他们可能会忽视你选择的配置。有关更多信息，请参阅托管平台的文档。此时，你不能使用 Astro [重定向](#redirects) 来处理这种情况。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   // 示例：在开发过程中要求有末尾斜杠
   trailingSlash: 'always'
-}
+});
 ```
 
 **另见**：
@@ -121,6 +136,9 @@ export default defineConfig({
 你可以重定向静态和动态路由，但只能重定向到相同类型的路由。例如，你不能有一个 `'/article': '/blog/[...slug]'` 的重定向。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
   redirects: {
    '/old': '/new',
@@ -131,8 +149,8 @@ export default defineConfig({
      destination: 'https://example.com/news'
  	},
    // '/product1/', '/product1' // 注意，这是不支持的
-	}
-})
+  }
+});
 ```
 
 对于未安装适配器的静态生成站点，这将生成一个使用 [`<meta http-equiv="refresh">` 标签](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/meta#http-equiv) 的客户端重定向，并且不支持状态码。
@@ -144,6 +162,9 @@ export default defineConfig({
 你可以使用重定向配置中的对象自定义 [重定向状态码](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Status#redirection_messages)：
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
   redirects: {
     '/other': {
@@ -151,9 +172,7 @@ export default defineConfig({
       destination: '/place',
     },
   }
-})
-
-
+});
 ```
 
 ### output
@@ -170,11 +189,12 @@ export default defineConfig({
 - `server` - 默认使用服务器端渲染（SSR）渲染所有页面，始终输出一个服务器渲染的站点。
 
 ```js
+// astro.config.mjs
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   output: 'static'
-})
+});
 ```
 
 **另见**：
@@ -193,11 +213,14 @@ export default defineConfig({
 有关 SSR 的更多信息，请参见我们的 [按需渲染指南](/zh-cn/guides/on-demand-rendering/) 以获得完整的 Astro 服务端渲染选项。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
 import netlify from '@astrojs/netlify';
-{
+
+export default defineConfig({
   // 示例：使用 Netlify 无服务器部署构建
   adapter: netlify(),
-}
+});
 ```
 
 **另见**：
@@ -215,12 +238,15 @@ import netlify from '@astrojs/netlify';
 请阅读我们的[集成指南](/zh-cn/guides/integrations/)，以帮助开始使用 Astro 集成。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
-{
+
+export default defineConfig({
   // 示例：添加 React + MDX 支持
   integrations: [react(), mdx()]
-}
+});
 ```
 
 ### root
@@ -235,16 +261,19 @@ import mdx from '@astrojs/mdx';
 
 如果提供相对路径（例如：`--root: './my-project'`），Astro 会根据你当前的工作目录进行解析。
 
-#### 示例
-
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   root: './my-project-directory'
-}
+});
 ```
 
+下面的示例使用 CLI 设置根目录：
+
 ```bash
-$ astro build --root ./my-project-directory
+astro build --root ./my-project-directory
 ```
 
 ### srcDir
@@ -260,9 +289,12 @@ $ astro build --root ./my-project-directory
 这个值可以是绝对路径，也可以是相对路径。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   srcDir: './www'
-}
+});
 ```
 
 ### publicDir
@@ -278,9 +310,12 @@ $ astro build --root ./my-project-directory
 这个值可以是绝对路径，也可以是相对路径。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   publicDir: './my-custom-publicDir-directory'
-}
+});
 ```
 
 ### outDir
@@ -296,9 +331,12 @@ $ astro build --root ./my-project-directory
 这个值可以是绝对路径，也可以是相对路径。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   outDir: './my-custom-build-directory'
-}
+});
 ```
 
 **另见**：
@@ -317,31 +355,39 @@ $ astro build --root ./my-project-directory
 这个值可以是绝对路径，也可以是相对路径。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   cacheDir: './my-custom-cache-directory'
-}
+});
 ```
 
 ### compressHTML
 
 <p>
 
-**类型：** `boolean`<br />
-**默认值：** `true`
+**类型：** `boolean | "jsx"`<br />
+**默认值：** `'jsx'`
 </p>
 
-这是一个用于缩小 HTML 输出并减少 HTML 文件大小的选项。
+控制 Astro 如何处理 HTML 中的空白字符。这会同时影响开发模式和最终构建输出。
 
-默认情况下，Astro 会从 `.astro` 组件中，通过无损的方式来移除空格，当然也包括换行符。
+自 v7.0 起，Astro 默认应用 React 等框架所使用的 JSX 空白规则。这会移除元素周围的空白和换行符、将多行文本折叠为一行，并保留单行内的空白（例如两个行内元素之间的空格）。如果要保留一个原本会被移除的空格，请在源码中通过 `{" "}` 之类的写法显式包含它。
 
-为了满足对 HTML 的视觉化渲染，有些空格可能会因此而被保留。这个优化会在开发模式和最终构建中生效。
+将此选项设置为 `true` 则会以无损方式移除 `.astro` 组件中的空白字符（包括换行符）。为了维持 HTML 的视觉渲染效果，某些空白可能会被按需保留。
 
-要禁用 HTML 压缩，请将 `compressHTML` 标志设置为 `false`。
+将此选项设置为 `false` 会禁用 HTML 压缩并保留所有空白字符。
 
 ```js
-{
-  compressHTML: false
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  compressHTML: true
+  // 或者：
+  // compressHTML: false
+});
 ```
 
 ### scopedStyleStrategy
@@ -364,6 +410,67 @@ $ astro build --root ./my-project-directory
 
 使用 `'attribute'` 在你操作元素的 `class` 属性时很有用，这样你就可以避免你自己的样式逻辑和 Astro 的样式应用之间的冲突。
 
+### prerenderConflictBehavior
+
+<p>
+
+**类型：** `'error' | 'warn' | 'ignore'`<br />
+**默认值：** `'warn'`<br />
+<Since v="6.0" />
+</p>
+
+决定当两个路由生成相同的预渲染 URL 时的默认行为：
+- `error`：构建失败并显示错误，强制你解决冲突
+- `warn`（默认）：发生冲突时记录警告，但使用最高优先级的路由进行构建
+- `ignore`：发生冲突时静默地使用最高优先级的路由进行构建
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  prerenderConflictBehavior: 'error'
+});
+```
+
+### vite
+
+<p>
+**类型：** `ViteUserConfig`
+</p>
+
+传递额外的配置选项给 Vite。适用于需要使用一些 Astro 不支持的高级配置。
+
+在 [vite.dev](https://cn.vite.dev/config/) 上查看完整的 `vite` 配置对象文档。
+
+#### 示例
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  vite: {
+    ssr: {
+      // 示例；如果需要的话，可以强制破坏性包跳过 SSR 处理
+      external: ['broken-npm-package'],
+    }
+  }
+});
+```
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  vite: {
+    // 示例：直接在 Astro 项目中添加自定义 Vite 插件
+    plugins: [myPlugin()],
+  }
+});
+```
+
 ### security
 
 <p>
@@ -381,12 +488,14 @@ $ astro build --root ./my-project-directory
 
 ```js
 // astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
   output: "server",
   security: {
     checkOrigin: false
   }
-})
+});
 ```
 
 #### security.checkOrigin
@@ -417,10 +526,17 @@ export default defineConfig({
 
 这样可以防止主机 header 注入攻击，恶意行为者可能通过发送精心构造的 `X-Forwarded-Host` header 来操纵 `Astro.url` 的值。
 
-每个模式可以指定 `protocol`、`hostname` 和 `port`。如果提供了这三项中的任意项，都会进行验证。模式支持通配符以实现灵活的主机名匹配：
+每个模式可以指定 `protocol`、`hostname` 和 `port`。如果提供了这三项中的任意项，都会进行验证。
+模式支持通配符以实现灵活的主机名匹配：
+
+- `*.example.com` - 仅匹配一级子域（例如 `sub.example.com`，但不包括 `deep.sub.example.com`）
+- `**.example.com` - 匹配任意深度的子域（例如 `sub.example.com` 和 `deep.sub.example.com` 均可）
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   security: {
     // 示例：允许通过 HTTPS 访问 example.com 的任意子域
     allowedDomains: [
@@ -435,42 +551,543 @@ export default defineConfig({
       }
     ]
   }
-}
+});
+```
+
+在某些特定场景下（例如位于使用动态域名的可信反向代理之后的应用），你可能需要允许所有域名。为此，请使用空对象：
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    // 允许任何域名——仅在必要时使用
+    allowedDomains: [{}]
+  }
+});
 ```
 
 如果未配置，`X-Forwarded-Host` header 不会被信任并将被忽略。
 
-### vite
+#### security.actionBodySizeLimit
 
 <p>
-**类型：** `ViteUserConfig`
+
+**类型：** `number`<br />
+**默认值：** `1048576` (1 MB)<br />
+<Since v="5.18.0" />
 </p>
 
-传递额外的配置选项给 Vite。适用于需要使用一些 Astro 不支持的高级配置。
+设置 action 请求体允许的最大字节数。
 
-在 [vite.dev](https://cn.vite.dev/config/) 上查看完整的 `vite` 配置对象文档。
-
-#### 示例
+默认情况下，action 请求体被限制为 1 MB（1048576 字节）以防止滥用。如果你的 action 需要接受更大的负载（例如处理文件上传时），你可以提高此限制。
 
 ```js
-{
-  vite: {
-    ssr: {
-      // 示例；如果需要的话，可以强制破坏性包跳过 SSR 处理
-      external: ['broken-npm-package'],
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    actionBodySizeLimit: 10 * 1024 * 1024 // 10 MB
+  }
+});
+```
+
+#### security.serverIslandBodySizeLimit
+
+<p>
+
+**类型：** `number`<br />
+**默认值：** `1048576` (1 MB)<br />
+<Since v="6.0.0" />
+</p>
+
+设置服务器岛屿请求体允许的最大字节数，其中包含传递给岛屿组件的加密 props 和插槽 HTML。
+
+默认情况下，服务器岛屿请求体被限制为 1 MB（1048576 字节）以防止滥用。如果你的服务器岛屿需要接受更大的负载，你可以提高此限制。
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    serverIslandBodySizeLimit: 10 * 1024 * 1024 // 10 MB
+  }
+});
+```
+
+#### security.csp
+
+<p>
+
+**类型：** `boolean | object`<br />
+**默认值：** `false`<br />
+<Since v="6.0.0" />
+</p>
+
+启用对[内容安全策略（CSP）](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Guides/CSP)的支持，通过控制文档允许加载哪些资源，来帮助最大限度地减少某些类型的安全威胁。这为抵御[跨站脚本（XSS）](https://developer.mozilla.org/zh-CN/docs/Glossary/Cross-site_scripting)攻击提供了额外的保护。
+
+启用此功能后，Astro 默认会对其处理和打包的脚本与样式施加额外的安全性，并允许你进一步配置这些以及其他的内容类型。
+
+此功能有一些限制：
+- 开箱即用地不支持外部脚本和外部样式，但你可以[提供自己的哈希](#securitycspscriptdirectivehashes)。
+- 不支持使用 `<ClientRouter />` 的 [Astro 视图过渡](/zh-cn/guides/view-transitions/)，但如果你没有使用 Astro 对原生 View Transitions 和 Navigation API 的增强，可以[考虑迁移到浏览器原生的 View Transition API](https://events-3bg.pages.dev/jotter/astro-view-transitions/)。
+- 目前不支持 Shiki。由于设计原因，Shiki 函数使用内联样式，无法与 Astro 的 CSP 实现兼容。当你的项目同时需要 CSP 和语法高亮时，请考虑[使用 `<Prism />`](/zh-cn/guides/syntax-highlighting/#prism-)。
+- `unsafe-inline` 指令与 Astro 的 CSP 实现不兼容。默认情况下，Astro 会为其所有打包的脚本（例如客户端岛屿）生成哈希，并且当 `unsafe-inline` 与哈希或 nonce 同时出现在指令中时，所有现代浏览器都会自动拒绝 `unsafe-inline`。
+
+:::note
+由于 Vite 开发服务器的特性，此功能在 `dev` 模式下不受支持。不过，你可以在你的 Astro 项目中使用 `build` 和 `preview` 来测试它。
+:::
+
+启用后，Astro 会在每个页面的 `<head>` 元素内添加一个 `<meta>` 元素。该元素带有 `http-equiv="content-security-policy"` 属性，其 `content` 属性会根据页面中使用的脚本和样式为 `script-src` 和 `style-src` [指令](#securitycspdirectives)提供值。
+
+```html
+
+<head>
+  <meta
+    http-equiv="content-security-policy"
+    content="
+    script-src 'self' 'sha256-somehash';
+    style-src 'self' 'sha256-somehash';
+    "
+  >
+</head>
+```
+
+你可以通过一个包含额外选项的配置对象启用此功能，进一步自定义 `<meta>` 元素。
+
+##### security.csp.algorithm
+
+<p>
+
+**类型：** `"SHA-256" | "SHA-384" | "SHA-512"`<br />
+**默认值：** `'SHA-256'`<br />
+<Since v="6.0.0" />
+</p>
+
+为 Astro 生成的样式和脚本生成哈希时使用的[哈希函数](https://developer.mozilla.org/zh-CN/docs/Glossary/Hash_function)。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+     algorithm: 'SHA-512'
     }
   }
-}
+});
 ```
 
-```js
-{
-  vite: {
-    // 示例：直接在 Astro 项目中添加自定义 Vite 插件
-    plugins: [myPlugin()],
+##### security.csp.directives
+
+<p>
+
+**类型：** `Array<string>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+一个 [CSP 指令](https://content-security-policy.com/#directive)列表（默认包含的 `script-src` 和 `style-src` 之外），用于定义特定内容类型的有效来源。这些指令会被添加到所有页面。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      directives: [
+        "default-src 'self'",
+        "img-src 'self' https://images.cdn.example.com"
+      ]
+    }
   }
-}
+});
 ```
+
+构建完成后，`<meta>` 元素会将你的指令与 Astro 的默认指令一起添加到 `content` 值中：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    default-src 'self';
+    img-src 'self' 'https://images.cdn.example.com';
+    script-src 'self' 'sha256-somehash';
+    style-src 'self' 'sha256-somehash';
+  "
+>
+```
+
+##### security.csp.styleDirective
+
+<p>
+
+**类型：** `CspStyleDirective`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+一个配置对象，允许你通过 [`resources`](#securitycspstyledirectiveresources) 属性覆盖 `style-src` 指令的默认来源，或提供额外要渲染的[哈希](#securitycspstyledirectivehashes)。
+
+###### security.csp.styleDirective.hashes
+
+<p>
+
+**类型：** `Array<CspHashEntry>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+要渲染的额外哈希列表。
+
+你必须提供以 `sha384-`、`sha512-` 或 `sha256-` 开头的哈希。其他值会导致验证错误。这些哈希会被添加到所有页面。
+
+自 Astro v7.1 起，每个条目可以是字符串或对象。对象允许通过 `kind` 字段更改哈希的作用域。`kind` 字段接受：
+- `"element"`：将哈希存储在 `style-src-elem` 指令中
+- `"attribute"`：将哈希存储在 `style-src-attr` 指令中
+- `"default"`：将哈希存储在 `style-src` 指令中
+
+`"default"` 哈希会进入 `style-src`；一旦你使用 `kind: "element"`，则会改为进入 `style-src-elem`。它永远不会被添加到 `style-src-attr`。Astro 生成的哈希遵循同样的规则。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      styleDirective: {
+        hashes: [
+          "sha384-styleHash",
+          "sha512-styleHash",
+          "sha256-styleHash"
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会在 `style-src` 指令中包含你的额外哈希：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    style-src 'self' 'sha384-styleHash' 'sha512-styleHash' 'sha256-styleHash' 'sha256-generatedByAstro';
+  "
+>
+```
+
+将哈希的作用域指定为 `"element"` 会将其改为存储在 `style-src-elem` 中。Astro 生成的哈希也会移动到那里：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      styleDirective: {
+        hashes: [{ hash: "sha256-styleHash", kind: "element" }]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会在 `style-src-elem` 指令（而非 `style-src`）中包含该哈希：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    style-src 'self';
+    style-src-elem 'self' 'sha256-styleHash' 'sha256-generatedByAstro';
+  "
+>
+```
+
+###### security.csp.styleDirective.resources
+
+<p>
+
+**类型：** `Array<CspResourceEntry>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+`style-src` 指令的有效来源列表，用于覆盖 Astro 的默认来源。默认不包含 `'self'`，如果你希望保留它，必须将其包含在此列表中。这些资源会被添加到所有页面。
+
+自 Astro v7.1 起，每个条目可以是字符串或对象。对象允许通过 `kind` 字段更改来源的作用域。`kind` 字段接受：
+- `"element"`：将来源存储在 `style-src-elem` 指令中
+- `"attribute"`：将来源存储在 `style-src-attr` 指令中
+- `"default"`：将来源存储在 `style-src` 指令中
+
+`"attribute"` 来源必须是 `'none'`、`'unsafe-hashes'`、`'unsafe-inline'` 或 `'report-sample'` 之一，且 `'unsafe-hashes'` 不能与 `"element"` 一起使用。一个常见用法是用 `{ resource: "'unsafe-inline'", kind: "attribute" }` 允许内联 `style` 属性（例如来自 `define:vars` 或 Shiki 的）。
+
+与哈希不同，`"default"` 来源永远不会被移动：它只保留在 `style-src` 上。当 `"default"` 与特定来源（例如 `"element"` 或 `"attribute"`）混合存在时，Astro 会发出警告。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      styleDirective: {
+        resources: [
+          "'self'",
+          "https://styles.cdn.example.com"
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会改为将你的来源应用到 `style-src` 指令：
+
+```html
+<head>
+  <meta
+    http-equiv="content-security-policy"
+    content="
+     style-src 'self' https://styles.cdn.example.com 'sha256-somehash';
+    "
+  >
+</head>
+```
+
+`"default"` 来源不会被复制到更具体的指令中。下面的例子中，一个 `"default"` 来源和一个 `"element"` 来源会渲染在不同的指令里：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      styleDirective: {
+        resources: [
+          "https://styles.cdn.example.com",
+          { resource: "https://elements.cdn.example.com", kind: "element" }
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素仅将 `https://styles.cdn.example.com` 保留在 `style-src` 上。这意味着该值不会被添加到 `style-src-elem`，也不适用于 `<style>` 和 `<link>` 元素（相比之下，生成的哈希会移动到那里）：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    style-src https://styles.cdn.example.com;
+    style-src-elem https://elements.cdn.example.com 'sha256-generatedByAstro';
+  "
+>
+```
+
+当资源被多次插入或来自多个来源（例如在你的 `csp` 配置中定义，又通过 [CSP 运行时 API](/zh-cn/reference/api-reference/#csp) 添加）时，Astro 会合并并去重所有资源来生成你的 `<meta>` 元素。
+
+##### security.csp.scriptDirective
+
+<p>
+
+**类型：** `CspScriptDirective`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+一个配置对象，允许你通过 [`resources`](#securitycspscriptdirectiveresources) 属性覆盖 `script-src` 指令的默认来源，或提供额外要渲染的[哈希](#securitycspscriptdirectivehashes)。
+
+###### security.csp.scriptDirective.hashes
+
+<p>
+
+**类型：** `Array<CspHashEntry>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+要渲染的额外哈希列表。
+
+你必须提供以 `sha384-`、`sha512-` 或 `sha256-` 开头的哈希。其他值会导致验证错误。这些哈希会被添加到所有页面。
+
+自 Astro v7.1 起，每个条目可以是字符串或对象。对象允许通过 `kind` 字段更改哈希的作用域。`kind` 字段接受：
+- `"element"`：将哈希存储在 `script-src-elem` 指令中
+- `"attribute"`：将哈希存储在 `script-src-attr` 指令中
+- `"default"`：将哈希存储在 `script-src` 指令中
+
+`"default"` 哈希会进入 `script-src`；一旦你使用 `kind: "element"`，则会改为进入 `script-src-elem`。它永远不会被添加到 `script-src-attr`。Astro 生成的哈希遵循同样的规则。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      scriptDirective: {
+        hashes: [
+          "sha384-scriptHash",
+          "sha512-scriptHash",
+          "sha256-scriptHash"
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会在 `script-src` 指令中包含你的额外哈希：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    script-src 'self' 'sha384-scriptHash' 'sha512-scriptHash' 'sha256-scriptHash' 'sha256-generatedByAstro';
+  "
+>
+```
+
+将哈希的作用域指定为 `"element"` 会将其改为存储在 `script-src-elem` 中。Astro 生成的哈希也会移动到那里：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      scriptDirective: {
+        hashes: [{ hash: "sha256-scriptHash", kind: "element" }]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会在 `script-src-elem` 指令（而非 `script-src`）中包含该哈希：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    script-src 'self';
+    script-src-elem 'self' 'sha256-scriptHash' 'sha256-generatedByAstro';
+  "
+>
+```
+
+###### security.csp.scriptDirective.resources
+
+<p>
+
+**类型：** `Array<CspResourceEntry>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+`script-src` 指令的有效来源列表，用于覆盖 Astro 的默认来源。默认不包含 `'self'`，如果你希望保留它，必须将其包含在此列表中。这些资源会被添加到所有页面。
+
+自 Astro v7.1 起，每个条目可以是字符串或对象。对象允许通过 `kind` 字段更改来源的作用域。`kind` 字段接受：
+- `"element"`：将来源存储在 `script-src-elem` 指令中
+- `"attribute"`：将来源存储在 `script-src-attr` 指令中
+- `"default"`：将来源存储在 `script-src` 指令中
+
+`"attribute"` 来源必须是 `'none'`、`'unsafe-hashes'`、`'unsafe-inline'` 或 `'report-sample'` 之一，且 `'unsafe-hashes'` 不能与 `"element"` 一起使用。
+
+与哈希不同，`"default"` 来源永远不会被移动，只保留在 `script-src` 上。但当你同时将来源限定为 `"element"` 或 `"attribute"` 时则不适用，因为浏览器不会回退。发生这种情况时 Astro 会发出警告。如有必要，请将它也添加到更具体的指令中。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      scriptDirective: {
+        resources: [
+          "'self'", "https://cdn.example.com"
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素会改为将你的来源应用到 `script-src` 指令：
+
+```html
+<head>
+  <meta
+    http-equiv="content-security-policy"
+    content="
+     script-src 'self' https://cdn.example.com 'sha256-somehash';
+    "
+  >
+</head>
+```
+
+`"default"` 来源不会被复制到更具体的指令中。下面的例子中，一个 `"default"` 来源和一个 `"element"` 来源会渲染在不同的指令里：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      scriptDirective: {
+        resources: [
+          "https://cdn.example.com",
+          { resource: "https://elements.cdn.example.com", kind: "element" }
+        ]
+      }
+    }
+  }
+});
+```
+
+构建完成后，`<meta>` 元素仅将 `https://cdn.example.com` 保留在 `script-src` 上。这意味着该值不会被添加到 `script-src-elem`，也不适用于 `<script>` 元素（相比之下，生成的哈希会移动到那里）：
+
+```html
+<meta
+  http-equiv="content-security-policy"
+  content="
+    script-src https://cdn.example.com;
+    script-src-elem https://elements.cdn.example.com 'sha256-generatedByAstro';
+  "
+>
+```
+
+当资源被多次插入或来自多个来源（例如在你的 `csp` 配置中定义，又通过 [CSP 运行时 API](/zh-cn/reference/api-reference/#csp) 添加）时，Astro 会合并并去重所有资源来生成你的 `<meta>` 元素。
+
+###### security.csp.scriptDirective.strictDynamic
+
+<p>
+
+**类型：** `boolean`<br />
+**默认值：** `false`<br />
+<Since v="6.0.0" />
+</p>
+
+启用 [`strict-dynamic` 关键字](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Guides/CSP#the_strict-dynamic_keyword)以支持动态注入脚本。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  security: {
+    csp: {
+      scriptDirective: {
+        strictDynamic: true
+      }
+    }
+  }
+});
+```
+
+这会应用于 `script-src`。当你同时将 `script` 资源或哈希限定到 `script-src-elem`（使用 `kind: "element"`）时，`strict-dynamic` 会被 `script-src-elem` 继承，从而使动态注入的 `<script>` 元素继续工作。
 
 ## 构建选项
 
@@ -489,12 +1106,15 @@ export default defineConfig({
   - `'preserve'`：Astro 将根据你的源文件夹中的文件生成 HTML 文件。 (例如：`src/pages/about.astro` 生成 `/about.html`，`src/pages/about/index.astro` 生成 `/about/index.html`)
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     // 示例：在构建过程中生 成`page.html` 而不是 `page/index.html`。
     format: 'file'
   }
-}
+});
 ```
 
 #### 对 Astro.url 的影响
@@ -503,6 +1123,7 @@ export default defineConfig({
 
 - `directory` - `Astro.url.pathname` 将包括一个末尾斜杠，以模仿文件夹行为。（例如 `/foo/`）。
 - `file` - `Astro.url.pathname` 将包括 `.html`。（例如 `/foo.html`）。
+- `preserve` - `Astro.url.pathname` 与每个页面生成的文件一致：index 页面包含末尾斜杠（例如 `/foo/`），而非 index 页面包含 `.html`（例如 `/foo.html`）。
 
 这意味着当你使用 `new URL('./relative', Astro.url)` 创建相对的连接时，开发和构建会得到一致的行为。
 
@@ -525,12 +1146,15 @@ export default defineConfig({
 这个值是相对于 `outDir` 的。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   output: 'server',
   build: {
     client: './client'
   }
-}
+});
 ```
 
 ### build.server
@@ -546,11 +1170,14 @@ export default defineConfig({
 这个值是相对于 `outDir` 的。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     server: './server'
   }
-}
+});
 ```
 
 ### build.assets
@@ -565,11 +1192,14 @@ export default defineConfig({
 指定 Astro 生成的资源（例如打包的 JS 和 CSS）在构建输出中的目录。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     assets: '_custom'
   }
-}
+});
 ```
 **另见**：
 - outDir
@@ -590,11 +1220,14 @@ export default defineConfig({
 要获取上传到同一域名下的所有资源（例如 `https://cdn.example.com/_astro/...`），请将 `assetsPrefix` 设置为根域名的字符串（不管你的 `base` 配置如何）：
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     assetsPrefix: 'https://cdn.example.com'
   }
-}
+});
 ```
 
 **新增于：** `astro@4.5.0`
@@ -602,7 +1235,10 @@ export default defineConfig({
 你也可以传递一个对象给 `assetsPrefix`，以指定每种文件类型的不同域名。在这种情况下，`fallback`属性是必填的，并且它将作为默认值用于任何其他文件。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     assetsPrefix: {
       'js': 'https://js.cdn.example.com',
@@ -611,7 +1247,7 @@ export default defineConfig({
       'fallback': 'https://cdn.example.com'
     }
   }
-}
+});
 ```
 
 ### build.serverEntry
@@ -627,11 +1263,14 @@ export default defineConfig({
 注意，建议该文件以 `.mjs` 结尾，这样运行时就能检测到该文件是一个 JavaScript 模块。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     serverEntry: 'main.mjs'
   }
-}
+});
 ```
 
 ### build.redirects
@@ -648,11 +1287,14 @@ export default defineConfig({
 此选项主要适用于具有用于重定向的特殊配置文件且不需要（或不希望）基于 HTML 的重定向的适配器。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     redirects: false
   }
-}
+});
 ```
 
 ### build.inlineStylesheets
@@ -671,11 +1313,14 @@ export default defineConfig({
 -  `'never'` - 项目样式都以外部样式表的形式发送。
 
 ```js
-{
-	build: {
-		inlineStylesheets: `never`,
-	},
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  build: {
+    inlineStylesheets: `never`,
+  },
+});
 ```
 
 ### build.concurrency
@@ -694,11 +1339,14 @@ export default defineConfig({
 仅当其他减少总体渲染时间的尝试（例如，批处理或缓存长时间运行的任务，如网络请求或数据访问）无法实现或没有帮助时，才使用此选项。如果该值设置得太高，可能会由于内存资源不足以及 JS 单线程的原因，导致页面渲染变慢。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   build: {
     concurrency: 2
   }
-}
+});
 ```
 
 :::caution[潜在的破坏性变更]
@@ -710,18 +1358,24 @@ export default defineConfig({
 定制 Astro 开发服务器，适用于 `astro dev` 和 `astro preview`。
 
 ```js
-{
-  server: { port: 1234, host: true }
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  server: { port: 1234, host: true}
+});
 ```
 
 要根据运行的命令（`dev`、`preview`）设置不同的配置，也可以向这个配置选项传递函数。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   // 示例：使用函数语法，根据命令进行定制
   server: ({ command }) => ({ port: command === 'dev' ? 4321 : 4000 })
-}
+});
 ```
 
 ### server.host
@@ -752,9 +1406,12 @@ export default defineConfig({
 如果给定的端口已经在使用，Astro 会自动尝试下一个可用的端口。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   server: { port: 8080 }
-}
+});
 ```
 
 ### server.allowedHosts
@@ -769,11 +1426,14 @@ export default defineConfig({
 一个主机名列表，Astro 允许响应这些主机名。当该值设置为 `true` 时，任何主机名都是允许的。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   server: {
-  	allowedHosts: ['staging.example.com', 'qa.example.com']
+    allowedHosts: ['staging.example.com', 'qa.example.com']
   }
-}
+});
 ```
 
 ### server.open
@@ -790,9 +1450,12 @@ export default defineConfig({
 传递一个完整的 URL 字符串（例如："http://example.com" ）或一个路径（例如："/about"）来指定要打开的 URL。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   server: { open: "/about" }
-}
+});
 ```
 
 ### server.headers
@@ -806,50 +1469,162 @@ export default defineConfig({
 
 设置要在 `astro dev` 和 `astro preview` 中发送的自定义 HTTP 响应标头。
 
+## fetchFile
+
+<p>
+
+**类型：** `string | null`<br />
+**默认值：** `'fetch'`<br />
+<Since v="7.0.0" />
+</p>
+
+自定义 `srcDir` 内用作 fetch 入口点的文件。默认为 `'fetch'`，即 Astro 会查找 `src/fetch.ts`（或 `.js` / `.mjs` / `.mts`）。
+
+fetch 文件允许你将 Astro 的请求管线与 Web Fetch 标准或你自己的 Hono 中间件组合起来。
+
+如果你已经有用于其他用途的 `src/fetch.ts` 文件，可以定义一个不同的文件名，或将该值设置为 `null` 来禁用此入口点：
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  fetchFile: 'handler',
+});
+```
+
+在[高级路由指南](/zh-cn/guides/routing/#高级路由)中了解更多关于自定义请求管线的内容。
+
+## Logger Options
+
+<p>
+
+**类型：** `LoggerHandlerConfig`<br />
+**默认值：** `undefined`<br />
+<Since v="7.0.0" />
+</p>
+
+配置 Astro 在开发和生产期间如何记录日志消息。
+
+默认情况下，Astro 使用内置的日志记录器向控制台输出对人类友好的日志。你可以通过提供[你自己的日志处理器](/zh-cn/reference/logger-reference/#自定义日志记录器)或使用某个[内置日志处理器](/zh-cn/reference/logger-reference/#内置日志记录器)来自定义此行为：
+
+```js title="astro.config.mjs"
+import { defineConfig, logHandlers } from 'astro/config';
+
+export default defineConfig({
+  logger: logHandlers.json({ level: 'info' })
+});
+```
+
+更多信息请参阅[日志记录器 API 参考](/zh-cn/reference/logger-reference/)。
+
+### logger.entrypoint
+
+<p>
+
+**类型：** `string | URL`<br />
+<Since v="7.0.0" />
+</p>
+
+[日志记录器实现](/zh-cn/reference/logger-reference/#logger-实现)的入口点。它可以是一个 npm 包、一个相对于项目根目录的路径，或一个指向项目中文件的 `URL`：
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  logger: {
+    entrypoint: "@org/astro-logger",
+  }
+});
+```
+
+日志记录器入口点必须是 JavaScript 文件，不支持 TypeScript。如果 Astro 加载该实现失败，则会回退到其默认日志记录器。
+
+### logger.config
+
+<p>
+
+**类型：** `Record<string, unknown> | undefined`<br />
+**默认值：** `{}`<br />
+<Since v="7.0.0" />
+</p>
+
+日志处理器的配置对象。选项取决于所配置的日志记录器。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  logger: {
+    entrypoint: "@org/astro-logger",
+    config: {
+     level: "error"
+    }
+  }
+});
+```
+
 ## Session 选项
 
 <p>
 
+**类型：** `object | false`<br />
 <Since v="5.7.0" />
 </p>
 
-为你的 Astro 项目配置会话（session）存储。该功能用于以持久化方式存储会话数据，使其能够在不同请求之间被访问。部分适配器可能会提供默认的会话驱动，但你可以通过手动个人配置来覆盖它。
+为你的 Astro 项目配置会话（session）存储。该功能用于以持久化方式存储会话数据，使其能够在不同请求之间被访问。
 
-更多信息请参阅 [session 指南](/zh-cn/guides/sessions/)。
+部分适配器可能会提供默认的会话驱动，但你可以通过自己的配置来覆盖它：
 
 ```js title="astro.config.mjs"
-  {
-    session: {
-      // Unstorage 上驱动的名字
-      driver: 'redis',
-      // 所需项取决于驱动程序
-      options: {
-        url: process.env.REDIS_URL,
-      },
-      ttl: 3600, // 1 小时
-    }
+import { defineConfig, sessionDrivers } from 'astro/config';
+
+export default defineConfig({
+  session: {
+    driver: sessionDrivers.redis({
+      // 选项取决于驱动，有些是必需的。
+      url: process.env.REDIS_URL
+    }),
   }
+});
 ```
+
+会话驱动在构建时配置。这意味着驱动配置中使用的环境变量会被内联。你必须创建自己的驱动入口点来[在运行时覆盖配置](/zh-cn/guides/sessions/)。
+
+自 Astro v7.2.0 起，你可以通过将该选项设置为 `false` 来选择退出会话支持。会话被禁用后，会话运行时会被排除在 SSR 产物之外，适配器也会跳过接入其默认会话驱动。这对产物解析时间敏感的 serverless 和边缘运行时很有用。
+
+```js title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  session: false,
+});
+```
+
+更多信息请参阅 [session 指南](/zh-cn/guides/sessions/)。
 
 ### session.driver
 
 <p>
 
-**类型：** `string | undefined`<br />
+**类型：** `SessionDriverConfig | undefined`<br />
 <Since v="5.7.0" />
 </p>
 
 Unstorage 上用于会话存储的驱动。[Node](/zh-cn/guides/integrations-guide/node/#sessions)、[Cloudflare](/zh-cn/guides/integrations-guide/cloudflare/#会话) 和 [Netlify](/zh-cn/guides/integrations-guide/netlify/#sessions) 适配器都会为你自动配置默认的驱动，但是如果你更倾向于手动配置，或者是你正在使用的适配器并未提供驱动，你仍然可以自己指定。
 
-该值为 [Unstorage 驱动文档](https://unstorage.unjs.io/drivers) 的“驱动名称（Driver name）”。
+```js title="astro.config.mjs" ins={7-9} ins=" sessionDrivers "
+import { defineConfig, sessionDrivers } from 'astro/config'
+import vercel from '@astrojs/vercel'
 
-```js title="astro.config.mjs" ins={4}
-{
+export default defineConfig({
   adapter: vercel(),
   session: {
-    driver: "redis",
-  },
-}
+    driver: sessionDrivers.redis({
+      url: process.env.REDIS_URL
+    }),
+  }
+});
 ```
 :::note
 部分驱动可能需要安装额外的包。部分驱动可能会要求设置环境变量或凭证。更多信息请参阅 [Unstorage 文档](https://unstorage.unjs.io/drivers)。
@@ -864,18 +1639,24 @@ Unstorage 上用于会话存储的驱动。[Node](/zh-cn/guides/integrations-gui
 <Since v="5.7.0" />
 </p>
 
+:::caution[已弃用]
+此选项已弃用，并将在未来的 major 版本中移除。取而代之的是，将选项传递给驱动函数。
+:::
+
 用于会话存储的驱动专用配置选项。该选项具体取决于你所使用的驱动程序。请参阅 [Unstorage 文档](https://unstorage.unjs.io/drivers) 以获取不同驱动的详细配置参数。
 
 
-```js title="astro.config.mjs" ins={4-6}
-{
-   session: {
-     driver: "redis",
-     options: {
-       url: process.env.REDIS_URL
-     },
-   }
-}
+```js title="astro.config.mjs" ins={6-8}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  session: {
+    driver: "redis",
+    options: {
+      url: process.env.REDIS_URL
+    },
+  }
+});
 ```
 
 ### session.cookie
@@ -889,27 +1670,30 @@ Unstorage 上用于会话存储的驱动。[Node](/zh-cn/guides/integrations-gui
 
 用于配置会话 cookie 的选项。如果将该选项设置为字符串，则它会被用作 cookie 名称。或者，你也可以传入一个带有额外选项的对象。那么它将会和默认值一同合并。
 
-```js title="astro.config.mjs" ins={3-4}
-{
- session: {
-   // 如果设置为字符串，则该项会被视为 cookie 名称。
-   cookie: "my-session-cookie",
- }
-}
+```js title="astro.config.mjs" ins={5-6}
+import { defineConfig } from 'astro/config';
 
+export default defineConfig({
+  session: {
+    // 如果设置为字符串，则该项会被视为 cookie 名称。
+    cookie: "my-session-cookie",
+  }
+});
 ```
 
-```js title="astro.config.mjs" ins={4-8}
-{
- session: {
-   // 如果设置为对象，那么它将被视为 cookie 选项。
-   cookie: {
-     name: "my-session-cookie",
-     sameSite: "lax",
-     secure: true,
-   }
- }
-}
+```js title="astro.config.mjs" ins={5-10}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  session: {
+    // 如果设置为对象，那么它将被视为 cookie 选项。
+    cookie: {
+      name: "my-session-cookie",
+      sameSite: "lax",
+      secure: true,
+    }
+  }
+});
 ```
 
 ### session.ttl
@@ -923,15 +1707,17 @@ Unstorage 上用于会话存储的驱动。[Node](/zh-cn/guides/integrations-gui
 
 一个可选的默认选项，用于配置会话值直到过期的生存时间（以秒为单位）。
 
-默认情况下，会话值会一直存续直到它们被删除或是会话被销毁，并且由于特定的时间已经过去，因此它们也不会自动过期。通过设置 `session.ttl` 能为你的会话值添加一个默认的过期时间。将 `ttl` 选项传递给 [`session.set()`](/zh-cn/reference/api-reference/#set) 将覆盖该单个条目的全局默认值。
+默认情况下，会话值会一直存续直到它们被删除或是会话被销毁，并且由于特定的时间已经过去，因此它们也不会自动过期。通过设置 `session.ttl` 能为你的会话值添加一个默认的过期时间。将 `ttl` 选项传递给 [`session.set()`](/zh-cn/reference/api-reference/#sessionset) 将覆盖该单个条目的全局默认值。
 
-```js title="astro.config.mjs" ins={3-4}
-{
- session: {
-   // 设置一个时长为 1 小时（3600 秒）的默认过期时间
-   ttl: 3600,
- }
-}
+```js title="astro.config.mjs" ins={5-6}
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  session: {
+    // 设置一个时长为 1 小时（3600 秒）的默认过期时间
+    ttl: 3600,
+  }
+});
 ```
 
 :::note
@@ -981,7 +1767,7 @@ Astro 开发工具栏在屏幕上的默认位置。
 此配置自动将预获取脚本添加到项目中的每个页面上，让你可以访问 `data-astro-prefetch` 属性。将此属性添加到页面上的任何 `<a />` 链接，以启用该页面的预获取。
 
 ```html
-<a href="/about" data-astro-prefetch>about</a>
+<a href="/about" data-astro-prefetch>About</a>
 ```
 
 使用 [`prefetch.defaultStrategy`](#prefetchdefaultstrategy) 和 [`prefetch.prefetchAll`](#prefetchprefetchall) 选项进一步自定义默认的预获取行为。
@@ -998,9 +1784,14 @@ Astro 开发工具栏在屏幕上的默认位置。
 为所有链接启用预获取，包括那些没有 `data-astro-prefetch` 属性的链接。当使用 `<ClientRouter />` 路由器时，此值默认为 `true`。否则，默认值为 `false`。
 
 ```js
-prefetch: {
-	prefetchAll: true
-}
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  prefetch: {
+    prefetchAll: true,
+  },
+});
 ```
 
 当设置为 `true` 时，你可以通过在任何单独的链接上设置 `data-astro-prefetch="false"` 来单独禁用预获取。
@@ -1044,7 +1835,10 @@ prefetch: {
 设置在开发和 SSR 中用于图像优化的端点。`entrypoint` 可以设置为 `undefined` 来使用默认端点。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   image: {
     // 示例：使用自定义的图像端点 `/custom_endpoint`
     endpoint: {
@@ -1052,7 +1846,7 @@ prefetch: {
       entrypoint: 'src/my_endpoint.ts',
     },
   },
-}
+});
 ```
 
 ### image.service
@@ -1071,17 +1865,27 @@ prefetch: {
 服务的入口点可以是涵盖的服务之一，也可以是第三方包。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   image: {
     // 示例：通过自定义配置启用基于 Sharp 的图像服务
     service: {
-			 entrypoint: 'astro/assets/services/sharp',
-			 config: {
-				 limitInputPixels: false,
+      entrypoint: 'astro/assets/services/sharp',
+      config: {
+        limitInputPixels: false,
+        webp: {
+          effort: 6,
+          alphaQuality: 80,
+        },
+        jpeg: {
+          mozjpeg: true,
+        },
       },
-		 },
+    },
   },
-}
+});
 ```
 
 #### image.service.config.limitInputPixels
@@ -1110,6 +1914,71 @@ Sharp 图像服务中用于 [调整图像大小的默认内核](https://sharp.pi
 
 默认情况下这是 `undefined`，对应于 Sharp 的默认内核 `lanczos3`。
 
+#### image.service.config.jpeg
+
+<p>
+
+**类型：** `Record<string, any> | undefined`<br />
+**默认值：** `undefined`<br />
+<Since v="6.1.0" />
+</p>
+
+使用 Astro 内置的 Sharp 图像服务时，传递给 `sharp().jpeg()` 的默认编码器选项。
+
+可用于 `mozjpeg`、`progressive`、`chromaSubsampling` 或默认 `quality` 等选项。来自 `<Image />`、`<Picture />` 和 `getImage()` 的逐图像 `quality` 值仍然优先。
+
+#### image.service.config.webp
+
+<p>
+
+**类型：** `Record<string, any> | undefined`<br />
+**默认值：** `undefined`<br />
+<Since v="6.1.0" />
+</p>
+
+使用 Astro 内置的 Sharp 图像服务时，传递给 `sharp().webp()` 的默认编码器选项。
+
+可用于 `effort`、`alphaQuality`、`lossless`、`nearLossless` 或默认 `quality` 等选项。来自 `<Image />`、`<Picture />` 和 `getImage()` 的逐图像 `quality` 值仍然优先。
+
+#### image.service.config.avif
+
+<p>
+
+**类型：** `Record<string, any> | undefined`<br />
+**默认值：** `undefined`<br />
+<Since v="6.1.0" />
+</p>
+
+使用 Astro 内置的 Sharp 图像服务时，传递给 `sharp().avif()` 的默认编码器选项。
+
+可用于 `effort`、`chromaSubsampling`、`bitdepth`、`lossless` 或默认 `quality` 等选项。来自 `<Image />`、`<Picture />` 和 `getImage()` 的逐图像 `quality` 值仍然优先。
+
+#### image.service.config.png
+
+<p>
+
+**类型：** `Record<string, any> | undefined`<br />
+**默认值：** `undefined`<br />
+<Since v="6.1.0" />
+</p>
+
+使用 Astro 内置的 Sharp 图像服务时，传递给 `sharp().png()` 的默认编码器选项。
+
+可用于 `compressionLevel`、`effort`、`palette` 或默认 `quality` 等选项。来自 `<Image />`、`<Picture />` 和 `getImage()` 的逐图像 `quality` 值仍然优先。
+
+### image.dangerouslyProcessSVG
+
+<p>
+
+**类型：** `boolean`<br />
+**默认值：** `false`<br />
+<Since v="6.3.0" />
+</p>
+
+允许 SVG 源图像由图像优化管线处理。
+
+此选项默认禁用，因为特制（specifically formed）的 SVG 处理起来可能代价极高，并可能被恶意行为者用来发起拒绝服务攻击。只有当你信任 SVG 图像的来源并了解处理它们的风险时，才应启用此选项。
+
 ### image.domains
 
 <p>
@@ -1125,12 +1994,14 @@ Sharp 图像服务中用于 [调整图像大小的默认内核](https://sharp.pi
 
 ```js
 // astro.config.mjs
-{
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   image: {
     // 示例：允许来自单个域名的远程图像优化。
     domains: ['astro.build'],
   },
-}
+});
 ```
 
 ### image.remotePatterns
@@ -1152,7 +2023,10 @@ Sharp 图像服务中用于 [调整图像大小的默认内核](https://sharp.pi
 4. pathname
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   image: {
     // 示例：允许处理所有来自 aws s3 存储桶的图像
     remotePatterns: [{
@@ -1160,7 +2034,7 @@ Sharp 图像服务中用于 [调整图像大小的默认内核](https://sharp.pi
       hostname: '**.amazonaws.com',
     }],
   },
-}
+});
 ```
 
 你可以使用通配符来定义允许的 `hostname` 和 `pathname` 值，正如下所述一样。否则，只有提供的具体值将被配置：
@@ -1311,12 +2185,15 @@ export default defineConfig({
 - `false` - 不使用语法高亮。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   markdown: {
     // 示例：在 Markdown 中使用 prism 进行语法高亮显示
     syntaxHighlight: 'prism',
   }
-}
+});
 ```
 
 对于更多对语法高亮的控制，你可以指定一个配置对象，其中包含以下列出的属性：
@@ -1358,6 +2235,13 @@ export default defineConfig({
 
 ### markdown.remarkPlugins
 
+
+:::caution[已弃用]
+此属性已弃用，并将在未来的 major 版本中移除。取而代之的是，将插件传递给配置的 [`markdown.processor`](#markdownprocessor)。
+
+在 Markdown 指南中了解更多关于[设置 Markdown 处理器](/zh-cn/guides/markdown-content/)和[使用插件](/zh-cn/guides/markdown-content/)的内容。
+:::
+
 <p>
 
 **类型**：`RemarkPlugins`
@@ -1366,15 +2250,25 @@ export default defineConfig({
 通过自定义 [Remark 插件](https://github.com/remarkjs/remark)来定制 Markdown 构建方式。你可以导入并应用插件函数（推荐），或传递一个值为插件名的字符串。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
 import remarkToc from 'remark-toc';
-{
+
+export default defineConfig({
   markdown: {
-    remarkPlugins: [ [remarkToc, { heading: "contents" }] ]
+    remarkPlugins: [ [remarkToc, { heading: "contents"} ] ]
   }
-}
+});
 ```
 
 ### markdown.rehypePlugins
+
+
+:::caution[已弃用]
+此属性已弃用，并将在未来的 major 版本中移除。取而代之的是，将插件传递给配置的 [`markdown.processor`](#markdownprocessor)。
+
+在 Markdown 指南中了解更多关于[设置 Markdown 处理器](/zh-cn/guides/markdown-content/)和[使用插件](/zh-cn/guides/markdown-content/)的内容。
+:::
 
 <p>
 
@@ -1384,15 +2278,25 @@ import remarkToc from 'remark-toc';
 通过自定义 [Rehype 插件](https://github.com/remarkjs/remark-rehype) 插件来定制对你的 Markdown 输出内容的处理方式。你可以导入并应用插件函数（推荐），或传递一个值为插件名的字符串。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
 import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
-{
+
+export default defineConfig({
   markdown: {
     rehypePlugins: [rehypeAccessibleEmojis]
   }
-}
+});
 ```
 
 ### markdown.gfm
+
+
+:::caution[已弃用]
+此属性已弃用，并将在未来的 major 版本中移除。取而代之的是，将 `gfm` 传递给配置的 [`markdown.processor`](#markdownprocessor)。
+
+在 Markdown 指南中了解更多关于[设置 Markdown 处理器](/zh-cn/guides/markdown-content/)和[使用 GitHub 风格的 Markdown](/zh-cn/guides/markdown-content/) 的内容。
+:::
 
 <p>
 
@@ -1404,33 +2308,48 @@ import { rehypeAccessibleEmojis } from 'rehype-accessible-emojis';
 Astro 默认使用 [GitHub-flavored Markdown](https://github.com/remarkjs/remark-gfm)。如果要禁用它，请将`gfm`标志设置为 `false`:
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   markdown: {
     gfm: false,
   }
-}
+});
 ```
 
 ### markdown.smartypants
 
+
+:::caution[已弃用]
+此属性已弃用，并将在未来的 major 版本中移除。取而代之的是，将它传递给配置的 [`markdown.processor`](#markdownprocessor)。`unified()` 使用 `smartypants`，`satteri()` 使用 `smartPunctuation`。
+
+在 Markdown 指南中了解更多关于[设置 Markdown 处理器](/zh-cn/guides/markdown-content/)和[使用智能标点](/zh-cn/guides/markdown-content/)的内容。
+:::
+
 <p>
 
-**类型**：`boolean`<br />
+**类型**：`boolean | Smartypants`<br />
 **默认值**：`true`<br />
 <Since v="2.0.0" />
 </p>
 
-Astro 默认使用 [SmartyPants formatter](https://daringfireball.net/projects/smartypants/)。如果要禁用它，请将`smartypants`标志设置为 `false`:
+是否使用 [SmartyPants formatter](https://daringfireball.net/projects/smartypants/) 将直引号转换为智能引号、将连字符转换为 en/em 破折号、将三个点转换为省略号。
 
-```js
-{
-  markdown: {
-    smartypants: false,
-  }
-}
-```
+要禁用它，请将 `smartypants` 标志设置为 `false`。
+
+如需更精细的排版控制，你也可以指定一个带有 [`retext-smartypants` 支持的属性](https://github.com/retextjs/retext-smartypants?tab=readme-ov-file#fields)的配置对象。
 
 ### markdown.remarkRehype
+
+
+:::caution[已弃用]
+此属性已弃用，并将在未来的 major 版本中移除。
+
+要配置脚注，请改为将 `remarkRehype` 传递给 `unified()` 处理器，或将 `gfm.footnotes` 传递给 `satteri()` 处理器。其他 `remark-rehype` 选项仅在使用 `unified()` 时受支持。
+
+在 Markdown 指南中了解更多关于[设置 Markdown 处理器](/zh-cn/guides/markdown-content/)和[使用内置功能](/zh-cn/guides/markdown-content/)的内容。
+:::
 
 <p>
 
@@ -1440,13 +2359,61 @@ Astro 默认使用 [SmartyPants formatter](https://daringfireball.net/projects/s
 向 [remark-rehype](https://github.com/remarkjs/remark-rehype#api) 传递选项。
 
 ```js
-{
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
   markdown: {
     // 示例：将脚注文本翻译成另一种语言，这里是默认的英文内容
-    remarkRehype: { footnoteLabel: "Footnotes", footnoteBackLabel: "Back to reference 1" },
+    remarkRehype: { footnoteLabel: "Footnotes", footnoteBackLabel: "Back to reference 1"},
   },
-};
+});
 ```
+
+### markdown.processor
+
+<p>
+
+**类型：** `MarkdownProcessor`<br />
+<Since v="6.4.0" />
+</p>
+
+配置用于渲染 `.md` 文件的 [Markdown 处理器](/zh-cn/guides/markdown-content/)。
+
+Sätteri 是 Astro 的原生 Markdown 管线，也是默认的处理器。要配置它，请安装 `@astrojs/markdown-satteri` 并将选项传递给 `satteri()`：
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import { satteri } from '@astrojs/markdown-satteri';
+
+export default defineConfig({
+  markdown: {
+    processor: satteri({
+      features: { gfm: false },
+    }),
+  },
+});
+```
+
+要保留 remark/rehype 管线，请安装 `@astrojs/markdown-remark` 并传入 `unified()`：
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import { unified } from '@astrojs/markdown-remark';
+import remarkToc from 'remark-toc';
+
+export default defineConfig({
+  markdown: {
+    processor: unified({
+      remarkPlugins: [remarkToc],
+    }),
+  },
+});
+```
+
+在 Markdown 指南中了解更多关于[官方 Markdown 处理器以及如何选择其一](/zh-cn/guides/markdown-content/)的内容。
 
 ## i18n
 
@@ -1503,16 +2470,19 @@ Astro 默认使用 [SmartyPants formatter](https://daringfireball.net/projects/s
 以下示例配置你的内容回退策略，将 `/pt-br/` 中无法访问的页面重定向到它们的 `es` 版本，将 `/fr/` 中无法访问的页面重定向到它们的 `en` 版本。无法访问的 `/es/` 页面将返回 404。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
-	i18n: {
-		defaultLocale: "en",
-		locales: ["en", "fr", "pt-br", "es"],
-		fallback: {
-			pt: "es",
-		  fr: "en"
-		}
-	}
-})
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "fr", "pt-br", "es"],
+    fallback: {
+      "pt-br": "es",
+      fr: "en"
+    }
+  }
+});
 ```
 
 ### i18n.routing
@@ -1527,29 +2497,35 @@ export default defineConfig({
 控制路由策略以确定你的网站 URL。请根据你的默认语言的文件夹（或 URL）路径配置来进行设置。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
-	i18n: {
-		defaultLocale: "en",
-		locales: ["en", "fr"],
-		routing: {
-			prefixDefaultLocale: false,
-			redirectToDefaultLocale: true,
-			fallbackType: "redirect",
-		}
-	}
-})
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "fr"],
+    routing: {
+      prefixDefaultLocale: false,
+      redirectToDefaultLocale: true,
+      fallbackType: "redirect",
+    }
+  }
+});
 ```
 
 自 4.6.0 起，此选项也可以设置为 `manual`。启用此路由策略后，Astro 将**禁用**其 i18n 中间件，并且无法配置其他 `routing` 选项（例如 `prefixDefaultLocale`）。你需要自行编写路由逻辑，或者手动执行 Astro 的 i18n 中间件与自定义逻辑配合使用。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
-	i18n: {
-		defaultLocale: "en",
-		locales: ["en", "fr"],
-		routing: "manual"
-	}
-})
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "fr"],
+    routing: "manual"
+  }
+});
 ```
 
 #### i18n.routing.prefixDefaultLocale
@@ -1570,15 +2546,18 @@ export default defineConfig({
 包括默认语言的所有语言都会使用本地化的文件夹。
 
 ```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
-	i18n: {
-		defaultLocale: "en",
-		locales: ["en", "fr", "pt-br", "es"],
-		routing: {
-			prefixDefaultLocale: true,
-		}
-	}
-})
+  i18n: {
+    defaultLocale: "en",
+    locales: ["en", "fr", "pt-br", "es"],
+    routing: {
+      prefixDefaultLocale: true,
+    }
+  }
+});
 ```
 
 #### i18n.routing.redirectToDefaultLocale
@@ -1592,19 +2571,21 @@ export default defineConfig({
 
 可以用来配置由 `src/pages/index.astro` 生成的主页 URL (`/`) 是否在设置 `prefixDefaultLocale: true` 时重定向到 `/[defaultLocale]`。
 
-设置 `redirectToDefaultLocale: false` 可以在你的网站根目录禁用这个自动重定向：
+设置 `redirectToDefaultLocale: true` 可以在你的网站根目录启用这个自动重定向：
 ```js
 // astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
   i18n:{
     defaultLocale: "en",
-		locales: ["en", "fr"],
+    locales: ["en", "fr"],
     routing: {
       prefixDefaultLocale: true,
-      redirectToDefaultLocale: false
+      redirectToDefaultLocale: true
     }
   }
-})
+});
 ```
 
 #### i18n.routing.fallbackType
@@ -1627,19 +2608,21 @@ export default defineConfig({
 
 ```js
 //astro.config.mjs
+import { defineConfig } from 'astro/config';
+
 export default defineConfig({
-	 i18n: {
+  i18n: {
     defaultLocale: "en",
     locales: ["en", "fr"],
     routing: {
-    	prefixDefaultLocale: false,
-    	fallbackType: "rewrite",
+      prefixDefaultLocale: false,
+      fallbackType: "rewrite",
     },
     fallback: {
-    	fr: "en",
+      fr: "en",
     }
   },
-})
+});
 ```
 
 ### i18n.domains
@@ -1661,21 +2644,23 @@ export default defineConfig({
 ```js
 //astro.config.mjs
 export default defineConfig({
-	 site: "https://example.com",
-	 output: "server", // 必须，没有预渲染页面
-	 adapter: node({
-	   mode: 'standalone',
-	 }),
-	 i18n: {
+  site: "https://example.com",
+  output: "server", // 必须，没有预渲染页面
+  adapter: node({
+    mode: 'standalone',
+  }),
+  i18n: {
     defaultLocale: "en",
     locales: ["en", "fr", "pt-br", "es"],
-    prefixDefaultLocale: false,
+    routing: {
+      prefixDefaultLocale: false,
+    },
     domains: {
       fr: "https://fr.example.com",
       es: "https://example.es"
     }
   },
-})
+});
 ```
 
 由 `astro:i18n` 辅助函数 [`getAbsoluteLocaleUrl()`](/zh-cn/reference/modules/astro-i18n/#getabsolutelocaleurl) 和 [`getAbsoluteLocaleUrlList()`](/zh-cn/reference/modules/astro-i18n/#getabsolutelocaleurllist) 返回的 URL 以及构建的页面路由，都将使用 `i18n.domains` 中设置的选项。  
@@ -1704,7 +2689,9 @@ export default defineConfig({
 <Since v="5.0.0" />
 </p>
 
-使用 `envField` 定义环境变量的数据类型和属性：`context`（client 或 server）、`access`（public 或 secret）、要使用的 `default` 值，以及此环境变量是否是 `optional`（默认为 `false`）。
+定义要通过 Zod 验证强制执行、并可获得 TypeScript 支持（例如自动补全、类型安全）的环境变量。每个键对应变量名，每个值对应[用 `envField` 定义](/zh-cn/reference/modules/astro-config/#envfield)的数据类型和验证规则。
+
+支持四种数据类型：string、number、枚举（enumeration）和 boolean。每种类型都需要 `context`（client 或 server）、`access` 级别（public 或 secret）以及额外的验证规则，例如 `default` 值和该变量是否 `optional`（默认为 `false`）的标示。
 
 ```js
 // astro.config.mjs
@@ -1718,47 +2705,7 @@ export default defineConfig({
       API_SECRET: envField.string({ context: "server", access: "secret" }),
     }
   }
-})
-```
-
-`envField` 支持四种数据类型：string、number、enum 和 boolean。`context` 和 `access` 是所有数据类型的必需属性。以下显示了每种数据类型可用的所有属性的完整列表：
-
-```js
-import { envField } from "astro/config"
-
-envField.string({
-   // context & access
-   optional: true,
-   default: "foo",
-   max: 20,
-   min: 1,
-   length: 13,
-   url: true,
-   includes: "oo",
-   startsWith: "f",
-   endsWith: "o",
-})
-envField.number({
-   // context & access
-   optional: true,
-   default: 15,
-   gt: 2,
-   min: 1,
-   lt: 3,
-   max: 4,
-   int: true,
-})
-envField.boolean({
-   // context & access
-   optional: true,
-   default: true,
-})
-envField.enum({
-   // context & access
-   values: ['foo', 'bar', 'baz'], // 必需
-   optional: true,
-   default: 'baz',
-})
+});
 ```
 
 ### env.validateSecrets
@@ -1785,5 +2732,343 @@ export default defineConfig({
     },
     validateSecrets: true
   }
-})
+});
 ```
+
+## fonts
+
+<p>
+
+**类型：** `Array<FontFamily>`<br />
+**默认值：** `[]`<br />
+<Since v="6.0.0" />
+</p>
+
+配置字体，并允许你针对每个字体指定一些自定义选项。
+
+有关[在 Astro 中使用自定义字体](/zh-cn/guides/fonts/)的更多信息，请参阅我们的指南。
+
+### font.provider
+
+<p>
+
+**类型：** `FontProvider`<br />
+<Since v="6.0.0" />
+</p>
+
+字体文件的来源。你可以使用[内置字体提供程序](/zh-cn/reference/font-provider-reference/#内置字体提供程序)，或编写你自己的[自定义字体提供程序](/zh-cn/reference/font-provider-reference/#构建字体提供程序)：
+
+```js
+// astro.config.mjs
+import { defineConfig, fontProviders } from "astro/config";
+
+export default defineConfig({
+  fonts: [{
+    provider: fontProviders.google(),
+    name: "Roboto",
+    cssVariable: "--font-roboto"
+  }]
+});
+```
+
+### font.name
+
+<p>
+
+**类型：** `string`<br />
+<Since v="6.0.0" />
+</p>
+
+字体系列名称，由你的字体提供程序标识：
+
+```js
+name: "Roboto"
+```
+
+### font.cssVariable
+
+<p>
+
+**类型：** `string`<br />
+<Since v="6.0.0" />
+</p>
+
+由你选择的、以 CSS 变量形式（即以 `--` 开头）呈现的有效 [ident](https://developer.mozilla.org/zh-CN/docs/Web/CSS/ident)：
+
+```js
+cssVariable: "--font-roboto"
+```
+
+### font.fallbacks
+
+<p>
+
+**类型：** `Array<string>`<br />
+**默认值：** `["sans-serif"]`<br />
+<Since v="6.0.0" />
+</p>
+
+当你选择的字体不可用或正在加载时使用的字体数组。回退字体将按所列顺序选择，并使用第一个可用的字体：
+
+```js
+fallbacks: ["CustomFont", "serif"]
+```
+
+要完全禁用回退字体，请配置一个空数组：
+
+```js
+fallbacks: []
+```
+
+请至少指定一个与你字体预期外观相匹配的[通用字体系列名称](https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-family#generic-name)。Astro 随后会尝试使用字体度量生成[优化的回退字体](https://developer.chrome.com/blog/font-fallbacks)。要禁用此优化，请将 `optimizedFallbacks` 设置为 false。
+
+### font.optimizedFallbacks
+
+<p>
+
+**类型：** `boolean`<br />
+**默认值：** `true`<br />
+<Since v="6.0.0" />
+</p>
+
+是否启用 Astro 在生成回退字体时的默认优化。你可以禁用此默认优化，以完全控制 [`fallbacks`](#fontfallbacks) 的生成方式：
+
+```js
+optimizedFallbacks: false
+```
+
+### font.weights
+
+<p>
+
+**类型：** `Array<(number|string)>`<br />
+**默认值：** `[400]`<br />
+<Since v="6.0.0" />
+</p>
+
+一个[字重](https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-weight)数组。如果你的配置中未指定值，默认仅包含字重 `400`，以避免不必要的下载。要使用任何其他字重，你需要包含此属性：
+
+```js
+weights: [200, "400", "bold"]
+```
+
+如果关联的字体是[可变字体](https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_fonts/Variable_fonts_guide)，你可以指定一个字重范围：
+
+```js
+weights: ["100 900"]
+```
+
+### font.styles
+
+<p>
+
+**类型：** `Array<("normal"|"italic"|"oblique")>`<br />
+**默认值：** `["normal", "italic"]`<br />
+<Since v="6.0.0" />
+</p>
+
+一个[字体样式](https://developer.mozilla.org/zh-CN/docs/Web/CSS/font-style)数组：
+
+```js
+styles: ["normal", "oblique"]
+```
+
+### font.subsets
+
+<p>
+
+**类型：** `Array<string>`<br />
+**默认值：** `["latin"]`<br />
+<Since v="6.0.0" />
+</p>
+
+定义要预加载的[字体子集](https://knaap.dev/posts/font-subsetting/)列表。
+
+```js
+subsets: ["latin"]
+```
+
+### font.formats
+
+<p>
+
+**类型：** `Array<("woff2"|"woff"|"otf"|"ttf"|"eot")>`<br />
+**默认值：** `["woff2"]`<br />
+<Since v="6.0.0" />
+</p>
+
+一个[字体格式](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/src#font_formats)数组：
+
+```js
+formats: ["woff2", "woff"]
+```
+
+### font.options
+
+<p>
+
+**类型：** `Record<string, any>`<br />
+<Since v="6.0.0" />
+</p>
+
+一个用于传递特定于提供程序的选项的对象。它会根据字体系列的 [provider](#fontprovider) 自动获得类型：
+
+```js
+options: {
+  experimental: {
+    glyphs: ["a"]
+  }
+}
+```
+
+### font.display
+
+<p>
+
+**类型：** `"auto" | "block" | "swap" | "fallback" | "optional"`<br />
+**默认值：** `"swap"`<br />
+<Since v="6.0.0" />
+</p>
+
+根据字体的下载和就绪时间，定义[字体如何显示](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face/font-display)：
+
+```js
+display: "block"
+```
+
+### font.unicodeRange
+
+<p>
+
+**类型：** `Array<string>`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+根据特定的 [unicode 字符范围](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face/unicode-range)决定何时必须下载并使用某个字体。如果页面上的某个字符匹配配置的范围，浏览器就会下载该字体，并且页面上的所有字符都可使用该字体显示。要为单个字体配置预加载的字符子集，请改用 [subsets](#fontsubsets) 属性。
+
+这在本地化时很有用：当网站的特定部分使用不同的字母体系并将以单独的字体显示时，可以避免不必要的字体下载。例如，一个同时提供英文和日文版本的网站，可以阻止浏览器在不含任何 `unicodeRange` 中所列日文字符的英文页面上下载日文字体。
+
+```js
+unicodeRange: ["U+26"]
+```
+
+### font.stretch
+
+<p>
+
+**类型：** `string`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+一个[字体伸缩度](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face/font-stretch)：
+
+```js
+stretch: "condensed"
+```
+
+### font.featureSettings
+
+<p>
+
+**类型：** `string`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+控制[排版字体特性](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face/font-feature-settings)（例如连字、小型大写字母或花饰）：
+
+```js
+featureSettings: "'smcp' 2"
+```
+
+### font.variationSettings
+
+<p>
+
+**类型：** `string`<br />
+**默认值：** `undefined`<br />
+<Since v="6.0.0" />
+</p>
+
+字体的[可变设置](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@font-face/font-variation-settings)：
+
+```js
+variationSettings: "'xhgt' 0.7"
+```
+
+## cache
+
+<p>
+
+**类型：** `object`<br />
+**默认值：** `undefined`<br />
+<Since v="7.0.0" />
+</p>
+
+为 SSR 响应启用路由缓存。提供了一套平台无关的 API，用于缓存渲染后的页面和 API 响应，并带有可由适配器自动配置的可插拔提供程序。
+
+```js
+// astro.config.mjs
+import { defineConfig, memoryCache } from 'astro/config';
+
+export default defineConfig({
+  cache: {
+    provider: memoryCache(),
+  },
+  routeRules: {
+    '/blog/[...path]': { maxAge: 300, swr: 60 },
+  },
+});
+```
+
+在路由中使用 `Astro.cache.set()`，在中间件或 API 路由中使用 `context.cache.set()`，即可按请求控制缓存。
+
+### cache.provider
+
+<p>
+
+**类型：** `CacheProviderConfig`<br />
+<Since v="7.0.0" />
+</p>
+
+控制响应如何缓存的提供程序。
+
+使用提供程序的配置函数可获得类型安全的配置：
+
+```js
+// astro.config.mjs
+import { defineConfig, memoryCache } from 'astro/config';
+
+export default defineConfig({
+  cache: { provider: memoryCache() },
+});
+```
+
+## routeRules
+
+<p>
+
+**类型：** `Record<string, RouteRule>`<br />
+**默认值：** `undefined`<br />
+<Since v="7.0.0" />
+</p>
+
+映射到缓存规则的路由模式。
+使用与[基于文件的路由](/zh-cn/guides/routing/#路由优先级顺序)相同的 `[param]` 和 `[...rest]` 语法。
+使用 `[...rest]` 参数来匹配一组路由：
+
+```js
+// astro.config.mjs
+import { defineConfig, memoryCache } from 'astro/config';
+
+export default defineConfig({
+  cache: { provider: memoryCache() },
+  routeRules: {
+    '/api/[...path]': { swr: 600 },
+    '/products/[...slug]': { maxAge: 3600, tags: ['products'] },
+  },
+});
+```
+


### PR DESCRIPTION
#### Description (required)

Brings the zh-CN `reference/configuration-reference.mdx` translation up to date with the current English version (syncs 7 upstream commits).

Main changes synced:
- Newly translated sections that were missing from zh-CN: `fonts` (all `font.*` options), `logger.options` / `logger.entrypoint` / `logger.config`, `security.csp`, `fetchFile`, `markdown.processor`, `cache`, `routeRules` — these provide the anchors that the new zh-CN fonts/logger/caching pages link to (#14451, #14452, #14453, #14455)
- Modernized code samples (`defineConfig` wrapping), session/markdown deprecations, i18n routing fixes
- Rewrote the outdated `env.schema` section to match the current English version (removed the long-obsolete `envField` property dump)

Terminology follows the [Simplified Chinese translation guide](https://github.com/withastro/docs/blob/main/i18n-guides/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87.md).