### PR TITLE
Remove unused import from content-collections.mdx

### DIFF
--- a/src/content/docs/en/guides/content-collections.mdx
+++ b/src/content/docs/en/guides/content-collections.mdx
@@ -136,7 +136,7 @@ Each individual collection configures:
 import { defineCollection } from 'astro:content';
 
 // 2. Import loader(s)
-import { glob, file } from 'astro/loaders';
+import { glob } from 'astro/loaders';
 
 // 3. Import Zod
 import { z } from 'astro/zod';


### PR DESCRIPTION
This PR removes the unused `file` import from a documentation code example. 

While `file` is used in other examples below, it is not used in this particular example. Importing `file` here is therefore unnecessary and may confuse readers about whether it is required for this example.

This change does not affect fuctionality.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!--
- Describe the change you are proposing, and why.
- Only make changes to **one language**.
- Use  `<Since v="x.x.x" />` when adding features for a specific version of Astro.
- Follow additional guidance at https://contribute.docs.astro.build/ for faster reviews.
-->

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR closes an issue, add the issue number below. -->
- Closes #...
<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to ...
<!-- If this PR needs to be merged for a specific Astro release, add the version below. -->
- For Astro version `x.x.x`
<!-- First-time contributor to Astro Docs? Add your Discord username below so we can welcome you on the Astro Discord (https://astro.build/chat)! -->
- Discord username: ...
