### PR TITLE
feat: document shutdown config option for @astrojs/node

### DIFF
--- a/src/content/docs/en/guides/integrations-guide/node.mdx
+++ b/src/content/docs/en/guides/integrations-guide/node.mdx
@@ -185,6 +185,36 @@ export default defineConfig({
 });
 ```
 
+### `shutdown`
+
+<p>
+**Type:** `{ timeout?: number; exit?: boolean }` <br />
+**Default:** `{ timeout: 10000, exit: false }` (10 second timeout, process exits naturally)<br />
+<Since pkg="@astrojs/node" v="11.2.0" />
+</p>
+
+Controls graceful shutdown of the [`standalone`](#mode) server when it receives a `SIGTERM` or `SIGINT` signal (for example, when your host stops or restarts the process). The server stops accepting new connections but waits for in-flight requests to finish before closing.
+
+Configure the following:
+
+* **`timeout`** controls how long, in milliseconds, to wait for in-flight requests to finish before force-closing any remaining connections. Set to `0` to force-close immediately, or `Infinity` to wait indefinitely for in-flight requests to finish.
+* **`exit`** controls whether to call `process.exit()` once shutdown completes. By default, the adapter lets the process exit naturally once the event loop is empty, so any other `SIGTERM`/`SIGINT` listeners your app has registered (for example, to close a database connection) get a chance to finish first. Enable this only if you want a guaranteed exit even when something else in the process (a timer, an open connection) would otherwise keep it running.
+
+```js title="astro.config.mjs" {7-10}
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+
+export default defineConfig({
+  adapter: node({
+    mode: 'standalone',
+    shutdown: {
+      timeout: 30 * 1000, // wait up to 30 seconds
+      exit: true,
+    },
+  }),
+});
+```
+
 ## Usage
 
 First, [performing a build](/en/guides/deploy/#building-your-site-locally). Depending on which `mode` selected (see above) follow the appropriate steps below:


### PR DESCRIPTION
#### Description
Documents the new `shutdown` config option for the Node adapter, which controls graceful shutdown behavior (timeout and `exit`) when the standalone server receives `SIGTERM`/`SIGINT`.

#### References
- Related to https://github.com/withastro/astro/pull/17655
- For Astro version `tbd`
- Discord username: whatcats
