### PR TITLE
docs: fix outdated astro:assets imports/snippets

### DIFF
--- a/src/content/docs/en/reference/modules/astro-assets.mdx
+++ b/src/content/docs/en/reference/modules/astro-assets.mdx
@@ -453,6 +453,10 @@ The background color to use when flattening an image to transform it into the re
 By default, Sharp uses a black background when flattening an image. Specifying a different background color is especially useful when transforming images with transparent backgrounds to a format that does not support transparency (e.g. `.jpeg`):
 
 ```astro title="src/components/MyComponent.astro" "background"
+---
+import { Image } from 'astro:assets';
+import myImage from '../assets/my_image.png';
+---
 <Image
   src={myImage}
   alt="A description of my image"
@@ -840,7 +844,9 @@ import {
   baseService,
   getConfiguredImageService,
   getImage,
+  hashTransform,
   isLocalService,
+  propsToFilename,
 } from "astro/assets";
 ```
 
@@ -888,6 +894,62 @@ A function similar to [`getImage()`](#getimage) from `astro:assets` with two req
 
 Checks the type of an image service and returns `true` when this is a [local service](#localimageservice).
 
+### `propsToFilename()`
+
+<p>
+
+**Type:** <code>(filePath: string, transform: <a href="#imagetransform">ImageTransform</a>, hash: string) => string</code><br />
+<Since v="4.0.0" />
+</p>
+
+Generates a formatted filename for an image based on its source path, transformation properties, and a unique hash.
+
+The formatted filename follows this structure:
+
+`<prefixDirname>/<baseFilename>_<hash><outputExtension>`
+
+- `prefixDirname`: If the image is an ESM imported image, this is the directory name of the original file path; otherwise, it will be an empty string.
+- `baseFilename`: The base name of the file or a hashed short name if the file is a `data:` URI.
+- `hash`: A unique hash string generated to distinguish the transformed file.
+- `outputExtension`: The desired output file extension derived from the `transform.format` or the original file extension.
+
+```ts
+import { propsToFilename } from 'astro/assets';
+
+const filePath = '/images/photo.jpg';
+const transform = { format: 'png', src: filePath };
+const hash = 'abcd1234';
+
+const filename = propsToFilename(filePath, transform, hash);
+// Example value: '/images/photo_abcd1234.png'
+```
+
+### `hashTransform()`
+
+<p>
+
+**Type:** <code>(transform: <a href="#imagetransform">ImageTransform</a>, imageService: string, propertiesToHash: string[]) => string</code><br />
+<Since v="4.0.0" />
+</p>
+
+Transforms the provided `transform` object into a hash string based on selected properties and the specified `imageService`.
+
+```ts
+import { hashTransform } from 'astro/assets';
+
+const transform = {
+  src: '/images/photo.jpg',
+  width: 800,
+  height: 600,
+  format: 'jpg',
+};
+const imageService = 'astro/assets/services/sharp';
+const propertiesToHash = ['width', 'height', 'format'];
+
+const hash = hashTransform(transform, imageService, propertiesToHash);
+// Example value: 'd41d8cd98f00b204e9800998ecf8427e'
+```
+
 ## `astro/assets` types
 
 The following types are imported from the regular assets module:
@@ -914,21 +976,14 @@ The following helpers are imported from the `utils` directory in the regular ass
 ```ts
 import { 
   isRemoteAllowed,
-  matchHostname,
-  matchPathname,
   matchPattern,
-  matchPort,
-  matchProtocol,
   isESMImportedImage,
   isRemoteImage,
   resolveSrc,
   imageMetadata,
-  emitImageMetadata,
   emitClientAsset,
   getOrigQueryParams,
   inferRemoteSize,
-  propsToFilename,
-  hashTransform,
 } from "astro/assets/utils";
 ```
 
@@ -959,45 +1014,6 @@ const remotePatterns = [
 isRemoteAllowed(url.href, { domains, remotePatterns }); // Output: `true`
 ```
 
-### `matchHostname()`
-
-<p>
-
-**Type:** `(url: URL, hostname?: string, allowWildcard = false) => boolean`<br />
-<Since v="4.0.0" />
-</p>
-
-Matches a given URL's hostname against a specified hostname, with optional support for wildcard patterns.
-
-```ts
-import { matchHostname } from 'astro/assets/utils';
-
-const url = new URL('https://sub.example.com/path/to/resource');
-
-matchHostname(url, 'example.com'); // Output: `false`
-matchHostname(url, 'example.com', true); // Output: `true`
-```
-
-### `matchPathname()`
-
-<p>
-
-**Type:** `(url: URL, pathname?: string, allowWildcard = false) => boolean`<br />
-<Since v="4.0.0" />
-</p>
-
-Matches a given URL's pathname against a specified pattern, with optional support for wildcards.
-
-```ts
-import { matchPathname } from 'astro/assets/utils';
-
-const testURL = new URL('https://example.com/images/photo.jpg');
-
-matchPathname(testURL, '/images/photo.jpg'); // Output: `true`
-matchPathname(testURL, '/images/'); // Output: `false`
-matchPathname(testURL, '/images/*', true); // Output: `true`
-```
-
 ### `matchPattern()`
 
 <p>
@@ -1019,48 +1035,6 @@ const remotePattern = {
 };
 
 matchPattern(url, remotePattern); // Output: `true`
-```
-
-### `matchPort()`
-
-<p>
-
-**Type:** `(url: URL, port?: string) => boolean`<br />
-**Default:** `true`<br />
-<Since v="4.0.0" />
-</p>
-
-Checks if the given URL's port matches the specified port. If no port is provided, it returns `true`.
-
-```ts
-import { matchPort } from 'astro/assets/utils';
-
-const urlWithPort = new URL('https://example.com:8080/resource');
-const urlWithoutPort = new URL('https://example.com/resource');
-
-matchPort(urlWithPort, '8080'); // Output: `true`
-matchPort(urlWithoutPort, '8080'); // Output: `false`
-```
-
-### `matchProtocol()`
-
-<p>
-
-**Type:** `(url: URL, protocol?: string) => boolean`<br />
-**Default:** `true`<br />
-<Since v="4.0.0" />
-</p>
-
-Compares the protocol of the provided URL with a specified protocol. This returns `true` if the protocol matches or if no protocol is provided.
-
-```ts
-import { matchProtocol } from 'astro/assets/utils';
-
-const secureUrl = new URL('https://example.com/resource');
-const regularUrl = new URL('http://example.com/resource');
-
-matchProtocol(secureUrl, 'https'); // Output: `true`
-matchProtocol(regularUrl, 'https'); // Output: `false`
 ```
 
 ### `isESMImportedImage()`
@@ -1163,32 +1137,6 @@ const metadata = await imageMetadata(binaryImage, sourcePath);
 // }
 ```
 
-### `emitImageMetadata()`
-
-<p>
-
-**Type:** <code>(id: string | undefined, fileEmitter?: Rollup.EmitFile) => Promise\<(<a href="#imagemetadata-1">ImageMetadata</a> & \{ contents?: Buffer \}) | undefined\></code><br />
-<Since v="5.7.0" />
-</p>
-
-Processes an image file and emits its metadata and optionally its contents. In build mode, the function uses `fileEmitter` to generate an asset reference. In development mode, it resolves to a local file URL with query parameters for metadata.
-
-```ts
-import { emitImageMetadata } from 'astro/assets/utils';
-
-const imageId = '/images/photo.jpg';
-const metadata = await emitImageMetadata(imageId);
-// Example value:
-// {
-//    src: '/@fs/home/username/dev/astro-project/src/images/photo.jpg?origWidth=800&origHeight=600&origFormat=jpg',
-//    width: 800,
-//    height: 600,
-//    format: 'jpg',
-//    contents: Uint8Array([...])
-// }
-```
-
-
 ### `emitClientAsset()`
 
 <p>
@@ -1264,62 +1212,6 @@ const imageSize = await inferRemoteSize(remoteImageUrl);
 //    height: 1080,
 //    format: 'jpg'
 // }
-```
-
-### `propsToFilename()`
-
-<p>
-
-**Type:** <code>(filePath: string, transform: <a href="#imagetransform">ImageTransform</a>, hash: string) => string</code><br />
-<Since v="4.0.0" />
-</p>
-
-Generates a formatted filename for an image based on its source path, transformation properties, and a unique hash.
-
-The formatted filename follows this structure:
-
-`<prefixDirname>/<baseFilename>_<hash><outputExtension>`
-
-- `prefixDirname`: If the image is an ESM imported image, this is the directory name of the original file path; otherwise, it will be an empty string.
-- `baseFilename`: The base name of the file or a hashed short name if the file is a `data:` URI.
-- `hash`: A unique hash string generated to distinguish the transformed file.
-- `outputExtension`: The desired output file extension derived from the `transform.format` or the original file extension.
-
-```ts
-import { propsToFilename } from 'astro/assets/utils';
-
-const filePath = '/images/photo.jpg';
-const transform = { format: 'png', src: filePath };
-const hash = 'abcd1234';
-
-const filename = propsToFilename(filePath, transform, hash);
-// Example value: '/images/photo_abcd1234.png'
-```
-
-### `hashTransform()`
-
-<p>
-
-**Type:** <code>(transform: <a href="#imagetransform">ImageTransform</a>, imageService: string, propertiesToHash: string[]) => string</code><br />
-<Since v="4.0.0" />
-</p>
-
-Transforms the provided `transform` object into a hash string based on selected properties and the specified `imageService`.
-
-```ts
-import { hashTransform } from 'astro/assets/utils';
-
-const transform = {
-  src: '/images/photo.jpg',
-  width: 800,
-  height: 600,
-  format: 'jpg',
-};
-const imageService = 'astro/assets/services/sharp';
-const propertiesToHash = ['width', 'height', 'format'];
-
-const hash = hashTransform(transform, imageService, propertiesToHash);
-// Example value: 'd41d8cd98f00b204e9800998ecf8427e'
 ```
 
 ## `astro` types
@@ -1453,6 +1345,18 @@ The width of the image.
 </p>
 
 The height of the image.
+
+#### `ImageTransform.background`
+
+<p>
+
+**Type:** `string | undefined`<br />
+<Since v="5.17.0" />
+</p>
+
+The background color to use when flattening an image to transform it into the requested output `format`. This is especially useful when converting images with transparency to a format that does not support an alpha channel (e.g. PNG to JPEG).
+
+Values are passed directly to the image service. Sharp accepts [any value the `color-string` package can parse](https://github.com/Qix-/color-string/blob/master/README.md#parsing).
 
 ### `UnresolvedImageTransform`
 


### PR DESCRIPTION
## Summary
Update the `astro:assets` reference for current exports:

- Drop removed `astro/assets/utils` helpers from imports/docs
- Document `propsToFilename` / `hashTransform` under `astro/assets`
- Fix `<Image />` `background` snippet frontmatter
- Document `background` on `ImageTransform`

English page only (keeps the PR small). Upgrade-guide `emitImageMetadata` wording left for a follow-up.

Fixes #14281