### PR TITLE
docs(firebase): set maxAge on session cookie in signin example

### DIFF
--- a/src/content/docs/en/guides/backend/firebase.mdx
+++ b/src/content/docs/en/guides/backend/firebase.mdx
@@ -233,6 +233,7 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
 
   cookies.set("__session", sessionCookie, {
     path: "/",
+    maxAge: fiveDays / 1000,
   });
 
   return redirect("/dashboard");


### PR DESCRIPTION
## Summary

The Firebase auth signin example created a 5-day session cookie via `expiresIn` but did not set `maxAge` on Astro's `cookies.set()`, so browsers treated `__session` as a session cookie and cleared it on tab close.

Adds `maxAge: fiveDays / 1000` so the browser lifetime matches the Firebase cookie.

## Test plan

- [x] Diff is English guide only (`src/content/docs/en/guides/backend/firebase.mdx`)
- [ ] Confirm snippet renders on the Firebase backend guide preview

Closes #14526