### PR TITLE
docs: clarify which errors Astro error pages catch

### DIFF
--- a/src/content/docs/en/basics/astro-pages.mdx
+++ b/src/content/docs/en/basics/astro-pages.mdx
@@ -115,7 +115,7 @@ During development, if you have a `500.astro`, the error thrown at runtime is lo
 
 <p><Since v="4.11.0" /></p>
 
-`src/pages/500.astro` is a special page that is automatically passed an `error` prop for any error thrown during rendering. This allows you to use the details of an error (e.g. from a page, from middleware, etc.) to display information to your visitor.
+`src/pages/500.astro` is a special page that is automatically passed an `error` prop for errors thrown before the response body starts streaming—for example in a page's component script or in [middleware](/en/guides/middleware/) before the response is sent. This allows you to use the details of that error to display information to your visitor. Errors thrown later while Astro streams HTML from your page or components cannot be turned into a `500.astro` page.
 
 The `error` prop's data type can be anything, which may affect how you type or use the value in your code:
 


### PR DESCRIPTION
## Summary
The `error` prop on `500.astro` is not “any error thrown during rendering.” Per maintainer guidance, it covers failures before the response body streams (route component script / middleware at `await next()`), not errors thrown while HTML is streamed from templates and components.

Update that wording and link to middleware.

Fixes #12172