### PR TITLE
i18n(fr): update UI strings

### DIFF
--- a/src/content/i18n/fr.yml
+++ b/src/content/i18n/fr.yml
@@ -56,6 +56,10 @@ tutorial.unit: Unité
 tutorial.title.prefix: "Tutoriel de création d'un blog : {{title}}"
 # Tutorial
 tutorial.getReady: Préparez-vous à…
+# Code snippet vocabulary
+expressiveCode.terminalWindowFallbackTitle: Fenêtre du terminal
+expressiveCode.copyButtonTooltip: Copier dans le presse-papiers
+expressiveCode.copyButtonCopied: Copié!
 # Backend Guides vocabulary
 backend.navTitle: Plus de guides sur les services backend
 # Starlight banner

--- a/src/content/i18n/fr.yml
+++ b/src/content/i18n/fr.yml
@@ -1,5 +1,5 @@
 # Site settings
-site.title: Documentation Astro
+site.title: Documentation d'Astro
 # Left Sidebar
 leftSidebar.sponsoredBy: Sponsorisé par
 # Footer
@@ -12,12 +12,12 @@ since.addedIn: 'Ajouté à la version :'
 since.new: Nouveau
 since.beta: Bêta
 # Installation Guide
-install.autoTab: "Automatiquement via l'ILC"
+install.autoTab: "Automatiquement via la CLI"
 install.manualTab: Configuration manuelle
 # `<DeployGuidesNav>` vocabulary
 deploy.sectionTitle: Guides de déploiement
 deploy.altSectionTitle: Plus de guides de déploiement
-deploy.ssrTag: SSR
+deploy.ssrTag: À la demande
 deploy.staticTag: Statique
 # CMS Guides vocabulary
 cms.navTitle: Plus de guides sur les CMS
@@ -28,28 +28,28 @@ media.navTitle: Plus de guides sur les médias hébergés
 # Migration Guides vocabulary
 migration.navTitle: Plus de guides sur les migrations
 # `<RecipeLinks>` vocabulary
-recipesLink.singular: 'Méthode associée :'
-recipesLink.plural: Méthodes associées
+recipesLink.singular: 'Recette associée :'
+recipesLink.plural: Recettes associées
 # 404 Page
 404.title: Page introuvable
 404.content: Cette page ne fait pas partie de notre système solaire.
-404.linkText: Ramenez moi à la maison
+404.linkText: Ramenez-moi à la maison
 # Integrations vocabulary
 integrations.changelog: Journal des modifications
 integrations.footerTitle: "Plus d'intégrations"
-integrations.renderers: "Framework d'interface utilisateur"
-integrations.adapters: Adaptateurs SSR
+integrations.renderers: "Frameworks front-end"
+integrations.adapters: Adaptateurs
 integrations.others: Autres intégrations
 integrations.more: "Plus d'intégrations"
 # Checklist component
 checklist.or: ou
 # Multiple Choice component
 multipleChoice.defaultCorrect: Correct !
-multipleChoice.defaultIncorrect: Réessayer !
+multipleChoice.defaultIncorrect: Réessayez !
 multipleChoice.submitLabel: Envoyer
 # Tutorial Progress
 progress.todo: À faire
-progress.done: Terminer
+progress.done: Terminé
 # Tutorial Navigation
 tutorial.trackerLabel: Suivi du tutoriel
 tutorial.unit: Unité
@@ -57,9 +57,9 @@ tutorial.title.prefix: "Tutoriel de création d'un blog : {{title}}"
 # Tutorial
 tutorial.getReady: Préparez-vous à…
 # Code snippet vocabulary
-expressiveCode.terminalWindowFallbackTitle: Fenêtre du terminal
+expressiveCode.terminalWindowFallbackTitle: Fenêtre de terminal
 expressiveCode.copyButtonTooltip: Copier dans le presse-papiers
-expressiveCode.copyButtonCopied: Copié!
+expressiveCode.copyButtonCopied: Copié !
 # Backend Guides vocabulary
 backend.navTitle: Plus de guides sur les services backend
 # Starlight banner
@@ -83,9 +83,9 @@ docsearch.modal.searchBox.cancelButtonAriaLabel: Annuler
 docsearch.modal.startScreen.recentSearchesTitle: Recherches récentes
 docsearch.modal.startScreen.noRecentSearchesText: Aucune recherche récente
 docsearch.modal.startScreen.saveRecentSearchButtonTitle: Sauvegarder cette recherche
-docsearch.modal.startScreen.removeRecentSearchButtonTitle: Enlever cette recherche de l'historique
+docsearch.modal.startScreen.removeRecentSearchButtonTitle: Supprimer cette recherche de l'historique
 docsearch.modal.startScreen.favoriteSearchesTitle: Favoris
-docsearch.modal.startScreen.removeFavoriteSearchButtonTitle: Enlever cette recherche des favoris
+docsearch.modal.startScreen.removeFavoriteSearchButtonTitle: Supprimer cette recherche des favoris
 # ERROR SCREEN
 docsearch.modal.errorScreen.titleText: Erreur lors de la récupération des résultats
 docsearch.modal.errorScreen.helpText: Vous devriez vérifier l'état de votre connection internet.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Reverts #14477 because Lunaria expects all English strings to be translated
- Fixes a few issues with the translations:
  - missing article
  - missing space
  - mismatch with the English version (e.g. SSR)
  - mismatch with our [i18n guide](https://github.com/withastro/docs/blob/main/i18n-guides/fran%C3%A7ais.md) (e.g. front-end, recipe)
  - grammar
- Replaces some translations with more natural ones (e.g. "supprimer de l'historique" is more natural than "enlever")

