### PR TITLE
i18n(es): add `guides/deploy/aws-via-flightcontrol.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/aws-via-flightcontrol.mdx
+++ b/src/content/docs/es/guides/deploy/aws-via-flightcontrol.mdx
@@ -1,0 +1,38 @@
+---
+title: Despliega tu sitio de Astro en AWS con Flightcontrol
+description: Cómo desplegar tu sitio de Astro en AWS con Flightcontrol
+sidebar:
+  label: AWS via Flightcontrol
+type: deploy
+logo: flightcontrol
+supports: ['ssr', 'static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+
+Puedes desplegar un sitio de Astro usando [Flightcontrol](https://www.flightcontrol.dev?ref=astro), el cual ofrece despliegues completamente automatizados en tu cuenta de AWS.
+
+Admite sitios de Astro tanto estáticos como SSR.
+
+## Cómo desplegar
+
+<Steps>
+1. Crea una cuenta de Flightcontrol en [app.flightcontrol.dev/signup](https://app.flightcontrol.dev/signup?ref=astro)
+
+2. Ve a [app.flightcontrol.dev/projects/new/1](https://app.flightcontrol.dev/projects/new/1)
+
+3. Conecta tu cuenta de GitHub y selecciona tu repo
+
+4. Selecciona el "Config Type" que desees:
+    - `GUI` (toda la configuración se gestiona a través del panel de Flightcontrol) donde seleccionarás el preset `Astro Static` o `Astro SSR`
+    - `flightcontrol.json` (opción de "infraestructura como código" donde toda la configuración está en tu repo), donde seleccionarás una configuración de ejemplo de Astro y luego la añadirás a tu código fuente como `flightcontrol.json`
+
+5. Ajusta cualquier configuración según sea necesario
+
+6. Haz clic en "Create Project" y completa cualquier paso requerido (como vincular tu cuenta de AWS).
+</Steps>
+
+### Configuración de SSR
+
+{/* TODO: add link to: es/guides/integrations-guide/node/ */}
+Para desplegar con soporte para SSR, asegúrate de configurar primero el adaptador `@astrojs/node`. Luego, sigue los pasos anteriores, eligiendo las configuraciones adecuadas para Astro SSR.


### PR DESCRIPTION
#### Description (required)

- Adds the Spanish translation of `guides/deploy/aws-via-flightcontrol.mdx`.

