### PR TITLE
docs: document Oxc React Compiler and Babel migration

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -223,6 +223,49 @@ export default defineConfig({
 });
 ```
 
+### React Compiler (experimental)
+
+Set `compiler: true` to automatically memoize client components and hooks with the [Oxc React Compiler](https://oxc.rs/docs/guide/usage/transformer/react-compiler). This option is disabled by default.
+
+First, install `oxc-transform-react`:
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install -D oxc-transform-react
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add -D oxc-transform-react
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add -D oxc-transform-react
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Then, enable the compiler in your React integration:
+
+```js title="astro.config.mjs" ins={6}
+import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  integrations: [
+    react({ compiler: true }),
+  ],
+});
+```
+
+The compiler targets your installed React version. For React 17 or 18, also install `react-compiler-runtime` as a dependency.
+
+You can pass compiler options instead of `true`, such as `compiler: { compilationMode: 'annotation' }`. The integration's `include` and `exclude` filters apply. Server rendering, dependencies, and `.astro` files are not compiled.
+
+Existing `babel` configuration continues to work. Do not enable `babel-plugin-react-compiler` on the same client components as the Oxc compiler.
+
 ### Children parsing
 
 Children passed into a React component from an Astro component are parsed as plain strings, not React nodes.

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -264,7 +264,71 @@ The compiler targets your installed React version. For React 17 or 18, also inst
 
 You can pass compiler options instead of `true`, such as `compiler: { compilationMode: 'annotation' }`. The integration's `include` and `exclude` filters apply. Server rendering, dependencies, and `.astro` files are not compiled.
 
-Existing `babel` configuration continues to work. Do not enable `babel-plugin-react-compiler` on the same client components as the Oxc compiler.
+Do not enable `babel-plugin-react-compiler` on the same client components as the Oxc compiler. For other custom Babel transformations, see [Migrating custom Babel transforms](#migrating-custom-babel-transforms).
+
+### Migrating custom Babel transforms
+
+The integration uses `@vitejs/plugin-react` v6 and Oxc for JSX and Fast Refresh. The `babel` integration option has been removed.
+
+If you use custom Babel transforms, install `@rolldown/plugin-babel` and `@babel/core`, keeping your existing Babel plugins and presets installed:
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Move your Babel plugins and presets from `react({ babel: ... })` to `babel()` in `vite.plugins`. For example, migrate a project using `babel-plugin-styled-components` from:
+
+```js title="astro.config.mjs"
+import react from '@astrojs/react';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [
+    react({
+      babel: {
+        plugins: ['babel-plugin-styled-components'],
+      },
+    }),
+  ],
+});
+```
+
+To:
+
+```js title="astro.config.mjs"
+import react from '@astrojs/react';
+import babel from '@rolldown/plugin-babel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [react()],
+  vite: {
+    plugins: [
+      babel({
+        plugins: ['babel-plugin-styled-components'],
+      }),
+    ],
+  },
+});
+```
+
+This also works with `react({ compiler: true })`. Babel runs before Oxc transforms TypeScript and JSX. The Babel plugin automatically enables parsing for `.jsx`, `.ts`, and `.tsx` files. It does not load `babel.config.js` or `.babelrc` files; pass the options directly to `babel()`. The old `babel` callback is not supported; use the plugin's [`overrides` and preset hooks](https://github.com/rolldown/plugins/tree/main/packages/babel#options) for conditional transforms.
+
+Do not enable `babel-plugin-react-compiler` on the same components as the Oxc compiler.
 
 ### Children parsing
 

--- a/src/content/docs/en/guides/integrations-guide/react.mdx
+++ b/src/content/docs/en/guides/integrations-guide/react.mdx
@@ -13,6 +13,10 @@ import Since from '~/components/Since.astro';
 
 This **[Astro integration][astro-integration]** enables rendering and client-side hydration for your [React](https://react.dev/) components.
 
+:::tip[Upgrading to v7.0.0?]
+`@astrojs/react` v7.0.0 removes the `babel` integration option. See [Upgrading the React integration to v7.0.0](#upgrading-the-react-integration-to-v700) for migration instructions.
+:::
+
 ## Installation
 
 Astro includes an `astro add` command to automate the setup of official integrations. If you prefer, you can [install integrations manually](#manual-install) instead.
@@ -225,9 +229,18 @@ export default defineConfig({
 
 ### React Compiler (experimental)
 
-Set `compiler: true` to automatically memoize client components and hooks with the [Oxc React Compiler](https://oxc.rs/docs/guide/usage/transformer/react-compiler). This option is disabled by default.
+<p>
 
-First, install `oxc-transform-react`:
+**Type:** `boolean | object`<br />
+**Default:** `false`<br />
+<Since v="7.0.0" pkg="@astrojs/react" />
+</p>
+
+By default, `@astrojs/react` uses [Oxc](https://oxc.rs/) to compile your JSX and enable Fast Refresh. It doesn't memoize your components or hooks.
+
+Set `compiler: true` to automatically memoize client components and hooks with the [experimental Oxc React Compiler](https://oxc.rs/docs/guide/usage/transformer/react-compiler). This can reduce unnecessary re-renders without writing `useMemo()`, `useCallback()`, or `React.memo()` yourself.
+
+The compiler requires the installation of [`oxc-transform-react`](https://www.npmjs.com/package/oxc-transform-react):
 
 <PackageManagerTabs>
   <Fragment slot="npm">
@@ -247,6 +260,26 @@ First, install `oxc-transform-react`:
   </Fragment>
 </PackageManagerTabs>
 
+The compiler targets your installed React version. React 17 and 18 don't ship the compiler runtime helpers. If your project uses one of these versions, also install [`react-compiler-runtime`](https://www.npmjs.com/package/react-compiler-runtime):
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install react-compiler-runtime
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add react-compiler-runtime
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add react-compiler-runtime
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
 Then, enable the compiler in your React integration:
 
 ```js title="astro.config.mjs" ins={6}
@@ -260,75 +293,26 @@ export default defineConfig({
 });
 ```
 
-The compiler targets your installed React version. For React 17 or 18, also install `react-compiler-runtime` as a dependency.
+You can also pass an object for finer control over the compiler configuration.
 
-You can pass compiler options instead of `true`, such as `compiler: { compilationMode: 'annotation' }`. The integration's `include` and `exclude` filters apply. Server rendering, dependencies, and `.astro` files are not compiled.
+The following example configures `compilationMode` to compile only components and hooks marked with a `"use memo"` directive:
 
-Do not enable `babel-plugin-react-compiler` on the same client components as the Oxc compiler. For other custom Babel transformations, see [Migrating custom Babel transforms](#migrating-custom-babel-transforms).
-
-### Migrating custom Babel transforms
-
-The integration uses `@vitejs/plugin-react` v6 and Oxc for JSX and Fast Refresh. The `babel` integration option has been removed.
-
-If you use custom Babel transforms, install `@rolldown/plugin-babel` and `@babel/core`, keeping your existing Babel plugins and presets installed:
-
-<PackageManagerTabs>
-  <Fragment slot="npm">
-  ```sh
-  npm install -D @rolldown/plugin-babel @babel/core
-  ```
-  </Fragment>
-  <Fragment slot="pnpm">
-  ```sh
-  pnpm add -D @rolldown/plugin-babel @babel/core
-  ```
-  </Fragment>
-  <Fragment slot="yarn">
-  ```sh
-  yarn add -D @rolldown/plugin-babel @babel/core
-  ```
-  </Fragment>
-</PackageManagerTabs>
-
-Move your Babel plugins and presets from `react({ babel: ... })` to `babel()` in `vite.plugins`. For example, migrate a project using `babel-plugin-styled-components` from:
-
-```js title="astro.config.mjs"
-import react from '@astrojs/react';
+```js title="astro.config.mjs" {7-9}
 import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
 
 export default defineConfig({
   integrations: [
     react({
-      babel: {
-        plugins: ['babel-plugin-styled-components'],
+      compiler: {
+        compilationMode: 'annotation',
       },
     }),
   ],
 });
 ```
 
-To:
-
-```js title="astro.config.mjs"
-import react from '@astrojs/react';
-import babel from '@rolldown/plugin-babel';
-import { defineConfig } from 'astro/config';
-
-export default defineConfig({
-  integrations: [react()],
-  vite: {
-    plugins: [
-      babel({
-        plugins: ['babel-plugin-styled-components'],
-      }),
-    ],
-  },
-});
-```
-
-This also works with `react({ compiler: true })`. Babel runs before Oxc transforms TypeScript and JSX. The Babel plugin automatically enables parsing for `.jsx`, `.ts`, and `.tsx` files. It does not load `babel.config.js` or `.babelrc` files; pass the options directly to `babel()`. The old `babel` callback is not supported; use the plugin's [`overrides` and preset hooks](https://github.com/rolldown/plugins/tree/main/packages/babel#options) for conditional transforms.
-
-Do not enable `babel-plugin-react-compiler` on the same components as the Oxc compiler.
+The compiler applies wherever the integration's [`include` and `exclude` options](#combining-multiple-jsx-frameworks) apply. It skips server rendering, dependencies, and `.astro` files.
 
 ### Children parsing
 
@@ -386,6 +370,66 @@ export default defineConfig({
   ]
 });
 ```
+
+## Upgrading the React integration to v7.0.0
+
+`@astrojs/react` v7.0.0 replaces Babel with [Oxc](https://oxc.rs/) to compile JSX and enable Fast Refresh, and upgrades to `@vitejs/plugin-react` v6.
+
+### Removed: `babel` option
+
+Configure custom Babel transforms with [`@rolldown/plugin-babel`](https://github.com/rolldown/plugins/tree/main/packages/babel) in [`vite.plugins`](/en/reference/configuration-reference/#vite) instead of the removed `babel` option.
+
+Install `@rolldown/plugin-babel` and `@babel/core`:
+
+<PackageManagerTabs>
+  <Fragment slot="npm">
+  ```sh
+  npm install -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+  <Fragment slot="pnpm">
+  ```sh
+  pnpm add -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+  <Fragment slot="yarn">
+  ```sh
+  yarn add -D @rolldown/plugin-babel @babel/core
+  ```
+  </Fragment>
+</PackageManagerTabs>
+
+Then, move your Babel plugins and presets to a `babel()` plugin under `vite.plugins`.
+
+The following example moves `babel-plugin-styled-components` out of the removed `babel` option:
+
+```js title="astro.config.mjs" del={7-11} ins={2,12,14-20}
+import react from '@astrojs/react';
+import babel from '@rolldown/plugin-babel';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  integrations: [
+    react({
+      babel: {
+        plugins: ['babel-plugin-styled-components'],
+      },
+    }),
+    react(),
+  ],
+  vite: {
+    plugins: [
+      babel({
+        plugins: ['babel-plugin-styled-components'],
+      }),
+    ],
+  },
+});
+```
+
+For conditional transforms previously configured with a `babel` callback, see the [`overrides` and preset hooks of `@rolldown/plugin-babel`](https://github.com/rolldown/plugins/tree/main/packages/babel#options).
+
+You can combine `babel()` with [`compiler: true`](#react-compiler-experimental). If your Babel configuration includes `babel-plugin-react-compiler`, remove it first. This avoids applying React Compiler transformations twice to the same components.
 
 [astro-integration]: /en/guides/integrations/
 


### PR DESCRIPTION
#### Description (required)

Documents the experimental Oxc React Compiler option introduced in `@astrojs/react` v7.0.0, including its API block, default behavior, installation, React 17/18 runtime dependency, and an annotation-mode configuration example.

Adds a separate v7 upgrade section for the removed `babel` integration option, linked from a tip at the top of the page. A single configuration diff shows how to move custom Babel transforms into `vite.plugins`. Links to the Babel plugin documentation cover advanced configuration, and the upgrade section explains avoiding duplicate React Compiler transformations.

The docs retain the current implementation's `compiler` option name. Implementation: https://github.com/withastro/astro/pull/17951.

Validation: Prettier and `git diff --check` passed. `pnpm check` reported 0 errors, 0 warnings, and one existing hint. Verified the API block, package-manager installation commands, upgrade section, migration diff, and section navigation in the local preview.

#### References

- Implementation: https://github.com/withastro/astro/pull/17951
- Related issue: https://github.com/withastro/astro/issues/17952
