### PR TITLE
Repo housekeeping

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shell-emulator=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,6 @@ allowBuilds:
   esbuild: false
   sharp: false
   workerd: false
+
+# Run package scripts with an emulated bash environment for better cross-platform support.
+shellEmulator: true

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -3,7 +3,7 @@ import { Icon } from '@astrojs/starlight/components';
 import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
 import SidebarSublist from '@astrojs/starlight/components/SidebarSublist.astro';
 import type { StarlightRouteData } from '@astrojs/starlight/route-data';
-import { stripLeadingAndTrailingSlashes } from 'node_modules/@astrojs/starlight/utils/path';
+import { stripLeadingAndTrailingSlashes } from '../../../node_modules/@astrojs/starlight/utils/path';
 import { allPages } from '~/content';
 import { isSubPage } from '~/util/isSubPage';
 import { stripLangFromSlug } from '~/util/path-utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "exclude": ["dist"],
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"]
     }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)
This PR includes two small changes that I thought probably didn’t each deserve a dedicated PR:

- Moves the PNPM shell emulator config from `.npmrc` to `pnpm-workspace.yaml`. Since PNPM v11, the `.npmrc` file is no longer used for configurations like this, but looks like we forgot to move this setting when migrating to the workspace config file. This option is usually most important for contributors running package scripts on non-compatible shells (I remember Hippo needed it for certain scripts on Windows for example).

- Removes the `baseUrl` option from our `tsconfig.json` as it is now deprecated and our aliases should work fine without it. This required one change for a hacky import from `node_modules` which apparently worked as a bare specifier with the `baseUrl` config in place, but now uses a relative path instead.