### PR TITLE
i18n(es): add `guides/deploy/firebase.mdx`

### DIFF
--- a/src/content/docs/es/guides/deploy/firebase.mdx
+++ b/src/content/docs/es/guides/deploy/firebase.mdx
@@ -1,0 +1,137 @@
+---
+title: Despliega tu sitio de Astro en Firebase Hosting de Google
+description: Cómo desplegar tu sitio de Astro en la web usando Firebase Hosting de Google.
+sidebar:
+  label: Firebase
+type: deploy
+logo: firebase
+supports: ['ssr', 'static']
+i18nReady: true
+---
+import { Steps } from '@astrojs/starlight/components';
+import PackageManagerTabs from '~/components/tabs/PackageManagerTabs.astro';
+
+[Firebase Hosting](https://firebase.google.com/products/hosting) es un servicio proporcionado por la plataforma de desarrollo de aplicaciones [Firebase](https://firebase.google.com/) de Google, que se puede utilizar para desplegar un sitio de Astro.
+
+Consulta nuestra guía separada para [agregar servicios de backend de Firebase](/es/guides/backend/firebase/) como bases de datos, autenticación y almacenamiento.
+
+## Configuración del proyecto
+
+Tu proyecto de Astro se puede desplegar en Firebase como un sitio estático o como un sitio renderizado del lado del servidor (SSR).
+
+### Sitio estático
+
+Tu proyecto de Astro es un sitio estático de forma predeterminada. No necesitas ninguna configuración adicional para desplegar un sitio estático de Astro en Firebase.
+
+### Adaptador para SSR
+
+{/* TODO: add link to: /en/guides/integrations-guide/node/ */}
+Para habilitar SSR en tu proyecto de Astro y desplegarlo en Firebase, agrega el adaptador de Node.js. 
+
+:::note
+Desplegar un sitio SSR de Astro en Firebase requiere el [plan Blaze](https://firebase.google.com/pricing) o superior.
+:::
+
+## Cómo desplegar
+
+<Steps>
+1. Instala la [Firebase CLI](https://github.com/firebase/firebase-tools). Esta es una herramienta de línea de comandos que te permite interactuar con Firebase desde la terminal.
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npm install firebase-tools
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm add firebase-tools
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn add firebase-tools
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+2. Autentica la Firebase CLI con tu cuenta de Google. Esto abrirá una ventana del navegador donde podrás iniciar sesión en tu cuenta de Google.
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npx firebase login
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm exec firebase login
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn firebase login
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+3. Habilita el soporte experimental para frameworks web. Esta es una característica experimental que permite a la Firebase CLI detectar y configurar tus ajustes de despliegue para Astro.
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npx firebase experiments:enable webframeworks
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm exec firebase experiments:enable webframeworks
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn firebase experiments:enable webframeworks
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+4. Inicializa Firebase Hosting en tu proyecto. Esto creará los archivos `firebase.json` y `.firebaserc` en la raíz de tu proyecto.
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npx firebase init hosting
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm exec firebase init hosting
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn firebase init hosting
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+
+5. Despliega tu sitio en Firebase Hosting. Esto construirá tu sitio de Astro y lo desplegará en Firebase.
+
+    <PackageManagerTabs>
+      <Fragment slot="npm">
+      ```shell
+      npx firebase deploy --only hosting
+      ```
+      </Fragment>
+      <Fragment slot="pnpm">
+      ```shell
+      pnpm exec firebase deploy --only hosting
+      ```
+      </Fragment>
+      <Fragment slot="yarn">
+      ```shell
+      yarn firebase deploy --only hosting
+      ```
+      </Fragment>
+    </PackageManagerTabs>
+</Steps>


### PR DESCRIPTION
#### Description (required)

- Adds the Spanish translation of `guides/deploy/firebase.mdx`.