### PR TITLE
Fix incorrect indefinite article before "image" (en-only)

### DIFF
--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -423,7 +423,7 @@ The value for `layout` also defines the default styles applied to the `<img>` ta
 <Since v="5.10.0" />
 </p>
 
-Defines how a image should be cropped if its aspect ratio is changed.
+Defines how an image should be cropped if its aspect ratio is changed.
 
 Values match those of CSS `object-fit`. Defaults to `cover`, or the value of [`image.objectFit`](/en/reference/configuration-reference/#imageobjectfit) if set. Can be used to override the default `object-fit` styles.
 
@@ -436,7 +436,7 @@ Values match those of CSS `object-fit`. Defaults to `cover`, or the value of [`i
 <Since v="5.10.0" />
 </p>
 
-Defines the position of the image crop for a image if the aspect ratio is changed.
+Defines the position of the image crop for an image if the aspect ratio is changed.
 
 Values match those of CSS `object-position`. Defaults to `center`, or the value of [`image.objectPosition`](/en/reference/configuration-reference/#imageobjectposition) if set. Can be used to override the default `object-position` styles.
 


### PR DESCRIPTION
#### Description

The `fit` and `position` property descriptions in the `astro:assets` reference (`src/content/docs/en/reference/modules/astro-assets.mdx`) use the incorrect indefinite article "a image" instead of "an image".

This changes both to "an image", matching the article used consistently everywhere else in the docs. For reference, "an image" is already used correctly elsewhere on this same page, for example in the descriptions of the `alt` and `background` properties.

This is an English-only grammar fix that should not require translating, so I have added the `en-only` keyword to the PR title.
