### PR TITLE
docs: keep Solid cart visibility reactive in shared-state recipe

### DIFF
--- a/src/content/docs/en/recipes/sharing-state-islands.mdx
+++ b/src/content/docs/en/recipes/sharing-state-islands.mdx
@@ -274,12 +274,17 @@ export default function CartFlyout() {
 ```jsx
 // src/components/CartFlyout.jsx
 import { useStore } from '@nanostores/solid';
+import { Show } from 'solid-js';
 import { isCartOpen } from '../cartStore';
 
 export default function CartFlyout() {
   const $isCartOpen = useStore(isCartOpen);
 
-  return $isCartOpen() ? <aside>...</aside> : null;
+  return (
+    <Show when={$isCartOpen()}>
+      <aside>...</aside>
+    </Show>
+  );
 }
 ```
 </Fragment>
@@ -621,27 +626,30 @@ export default function CartFlyout() {
 ```jsx
 // src/components/CartFlyout.jsx
 import { useStore } from '@nanostores/solid';
+import { Show } from 'solid-js';
 import { isCartOpen, cartItems } from '../cartStore';
 
 export default function CartFlyout() {
   const $isCartOpen = useStore(isCartOpen);
   const $cartItems = useStore(cartItems);
 
-  return $isCartOpen() ? (
-    <aside>
-      {Object.values($cartItems()).length ? (
-        <ul>
-          {Object.values($cartItems()).map(cartItem => (
-            <li>
-              <img src={cartItem.imageSrc} alt={cartItem.name} />
-              <h3>{cartItem.name}</h3>
-              <p>Quantity: {cartItem.quantity}</p>
-            </li>
-          ))}
-        </ul>
-      ) : <p>Your cart is empty!</p>}
-    </aside>
-  ) : null;
+  return (
+    <Show when={$isCartOpen()}>
+      <aside>
+        {Object.values($cartItems()).length ? (
+          <ul>
+            {Object.values($cartItems()).map(cartItem => (
+              <li>
+                <img src={cartItem.imageSrc} alt={cartItem.name} />
+                <h3>{cartItem.name}</h3>
+                <p>Quantity: {cartItem.quantity}</p>
+              </li>
+            ))}
+          </ul>
+        ) : <p>Your cart is empty!</p>}
+      </aside>
+    </Show>
+  );
 }
 ```
 </Fragment>


### PR DESCRIPTION
#### Description (required)

The two Solid `CartFlyout` examples in the shared-state recipe read `$isCartOpen()` in a top-level ternary. Solid executes the component once, so toggling the Nano Store afterward does not open or close the cart. Wrap each cart in `<Show when={$isCartOpen()}>` and add the `Show` import so visibility stays reactive.

I extracted both snippets directly from this page and mounted them with Solid, `@nanostores/solid`, and Vitest/jsdom. Four checks exercise opening and closing from both initial states: all four fail before the change and pass afterward. Only the English page is changed; translations should receive the code fix.

The full docs build could not be run locally because the dependency policy rejects the existing `@lunariajs/core` lockfile entry, which lacks tarball integrity. I have not changed the lockfile or relaxed that policy. The snippet checks pass independently. Prepared with AI assistance.

#### References

- [Solid conditional rendering](https://docs.solidjs.com/concepts/control-flow/conditional-rendering)
