### PR TITLE
docs: clarify HTTP header setting from layouts

### DIFF
--- a/src/content/docs/en/guides/on-demand-rendering.mdx
+++ b/src/content/docs/en/guides/on-demand-rendering.mdx
@@ -141,7 +141,9 @@ With HTML streaming, a document is broken up into chunks, sent over the network 
 <RecipeLinks slugs={["en/recipes/streaming-improve-page-performance"]}/>
 
 :::caution
-Features that modify the [Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) are only available at the **page level**. (You can't use them inside of components, including layout components.) By the time Astro runs your component code, it has already sent the Response headers and they cannot be modified.
+[Response headers](https://developer.mozilla.org/en-US/docs/Glossary/Response_header) are only sent for [on-demand rendered](/en/guides/on-demand-rendering/) routes. Changes made on prerendered pages are not included in the HTTP response.
+
+With [HTML streaming](#html-streaming), Astro finalizes response headers when it begins sending the HTML body. You can set headers from the frontmatter of any `.astro` component in the page tree (including [layout components](/en/basics/layouts/)), but updates from components that run later in the stream (such as after an `await` in an async component) may not be applied.
 
 :::
 


### PR DESCRIPTION
## Summary
The on-demand rendering caution said HTTP headers could only be set at the page level, not in layouts. That was too strict.

On on-demand routes, `Astro.response.headers` set from layouts and nested `.astro` components does reach the response if set before the body streams. Prerendered pages still ignore custom headers, and late/async updates after streaming starts may not apply.

Fixes #11843