### PR TITLE
docs: set Firebase session cookie maxAge to match expiresIn

### DIFF
--- a/src/content/docs/en/guides/backend/firebase.mdx
+++ b/src/content/docs/en/guides/backend/firebase.mdx
@@ -233,6 +233,9 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
 
   cookies.set("__session", sessionCookie, {
     path: "/",
+    maxAge: fiveDays / 1000,
+    httpOnly: true,
+    secure: new URL(request.url).protocol === "https:",
   });
 
   return redirect("/dashboard");


### PR DESCRIPTION
Fixes #14526

The Firebase auth signin endpoint example now passes `maxAge: fiveDays / 1000` to `cookies.set()` so the browser cookie lifetime matches Firebase's `expiresIn` value. Without `maxAge`, browsers treat the cookie as a session cookie and discard it when the tab closes.

Also sets `httpOnly` and `secure` (when served over HTTPS) on the session cookie, consistent with other auth examples in the docs.