### PR TITLE
docs: add an ESM and CommonJS interoperability resource

### DIFF
--- a/src/content/docs/en/guides/imports.mdx
+++ b/src/content/docs/en/guides/imports.mdx
@@ -42,6 +42,8 @@ Download the <a href="/reports/annual/2024.pdf">2024 annual statement as a PDF</
 
 Astro uses ESM, the same [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax) and [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) syntax supported in the browser.
 
+For a compact explanation of module semantics, packaging, and mixed-module behavior, see [ESM and CommonJS interoperability](https://frontendatlas.com/javascript/trivia/js-esm-vs-cjs).
+
 ### JavaScript
 
 ```js


### PR DESCRIPTION
## Summary
Add one optional companion resource after the Import statements introduction.

## Why
This section links to `import` and `export` syntax separately, but readers may still encounter CommonJS packages in an Astro project. The proposed resource explains static analysis, package exports, and mixed-module interoperability without repeating Astro-specific instructions.

## Disclosure
I’m affiliated with FrontendAtlas, which publishes the linked free resource.

## Validation
Documentation-only change; the rendered Markdown link and live destination were checked. No `[i18nIgnore]` marker was added so the normal translation workflow remains intact.