### PR TITLE
Fix "a each" typo in the Umbraco CMS guide (en-only)

### DIFF
--- a/src/content/docs/en/guides/cms/umbraco.mdx
+++ b/src/content/docs/en/guides/cms/umbraco.mdx
@@ -126,7 +126,7 @@ Your project should now contain the following files:
     - index.astro
 </FileTree>
 
-To create a list of blog posts, first `fetch` to call the Content Delivery API  `content` endpoint and filter by contentType of 'article'. The article objects will include the properties and content set in the CMS. You can then loop through the articles and display a each title with a link to its article.
+To create a list of blog posts, first `fetch` to call the Content Delivery API  `content` endpoint and filter by contentType of 'article'. The article objects will include the properties and content set in the CMS. You can then loop through the articles and display each title with a link to its article.
 
 Replace the default contents of `index.astro` with the following code:
 


### PR DESCRIPTION
#### Description

In the Umbraco CMS guide (`src/content/docs/en/guides/cms/umbraco.mdx`), the sentence describing the blog post loop reads "display a each title with a link to its article". The "a" before "each" is a stray word.

This removes it so the sentence reads "display each title with a link to its article", which matches the code example directly below that maps over each article and renders its title.

This is an English-only typo fix that should not require translating, so I have added the `en-only` keyword to the PR title.
