### PR TITLE
Document `--ignore-lock` support with `astro preview`

### DIFF
--- a/src/content/docs/en/reference/cli-reference.mdx
+++ b/src/content/docs/en/reference/cli-reference.mdx
@@ -196,25 +196,7 @@ The following hotkeys can be used in the terminal where the Astro development se
 - `o + enter` to open your Astro site in the browser.
 - `q + enter` to quit the development server.
 
-<h3>Flags</h3>
-
-<p><Since v="7.0.0" /></p>
-
-The command accepts [common flags](#common-flags) and the following additional flags.
-
-#### `--ignore-lock`
-
-<p><Since v="7.1.0" /></p>
-
-Starts the dev server without checking or writing the lock file used to detect other running dev servers. This allows a new dev server to start alongside one that's already running for the same project, instead of erroring.
-
-```shell
-astro dev --ignore-lock --port 4322
-```
-
-The new server is not tracked by the [`stop`, `status`, or `logs` subcommands](#common-subcommands).
-
-When combined with `--background` (including when triggered by an AI coding agent) or `--force`, an error is thrown, as both rely on the lock file.
+The command can be combined with the [common flags](#common-flags) and [common subcommands](#common-subcommands) to further control the dev experience.
 
 ## `astro build`
 
@@ -240,7 +222,7 @@ The following hotkeys can be used in the terminal where the Astro preview server
 - `o` + `enter` to open your Astro site in the browser.
 - `q` + `enter` to quit the preview server.
 
-The `astro preview` command can be combined with the [common flags](#common-flags) documented below to further control the preview experience. Since v7.2.0, it also accepts the [`--background` flag](#--background) and the [`stop`, `status`, and `logs` subcommands](#common-subcommands) to manage a background preview server.
+The command can be combined with the [common flags](#common-flags) and [common subcommands](#common-subcommands) to further control the preview experience.
 
 ## `astro check`
 
@@ -559,6 +541,20 @@ astro dev --background --force
 <p><Since v="7.0.0" /></p>
 
 Enables [JSON logging](/en/reference/logger-reference/#loghandlersjson), which is useful for machine-readable output.
+
+### `--ignore-lock`
+
+<p><Since v="7.1.0" /></p>
+
+Prevents checking for the existence of a lock file and the need to write one. This allows a new dev server or, since v7.3.0, a preview server to start alongside an already running server, instead of erroring.
+
+```shell
+astro dev --ignore-lock --port 4322
+```
+
+The new server is not tracked by the [common subcommands](#common-subcommands).
+
+When combined with [`--background`](#--background) or [`--force`](#--force-string), an error is thrown, as both rely on the lock file.
 
 ## Global flags
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Moves the `--ignore-lock` section from `astro dev` to "Common flags" as this is also supported by `astro preview` in 7.3
- Rewords the first sentence as I think we are repeating twice the same info: instead this explains what the flag does (ie. ignore lock file) and when this is useful (ie. start another server).
- Trims the last sentence in `astro preview` since we now have different "Since": the linked section already say since when this is available, so it seems enough.

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to https://github.com/withastro/astro/pull/17767
<!-- If this PR needs to be merged for a specific Astro release, add the version below. -->
- For Astro version `7.3.0`