### PR TITLE
docs: set Firebase session cookie maxAge to match expiresIn

### DIFF
--- a/src/content/docs/en/guides/backend/firebase.mdx
+++ b/src/content/docs/en/guides/backend/firebase.mdx
@@ -233,6 +233,7 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
 
   cookies.set("__session", sessionCookie, {
     path: "/",
+    maxAge: fiveDays / 1000,
   });
 
   return redirect("/dashboard");


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

In the English Firebase auth sign-in example, `createSessionCookie()` is given a 5-day `expiresIn`, but `cookies.set()` only sets `path`. Without `maxAge`/`expires`, the browser treats `__session` as a session cookie and drops it when the tab closes.

Adds `maxAge: fiveDays / 1000` so the browser cookie lifetime matches the Firebase token. English only.

#### References

- Closes #14526