### PR TITLE
docs: fix 'allows to' grammar in paginate format option [i18nIgnore]

### DIFF
--- a/src/content/docs/en/reference/routing-reference.mdx
+++ b/src/content/docs/en/reference/routing-reference.mdx
@@ -247,7 +247,7 @@ const { page } = Astro.props;
   - `pageSize` - The number of items shown per page (`10` by default)
   - `params` - Send additional parameters for creating dynamic routes
   - `props` - Send additional props to be available on each page
-  - `format` - **Since v7.1.0.** A function that allows to manipulate the computed URLs before being rendered.
+  - `format` - **Since v7.1.0.** A function that allows you to manipulate the computed URLs before being rendered.
 
 `paginate()` assumes a file name of `[page].astro` or `[...page].astro`. The `page` param becomes the page number in your URL:
 


### PR DESCRIPTION
## Summary
- Fix grammar in `paginate()` `format` option docs: "allows to manipulate" → "allows you to manipulate".

Tiny unsolicited docs grammar fix.