### PR TITLE
i18n(fr): update `integrations-guide/markdoc.mdx`

### DIFF
--- a/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
+++ b/src/content/docs/fr/guides/integrations-guide/markdoc.mdx
@@ -117,15 +117,18 @@ Ensuite, [interrogez et affichez vos articles et collections](/fr/guides/content
 
 ```astro title="src/pages/why-markdoc.astro"
 ---
-import { getEntry, render } from 'astro:content';
+import { getEntry, render } from "astro:content";
 
-const entry = await getEntry('docs', 'why-markdoc');
+const entry = await getEntry("docs", "why-markdoc");
+if (!entry) {
+  throw new Error("Entrée introuvable");
+}
 const { Content } = await render(entry);
 ---
 
 <!--Accéder aux propriétés du Frontmatter avec `data`-->
 <h1>{entry.data.title}</h1>
-<!--Rendre le contenu d'un Markdoc avec le composant Content-->
+<!--Afficher le contenu Markdoc avec le composant Content-->
 <Content />
 ```
 
@@ -142,6 +145,9 @@ Les variables peuvent être transmises en tant que props via le composant `Conte
 import { getEntry, render } from 'astro:content';
 
 const entry = await getEntry('docs', 'why-markdoc');
+if (!entry) {
+  throw new Error("Entrée introuvable");
+}
 const { Content } = await render(entry);
 ---
 
@@ -180,6 +186,9 @@ Pour accéder à frontmatter, vous pouvez passer la propriété `data` de l'entr
 import { getEntry, render } from 'astro:content';
 
 const entry = await getEntry('docs', 'why-markdoc');
+if (!entry) {
+  throw new Error("Entrée introuvable");
+}
 const { Content } = await render(entry);
 ---
 
@@ -499,9 +508,16 @@ Les étapes suivantes permettent de créer une balise image Markdoc personnalis�
 
     const { src, alt, width, height, caption } = Astro.props;
     ---
+
     <figure>
-        <Image {src} {alt} {width} {height}  />
-        {caption && <figcaption>{caption}</figcaption>}
+      {
+        typeof src === "string" ? (
+          <img {src} {alt} {width} {height} />
+        ) : (
+          <Image {src} {alt} {width} {height} />
+        )
+      }
+      {caption && <figcaption>{caption}</figcaption>}
     </figure>
     ```
 
@@ -659,6 +675,37 @@ Lors de l'utilisation de balises imbriquées dans Markdoc, il peut être utile d
 
 {% /custom-tag %}
 {% /custom-tag %}
+```
+
+### `typographer`
+
+<p>
+
+**Type :** `boolean`<br />
+**Par défaut :** `false`<br />
+<Since v="0.11.2" pkg="@astrojs/markdoc" />
+</p>
+
+Active la prise en charge intégrée des guillemets intelligents par Markdoc. Remplace les guillemets droits, simples ou doubles, par les guillemets courbes appropriés.
+
+```js title="astro.config.mjs" ins={6}
+  import { defineConfig } from 'astro/config';
+  import markdoc from '@astrojs/markdoc';
+
+  export default defineConfig({
+    // ...
+    integrations: [markdoc({ typographer: true })],
+  });
+```
+
+```md title="src/content/docs/why-markdoc.mdoc"
+She continued, "You know what they said? They said, 'It's astonishing how fancy these smart quotes look!'. That's what they said."
+```
+
+Les guillemets droits sont remplacés intelligemment et rendus comme suit :
+
+```md
+She continued, “You know what they said? They said, ‘It’s astonishing how fancy these smart quotes look!’. That’s what they said.”
 ```
 
 ## Exemples


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Updates the French translation of `integrations-guide/markdoc.mdx`.

Because the option is named `typographer`, Lunaria did not triggered a status change... I missed that when reviewing #14310 👀 

#### References

<!-- Optional section. Delete any points that don’t apply. -->

<!-- If this PR is related to another PR, issue, or discussion, but does not close it, add a link below. -->
- Related to #14310 and #14481
